### PR TITLE
LSP language mapping, hover improvements, and diagnostic UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,22 +188,33 @@ TTT has built-in LSP support for language-aware editing features. Language serve
 
 #### Configuring Language Servers
 
-Add language servers to `~/.config/ttt/settings.json` under the `lsp.servers` key. Each entry maps a language identifier to a command array:
+Add language servers to `~/.config/ttt/settings.json` under the `lsp.servers` key. Each entry maps a server key to a config object with a `command` array:
 
 ```json
 {
   "lsp": {
     "servers": {
       "go": { "command": ["gopls"] },
-      "typescript": { "command": ["typescript-language-server", "--stdio"] },
-      "javascript": { "command": ["typescript-language-server", "--stdio"] },
+      "typescript": {
+        "command": ["typescript-language-server", "--stdio"],
+        "languages": {
+          ".ts": "typescript",
+          ".tsx": "typescriptreact",
+          ".js": "javascript",
+          ".jsx": "javascriptreact"
+        }
+      },
       "python": { "command": ["pyright-langserver", "--stdio"] }
     }
   }
 }
 ```
 
-The language identifier must match the language ID that TTT assigns to the file (e.g. `go`, `typescript`, `javascript`, `python`, `rust`, `c`, `cpp`). The server is started lazily on first use and shut down when the editor exits.
+For simple cases (Go, Python, Rust, etc.), the server key is used as the language ID and files are matched via the syntax highlighter name. No extra configuration is needed.
+
+The optional `languages` field is for servers that handle multiple file types requiring different `languageId` values. It maps file extensions to language IDs. In the example above, the TypeScript language server handles `.ts`, `.tsx`, `.js`, and `.jsx` files, each with the correct `languageId` sent to the server. Without the `languages` field, you would need to register the same server command multiple times under different keys.
+
+The server is started lazily on first use and shut down when the editor exits.
 
 #### Supported Features
 
