### PR TITLE
feat: add GitHub PR review in Changes sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ The codebase follows a strict layered architecture: **core → view → render �
 
 - **`cmd/ttt/main.go`** — Entry point with event loop. Wires all components together, handles key dispatch, viewport scrolling, and redraw. Accepts a `--workspace <file>` flag to open a saved workspace, or folder/file paths as positional arguments.
 
+### Design Philosophy
+
+- **UX comes first.** When making design decisions, prioritize user experience over implementation simplicity. If a feature needs good navigation, discoverability, or interaction patterns, invest in that rather than taking shortcuts.
+
 ### Key Design Constraints
 
 - Cursor `Col` is a visual column (rune-based), not a byte index — all line-length calculations use `[]rune()`.

--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/core/buffer"
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/ui"
 )
 
@@ -22,6 +23,7 @@ func registerCommands(reg *command.Registry, app *App, running *bool, quitPendin
 	registerExplorerCommands(reg, app)
 	registerGitCommands(reg, app)
 	registerWorkspaceCommands(reg, app)
+	registerPRCommands(reg, app)
 	registerWidgetCallbacks(reg, app)
 }
 
@@ -1051,6 +1053,29 @@ func registerWorkspaceCommands(reg *command.Registry, app *App) {
 	})
 }
 
+func registerPRCommands(reg *command.Registry, app *App) {
+	reg.Register(command.Command{
+		ID: "pr.open", Title: "Open Pull Request",
+		Handler: func() {
+			if !github.IsGHInstalled() {
+				app.StatusError("GitHub CLI (gh) is required. Install from https://cli.github.com/")
+				return
+			}
+			app.ShowInputDialog("Open Pull Request", "https://github.com/owner/repo/pull/123", "", func(url string) {
+				if url != "" {
+					app.fetchAndOpenPR(url)
+				}
+			})
+		},
+	})
+	reg.Register(command.Command{
+		ID: "pr.close", Title: "Close Pull Request",
+		Handler: func() {
+			app.changes.RemovePRGroups()
+		},
+	})
+}
+
 func registerWidgetCallbacks(reg *command.Registry, app *App) {
 	for i := range menuBarMenus {
 		idx := i
@@ -1083,6 +1108,7 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 		case "explorer":
 			items = []ui.ContextMenuItem{
 				{Label: "New File", Command: "file.new"},
+				{Label: "Add Folder", Command: "workspace.addFolder"},
 				{Label: "Refresh", Command: "explorer.refresh"},
 			}
 		case "search":
@@ -1098,6 +1124,7 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 		case "changes":
 			items = []ui.ContextMenuItem{
 				{Label: "Refresh", Command: "changes.refresh"},
+				{Label: "Open Pull Request", Command: "pr.open"},
 				ui.MenuSep(),
 				{Label: "Pull", Command: "git.pull"},
 				{Label: "Push", Command: "git.push"},
@@ -1277,6 +1304,46 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 		}
 		app.editorGroup.OpenDiff(status.Path, parsed)
 		app.root.SetFocus(app.editorGroup)
+	}
+
+	app.changes.OnOpenPRDiff = func(group *ui.ChangesGroup, status git.FileStatus) {
+		diffText, ok := group.PRDiffs[status.Path]
+		if !ok || diffText == "" {
+			app.StatusWarn("No diff available for " + status.Path)
+			return
+		}
+		parsed := diff.Parse(diffText)
+		if len(parsed.Hunks) == 0 {
+			app.StatusWarn("Empty diff for " + status.Path)
+			return
+		}
+		app.editorGroup.OpenDiff(status.Path, parsed)
+		app.root.SetFocus(app.editorGroup)
+	}
+
+	app.changes.OnPRGroupMenu = func(group *ui.ChangesGroup, sx, sy int) {
+		name := group.Name
+		url := group.PRURL
+		refreshID := "pr.refresh." + name
+		closeID := "pr.close." + name
+		reg.Register(command.Command{
+			ID: refreshID, Title: "Refresh",
+			Handler: func() {
+				app.changes.RemovePRGroup(name)
+				app.fetchAndOpenPR(url)
+			},
+		})
+		reg.Register(command.Command{
+			ID: closeID, Title: "Close",
+			Handler: func() {
+				app.changes.RemovePRGroup(name)
+			},
+		})
+		items := []ui.ContextMenuItem{
+			{Label: "Refresh", Command: refreshID},
+			{Label: "Close", Command: closeID},
+		}
+		openContextMenu(app, reg, items, sx, sy)
 	}
 
 	app.changes.OnGroupMenu = func(dir string, sx, sy int) {

--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -1061,11 +1061,19 @@ func registerPRCommands(reg *command.Registry, app *App) {
 				app.StatusError("GitHub CLI (gh) is required. Install from https://cli.github.com/")
 				return
 			}
-			app.ShowInputDialog("Open Pull Request", "https://github.com/owner/repo/pull/123", "", func(url string) {
+			dialog := ui.NewInputDialogWidget("Open Pull Request", "https://github.com/owner/repo/pull/123", "")
+			dialog.ConfirmLabel = "Open"
+			dialog.Borders = app.borders
+			dialog.OnSubmit = func(url string) {
+				app.DismissDialog()
 				if url != "" {
 					app.fetchAndOpenPR(url)
 				}
-			})
+			}
+			dialog.OnDismiss = func() {
+				app.DismissDialog()
+			}
+			app.ShowDialog(dialog)
 		},
 	})
 	reg.Register(command.Command{

--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -213,6 +213,28 @@ func runEventLoop(
 					app.allDiagnostics[v.path] = v.diagnostics
 				}
 				app.refreshProblems()
+			case *prFetchResult:
+				app.changes.Loading = false
+				if v.err != nil {
+					app.StatusError("PR fetch failed: " + v.err.Error())
+				} else {
+					var files []git.FileStatus
+					for _, f := range v.info.Files {
+						files = append(files, git.FileStatus{
+							Status: f.Status,
+							Path:   f.Path,
+						})
+					}
+					groupName := fmt.Sprintf("PR #%d: %s", v.info.Number, v.info.Title)
+					app.changes.AddPRGroup(groupName, v.url, files, v.diffs)
+					app.sidebar.SetActivePanel("changes")
+					if !app.sidebar.Visible {
+						app.ShowSidebar()
+					}
+					app.root.SetFocus(app.changes)
+					app.sidebar.SetPanelDirty("changes", app.changes.TotalChanges() > 0)
+					app.StatusNotify(fmt.Sprintf("Opened PR #%d: %s (%d files)", v.info.Number, v.info.Title, len(v.info.Files)))
+				}
 			}
 			redraw()
 		}

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/lsp"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
@@ -74,7 +75,7 @@ func main() {
 	cmdRegistry := command.NewRegistry()
 	borders := buildBorderSet(cfg.Theme.Borders)
 
-	app := buildApp(&cfg, &borders)
+	app, prURLs := buildApp(&cfg, &borders)
 	app.screen = screen
 	app.renderer = renderer
 	app.lspManager = lspManager
@@ -123,6 +124,18 @@ func main() {
 	running := true
 	registerCommands(cmdRegistry, app, &running, &quitPending)
 	bindKeys(app.root, cmdRegistry, cfg.Keybindings)
+
+	if len(prURLs) > 0 {
+		if !github.IsGHInstalled() {
+			app.StatusError("GitHub CLI (gh) is required. Install from https://cli.github.com/")
+		} else {
+			app.ShowSidebar()
+			app.sidebar.SetActivePanel("changes")
+			for _, url := range prURLs {
+				app.fetchAndOpenPR(url)
+			}
+		}
+	}
 
 	w, h := screen.Size()
 	app.root.SetSize(w, h)

--- a/cmd/ttt/menus.go
+++ b/cmd/ttt/menus.go
@@ -22,6 +22,8 @@ var menuBarMenus = [][]ui.ContextMenuItem{
 		{Label: "Add Folder to Workspace", Command: "workspace.addFolder"},
 		{Label: "Save Workspace As...", Command: "workspace.saveAs"},
 		ui.MenuSep(),
+		{Label: "Open Pull Request", Command: "pr.open"},
+		ui.MenuSep(),
 		{Label: "Quit", Command: "editor.quit"},
 	},
 	// Edit
@@ -58,8 +60,6 @@ var menuBarMenus = [][]ui.ContextMenuItem{
 		{Label: "New Terminal", Command: "terminal.new"},
 		ui.MenuSep(),
 		{Label: "Switch Theme", Command: "theme.switch"},
-		ui.MenuSep(),
-		{Label: "Open Pull Request", Command: "pr.open"},
 		ui.MenuSep(),
 		{Label: "Keyboard Tester", Command: "view.keyboardTester"},
 	},

--- a/cmd/ttt/menus.go
+++ b/cmd/ttt/menus.go
@@ -59,6 +59,8 @@ var menuBarMenus = [][]ui.ContextMenuItem{
 		ui.MenuSep(),
 		{Label: "Switch Theme", Command: "theme.switch"},
 		ui.MenuSep(),
+		{Label: "Open Pull Request", Command: "pr.open"},
+		ui.MenuSep(),
 		{Label: "Keyboard Tester", Command: "view.keyboardTester"},
 	},
 	// Help

--- a/cmd/ttt/pr.go
+++ b/cmd/ttt/pr.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/eugenioenko/ttt/internal/github"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+type prFetchResult struct {
+	url   string
+	info  *github.PRInfo
+	diffs map[string]string
+	err   error
+}
+
+func (a *App) fetchAndOpenPR(url string) {
+	owner, repo, number, err := github.ParsePRURL(url)
+	if err != nil {
+		a.StatusError("Invalid PR URL: " + err.Error())
+		return
+	}
+
+	a.changes.Loading = true
+	a.StatusNotify(fmt.Sprintf("Fetching PR #%d...", number))
+
+	go func() {
+		info, err := github.FetchPRInfo(owner, repo, number)
+		if err != nil {
+			a.screen.PostEvent(tcell.NewEventInterrupt(&prFetchResult{url: url, err: err}))
+			return
+		}
+
+		diffText, err := github.FetchPRDiff(owner, repo, number)
+		if err != nil {
+			a.screen.PostEvent(tcell.NewEventInterrupt(&prFetchResult{url: url, err: err}))
+			return
+		}
+
+		diffs := github.SplitMultiFileDiff(diffText)
+		a.screen.PostEvent(tcell.NewEventInterrupt(&prFetchResult{url: url, info: info, diffs: diffs}))
+	}()
+}

--- a/cmd/ttt/widgets.go
+++ b/cmd/ttt/widgets.go
@@ -3,15 +3,21 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/view"
 	"github.com/eugenioenko/ttt/internal/workspace"
 )
 
