### PR TITLE
fix: only create ttt.log when debug mode is enabled

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -15,16 +16,16 @@ import (
 )
 
 func initLogger(debug bool) *os.File {
-	level := slog.LevelError
-	if debug {
-		level = slog.LevelDebug
+	if !debug {
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
+		return nil
 	}
 	f, err := os.OpenFile("ttt.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
 		return nil
 	}
-	slog.SetDefault(slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level})))
+	slog.SetDefault(slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	return f
 }
 


### PR DESCRIPTION
## Summary
- `ttt.log` was being created in the current working directory unconditionally, even when debug mode was off
- Now the log file is only created when `--debug` is passed; otherwise logs go to `io.Discard`

## Test plan
- [ ] Run `ttt` without `--debug` — no `ttt.log` should appear in cwd
- [ ] Run `ttt --debug` — `ttt.log` should be created with debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)