### PR TITLE
fix: update functional tests for insertFinalNewline

### DIFF
--- a/tests/functional/duplicate-line.test.js
+++ b/tests/functional/duplicate-line.test.js
@@ -27,7 +27,7 @@ describe("duplicate line", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("AAA\nBBB\nBBB\nCCC");
+    expect(content).toBe("AAA\nBBB\nBBB\nCCC\n");
   });
 
   it("should duplicate last line", () => {
@@ -47,7 +47,7 @@ describe("duplicate line", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("First\nLast\nLast");
+    expect(content).toBe("First\nLast\nLast\n");
   });
 
   it("should undo duplicate line", () => {
@@ -67,6 +67,6 @@ describe("duplicate line", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("Only\nTwo");
+    expect(content).toBe("Only\nTwo\n");
   });
 });

--- a/tests/functional/insert-final-newline.test.js
+++ b/tests/functional/insert-final-newline.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("insertFinalNewline", () => {
+  it("should add trailing newline on save by default", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "default.txt", "no newline at end");
+
+    tui.start(file);
+    tui.waitFor("no newline at end");
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    expect(content).toBe("no newline at end\n");
+  });
+
+  it("should not add trailing newline when setting is false", () => {
+    dir = createTempDir();
+    const configFile = join(dir, "settings.json");
+    writeFileSync(configFile, JSON.stringify({ insertFinalNewline: false }));
+    const file = createTempFile(dir, "noeol.txt", "no trailing newline");
+
+    tui.start("--config", configFile, file);
+    tui.waitFor("no trailing newline");
+
+    tui.press("end");
+    tui.type("!");
+    tui.waitFor("no trailing newline!");
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    expect(content).toBe("no trailing newline!");
+  });
+
+  it("should not add trailing newline to multiline file when setting is false", () => {
+    dir = createTempDir();
+    const configFile = join(dir, "settings.json");
+    writeFileSync(configFile, JSON.stringify({ insertFinalNewline: false }));
+    const file = createTempFile(dir, "multi.txt", "AAA\nBBB\nCCC");
+
+    tui.start("--config", configFile, file);
+    tui.waitFor("AAA");
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nBBB\nCCC");
+  });
+
+  it("should add trailing newline to multiline file on save", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "multi.txt", "line one\nline two\nline three");
+
+    tui.start(file);
+    tui.waitFor("line one");
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    expect(content).toBe("line one\nline two\nline three\n");
+  });
+});

--- a/tests/functional/move-line.test.js
+++ b/tests/functional/move-line.test.js
@@ -24,7 +24,7 @@ describe("move line", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("BBB\nAAA\nCCC");
+    expect(content).toBe("BBB\nAAA\nCCC\n");
   });
 
   it("should move line up via command palette", () => {
@@ -45,7 +45,7 @@ describe("move line", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("AAA\nCCC\nBBB");
+    expect(content).toBe("AAA\nCCC\nBBB\n");
   });
 
   it("should not move first line up", () => {
@@ -62,7 +62,7 @@ describe("move line", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("First\nSecond");
+    expect(content).toBe("First\nSecond\n");
   });
 
   it("should undo move line", () => {
@@ -82,6 +82,6 @@ describe("move line", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("One\nTwo\nThree");
+    expect(content).toBe("One\nTwo\nThree\n");
   });
 });

--- a/tests/functional/open-edit-save.test.js
+++ b/tests/functional/open-edit-save.test.js
@@ -38,7 +38,7 @@ describe("open, edit, save", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("Original content Modified");
+    expect(content).toBe("Original content Modified\n");
   });
 
   it("should show dirty indicator after editing", () => {

--- a/tests/functional/select-all.test.js
+++ b/tests/functional/select-all.test.js
@@ -27,7 +27,7 @@ describe("select all and overwrite", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("replaced");
+    expect(content).toBe("replaced\n");
   });
 
   it("should undo select-all overwrite to restore original", () => {

--- a/tests/functional/undo-redo.test.js
+++ b/tests/functional/undo-redo.test.js
@@ -62,7 +62,7 @@ describe("undo and redo", () => {
 
     tui.press("ctrl+s");
     tui.waitStable();
-    expect(readFile(file)).toBe("First Second");
+    expect(readFile(file)).toBe("First Second\n");
 
     tui.type(" Third");
     tui.waitFor("First Second Third");
@@ -72,6 +72,6 @@ describe("undo and redo", () => {
 
     tui.press("ctrl+s");
     tui.waitStable();
-    expect(readFile(file)).toBe("First Second");
+    expect(readFile(file)).toBe("First Second\n");
   });
 });

--- a/tests/functional/unicode.test.js
+++ b/tests/functional/unicode.test.js
@@ -79,6 +79,6 @@ describe("unicode editing", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("→ línea número één");
+    expect(content).toBe("→ línea número één\n");
   });
 });

--- a/tests/functional/word-delete.test.js
+++ b/tests/functional/word-delete.test.js
@@ -27,7 +27,7 @@ describe("word delete", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("hello ");
+    expect(content).toBe("hello \n");
   });
 
   it("should delete word to the right via command palette", () => {
@@ -47,7 +47,7 @@ describe("word delete", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe(" world today");
+    expect(content).toBe(" world today\n");
   });
 
   it("should undo word delete", () => {
@@ -70,6 +70,6 @@ describe("word delete", () => {
     tui.waitStable();
 
     const content = readFile(file);
-    expect(content).toBe("keep these words");
+    expect(content).toBe("keep these words\n");
   });
 });


### PR DESCRIPTION
## Summary
- Update 14 file-content assertions across 7 test files to expect trailing `\n` (from the `insertFinalNewline` feature shipped in ba892ed)
- Add new `insert-final-newline.test.js` with 4 tests verifying the setting works when enabled (default) and disabled via `--config`

## Test plan
- [x] All 64 functional tests pass (24 LSP skipped)
- [x] `go test ./...` passes
- [x] New tests cover: default newline on save, no newline with `insertFinalNewline: false`, single-line and multi-line files

🤖 Generated with [Claude Code](https://claude.com/claude-code)