### PR TITLE
Fix CI lockfile cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: pnpm
+          cache-dependency-path: docs-web/pnpm-lock.yaml
 
       - name: Install docs dependencies
         working-directory: docs-web

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+          cache-dependency-path: docs-web/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: docs-web


### PR DESCRIPTION
## Summary

- Add `cache-dependency-path: docs-web/pnpm-lock.yaml` to both CI and docs workflows
- Lockfile moved to `docs-web/` with pnpm 11, but `setup-node` was looking at repo root

## Test plan

- [ ] CI workflow passes (no more "lock file not found" error)
- [ ] Docs deploy workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)