### PR TITLE
docs: update tagline to IDE and add tabbed install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TTT — Terminal Text Tool
 
-A fully-featured code editor that lives in the terminal. Not a simplified terminal editor — a real alternative to VS Code, Zed, and Sublime that happens to run in your terminal. Single Go binary, zero config.
+The IDE that lives in your terminal. Not a simplified terminal editor — a real alternative to VS Code, Zed, and Sublime that happens to run in your terminal. Single Go binary, zero config.
 
 ![TTT Screenshot](screenshot.png)
 

--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -5,26 +5,31 @@ sidebar:
   order: 2
 ---
 
-## Quick Install (Linux / macOS)
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Download the latest release binary for your platform:
+## Quick Install
 
-```sh
-curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
-```
+<Tabs>
+  <TabItem label="macOS">
+    ```sh
+    brew tap eugenioenko/ttt
+    brew install ttt
+    ```
+  </TabItem>
+  <TabItem label="Linux">
+    Download the latest release binary for your platform:
 
-This installs to `/usr/local/bin`. To install to a different directory:
+    ```sh
+    curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
+    ```
 
-```sh
-INSTALL_DIR=~/.local/bin curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
-```
+    This installs to `/usr/local/bin`. To install to a different directory:
 
-## Homebrew (macOS / Linux)
-
-```sh
-brew tap eugenioenko/ttt
-brew install ttt
-```
+    ```sh
+    INSTALL_DIR=~/.local/bin curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
+    ```
+  </TabItem>
+</Tabs>
 
 ## Download Binary
 

--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: TTT - Terminal Text Tool
 description: A terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal.
 template: splash
 hero:
-  tagline: A fully-featured code editor that lives in the terminal.
+  tagline: The IDE that lives in your terminal.
   actions:
     - text: Get Started
       link: /getting-started/installation/

--- a/docs-web/src/styles/custom.css
+++ b/docs-web/src/styles/custom.css
@@ -19,6 +19,11 @@
   max-width: none !important;
 }
 
+.hero .tagline {
+  width: 100%;
+  text-align: center;
+}
+
 .hero h1::after {
   content: '_';
   animation: blink 1s step-end infinite;


### PR DESCRIPTION
## Summary
- Update tagline from "A fully-featured code editor that lives in the terminal" to "The IDE that lives in your terminal" in README and docs-web
- Convert installation page to mdx with tabbed Quick Install section: macOS (Homebrew) and Linux (shell script)
- Center the hero tagline in docs-web by adding `width: 100%` to `.hero .tagline`

## Test plan
- [ ] Verify docs-web builds successfully
- [ ] Check installation page renders tabs correctly with macOS tab open by default
- [ ] Confirm tagline is centered on the splash page
- [ ] Verify README tagline is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)