### PR TITLE
feat: LSP functional tests and hover/diagnostic fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,13 @@ jobs:
       - name: Install tui-use
         run: npm install -g tui-use
 
+      - name: Install LSP servers
+        run: |
+          go install golang.org/x/tools/gopls@latest
+          npm install -g typescript typescript-language-server
+          pip install pyright
+          sudo apt-get install -y clangd
+
       - name: Install test dependencies
         working-directory: tests/functional
         run: pnpm install

--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -57,6 +57,7 @@ type App struct {
 	lspCompletionItems []lsp.CompletionItem
 	autocompleteTimer  *time.Timer
 	hoverTimer         *time.Timer
+	hoverGen           uint64
 	lastHoverLine      int
 	lastHoverCol       int
 	problems           *ui.ProblemsWidget
@@ -313,6 +314,8 @@ func (a *App) ShowHover(text string, anchorX, anchorY int) {
 
 func (a *App) DismissHover() {
 	a.editorGroup.Hover = nil
+	a.cancelHoverTimer()
+	a.hoverGen++
 }
 
 func (a *App) ShowAutocomplete(items []ui.CompletionItem, lspItems []lsp.CompletionItem) {
@@ -938,8 +941,9 @@ func (a *App) RequestHover(path, lang string, line, col, anchorX, anchorY int) {
 		}
 	}
 
+	gen := a.hoverGen
 	post := func(text string) {
-		a.screen.PostEvent(tcell.NewEventInterrupt(&hoverResult{text: text, anchorX: anchorX, anchorY: anchorY}))
+		a.screen.PostEvent(tcell.NewEventInterrupt(&hoverResult{text: text, anchorX: anchorX, anchorY: anchorY, gen: gen}))
 	}
 
 	serverKey, _, ok := a.lspResolve(path, lang)
@@ -970,6 +974,7 @@ func (a *App) RequestHover(path, lang string, line, col, anchorX, anchorY int) {
 		text := ""
 		if hover != nil {
 			text = hover.Contents.Value
+			slog.Debug("lsp hover response", "length", len(text))
 		}
 		if diagText != "" {
 			if text != "" {
@@ -1048,6 +1053,7 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 	a.docVersionsMu.Lock()
 	a.docVersions[path] = 1
 	a.docVersionsMu.Unlock()
+	slog.Debug("lsp didOpen", "path", path, "language", langID)
 	go func() {
 		client, err := a.lspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {

--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -209,11 +209,11 @@ func registerEditorCommands(reg *command.Registry, app *App, running *bool, quit
 	reg.Register(command.Command{
 		ID: "editor.focus", Title: "Focus Editor",
 		Handler: func() {
+			app.DismissHover()
 			if app.IsAutocompleteActive() {
 				app.DismissAutocomplete()
 				return
 			}
-			app.DismissHover()
 			app.FocusEditor()
 		},
 	})

--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -179,7 +179,7 @@ func runEventLoop(
 					app.ShowAutocomplete(v.items, v.lspItems)
 				}
 			case *hoverResult:
-				if v.text != "" {
+				if v.text != "" && v.gen == app.hoverGen {
 					app.ShowHover(v.text, v.anchorX, v.anchorY)
 				}
 			case *locationResult:

--- a/cmd/ttt/lsp.go
+++ b/cmd/ttt/lsp.go
@@ -23,6 +23,7 @@ type hoverResult struct {
 	text    string
 	anchorX int
 	anchorY int
+	gen     uint64
 }
 
 type autocompleteTrigger struct{}

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -28,8 +28,18 @@ func initLogger(debug bool) *os.File {
 	return f
 }
 
+func findConfigFlag() string {
+	args := os.Args[1:]
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--config" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
 func main() {
-	cfg := config.Load()
+	cfg := config.Load(findConfigFlag())
 	config.ParseKeyBindings(cfg.Keybindings)
 
 	logFile := initLogger(cfg.Settings.DebugMode)
@@ -76,6 +86,13 @@ func main() {
 	}
 	app.editorGroup.OnFileClose = func(path, lang string) {
 		app.NotifyLSPClose(path, lang)
+	}
+	if path := app.editorGroup.ActiveFilePath(); path != "" {
+		if app.editorGroup.Editor != nil && app.editorGroup.Editor.Highlighter != nil {
+			lang := app.editorGroup.Editor.Highlighter.Language()
+			text := strings.Join(app.editorGroup.Editor.Buf.Lines, "\n")
+			app.NotifyLSPOpen(path, lang, text)
+		}
 	}
 	app.problems.OnNavigate = func(file string, line, col int) {
 		app.editorGroup.OpenFile(file)

--- a/cmd/ttt/widgets.go
+++ b/cmd/ttt/widgets.go
@@ -11,7 +11,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/workspace"
 )
 
-func resolveArgs() (ws *workspace.Workspace, openFiles []string) {
+func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile string) {
 	var folders []string
 	var wsFile string
 
@@ -19,6 +19,11 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string) {
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--workspace" && i+1 < len(args) {
 			wsFile = args[i+1]
+			i++
+			continue
+		}
+		if args[i] == "--config" && i+1 < len(args) {
+			configFile = args[i+1]
 			i++
 			continue
 		}
@@ -65,7 +70,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string) {
 }
 
 func buildApp(cfg *config.AppConfig, borders *term.BorderSet) *App {
-	ws, openFiles := resolveArgs()
+	ws, openFiles, _ := resolveArgs()
 	return buildAppFromConfig(cfg, borders, ws, openFiles)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,7 @@ type AppConfig struct {
 	Theme       ThemeConfig
 }
 
-func Load() AppConfig {
+func Load(settingsFile string) AppConfig {
 	cfg := AppConfig{
 		Keybindings: DefaultKeybindings(),
 		Settings:    DefaultSettings(),
@@ -32,7 +32,11 @@ func Load() AppConfig {
 		}
 	}
 
-	if data, err := readFirst(paths, "settings.json"); err == nil {
+	if settingsFile != "" {
+		if data, err := os.ReadFile(settingsFile); err == nil {
+			json.Unmarshal(data, &cfg.Settings)
+		}
+	} else if data, err := readFirst(paths, "settings.json"); err == nil {
 		json.Unmarshal(data, &cfg.Settings)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLoadNoFiles(t *testing.T) {
-	cfg := Load()
+	cfg := Load("")
 	if len(cfg.Keybindings) == 0 {
 		t.Fatal("expected default keybindings")
 	}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -46,6 +46,7 @@ type editorTab struct {
 	Undo        *undo.UndoStack
 	Sel         *selection.Selection
 	Highlighter *highlight.Highlighter
+	Diagnostics []Diagnostic
 	TabSize     int
 	Content     Widget
 	Pinned      bool
@@ -455,9 +456,14 @@ func (g *EditorGroupWidget) ClearSearch() {
 }
 
 func (g *EditorGroupWidget) SetDiagnostics(path string, diags []Diagnostic) {
-	t := g.activeTab()
-	if t != nil && t.FilePath == path {
-		g.Editor.Diagnostics = diags
+	for i := range g.tabs {
+		if g.tabs[i].FilePath == path {
+			g.tabs[i].Diagnostics = diags
+			if i == g.active {
+				g.Editor.Diagnostics = diags
+			}
+			return
+		}
 	}
 }
 
@@ -617,6 +623,7 @@ func (g *EditorGroupWidget) syncTabs() {
 		g.Editor.Undo = t.Undo
 		g.Editor.Selection = t.Sel
 		g.Editor.Highlighter = t.Highlighter
+		g.Editor.Diagnostics = t.Diagnostics
 		if t.TabSize > 0 {
 			g.Editor.TabSize = t.TabSize
 		}

--- a/tests/functional/lsp.test.js
+++ b/tests/functional/lsp.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import {
+  cpSync,
+  readFileSync,
+  readdirSync,
+  unlinkSync,
+  existsSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as tui from "./tui.js";
+import { createTempDir, cleanupDir } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LSP_DIR = resolve(__dirname, "lsp");
+const LOG_FILE = resolve(__dirname, "ttt.log");
+
+function sleep(ms) {
+  execSync(`sleep ${ms / 1000}`);
+}
+
+function waitForLog(pattern, timeoutMs = 5000) {
+  const re = new RegExp(pattern);
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (existsSync(LOG_FILE)) {
+      const log = readFileSync(LOG_FILE, "utf8");
+      if (re.test(log)) return log;
+    }
+    sleep(500);
+  }
+  return existsSync(LOG_FILE) ? readFileSync(LOG_FILE, "utf8") : "";
+}
+
+function navigateTo(pos) {
+  const [line, col] = pos.split(":").map(Number);
+  tui.press("ctrl+g");
+  tui.waitStable();
+  tui.type(String(line));
+  tui.press("enter");
+  tui.waitStable();
+  tui.press("home");
+  for (let i = 0; i < col; i++) {
+    tui.press("arrow_right");
+  }
+}
+
+function lspServerAvailable(fixtureDir) {
+  const settings = JSON.parse(
+    readFileSync(resolve(fixtureDir, "settings.json"), "utf8")
+  );
+  for (const server of Object.values(settings.lsp.servers)) {
+    try {
+      execSync(`which ${server.command[0]}`, { stdio: "ignore" });
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+const languages = readdirSync(LSP_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .filter((d) => existsSync(resolve(LSP_DIR, d.name, "spec.json")))
+  .map((d) => d.name);
+
+describe("lsp", () => {
+  let dir;
+
+  beforeEach(() => {
+    if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
+  });
+
+  afterEach(() => {
+    tui.kill();
+    if (dir) cleanupDir(dir);
+    dir = null;
+  });
+
+  for (const lang of languages) {
+    const fixtureDir = resolve(LSP_DIR, lang);
+    const spec = JSON.parse(
+      readFileSync(resolve(fixtureDir, "spec.json"), "utf8")
+    );
+    const available = lspServerAvailable(fixtureDir);
+
+    describe(lang, () => {
+      const testFn = available ? it : it.skip;
+
+      testFn("diagnostics", () => {
+        dir = createTempDir();
+        cpSync(fixtureDir, dir, { recursive: true });
+
+        const files = readdirSync(dir).filter(
+          (f) => !["spec.json", "settings.json", "install.sh"].includes(f)
+        );
+        const testFile = resolve(
+          dir,
+          files.find((f) => f.startsWith("test."))
+        );
+        const configFile = resolve(fixtureDir, "settings.json");
+
+        tui.start("--config", configFile, testFile);
+        tui.waitFor(spec.waitFor);
+
+        const log = waitForLog(spec.diagnostic);
+        tui.press("ctrl+q");
+
+        expect(log).toContain("lsp starting server");
+        expect(log).toMatch(new RegExp(spec.diagnostic));
+      });
+
+      testFn("hover", () => {
+        if (!spec.hover) return;
+        dir = createTempDir();
+        cpSync(fixtureDir, dir, { recursive: true });
+
+        const files = readdirSync(dir).filter(
+          (f) => !["spec.json", "settings.json", "install.sh"].includes(f)
+        );
+        const testFile = resolve(
+          dir,
+          files.find((f) => f.startsWith("test."))
+        );
+        const configFile = resolve(fixtureDir, "settings.json");
+
+        tui.start("--config", configFile, testFile);
+        tui.waitFor(spec.waitFor);
+        waitForLog("lsp initialized");
+
+        navigateTo(spec.hover.goto);
+        tui.waitStable();
+        tui.pressChord("ctrl+k", "i");
+
+        const log = waitForLog(spec.hover.log);
+        tui.press("ctrl+q");
+
+        expect(log).toMatch(new RegExp(spec.hover.log));
+      });
+
+      testFn("completion", () => {
+        if (!spec.completion) return;
+        dir = createTempDir();
+        cpSync(fixtureDir, dir, { recursive: true });
+
+        const files = readdirSync(dir).filter(
+          (f) => !["spec.json", "settings.json", "install.sh"].includes(f)
+        );
+        const testFile = resolve(
+          dir,
+          files.find((f) => f.startsWith("test."))
+        );
+        const configFile = resolve(fixtureDir, "settings.json");
+
+        tui.start("--config", configFile, testFile);
+        tui.waitFor(spec.waitFor);
+        waitForLog("lsp initialized");
+
+        navigateTo(spec.completion.goto);
+        tui.waitStable();
+        tui.type(spec.completion.type);
+
+        const log = waitForLog(spec.completion.log);
+        tui.press("escape");
+        tui.press("ctrl+q");
+        sleep(200);
+        tui.press("arrow_right");
+        tui.press("enter");
+
+        expect(log).toMatch(new RegExp(spec.completion.log));
+      });
+    });
+  }
+});

--- a/tests/functional/lsp/c/install.sh
+++ b/tests/functional/lsp/c/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+sudo apt-get install -y clangd

--- a/tests/functional/lsp/c/settings.json
+++ b/tests/functional/lsp/c/settings.json
@@ -1,0 +1,16 @@
+{
+  "debugMode": true,
+  "lsp": {
+    "servers": {
+      "c": {
+        "command": ["clangd"],
+        "languages": {
+          ".c": "c",
+          ".h": "c",
+          ".cpp": "cpp",
+          ".hpp": "cpp"
+        }
+      }
+    }
+  }
+}

--- a/tests/functional/lsp/c/spec.json
+++ b/tests/functional/lsp/c/spec.json
@@ -1,0 +1,13 @@
+{
+  "waitFor": "int main",
+  "diagnostic": "lsp diagnostics.*count=[1-9]",
+  "hover": {
+    "goto": "5:11",
+    "log": "lsp hover response.*length=[1-9]"
+  },
+  "completion": {
+    "goto": "6:0",
+    "type": "\nprin",
+    "log": "lsp completion response.*count=[1-9]"
+  }
+}

--- a/tests/functional/lsp/c/test.c
+++ b/tests/functional/lsp/c/test.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main() {
+    int x = "hello";
+    printf("%d\n", x);
+    return 0;
+}

--- a/tests/functional/lsp/go/go.mod
+++ b/tests/functional/lsp/go/go.mod
@@ -1,0 +1,3 @@
+module lsptest
+
+go 1.21

--- a/tests/functional/lsp/go/install.sh
+++ b/tests/functional/lsp/go/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+go install golang.org/x/tools/gopls@latest

--- a/tests/functional/lsp/go/settings.json
+++ b/tests/functional/lsp/go/settings.json
@@ -1,0 +1,10 @@
+{
+  "debugMode": true,
+  "lsp": {
+    "servers": {
+      "go": {
+        "command": ["gopls", "serve"]
+      }
+    }
+  }
+}

--- a/tests/functional/lsp/go/spec.json
+++ b/tests/functional/lsp/go/spec.json
@@ -1,0 +1,13 @@
+{
+  "waitFor": "var x int",
+  "diagnostic": "lsp diagnostics.*count=[1-9]",
+  "hover": {
+    "goto": "4:5",
+    "log": "lsp hover response.*length=[1-9]"
+  },
+  "completion": {
+    "goto": "5:0",
+    "type": "\n\tx",
+    "log": "lsp completion response.*count=[1-9]"
+  }
+}

--- a/tests/functional/lsp/go/test.go
+++ b/tests/functional/lsp/go/test.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	var x int = "hello"
+	_ = x
+}

--- a/tests/functional/lsp/python/install.sh
+++ b/tests/functional/lsp/python/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+pip install pyright

--- a/tests/functional/lsp/python/settings.json
+++ b/tests/functional/lsp/python/settings.json
@@ -1,0 +1,10 @@
+{
+  "debugMode": true,
+  "lsp": {
+    "servers": {
+      "python": {
+        "command": ["pyright-langserver", "--stdio"]
+      }
+    }
+  }
+}

--- a/tests/functional/lsp/python/spec.json
+++ b/tests/functional/lsp/python/spec.json
@@ -1,0 +1,13 @@
+{
+  "waitFor": "def greet",
+  "diagnostic": "lsp diagnostics.*count=[1-9]",
+  "hover": {
+    "goto": "1:4",
+    "log": "lsp hover response.*length=[1-9]"
+  },
+  "completion": {
+    "goto": "5:0",
+    "type": "\nprin",
+    "log": "lsp completion response.*count=[1-9]"
+  }
+}

--- a/tests/functional/lsp/python/test.py
+++ b/tests/functional/lsp/python/test.py
@@ -1,0 +1,5 @@
+def greet(name: str) -> str:
+    return name + 1
+
+x: int = greet("hello")
+print(x)

--- a/tests/functional/lsp/typescript/install.sh
+++ b/tests/functional/lsp/typescript/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+npm install -g typescript typescript-language-server

--- a/tests/functional/lsp/typescript/settings.json
+++ b/tests/functional/lsp/typescript/settings.json
@@ -1,0 +1,16 @@
+{
+  "debugMode": true,
+  "lsp": {
+    "servers": {
+      "typescript": {
+        "command": ["typescript-language-server", "--stdio"],
+        "languages": {
+          ".ts": "typescript",
+          ".tsx": "typescriptreact",
+          ".js": "javascript",
+          ".jsx": "javascriptreact"
+        }
+      }
+    }
+  }
+}

--- a/tests/functional/lsp/typescript/spec.json
+++ b/tests/functional/lsp/typescript/spec.json
@@ -1,0 +1,13 @@
+{
+  "waitFor": "const x: number",
+  "diagnostic": "lsp diagnostics.*count=[1-9]",
+  "hover": {
+    "goto": "3:12",
+    "log": "lsp hover response.*length=[1-9]"
+  },
+  "completion": {
+    "goto": "3:0",
+    "type": "\nconsol",
+    "log": "lsp completion response.*count=[1-9]"
+  }
+}

--- a/tests/functional/lsp/typescript/test.ts
+++ b/tests/functional/lsp/typescript/test.ts
@@ -1,0 +1,3 @@
+const x: number = "hello";
+const y: string = 42;
+console.log(x, y);

--- a/tests/functional/lsp/typescript/tsconfig.json
+++ b/tests/functional/lsp/typescript/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- Add data-driven LSP functional tests for Go, TypeScript, Python, and C that verify server startup, diagnostics, hover, and completions
- Add `--config <file>` flag for loading settings from a specific file (enables test isolation)
- Fix Escape not dismissing hover when autocomplete is also active
- Fix stale hover responses reappearing after dismiss (generation counter)
- Fix diagnostics bleeding across tabs (now stored per-tab)
- Fix LSP not starting for files opened via CLI args (OnFileOpen callback ordering)
- Install LSP servers (gopls, typescript-language-server, pyright, clangd) in CI

## Test plan
- [x] `vitest run lsp.test.js -t "go"` — diagnostics, hover, completion pass
- [x] `vitest run lsp.test.js -t "typescript"` — diagnostics, hover, completion pass
- [ ] CI installs LSP servers and runs all language tests
- [ ] Verify Escape dismisses hover in normal usage
- [ ] Verify diagnostics don't bleed when switching tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)