@@ -325,7 +336,7 @@ Config files are loaded from `<exe-dir>/config/` (bundled defaults) or `~/.confi
 | `terminal.shell` | string | `""` | Shell command for the integrated terminal (empty = system default) |
 | `terminal.scrollback` | int | `1000` | Number of scrollback lines to retain in the terminal |
 | `lsp.saveOnRename` | bool | `false` | Auto-save all files affected by a rename operation |
-| `lsp.servers` | object | `{}` | Map of language ID to `{ "command": [...] }` for LSP servers |
+| `lsp.servers` | object | `{}` | Map of language ID to `{ "command": [...], "languages": {...} }` for LSP servers |
 | `autocomplete.enabled` | bool | `true` | Enable LSP-powered autocompletion |
 | `autocomplete.autoSuggest` | bool | `true` | Show completions automatically as you type |
 | `autocomplete.debounce` | int | `150` | Milliseconds to wait after typing before requesting completions |
@@ -355,7 +366,15 @@ Example `~/.config/ttt/settings.json`:
     "saveOnRename": true,
     "servers": {
       "go": { "command": ["gopls"] },
-      "typescript": { "command": ["typescript-language-server", "--stdio"] }
+      "typescript": {
+        "command": ["typescript-language-server", "--stdio"],
+        "languages": {
+          ".ts": "typescript",
+          ".tsx": "typescriptreact",
+          ".js": "javascript",
+          ".jsx": "javascriptreact"
+        }
+      }
     }
   },
   "autocomplete": {

--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -258,7 +258,7 @@ func (a *App) refreshProblems() {
 	a.problems.SetItems(items)
 }
 
-func (a *App) checkDiagnosticHover(mx, my int) {
+func (a *App) checkMouseHover(mx, my int) {
 	if a.editorGroup.Editor == nil {
 		return
 	}

--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -56,6 +56,9 @@ type App struct {
 	completionItems    []ui.CompletionItem
 	lspCompletionItems []lsp.CompletionItem
 	autocompleteTimer  *time.Timer
+	hoverTimer         *time.Timer
+	lastHoverLine      int
+	lastHoverCol       int
 	problems           *ui.ProblemsWidget
 	references         *ui.ReferencesWidget
 	allDiagnostics     map[string][]ui.Diagnostic
@@ -262,6 +265,7 @@ func (a *App) checkDiagnosticHover(mx, my int) {
 	r := a.editorGroup.Editor.GetRect()
 	if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
 		a.DismissHover()
+		a.cancelHoverTimer()
 		return
 	}
 	gw := a.editorGroup.Editor.GutterWidth()
@@ -269,21 +273,42 @@ func (a *App) checkDiagnosticHover(mx, my int) {
 	col := mx - r.X - gw + a.editorGroup.Editor.Viewport.LeftCol
 	if col < 0 {
 		a.DismissHover()
+		a.cancelHoverTimer()
 		return
 	}
-	d := a.editorGroup.Editor.DiagnosticAt(line, col)
-	if d != nil {
-		a.ShowHover(d.Message)
-	} else {
-		a.DismissHover()
+	if line == a.lastHoverLine && col == a.lastHoverCol {
+		return
+	}
+	a.lastHoverLine = line
+	a.lastHoverCol = col
+	a.DismissHover()
+	a.cancelHoverTimer()
+	delay := a.settings.LSP.HoverDelay
+	if delay <= 0 {
+		delay = 400
+	}
+	path := a.editorGroup.ActiveFilePath()
+	lang := ""
+	if a.editorGroup.Editor.Highlighter != nil {
+		lang = a.editorGroup.Editor.Highlighter.Language()
+	}
+	a.hoverTimer = time.AfterFunc(time.Duration(delay)*time.Millisecond, func() {
+		a.RequestHover(path, lang, line, col, mx, my)
+	})
+}
+
+func (a *App) cancelHoverTimer() {
+	if a.hoverTimer != nil {
+		a.hoverTimer.Stop()
+		a.hoverTimer = nil
 	}
 }
 
-func (a *App) ShowHover(text string) {
+func (a *App) ShowHover(text string, anchorX, anchorY int) {
 	if text == "" {
 		return
 	}
-	a.editorGroup.Hover = ui.NewHoverWidget(text, 0, 0)
+	a.editorGroup.Hover = ui.NewHoverWidget(text, anchorX, anchorY)
 }
 
 func (a *App) DismissHover() {
@@ -388,10 +413,10 @@ func (a *App) resolveAndInsert(item ui.CompletionItem) {
 		if a.editorGroup.Editor != nil && a.editorGroup.Editor.Highlighter != nil {
 			lang = a.editorGroup.Editor.Highlighter.Language()
 		}
-		langKey, ok := a.lspReady(lang)
+		serverKey, _, ok := a.lspResolve(path, lang)
 		if ok {
 			workDir := a.lspWorkDir(path)
-			client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+			client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 			if err == nil {
 				resolved, err := client.ResolveCompletion(*lspItem)
 				if err == nil && resolved != nil {
@@ -509,13 +534,13 @@ func (a *App) CheckSignatureHelpTrigger() {
 }
 
 func (a *App) RequestSignatureHelp(path, lang string, line, col int) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
@@ -553,7 +578,7 @@ func (a *App) editorTabSize() (int, bool) {
 }
 
 func (a *App) RequestFormatting(path, lang string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		if lang != "" {
 			a.StatusWarn(lang + " language server is not configured")
@@ -563,7 +588,7 @@ func (a *App) RequestFormatting(path, lang string) {
 	workDir := a.lspWorkDir(path)
 	tabSize, insertSpaces := a.editorTabSize()
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
@@ -580,7 +605,7 @@ func (a *App) RequestFormatting(path, lang string) {
 }
 
 func (a *App) RequestRangeFormatting(path, lang string, startLine, startCol, endLine, endCol int) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		if lang != "" {
 			a.StatusWarn(lang + " language server is not configured")
@@ -594,7 +619,7 @@ func (a *App) RequestRangeFormatting(path, lang string, startLine, startCol, end
 		End:   lsp.Position{Line: endLine, Character: endCol},
 	}
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
@@ -614,12 +639,12 @@ func (a *App) RunCodeActionsOnSave(path, lang string) {
 	if len(a.settings.LSP.CodeActionsOnSave) == 0 {
 		return
 	}
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
 	workDir := a.lspWorkDir(path)
-	client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+	client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 	if err != nil {
 		return
 	}
@@ -648,7 +673,7 @@ func (a *App) RunCodeActionsOnSave(path, lang string) {
 }
 
 func (a *App) RequestCodeAction(path, lang, kind string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		if lang != "" {
 			a.StatusWarn(lang + " language server is not configured")
@@ -657,7 +682,7 @@ func (a *App) RequestCodeAction(path, lang, kind string) {
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
@@ -685,13 +710,13 @@ func (a *App) RequestCodeAction(path, lang, kind string) {
 }
 
 func (a *App) FormatOnSave(path, lang string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
 	workDir := a.lspWorkDir(path)
 	tabSize, insertSpaces := a.editorTabSize()
-	client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+	client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 	if err != nil {
 		return
 	}
@@ -706,7 +731,7 @@ func (a *App) FormatOnSave(path, lang string) {
 }
 
 func (a *App) RequestRename(path, lang string, line, col int, newName string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		if lang != "" {
 			a.StatusWarn(lang + " language server is not configured")
@@ -715,7 +740,7 @@ func (a *App) RequestRename(path, lang string, line, col int, newName string) {
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
@@ -755,7 +780,7 @@ func (a *App) ApplyWorkspaceEdit(edit *lsp.WorkspaceEdit) {
 }
 
 func (a *App) RequestReferences(path, lang string, line, col int) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		if lang != "" {
 			a.StatusWarn(lang + " language server is not configured")
@@ -764,7 +789,7 @@ func (a *App) RequestReferences(path, lang string, line, col int) {
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
@@ -872,34 +897,32 @@ func isIdentRune(r rune) bool {
 	return r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
 }
 
-func (a *App) lspReady(lang string) (string, bool) {
-	if a.lspManager == nil || lang == "" {
-		return "", false
+func (a *App) lspResolve(path, lang string) (serverKey, languageID string, ok bool) {
+	if a.lspManager == nil {
+		return "", "", false
 	}
-	langKey := strings.ToLower(lang)
-	if !a.lspManager.HasServer(langKey) {
-		return "", false
-	}
-	return langKey, true
+	return a.lspManager.ResolveLanguage(path, lang)
 }
 
 func (a *App) RequestCompletions(path, lang string, line, col int) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
 		}
+		slog.Debug("lsp completion request", "path", path, "line", line, "col", col)
 		items, err := client.Completion(fileURI(path), line, col)
 		if err != nil {
 			slog.Error("lsp completion", "err", err)
 			return
 		}
+		slog.Debug("lsp completion response", "count", len(items))
 		uiItems := lspToUICompletions(items)
 		if len(uiItems) > 0 {
 			a.screen.PostEvent(tcell.NewEventInterrupt(&completionResult{items: uiItems, lspItems: items}))
@@ -907,28 +930,56 @@ func (a *App) RequestCompletions(path, lang string, line, col int) {
 	}()
 }
 
-func (a *App) RequestHover(path, lang string, line, col int) {
-	langKey, ok := a.lspReady(lang)
+func (a *App) RequestHover(path, lang string, line, col, anchorX, anchorY int) {
+	diagText := ""
+	if a.editorGroup.Editor != nil {
+		if d := a.editorGroup.Editor.DiagnosticAt(line, col); d != nil {
+			diagText = d.Message
+		}
+	}
+
+	post := func(text string) {
+		a.screen.PostEvent(tcell.NewEventInterrupt(&hoverResult{text: text, anchorX: anchorX, anchorY: anchorY}))
+	}
+
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
-		if lang != "" {
-			a.StatusWarn(lang + " language server is not configured")
+		if diagText != "" {
+			post(diagText)
 		}
 		return
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
+			if diagText != "" {
+				post(diagText)
+			}
 			return
 		}
 		hover, err := client.Hover(fileURI(path), line, col)
 		if err != nil {
 			slog.Error("lsp hover", "err", err)
+			if diagText != "" {
+				post(diagText)
+			}
 			return
 		}
-		if hover != nil && hover.Contents.Value != "" {
-			a.screen.PostEvent(tcell.NewEventInterrupt(&hoverResult{text: hover.Contents.Value}))
+		text := ""
+		if hover != nil {
+			text = hover.Contents.Value
+		}
+		if diagText != "" {
+			if text != "" {
+				text = diagText + "\n---\n" + text
+			} else {
+				text = diagText
+			}
+		}
+		if text != "" {
+			post(text)
 		}
 	}()
 }
@@ -946,7 +997,7 @@ func (a *App) RequestTypeDefinition(path, lang string, line, col int) {
 }
 
 func (a *App) requestLocation(method, path, lang string, line, col int) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		if lang != "" {
 			a.StatusWarn(lang + " language server is not configured")
@@ -955,7 +1006,7 @@ func (a *App) requestLocation(method, path, lang string, line, col int) {
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
 			return
@@ -989,7 +1040,7 @@ func (a *App) lspWorkDir(path string) string {
 }
 
 func (a *App) NotifyLSPOpen(path, lang, text string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, langID, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
@@ -998,16 +1049,16 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 	a.docVersions[path] = 1
 	a.docVersionsMu.Unlock()
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			return
 		}
-		client.DidOpen(fileURI(path), langKey, text)
+		client.DidOpen(fileURI(path), langID, text)
 	}()
 }
 
 func (a *App) NotifyLSPChange(path, lang, text string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
@@ -1017,7 +1068,7 @@ func (a *App) NotifyLSPChange(path, lang, text string) {
 	version := a.docVersions[path]
 	a.docVersionsMu.Unlock()
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			return
 		}
@@ -1026,13 +1077,13 @@ func (a *App) NotifyLSPChange(path, lang, text string) {
 }
 
 func (a *App) NotifyLSPSave(path, lang, text string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			return
 		}
@@ -1041,7 +1092,7 @@ func (a *App) NotifyLSPSave(path, lang, text string) {
 }
 
 func (a *App) NotifyLSPClose(path, lang string) {
-	langKey, ok := a.lspReady(lang)
+	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
@@ -1050,7 +1101,7 @@ func (a *App) NotifyLSPClose(path, lang string) {
 	delete(a.docVersions, path)
 	a.docVersionsMu.Unlock()
 	go func() {
-		client, err := a.lspManager.ClientForLanguage(langKey, workDir)
+		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			return
 		}

--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -213,6 +213,7 @@ func registerEditorCommands(reg *command.Registry, app *App, running *bool, quit
 				app.DismissAutocomplete()
 				return
 			}
+			app.DismissHover()
 			app.FocusEditor()
 		},
 	})
@@ -234,7 +235,7 @@ func registerEditorCommands(reg *command.Registry, app *App, running *bool, quit
 			}
 			if lang == "" {
 				app.StatusWarn("No language detected for this file")
-			} else if app.lspManager == nil || !app.lspManager.HasServer(strings.ToLower(lang)) {
+			} else if _, _, ok := app.lspResolve(path, lang); !ok {
 				app.StatusWarn(lang + " language server is not configured. Add it to settings.json under lsp.servers")
 			} else {
 				line, col := app.editorGroup.ActiveCursor()
@@ -255,7 +256,16 @@ func registerEditorCommands(reg *command.Registry, app *App, running *bool, quit
 
 	reg.Register(command.Command{
 		ID: "editor.hover", Title: "Show Hover",
-		Handler: func() { lspAction(app.RequestHover) },
+		Handler: func() {
+			path := app.editorGroup.ActiveFilePath()
+			lang := ""
+			if app.editorGroup.Editor != nil && app.editorGroup.Editor.Highlighter != nil {
+				lang = app.editorGroup.Editor.Highlighter.Language()
+			}
+			line, col := app.editorGroup.ActiveCursor()
+			ax, ay, _ := app.editorGroup.CursorPosition()
+			app.RequestHover(path, lang, line, col, ax, ay)
+		},
 	})
 
 	reg.Register(command.Command{

--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -131,7 +131,7 @@ func runEventLoop(
 			slog.Debug("mouse", "x", mx, "y", my, "btn", btn)
 			app.DismissSignatureHelp()
 			if btn == 0 {
-				app.checkDiagnosticHover(mx, my)
+				app.checkMouseHover(mx, my)
 			} else {
 				app.DismissHover()
 			}

--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -3,12 +3,9 @@ package main
 import (
 	"fmt"
 	"log/slog"
-	"strings"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
-	"github.com/eugenioenko/ttt/internal/ui"
-	"github.com/eugenioenko/ttt/internal/view"
 
 	"github.com/gdamore/tcell/v2"
 )
@@ -45,7 +42,8 @@ func runEventLoop(
 		if app.editorGroup.Editor != nil && app.editorGroup.Editor.Highlighter != nil {
 			lang := app.editorGroup.Editor.Highlighter.Language()
 			app.status.Language = lang
-			app.status.LSP = app.lspManager != nil && app.lspManager.HasServer(strings.ToLower(lang))
+			_, _, lspOk := app.lspResolve(filePath, lang)
+			app.status.LSP = lspOk
 		} else {
 			app.status.Language = ""
 			app.status.LSP = false
@@ -69,22 +67,6 @@ func runEventLoop(
 				app.status.Branch = git.BranchName(repoDir)
 			} else {
 				app.status.Branch = ""
-			}
-		}
-
-		app.status.DiagMessage = ""
-		if app.editorGroup.Editor != nil {
-			d := app.editorGroup.Editor.DiagnosticAt(line, col)
-			if d != nil {
-				app.status.DiagMessage = d.Message
-				switch d.Severity {
-				case ui.DiagError:
-					app.status.DiagLevel = view.NotifyError
-				case ui.DiagWarning:
-					app.status.DiagLevel = view.NotifyWarning
-				default:
-					app.status.DiagLevel = view.NotifyInfo
-				}
 			}
 		}
 
@@ -198,7 +180,7 @@ func runEventLoop(
 				}
 			case *hoverResult:
 				if v.text != "" {
-					app.ShowHover(v.text)
+					app.ShowHover(v.text, v.anchorX, v.anchorY)
 				}
 			case *locationResult:
 				if len(v.locations) > 0 {

--- a/cmd/ttt/lsp.go
+++ b/cmd/ttt/lsp.go
@@ -20,7 +20,9 @@ type locationResult struct {
 }
 
 type hoverResult struct {
-	text string
+	text    string
+	anchorX int
+	anchorY int
 }
 
 type autocompleteTrigger struct{}

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -52,6 +52,7 @@ func main() {
 	lspManager.OnDiagnostics = func(params lsp.PublishDiagnosticsParams) {
 		path := uriToPath(params.URI)
 		diags := lspToUIDiagnostics(params.Diagnostics)
+		slog.Debug("lsp diagnostics", "path", path, "count", len(diags))
 		screen.PostEvent(tcell.NewEventInterrupt(&diagnosticsResult{
 			path:        path,
 			diagnostics: diags,

--- a/docs-web/src/content/docs/guides/lsp.md
+++ b/docs-web/src/content/docs/guides/lsp.md
@@ -7,22 +7,35 @@ TTT has built-in LSP support for language-aware editing features. Language serve
 
 ## Configuring Language Servers
 
-Add language servers to `~/.config/ttt/settings.json` under the `lsp.servers` key. Each entry maps a language identifier to a command array:
+Add language servers to `~/.config/ttt/settings.json` under the `lsp.servers` key. Each entry maps a server key to a config object with a `command` array:
 
 ```json
 {
   "lsp": {
     "servers": {
       "go": { "command": ["gopls"] },
-      "typescript": { "command": ["typescript-language-server", "--stdio"] },
-      "javascript": { "command": ["typescript-language-server", "--stdio"] },
+      "typescript": {
+        "command": ["typescript-language-server", "--stdio"],
+        "languages": {
+          ".ts": "typescript",
+          ".tsx": "typescriptreact",
+          ".js": "javascript",
+          ".jsx": "javascriptreact"
+        }
+      },
       "python": { "command": ["pyright-langserver", "--stdio"] }
     }
   }
 }
 ```
 
-The language identifier must match the language ID that TTT assigns to the file (e.g. `go`, `typescript`, `javascript`, `python`, `rust`, `c`, `cpp`). The server is started lazily on first use and shut down when the editor exits.
+For simple cases (Go, Python, Rust, etc.), the server key is used as the language ID and files are matched via the syntax highlighter name. No extra configuration is needed.
+
+### The `languages` field
+
+The optional `languages` field is for servers that handle multiple file types requiring different `languageId` values. It maps file extensions to language IDs. In the example above, the TypeScript language server handles `.ts`, `.tsx`, `.js`, and `.jsx` files, each with the correct `languageId` sent to the server. Without the `languages` field, you would need to register the same server command multiple times under different keys.
+
+The server is started lazily on first use and shut down when the editor exits.
 
 ## Supported Features
 

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -42,7 +42,7 @@ Settings are stored in `~/.config/ttt/settings.json`.
 |-----|------|---------|-------------|
 | `lsp.saveOnRename` | bool | `false` | Auto-save files affected by a rename operation |
 | `lsp.codeActionsOnSave` | string[] | `[]` | Code actions to run before save (e.g. `"source.organizeImports"`) |
-| `lsp.servers` | object | `{}` | Map of language ID to `{ "command": [...] }` |
+| `lsp.servers` | object | `{}` | Map of server key to `{ "command": [...], "languages": {...} }`. The optional `languages` field maps file extensions to language IDs for servers handling multiple file types. |
 
 ## Autocomplete
 
@@ -81,7 +81,15 @@ Settings are stored in `~/.config/ttt/settings.json`.
     ],
     "servers": {
       "go": { "command": ["gopls"] },
-      "typescript": { "command": ["typescript-language-server", "--stdio"] }
+      "typescript": {
+        "command": ["typescript-language-server", "--stdio"],
+        "languages": {
+          ".ts": "typescript",
+          ".tsx": "typescriptreact",
+          ".js": "javascript",
+          ".jsx": "javascriptreact"
+        }
+      }
     }
   },
   "autocomplete": {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -33,13 +33,21 @@ func DefaultAutocompleteSettings() AutocompleteSettings {
 }
 
 type LSPServerConfig struct {
-	Command []string `json:"command"`
+	Command   []string          `json:"command"`
+	Languages map[string]string `json:"languages,omitempty"`
 }
 
 type LSPSettings struct {
 	Servers          map[string]LSPServerConfig `json:"servers,omitempty"`
 	SaveOnRename     bool                       `json:"saveOnRename"`
 	CodeActionsOnSave []string                  `json:"codeActionsOnSave,omitempty"`
+	HoverDelay       int                        `json:"hoverDelay,omitempty"`
+}
+
+func DefaultLSPSettings() LSPSettings {
+	return LSPSettings{
+		HoverDelay: 400,
+	}
 }
 
 type ExplorerSettings struct {
@@ -81,6 +89,7 @@ func DefaultSettings() Settings {
 		SidebarWidth:   30,
 		Explorer:       DefaultExplorerSettings(),
 		Terminal:       DefaultTerminalSettings(),
+		LSP:            DefaultLSPSettings(),
 		Autocomplete:   DefaultAutocompleteSettings(),
 	}
 }

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -63,6 +64,20 @@ func (m *Manager) HasServer(lang string) bool {
 	key := strings.ToLower(lang)
 	_, ok := m.config.Servers[key]
 	return ok
+}
+
+func (m *Manager) ResolveLanguage(filePath, chromaLang string) (serverKey, languageID string, ok bool) {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	for name, cfg := range m.config.Servers {
+		if langID, found := cfg.Languages[ext]; found {
+			return name, langID, true
+		}
+	}
+	key := strings.ToLower(chromaLang)
+	if _, found := m.config.Servers[key]; found {
+		return key, key, true
+	}
+	return "", "", false
 }
 
 func (m *Manager) Shutdown() {

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -60,11 +60,6 @@ func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 	return client, nil
 }
 
-func (m *Manager) HasServer(lang string) bool {
-	key := strings.ToLower(lang)
-	_, ok := m.config.Servers[key]
-	return ok
-}
 
 func (m *Manager) ResolveLanguage(filePath, chromaLang string) (serverKey, languageID string, ok bool) {
 	ext := strings.ToLower(filepath.Ext(filePath))

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -177,9 +177,14 @@ type CodeAction struct {
 	Diagnostics []Diagnostic   `json:"diagnostics,omitempty"`
 }
 
+type CompletionContext struct {
+	TriggerKind int `json:"triggerKind"`
+}
+
 type CompletionParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Position     Position               `json:"position"`
+	Context      *CompletionContext     `json:"context,omitempty"`
 }
 
 type CompletionItemKind int

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -177,14 +177,9 @@ type CodeAction struct {
 	Diagnostics []Diagnostic   `json:"diagnostics,omitempty"`
 }
 
-type CompletionContext struct {
-	TriggerKind int `json:"triggerKind"`
-}
-
 type CompletionParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Position     Position               `json:"position"`
-	Context      *CompletionContext     `json:"context,omitempty"`
 }
 
 type CompletionItemKind int

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -686,8 +686,8 @@ func (g *EditorGroupWidget) Render(surface *RenderSurface) {
 	}
 
 	if g.Hover != nil && len(g.Hover.Lines) > 0 {
-		g.Hover.AnchorX = g.Editor.CursorX - r.X
-		g.Hover.AnchorY = g.Editor.CursorY - r.Y - 1
+		g.Hover.OffsetX = r.X
+		g.Hover.OffsetY = r.Y
 		g.Hover.Borders = g.Borders
 		g.Hover.Render(surface)
 	}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -485,6 +485,9 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 			e.deleteSelection()
 		} else if e.Cursor.Col > 0 {
 			runes := []rune(e.Buf.Lines[e.Cursor.Line])
+			if e.Cursor.Col > len(runes) {
+				e.Cursor.Col = len(runes)
+			}
 			inLeadingWhitespace := true
 			for i := 0; i < e.Cursor.Col && i < len(runes); i++ {
 				if runes[i] != ' ' && runes[i] != '\t' {

--- a/internal/ui/hover_widget.go
+++ b/internal/ui/hover_widget.go
@@ -9,7 +9,6 @@ import (
 )
 
 const hoverMaxVisibleLines = 12
-const hoverMaxWidth = 60
 
 type HoverWidget struct {
 	BaseWidget
@@ -93,7 +92,7 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 	y := localY - menuH
 	if y < 0 {
 		if spaceAbove < menuH {
-			y = h.AnchorY + 1
+			y = localY + 1
 			if y+menuH > sh {
 				menuH = sh - y
 				visLines = menuH - 2

--- a/internal/ui/hover_widget.go
+++ b/internal/ui/hover_widget.go
@@ -9,12 +9,15 @@ import (
 )
 
 const hoverMaxVisibleLines = 12
+const hoverMaxWidth = 60
 
 type HoverWidget struct {
 	BaseWidget
 	Lines     []string
 	AnchorX   int
 	AnchorY   int
+	OffsetX   int
+	OffsetY   int
 	Borders   *term.BorderSet
 	scrollTop  int
 	scrollLeft int
@@ -75,7 +78,10 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 		menuH++
 	}
 
-	x := h.AnchorX
+	localX := h.AnchorX - h.OffsetX
+	localY := h.AnchorY - h.OffsetY
+
+	x := localX
 	if x+menuW > sw {
 		x = sw - menuW
 	}
@@ -83,8 +89,8 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 		x = 0
 	}
 
-	spaceAbove := h.AnchorY
-	y := h.AnchorY - menuH
+	spaceAbove := localY
+	y := localY - menuH
 	if y < 0 {
 		if spaceAbove < menuH {
 			y = h.AnchorY + 1
@@ -116,6 +122,14 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 		innerW := menuW - 2
 		if hasVScroll {
 			innerW--
+		}
+		if h.Lines[lineIdx] == "---" {
+			surface.SetCell(x, row, term.Cell{Ch: b.LeftTee, Style: term.StyleBorder})
+			for bx := x + 1; bx < x+1+innerW; bx++ {
+				surface.SetCell(bx, row, term.Cell{Ch: b.Horizontal, Style: term.StyleBorder})
+			}
+			surface.SetCell(x+menuW-1, row, term.Cell{Ch: b.RightTee, Style: term.StyleBorder})
+			continue
 		}
 		for bx := x + 1; bx < x+1+innerW; bx++ {
 			surface.SetCell(bx, row, term.Cell{Ch: ' ', Style: st})

--- a/internal/ui/statusbar_widget.go
+++ b/internal/ui/statusbar_widget.go
@@ -47,10 +47,7 @@ func (s *StatusBarWidget) Render(surface *RenderSurface) {
 		x += s.drawText(surface, x, "  ", term.StyleStatusBar)
 	}
 
-	if st.DiagMessage != "" {
-		x += s.drawText(surface, x, st.DiagMessage, st.DiagLevel.Style())
-		x += s.drawText(surface, x, "  ", term.StyleStatusBar)
-	} else if st.Blame != "" {
+	if st.Blame != "" {
 		x += s.drawText(surface, x, st.Blame, term.StyleMuted)
 	}
 

--- a/internal/view/statusbar.go
+++ b/internal/view/statusbar.go
@@ -32,8 +32,6 @@ type StatusBar struct {
 	Dirty        bool
 	Branch       string
 	Blame        string
-	DiagMessage  string
-	DiagLevel    NotifyLevel
 	Language     string
 	LSP          bool
 	TabSize      int


### PR DESCRIPTION
## Summary

- **LSP language mapping**: Add per-server `languages` field mapping file extensions to `languageId` values, fixing TSX/JSX files being sent with wrong languageId to typescript-language-server
- **Mouse hover**: Throttled LSP hover on mouse idle (configurable `lsp.hoverDelay`, default 400ms) showing type info at mouse position
- **Keyboard hover (Ctrl+K I)**: Shows combined diagnostic + LSP type info with border divider, positioned at cursor
- **Diagnostic UX**: Remove diagnostic messages from status bar (use Ctrl+K I instead), dismiss hover on Escape
- **Crash fix**: Guard backspace handler against cursor column exceeding line length

## Test plan

- [ ] Open a `.tsx` file — verify diagnostics appear correctly (not "wrong languageId" errors)
- [ ] Hover mouse over a Go/TS symbol for ~400ms — verify type info appears at mouse position
- [ ] Press Ctrl+K I on a symbol — verify hover appears at cursor position
- [ ] Press Ctrl+K I on a squiggly error — verify diagnostic + type info shown with divider
- [ ] Press Escape — verify hover dismisses
- [ ] Verify status bar no longer shows diagnostic messages
- [ ] Test backspace on empty line after undo — verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)