### PR TITLE
feat: default LSP configs with missing server notification

### DIFF
--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -1058,7 +1058,7 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 		if _, err := exec.LookPath(serverCfg.Command[0]); err != nil {
 			if !a.lspNotified[serverKey] {
 				a.lspNotified[serverKey] = true
-				msg := fmt.Sprintf("Language server %q not found. Click [Docs] for install instructions.", serverCfg.Command[0])
+				msg := fmt.Sprintf("Language server %q not found. Click Docs for install instructions.", serverCfg.Command[0])
 				anchor := serverKey
 				a.status.SetNotificationWithAction(msg, view.NotifyWarning, 10*time.Second, "Docs", func() {
 					openURL("https://tttedit.dev/guides/lsp/#" + anchor)

--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -1058,7 +1058,7 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 		if _, err := exec.LookPath(serverCfg.Command[0]); err != nil {
 			if !a.lspNotified[serverKey] {
 				a.lspNotified[serverKey] = true
-				msg := fmt.Sprintf("%s language server is available. Click Docs for installation instructions.", lang)
+				msg := fmt.Sprintf("%s autocomplete support is available. Click Docs for installation instructions.", lang)
 				anchor := serverKey
 				a.status.SetNotificationWithAction(msg, view.NotifyWarning, 10*time.Second, "Docs", func() {
 					openURL("https://tttedit.dev/guides/lsp/#" + anchor)

--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os/exec"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -64,6 +66,7 @@ type App struct {
 	references         *ui.ReferencesWidget
 	allDiagnostics     map[string][]ui.Diagnostic
 	keybindings        []config.KeyBinding
+	lspNotified        map[string]bool
 }
 
 func (a *App) KeyFor(cmd string) string {
@@ -901,7 +904,7 @@ func isIdentRune(r rune) bool {
 }
 
 func (a *App) lspResolve(path, lang string) (serverKey, languageID string, ok bool) {
-	if a.lspManager == nil {
+	if a.lspManager == nil || !a.settings.LSP.IsEnabled() {
 		return "", "", false
 	}
 	return a.lspManager.ResolveLanguage(path, lang)
@@ -1049,6 +1052,25 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 	if !ok {
 		return
 	}
+
+	serverCfg := a.lspManager.ServerConfig(serverKey)
+	if len(serverCfg.Command) > 0 {
+		if _, err := exec.LookPath(serverCfg.Command[0]); err != nil {
+			if !a.lspNotified[serverKey] {
+				a.lspNotified[serverKey] = true
+				msg := fmt.Sprintf("Language server %q not found. Click [Docs] for install instructions.", serverCfg.Command[0])
+				anchor := serverKey
+				a.status.SetNotificationWithAction(msg, view.NotifyWarning, 10*time.Second, "Docs", func() {
+					openURL("https://tttedit.dev/guides/lsp/#" + anchor)
+				})
+				time.AfterFunc(10*time.Second, func() {
+					a.screen.PostEvent(tcell.NewEventInterrupt(nil))
+				})
+			}
+			return
+		}
+	}
+
 	workDir := a.lspWorkDir(path)
 	a.docVersionsMu.Lock()
 	a.docVersions[path] = 1
@@ -1125,6 +1147,19 @@ func (a *App) statusMessage(msg string, level view.NotifyLevel) {
 func (a *App) StatusNotify(msg string) { a.statusMessage(msg, view.NotifyInfo) }
 func (a *App) StatusWarn(msg string)   { a.statusMessage(msg, view.NotifyWarning) }
 func (a *App) StatusError(msg string)  { a.statusMessage(msg, view.NotifyError) }
+
+func openURL(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	cmd.Start()
+}
 
 func (a *App) ShowDialog(w ui.Widget) {
 	a.root.PushOverlay(ui.Overlay{Widget: w, Modal: true})

--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -1058,7 +1058,7 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 		if _, err := exec.LookPath(serverCfg.Command[0]); err != nil {
 			if !a.lspNotified[serverKey] {
 				a.lspNotified[serverKey] = true
-				msg := fmt.Sprintf("Language server %q not found. Click Docs for install instructions.", serverCfg.Command[0])
+				msg := fmt.Sprintf("%s language server is available. Click Docs for installation instructions.", lang)
 				anchor := serverKey
 				a.status.SetNotificationWithAction(msg, view.NotifyWarning, 10*time.Second, "Docs", func() {
 					openURL("https://tttedit.dev/guides/lsp/#" + anchor)

--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -3,9 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"github.com/eugenioenko/ttt/internal/command"
@@ -188,19 +186,7 @@ func registerViewCommands(reg *command.Registry, app *App) {
 	reg.Register(command.Command{
 		ID: "about", Title: "About ttt",
 		Handler: func() {
-			url := "https://github.com/eugenioenko/ttt"
-			var cmd *exec.Cmd
-			switch runtime.GOOS {
-			case "darwin":
-				cmd = exec.Command("open", url)
-			case "windows":
-				cmd = exec.Command("cmd", "/c", "start", url)
-			default:
-				cmd = exec.Command("xdg-open", url)
-			}
-			if err := cmd.Start(); err != nil {
-				app.StatusNotify("ttt — Terminal Text Tool")
-			}
+			openURL("https://github.com/eugenioenko/ttt")
 		},
 	})
 }

--- a/cmd/ttt/widgets.go
+++ b/cmd/ttt/widgets.go
@@ -162,5 +162,6 @@ func buildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		references:     references,
 		docVersions:    make(map[string]int),
 		allDiagnostics: make(map[string][]ui.Diagnostic),
+		lspNotified:    make(map[string]bool),
 	}
 }

--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -2,8 +2,7 @@ import { defineConfig, passthroughImageService } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
 export default defineConfig({
-  site: 'https://eugenioenko.github.io',
-  base: '/ttt',
+  site: 'https://tttedit.dev',
   image: { service: passthroughImageService() },
   integrations: [
     starlight({

--- a/docs-web/src/content/docs/guides/lsp.md
+++ b/docs-web/src/content/docs/guides/lsp.md
@@ -56,6 +56,14 @@ sudo pacman -S clang
 
 Handles `.c`, `.h`, `.cpp`, `.hpp`, `.cc`, and `.cxx` files.
 
+### Vue {#vue}
+
+```sh
+npm install -g @vue/language-server
+```
+
+Handles `.vue` files.
+
 ### Rust {#rust}
 
 ```sh
@@ -97,16 +105,16 @@ Add or override language servers in `~/.config/ttt/settings.json` under the `lsp
 
 For simple cases, the server key is used as the language ID and files are matched via the syntax highlighter name. No extra configuration is needed.
 
-### The `languages` field
+### Overriding built-in configs
 
-The optional `languages` field is for servers that handle multiple file types requiring different `languageId` values. It maps file extensions to language IDs:
+To override a built-in server, use the same key. For example, to use `tsserver` instead of the default `typescript-language-server`:
 
 ```json
 {
   "lsp": {
     "servers": {
       "typescript": {
-        "command": ["typescript-language-server", "--stdio"],
+        "command": ["tsserver", "--stdio"],
         "languages": {
           ".ts": "typescript",
           ".tsx": "typescriptreact",
@@ -119,7 +127,31 @@ The optional `languages` field is for servers that handle multiple file types re
 }
 ```
 
-Without the `languages` field, you would need to register the same server command multiple times under different keys.
+To add file extensions to an existing server, override the full entry with the additional extensions included. For example, to add `.svelte` support to the TypeScript server:
+
+```json
+{
+  "lsp": {
+    "servers": {
+      "typescript": {
+        "command": ["typescript-language-server", "--stdio"],
+        "languages": {
+          ".ts": "typescript",
+          ".tsx": "typescriptreact",
+          ".js": "javascript",
+          ".jsx": "javascriptreact",
+          ".mjs": "javascript",
+          ".svelte": "typescript"
+        }
+      }
+    }
+  }
+}
+```
+
+### The `languages` field
+
+The optional `languages` field is for servers that handle multiple file types requiring different `languageId` values. It maps file extensions to language IDs. Without the `languages` field, the server key is used as the language ID and files are matched by their syntax highlighter name.
 
 The server is started lazily on first use and shut down when the editor exits.
 

--- a/docs-web/src/content/docs/guides/lsp.md
+++ b/docs-web/src/content/docs/guides/lsp.md
@@ -5,15 +5,106 @@ description: Language Server Protocol support in TTT.
 
 TTT has built-in LSP support for language-aware editing features. Language servers run as external processes and communicate over JSON-RPC 2.0 via stdio.
 
-## Configuring Language Servers
+## Built-in Language Support
 
-Add language servers to `~/.config/ttt/settings.json` under the `lsp.servers` key. Each entry maps a server key to a config object with a `command` array:
+TTT ships with built-in configurations for popular language servers. You just need to install the server binary — TTT will detect and use it automatically. If a server isn't installed, TTT shows a brief notification when you open a file of that language.
+
+To disable LSP entirely, set `lsp.enabled` to `false` in your settings:
+
+```json
+{
+  "lsp": {
+    "enabled": false
+  }
+}
+```
+
+### Go {#go}
+
+```sh
+go install golang.org/x/tools/gopls@latest
+```
+
+### TypeScript / JavaScript {#typescript}
+
+```sh
+npm install -g typescript typescript-language-server
+```
+
+Handles `.ts`, `.tsx`, `.js`, and `.jsx` files.
+
+### Python {#python}
+
+```sh
+pip install pyright
+# or
+npm install -g pyright
+```
+
+### C / C++ {#c}
+
+```sh
+# Ubuntu/Debian
+sudo apt install clangd
+
+# macOS
+brew install llvm
+
+# Arch
+sudo pacman -S clang
+```
+
+Handles `.c`, `.h`, `.cpp`, `.hpp`, `.cc`, and `.cxx` files.
+
+### Rust {#rust}
+
+```sh
+rustup component add rust-analyzer
+```
+
+### Lua {#lua}
+
+Install from [LuaLS releases](https://github.com/LuaLS/lua-language-server/releases) or via your package manager:
+
+```sh
+# macOS
+brew install lua-language-server
+
+# Arch
+sudo pacman -S lua-language-server
+```
+
+### Zig {#zig}
+
+```sh
+# From zigtools releases or package manager
+# See https://github.com/zigtools/zls
+```
+
+## Custom Language Servers
+
+Add or override language servers in `~/.config/ttt/settings.json` under the `lsp.servers` key. Each entry maps a server key to a config object with a `command` array:
 
 ```json
 {
   "lsp": {
     "servers": {
-      "go": { "command": ["gopls"] },
+      "ruby": { "command": ["solargraph", "stdio"] }
+    }
+  }
+}
+```
+
+For simple cases, the server key is used as the language ID and files are matched via the syntax highlighter name. No extra configuration is needed.
+
+### The `languages` field
+
+The optional `languages` field is for servers that handle multiple file types requiring different `languageId` values. It maps file extensions to language IDs:
+
+```json
+{
+  "lsp": {
+    "servers": {
       "typescript": {
         "command": ["typescript-language-server", "--stdio"],
         "languages": {
@@ -22,18 +113,13 @@ Add language servers to `~/.config/ttt/settings.json` under the `lsp.servers` ke
           ".js": "javascript",
           ".jsx": "javascriptreact"
         }
-      },
-      "python": { "command": ["pyright-langserver", "--stdio"] }
+      }
     }
   }
 }
 ```
 
-For simple cases (Go, Python, Rust, etc.), the server key is used as the language ID and files are matched via the syntax highlighter name. No extra configuration is needed.
-
-### The `languages` field
-
-The optional `languages` field is for servers that handle multiple file types requiring different `languageId` values. It maps file extensions to language IDs. In the example above, the TypeScript language server handles `.ts`, `.tsx`, `.js`, and `.jsx` files, each with the correct `languageId` sent to the server. Without the `languages` field, you would need to register the same server command multiple times under different keys.
+Without the `languages` field, you would need to register the same server command multiple times under different keys.
 
 The server is started lazily on first use and shut down when the editor exits.
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -61,6 +61,10 @@ func DefaultLSPSettings() LSPSettings {
 					".tsx": "typescriptreact",
 					".js":  "javascript",
 					".jsx": "javascriptreact",
+					".mjs": "javascript",
+					".mts": "typescript",
+					".cjs": "javascript",
+					".cts": "typescript",
 				},
 			},
 			"python": {Command: []string{"pyright-langserver", "--stdio"}},
@@ -73,6 +77,12 @@ func DefaultLSPSettings() LSPSettings {
 					".hpp": "cpp",
 					".cc":  "cpp",
 					".cxx": "cpp",
+				},
+			},
+			"vue": {
+				Command: []string{"vue-language-server", "--stdio"},
+				Languages: map[string]string{
+					".vue": "vue",
 				},
 			},
 			"rust": {Command: []string{"rust-analyzer"}},

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -38,15 +38,47 @@ type LSPServerConfig struct {
 }
 
 type LSPSettings struct {
+	Enabled          *bool                      `json:"enabled,omitempty"`
 	Servers          map[string]LSPServerConfig `json:"servers,omitempty"`
 	SaveOnRename     bool                       `json:"saveOnRename"`
 	CodeActionsOnSave []string                  `json:"codeActionsOnSave,omitempty"`
 	HoverDelay       int                        `json:"hoverDelay,omitempty"`
 }
 
+func (l LSPSettings) IsEnabled() bool {
+	return l.Enabled == nil || *l.Enabled
+}
+
 func DefaultLSPSettings() LSPSettings {
 	return LSPSettings{
 		HoverDelay: 400,
+		Servers: map[string]LSPServerConfig{
+			"go": {Command: []string{"gopls"}},
+			"typescript": {
+				Command: []string{"typescript-language-server", "--stdio"},
+				Languages: map[string]string{
+					".ts":  "typescript",
+					".tsx": "typescriptreact",
+					".js":  "javascript",
+					".jsx": "javascriptreact",
+				},
+			},
+			"python": {Command: []string{"pyright-langserver", "--stdio"}},
+			"c": {
+				Command: []string{"clangd"},
+				Languages: map[string]string{
+					".c":   "c",
+					".h":   "c",
+					".cpp": "cpp",
+					".hpp": "cpp",
+					".cc":  "cpp",
+					".cxx": "cpp",
+				},
+			},
+			"rust": {Command: []string{"rust-analyzer"}},
+			"lua":  {Command: []string{"lua-language-server"}},
+			"zig":  {Command: []string{"zls"}},
+		},
 	}
 }
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -25,6 +25,13 @@ func NewManager(cfg config.LSPSettings) *Manager {
 	}
 }
 
+func (m *Manager) ServerConfig(key string) config.LSPServerConfig {
+	if cfg, ok := m.config.Servers[strings.ToLower(key)]; ok {
+		return cfg
+	}
+	return config.LSPServerConfig{}
+}
+
 func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 	key := strings.ToLower(lang)
 

--- a/internal/ui/statusbar_widget.go
+++ b/internal/ui/statusbar_widget.go
@@ -18,6 +18,7 @@ type StatusBarWidget struct {
 	OnIndentClick  func()
 	indentSpan     statusBarSpan
 	okSpan         statusBarSpan
+	actionSpan     statusBarSpan
 }
 
 func NewStatusBarWidget(status *view.StatusBar) *StatusBarWidget {
@@ -110,9 +111,26 @@ func (s *StatusBarWidget) renderNotification(surface *RenderSurface, w int) {
 	x += s.drawText(surface, x, " ", style)
 	x += s.drawText(surface, x, s.Status.Notification, style)
 
+	s.actionSpan = statusBarSpan{}
+	rightX := w - 1
+
 	okLabel := " [OK] "
-	okX := w - len([]rune(okLabel)) - 1
-	if okX > x+2 {
+	okX := rightX - len([]rune(okLabel))
+	rightX = okX
+
+	if s.Status.ActionLabel != "" && s.Status.NotifyAction != nil {
+		actionLabel := " [" + s.Status.ActionLabel + "] "
+		actionX := rightX - len([]rune(actionLabel))
+		if actionX > x+2 {
+			s.actionSpan = statusBarSpan{r.X + actionX, r.X + actionX + len([]rune(actionLabel))}
+			for i, ch := range actionLabel {
+				surface.SetCell(actionX+i, 0, term.Cell{Ch: ch, Style: style})
+			}
+			rightX = actionX
+		}
+	}
+
+	if okX > x+2 && okX > rightX-1 {
 		s.okSpan = statusBarSpan{r.X + okX, r.X + okX + len([]rune(okLabel))}
 		for i, ch := range okLabel {
 			surface.SetCell(okX+i, 0, term.Cell{Ch: ch, Style: style})
@@ -133,9 +151,18 @@ func (s *StatusBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	if my != r.Y {
 		return EventIgnored
 	}
-	if s.Status.IsNotificationActive() && mx >= s.okSpan.start && mx < s.okSpan.end {
-		s.Status.DismissNotification()
-		return EventConsumed
+	if s.Status.IsNotificationActive() {
+		if mx >= s.okSpan.start && mx < s.okSpan.end {
+			s.Status.DismissNotification()
+			return EventConsumed
+		}
+		if s.actionSpan.start != s.actionSpan.end && mx >= s.actionSpan.start && mx < s.actionSpan.end {
+			if s.Status.NotifyAction != nil {
+				s.Status.NotifyAction()
+			}
+			s.Status.DismissNotification()
+			return EventConsumed
+		}
 	}
 	if mx >= s.indentSpan.start && mx < s.indentSpan.end && s.OnIndentClick != nil {
 		s.OnIndentClick()

--- a/internal/ui/statusbar_widget.go
+++ b/internal/ui/statusbar_widget.go
@@ -112,11 +112,8 @@ func (s *StatusBarWidget) renderNotification(surface *RenderSurface, w int) {
 	x += s.drawText(surface, x, s.Status.Notification, style)
 
 	s.actionSpan = statusBarSpan{}
+	s.okSpan = statusBarSpan{}
 	rightX := w - 1
-
-	okLabel := " [OK] "
-	okX := rightX - len([]rune(okLabel))
-	rightX = okX
 
 	if s.Status.ActionLabel != "" && s.Status.NotifyAction != nil {
 		actionLabel := " [" + s.Status.ActionLabel + "] "
@@ -126,14 +123,15 @@ func (s *StatusBarWidget) renderNotification(surface *RenderSurface, w int) {
 			for i, ch := range actionLabel {
 				surface.SetCell(actionX+i, 0, term.Cell{Ch: ch, Style: style})
 			}
-			rightX = actionX
 		}
-	}
-
-	if okX > x+2 && okX > rightX-1 {
-		s.okSpan = statusBarSpan{r.X + okX, r.X + okX + len([]rune(okLabel))}
-		for i, ch := range okLabel {
-			surface.SetCell(okX+i, 0, term.Cell{Ch: ch, Style: style})
+	} else {
+		okLabel := " [OK] "
+		okX := rightX - len([]rune(okLabel))
+		if okX > x+2 {
+			s.okSpan = statusBarSpan{r.X + okX, r.X + okX + len([]rune(okLabel))}
+			for i, ch := range okLabel {
+				surface.SetCell(okX+i, 0, term.Cell{Ch: ch, Style: style})
+			}
 		}
 	}
 }

--- a/internal/view/statusbar.go
+++ b/internal/view/statusbar.go
@@ -38,17 +38,31 @@ type StatusBar struct {
 	Notification string
 	NotifyLevel  NotifyLevel
 	NotifyExpiry time.Time
+	NotifyAction func()
+	ActionLabel  string
 }
 
 func (s *StatusBar) SetNotification(msg string, level NotifyLevel, duration time.Duration) {
 	s.Notification = msg
 	s.NotifyLevel = level
 	s.NotifyExpiry = time.Now().Add(duration)
+	s.NotifyAction = nil
+	s.ActionLabel = ""
+}
+
+func (s *StatusBar) SetNotificationWithAction(msg string, level NotifyLevel, duration time.Duration, label string, action func()) {
+	s.Notification = msg
+	s.NotifyLevel = level
+	s.NotifyExpiry = time.Now().Add(duration)
+	s.ActionLabel = label
+	s.NotifyAction = action
 }
 
 func (s *StatusBar) DismissNotification() {
 	s.Notification = ""
 	s.NotifyExpiry = time.Time{}
+	s.NotifyAction = nil
+	s.ActionLabel = ""
 }
 
 func (s *StatusBar) IsNotificationActive() bool {


### PR DESCRIPTION
## Summary
- Ship built-in LSP server configs for 7 languages (Go, TypeScript/JS, Python, C/C++, Rust, Lua, Zig) — zero config needed when the server binary is installed
- When a server binary is missing, show a 10s status bar warning with a clickable [Docs] button that opens install instructions in the browser
- Add `lsp.enabled` toggle (`false` to disable LSP entirely without removing server configs)
- Extract shared `openURL()` helper, reuse in `about` command
- Update docs site domain to `tttedit.dev`, add per-language install sections to LSP guide
- Notification shown once per language per session

## Test plan
- [ ] Open a Go file with gopls installed — LSP starts normally, no notification
- [ ] Open a Rust file without rust-analyzer — warning notification appears for 10s with [Docs] button
- [ ] Click [Docs] — opens browser to `tttedit.dev/guides/lsp/#rust`
- [ ] Click [OK] — dismisses notification
- [ ] Open another Rust file — no repeat notification (once per session)
- [ ] Set `"lsp": {"enabled": false}` in settings — no LSP, no notifications
- [ ] `go test ./...` passes
- [ ] `docs-web` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)