-func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile string) {
+func isPRURL(arg string) bool {
+	return strings.Contains(arg, "github.com/") && strings.Contains(arg, "/pull/")
+}
+
+func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile string, prURLs []string) {
 	var folders []string
 	var wsFile string
 
@@ -25,6 +31,12 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 		if args[i] == "--config" && i+1 < len(args) {
 			configFile = args[i+1]
 			i++
+			continue
+		}
+		if isPRURL(args[i]) {
+			if _, _, _, err := github.ParsePRURL(args[i]); err == nil {
+				prURLs = append(prURLs, args[i])
+			}
 			continue
 		}
 		absPath, err := filepath.Abs(args[i])
@@ -61,7 +73,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 		}
 	}
 
-	if len(folders) == 0 {
+	if len(folders) == 0 && len(prURLs) == 0 {
 		cwd, _ := os.Getwd()
 		folders = append(folders, cwd)
 	}
@@ -69,9 +81,9 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 	return
 }
 
-func buildApp(cfg *config.AppConfig, borders *term.BorderSet) *App {
-	ws, openFiles, _ := resolveArgs()
-	return buildAppFromConfig(cfg, borders, ws, openFiles)
+func buildApp(cfg *config.AppConfig, borders *term.BorderSet) (*App, []string) {
+	ws, openFiles, _, prURLs := resolveArgs()
+	return buildAppFromConfig(cfg, borders, ws, openFiles), prURLs
 }
 
 func buildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *workspace.Workspace, openFiles []string) *App {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1,0 +1,132 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type PRFile struct {
+	Path   string
+	Status string // A, M, D, R
+}
+
+type PRInfo struct {
+	Owner  string
+	Repo   string
+	Number int
+	Title  string
+	Files  []PRFile
+}
+
+func IsGHInstalled() bool {
+	_, err := exec.LookPath("gh")
+	return err == nil
+}
+
+func ParsePRURL(url string) (owner, repo string, number int, err error) {
+	url = strings.TrimRight(url, "/")
+	url = strings.SplitN(url, "?", 2)[0]
+	url = strings.SplitN(url, "#", 2)[0]
+	parts := strings.Split(url, "/")
+	for i, p := range parts {
+		if p == "pull" && i >= 2 && i+1 < len(parts) {
+			owner = parts[i-2]
+			repo = parts[i-1]
+			n, e := strconv.Atoi(parts[i+1])
+			if e != nil {
+				return "", "", 0, fmt.Errorf("invalid PR number: %s", parts[i+1])
+			}
+			return owner, repo, n, nil
+		}
+	}
+	return "", "", 0, fmt.Errorf("could not parse PR URL: %s", url)
+}
+
+func FetchPRInfo(owner, repo string, number int) (*PRInfo, error) {
+	repoArg := owner + "/" + repo
+	cmd := exec.Command("gh", "pr", "view", strconv.Itoa(number),
+		"--repo", repoArg,
+		"--json", "title,number,files")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view failed: %w", err)
+	}
+	var result struct {
+		Title  string `json:"title"`
+		Number int    `json:"number"`
+		Files  []struct {
+			Path   string `json:"path"`
+			Status string `json:"status"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("parse gh output: %w", err)
+	}
+	info := &PRInfo{
+		Owner:  owner,
+		Repo:   repo,
+		Number: result.Number,
+		Title:  result.Title,
+	}
+	for _, f := range result.Files {
+		status := "M"
+		switch f.Status {
+		case "added":
+			status = "A"
+		case "deleted":
+			status = "D"
+		case "renamed":
+			status = "R"
+		case "copied":
+			status = "A"
+		}
+		info.Files = append(info.Files, PRFile{Path: f.Path, Status: status})
+	}
+	return info, nil
+}
+
+func FetchPRDiff(owner, repo string, number int) (string, error) {
+	repoArg := owner + "/" + repo
+	cmd := exec.Command("gh", "pr", "diff", strconv.Itoa(number), "--repo", repoArg)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh pr diff failed: %w", err)
+	}
+	return string(out), nil
+}
+
+func SplitMultiFileDiff(unified string) map[string]string {
+	result := make(map[string]string)
+	lines := strings.Split(unified, "\n")
+	var currentFile string
+	var currentLines []string
+
+	flush := func() {
+		if currentFile != "" && len(currentLines) > 0 {
+			result[currentFile] = strings.Join(currentLines, "\n")
+		}
+	}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "diff --git ") {
+			flush()
+			parts := strings.Fields(line)
+			if len(parts) >= 4 {
+				bPath := parts[len(parts)-1]
+				if strings.HasPrefix(bPath, "b/") {
+					currentFile = bPath[2:]
+				} else {
+					currentFile = bPath
+				}
+			}
+			currentLines = []string{line}
+		} else {
+			currentLines = append(currentLines, line)
+		}
+	}
+	flush()
+	return result
+}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,67 @@
+package github
+
+import "testing"
+
+func TestParsePRURL(t *testing.T) {
+	tests := []struct {
+		url    string
+		owner  string
+		repo   string
+		number int
+		err    bool
+	}{
+		{"https://github.com/owner/repo/pull/123", "owner", "repo", 123, false},
+		{"https://github.com/owner/repo/pull/123/", "owner", "repo", 123, false},
+		{"https://github.com/owner/repo/pull/123/files", "owner", "repo", 123, false},
+		{"https://github.com/owner/repo/pull/456?tab=commits", "owner", "repo", 456, false},
+		{"https://github.com/owner/repo/pull/789#discussion", "owner", "repo", 789, false},
+		{"https://github.com/owner/repo", "", "", 0, true},
+		{"not-a-url", "", "", 0, true},
+		{"https://github.com/owner/repo/pull/abc", "", "", 0, true},
+	}
+	for _, tt := range tests {
+		owner, repo, number, err := ParsePRURL(tt.url)
+		if tt.err {
+			if err == nil {
+				t.Errorf("ParsePRURL(%q) expected error", tt.url)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParsePRURL(%q) unexpected error: %v", tt.url, err)
+			continue
+		}
+		if owner != tt.owner || repo != tt.repo || number != tt.number {
+			t.Errorf("ParsePRURL(%q) = (%q, %q, %d), want (%q, %q, %d)",
+				tt.url, owner, repo, number, tt.owner, tt.repo, tt.number)
+		}
+	}
+}
+
+func TestSplitMultiFileDiff(t *testing.T) {
+	unified := `diff --git a/file1.go b/file1.go
+--- a/file1.go
++++ b/file1.go
+@@ -1,3 +1,3 @@
+ line1
+-old
++new
+ line3
+diff --git a/pkg/file2.go b/pkg/file2.go
+--- a/pkg/file2.go
++++ b/pkg/file2.go
+@@ -1,2 +1,2 @@
+-removed
++added`
+
+	result := SplitMultiFileDiff(unified)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(result))
+	}
+	if _, ok := result["file1.go"]; !ok {
+		t.Error("missing file1.go")
+	}
+	if _, ok := result["pkg/file2.go"]; !ok {
+		t.Error("missing pkg/file2.go")
+	}
+}

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -18,6 +18,9 @@ type ChangesGroup struct {
 	StagedExpanded  bool
 	ChangesExpanded bool
 	Input           *InputWidget
+	IsPR            bool
+	PRURL           string
+	PRDiffs         map[string]string
 }
 
 type changesItemKind int
@@ -46,10 +49,13 @@ type ChangesWidget struct {
 	items        []changesItem
 	multiRoot    bool
 	inputFocused bool
+	Loading          bool
 	OnOpenDiff       func(dir string, status git.FileStatus)
+	OnOpenPRDiff     func(group *ChangesGroup, status git.FileStatus)
 	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
 	OnCommit         func(dir string, message string)
 	OnGroupMenu      func(dir string, screenX, screenY int)
+	OnPRGroupMenu    func(group *ChangesGroup, screenX, screenY int)
 	OnConfirmDiscard func(message string, onConfirm func())
 }
 
@@ -72,8 +78,12 @@ func (c *ChangesWidget) SetDirs(dirs []string) {
 
 func (c *ChangesWidget) Refresh() {
 	oldGroups := make(map[string]ChangesGroup)
+	var prGroups []ChangesGroup
 	for _, g := range c.Groups {
 		oldGroups[g.Dir] = g
+		if g.IsPR {
+			prGroups = append(prGroups, g)
+		}
 	}
 	c.Groups = nil
 	for _, dir := range c.Dirs {
@@ -116,6 +126,8 @@ func (c *ChangesWidget) Refresh() {
 			Input:           input,
 		})
 	}
+	c.Groups = append(c.Groups, prGroups...)
+	c.multiRoot = len(c.Groups) > 1
 	c.buildItems()
 	c.ClampSelected(len(c.items))
 }
@@ -123,16 +135,19 @@ func (c *ChangesWidget) Refresh() {
 func (c *ChangesWidget) buildItems() {
 	c.items = nil
 	for gi, g := range c.Groups {
-		if c.multiRoot {
+		showHeader := c.multiRoot || g.IsPR
+		if showHeader {
 			c.items = append(c.items, changesItem{kind: itemHeader, groupIndex: gi})
 		}
-		if !c.multiRoot || g.Expanded {
-			if c.multiRoot {
+		if !showHeader || g.Expanded {
+			if showHeader {
 				c.items = append(c.items, changesItem{kind: itemBorder, groupIndex: gi})
 			}
-			c.items = append(c.items, changesItem{kind: itemInput, groupIndex: gi})
-			c.items = append(c.items, changesItem{kind: itemBorder, groupIndex: gi})
-			if len(g.Staged) > 0 {
+			if !g.IsPR {
+				c.items = append(c.items, changesItem{kind: itemInput, groupIndex: gi})
+				c.items = append(c.items, changesItem{kind: itemBorder, groupIndex: gi})
+			}
+			if !g.IsPR && len(g.Staged) > 0 {
 				c.items = append(c.items, changesItem{kind: itemSection, groupIndex: gi, staged: true})
 				if g.StagedExpanded {
 					for fi := range g.Staged {
@@ -141,7 +156,9 @@ func (c *ChangesWidget) buildItems() {
 				}
 			}
 			if len(g.Unstaged) > 0 {
-				c.items = append(c.items, changesItem{kind: itemSection, groupIndex: gi, staged: false})
+				if !g.IsPR {
+					c.items = append(c.items, changesItem{kind: itemSection, groupIndex: gi, staged: false})
+				}
 				if g.ChangesExpanded {
 					for fi := range g.Unstaged {
 						c.items = append(c.items, changesItem{kind: itemFile, groupIndex: gi, fileIndex: fi, staged: false})
@@ -205,6 +222,9 @@ func (c *ChangesWidget) Render(surface *RenderSurface) {
 
 	if c.TotalChanges() == 0 {
 		msg := "No changes"
+		if c.Loading {
+			msg = "Loading..."
+		}
 		for i, ch := range msg {
 			if i+1 < w {
 				surface.SetCell(i+1, 0, term.Cell{Ch: ch, Style: term.StyleDefault})
@@ -269,8 +289,9 @@ func (c *ChangesWidget) renderHeader(surface *RenderSurface, y, w int, style ter
 		surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
 		x++
 	}
+	maxNameX := w - 3
 	for _, ch := range g.Name {
-		if x >= w {
+		if x >= maxNameX {
 			break
 		}
 		surface.SetCell(x, y, term.Cell{Ch: ch, Style: style})
@@ -354,7 +375,11 @@ func (c *ChangesWidget) renderFile(surface *RenderSurface, y, w int, style term.
 		x++
 	}
 
+	isPR := c.Groups[item.groupIndex].IsPR
 	maxPathX := w - 4
+	if isPR {
+		maxPathX = w - 1
+	}
 	for _, ch := range f.Path {
 		if x >= maxPathX {
 			break
@@ -363,13 +388,15 @@ func (c *ChangesWidget) renderFile(surface *RenderSurface, y, w int, style term.
 		x++
 	}
 
-	if item.staged {
-		if w >= 3 {
-			surface.SetCell(w-2, y, term.Cell{Ch: '−', Style: style})
-		}
-	} else {
-		if w >= 3 {
-			surface.SetCell(w-2, y, term.Cell{Ch: '+', Style: style})
+	if !isPR {
+		if item.staged {
+			if w >= 3 {
+				surface.SetCell(w-2, y, term.Cell{Ch: '−', Style: style})
+			}
+		} else {
+			if w >= 3 {
+				surface.SetCell(w-2, y, term.Cell{Ch: '+', Style: style})
+			}
 		}
 	}
 }
@@ -459,8 +486,13 @@ func (c *ChangesWidget) HandleEvent(ev tcell.Event) EventResult {
 			if idx >= 0 && idx < len(c.items) {
 				item := c.items[idx]
 				if item.kind == itemHeader && mx >= r.X+r.W-3 {
-					if c.OnGroupMenu != nil {
-						c.OnGroupMenu(c.Groups[item.groupIndex].Dir, mx, my)
+					g := &c.Groups[item.groupIndex]
+					if g.IsPR {
+						if c.OnPRGroupMenu != nil {
+							c.OnPRGroupMenu(g, mx, my)
+						}
+					} else if c.OnGroupMenu != nil {
+						c.OnGroupMenu(g.Dir, mx, my)
 					}
 					return EventConsumed
 				}
@@ -504,23 +536,24 @@ func (c *ChangesWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 
 	if tev, ok := ev.(*tcell.EventKey); ok {
+		inPR := c.selectedInPR()
 		switch {
 		case tev.Key() == tcell.KeyRune && (tev.Rune() == 'r' || tev.Rune() == 'R'):
 			c.Refresh()
 			return EventConsumed
-		case tev.Key() == tcell.KeyRune && tev.Rune() == ' ':
+		case !inPR && tev.Key() == tcell.KeyRune && tev.Rune() == ' ':
 			c.toggleStageSelected()
 			return EventConsumed
-		case tev.Key() == tcell.KeyRune && (tev.Rune() == 'a' || tev.Rune() == 'A'):
+		case !inPR && tev.Key() == tcell.KeyRune && (tev.Rune() == 'a' || tev.Rune() == 'A'):
 			c.stageAll()
 			return EventConsumed
-		case tev.Key() == tcell.KeyRune && (tev.Rune() == 'u' || tev.Rune() == 'U'):
+		case !inPR && tev.Key() == tcell.KeyRune && (tev.Rune() == 'u' || tev.Rune() == 'U'):
 			c.unstageAll()
 			return EventConsumed
-		case tev.Key() == tcell.KeyRune && tev.Rune() == 'd':
+		case !inPR && tev.Key() == tcell.KeyRune && tev.Rune() == 'd':
 			c.discardSelected()
 			return EventConsumed
-		case tev.Key() == tcell.KeyRune && tev.Rune() == 'D':
+		case !inPR && tev.Key() == tcell.KeyRune && tev.Rune() == 'D':
 			c.discardAllInGroup()
 			return EventConsumed
 		}
@@ -604,9 +637,17 @@ func (c *ChangesWidget) activateSelected() {
 		}
 		c.buildItems()
 	case itemFile:
-		dir, status, ok := c.SelectedFile()
-		if ok && c.OnOpenDiff != nil {
-			c.OnOpenDiff(dir, status)
+		g := &c.Groups[item.groupIndex]
+		if g.IsPR {
+			_, status, ok := c.SelectedFile()
+			if ok && c.OnOpenPRDiff != nil {
+				c.OnOpenPRDiff(g, status)
+			}
+		} else {
+			dir, status, ok := c.SelectedFile()
+			if ok && c.OnOpenDiff != nil {
+				c.OnOpenDiff(dir, status)
+			}
 		}
 	}
 }
@@ -677,4 +718,53 @@ func (c *ChangesWidget) confirmDiscardAll(gi int) {
 		}
 		c.Refresh()
 	})
+}
+
+func (c *ChangesWidget) selectedInPR() bool {
+	if c.Selected < 0 || c.Selected >= len(c.items) {
+		return false
+	}
+	return c.Groups[c.items[c.Selected].groupIndex].IsPR
+}
+
+func (c *ChangesWidget) AddPRGroup(name, url string, files []git.FileStatus, diffs map[string]string) {
+	c.Groups = append(c.Groups, ChangesGroup{
+		Dir:             "pr://" + name,
+		Name:            name,
+		Unstaged:        files,
+		Expanded:        true,
+		ChangesExpanded: true,
+		IsPR:            true,
+		PRURL:           url,
+		PRDiffs:         diffs,
+	})
+	c.multiRoot = len(c.Groups) > 1
+	c.buildItems()
+	c.ClampSelected(len(c.items))
+}
+
+func (c *ChangesWidget) RemovePRGroup(name string) {
+	var kept []ChangesGroup
+	for _, g := range c.Groups {
+		if !(g.IsPR && g.Name == name) {
+			kept = append(kept, g)
+		}
+	}
+	c.Groups = kept
+	c.multiRoot = len(c.Groups) > 1
+	c.buildItems()
+	c.ClampSelected(len(c.items))
+}
+
+func (c *ChangesWidget) RemovePRGroups() {
+	var kept []ChangesGroup
+	for _, g := range c.Groups {
+		if !g.IsPR {
+			kept = append(kept, g)
+		}
+	}
+	c.Groups = kept
+	c.multiRoot = len(c.Groups) > 1
+	c.buildItems()
+	c.ClampSelected(len(c.items))
 }

--- a/internal/ui/inputdialog_widget.go
+++ b/internal/ui/inputdialog_widget.go
@@ -8,15 +8,16 @@ import (
 
 type InputDialogWidget struct {
 	BaseWidget
-	Title      string
-	Input      InputWidget
-	Borders    *term.BorderSet
-	OnSubmit   func(value string)
-	OnDismiss  func()
-	focusedBtn int // 0 = input, 1 = cancel, 2 = save
-	boxX       int
-	boxY       int
-	boxW       int
+	Title        string
+	ConfirmLabel string
+	Input        InputWidget
+	Borders      *term.BorderSet
+	OnSubmit     func(value string)
+	OnDismiss    func()
+	focusedBtn   int // 0 = input, 1 = cancel, 2 = save
+	boxX         int
+	boxY         int
+	boxW         int
 }
 
 func NewInputDialogWidget(title, placeholder, initial string) *InputDialogWidget {
@@ -32,24 +33,21 @@ func (d *InputDialogWidget) Focusable() bool { return true }
 
 func (d *InputDialogWidget) CursorPosition() (int, int, bool) {
 	if d.focusedBtn == 0 {
-		return d.Input.CursorX(d.boxX + 1), d.boxY + 1, true
+		return d.Input.CursorX(d.boxX + 1), d.boxY + 3, true
 	}
 	return 0, 0, false
 }
 
 func (d *InputDialogWidget) Render(surface *RenderSurface) {
-	sw, sh := surface.Size()
+	sw, _ := surface.Size()
 
 	d.boxW = 50
 	if d.boxW > sw-4 {
 		d.boxW = sw - 4
 	}
-	boxH := 4
+	boxH := 7
 	d.boxX = (sw - d.boxW) / 2
-	d.boxY = (sh - boxH) / 2
-	if d.boxY < 1 {
-		d.boxY = 1
-	}
+	d.boxY = 2
 
 	b := term.DoubleBorderSet()
 	if d.Borders != nil {
@@ -60,17 +58,21 @@ func (d *InputDialogWidget) Render(surface *RenderSurface) {
 	surface.ClearRect(d.boxX, d.boxY, d.boxW, boxH, term.StylePaletteItem)
 	surface.DrawBorder(d.boxX, d.boxY, d.boxW, boxH, b, bs)
 
-	// Title on top border
-	surface.DrawText(d.boxX+2, d.boxY, d.Title, d.boxX+d.boxW-2, bs)
+	// Title inside box
+	surface.DrawText(d.boxX+2, d.boxY+1, d.Title, d.boxX+d.boxW-2, term.StylePaletteItem)
 
 	// Input row
 	inputW := d.boxW - 2
-	d.Input.Render(surface, d.boxX+1, d.boxY+1, inputW)
+	d.Input.Render(surface, d.boxX+1, d.boxY+3, inputW)
 
 	// Buttons row
-	btnY := d.boxY + 2
+	btnY := d.boxY + 5
 	cancelLabel := " Cancel "
-	saveLabel := " Save "
+	confirmText := "Save"
+	if d.ConfirmLabel != "" {
+		confirmText = d.ConfirmLabel
+	}
+	saveLabel := " " + confirmText + " "
 
 	cancelStyle := term.StyleMuted
 	saveStyle := term.StyleMuted
@@ -91,9 +93,13 @@ func (d *InputDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 	if mev, ok := ev.(*tcell.EventMouse); ok {
 		if mev.Buttons()&tcell.Button1 != 0 {
 			mx, my := mev.Position()
-			btnY := d.boxY + 2
+			btnY := d.boxY + 5
 			if my == btnY {
-				saveLabel := " Save "
+				confirmText := "Save"
+				if d.ConfirmLabel != "" {
+					confirmText = d.ConfirmLabel
+				}
+				saveLabel := " " + confirmText + " "
 				cancelLabel := " Cancel "
 				saveEnd := d.boxX + d.boxW - 2
 				saveStart := saveEnd - len([]rune(saveLabel))
@@ -114,7 +120,7 @@ func (d *InputDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 					return EventConsumed
 				}
 			}
-			if my == d.boxY+1 {
+			if my == d.boxY+3 {
 				d.focusedBtn = 0
 			}
 		}


### PR DESCRIPTION
## Summary
- Open pull requests directly by passing a GitHub PR URL: `ttt https://github.com/owner/repo/pull/123`
- PR files appear as a collapsible group in the Changes sidebar with clickable diffs
- Also accessible via command palette ("Open Pull Request") and View menu
- Per-PR group menu with Refresh (re-fetch from GitHub) and Close actions
- Auto-detects PR URLs in positional args; PR-only mode skips cwd folder and focuses Changes tab
- Uses `gh` CLI for GitHub API interaction (shows error if not installed)
- New `internal/github` package with URL parsing, PR info/diff fetching, and multi-file diff splitting

## Test plan
- [ ] `bin/ttt https://github.com/eugenioenko/ttt/pull/19` — PR files shown in Changes sidebar, clicking opens diff tabs
- [ ] `bin/ttt ~/project https://github.com/eugenioenko/ttt/pull/19` — project in explorer + PR in changes
- [ ] Command palette → "Open Pull Request" → enter URL — same result
- [ ] View menu → "Open Pull Request" works
- [ ] Changes `⋮` menu shows "Open Pull Request"
- [ ] PR group `⋮` menu shows Refresh and Close
- [ ] "Loading..." shown while fetching PR data
- [ ] Without `gh` installed: shows error message
- [ ] Explorer `⋮` menu shows "Add Folder"

🤖 Generated with [Claude Code](https://claude.com/claude-code)