### PR TITLE
feat: add scrollbars and diff view horizontal scrolling

### DIFF
--- a/cmd/ttt/theme.go
+++ b/cmd/ttt/theme.go
@@ -41,7 +41,7 @@ func buildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	applyStyleDef(&m, term.StyleDiffDeleted, theme.Diff.Deleted)
 	applyStyleDef(&m, term.StyleDiffModified, theme.Diff.Modified)
 	applyStyleDef(&m, term.StyleActiveLine, theme.Editor.ActiveLine)
-	applyStyleDef(&m, term.StyleScrollbar, config.StyleDef{Bg: theme.Scrollbar.Bg})
+	applyStyleDef(&m, term.StyleScrollbar, config.StyleDef{Fg: theme.Scrollbar.Bg})
 	applyStyleDef(&m, term.StyleScrollbarThumb, config.StyleDef{Fg: theme.Scrollbar.Fg})
 	applyStyleDef(&m, term.StyleSyntaxComment, theme.Syntax.Comment)
 	applyStyleDef(&m, term.StyleSyntaxString, theme.Syntax.String)

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -15,14 +15,30 @@ type DiffViewWidget struct {
 	Lines       []diff.DiffLine
 	Highlighter *highlight.Highlighter
 	TopLine     int
+	LeftCol     int
+	maxLineW    int
 	viewH       int
+	contentW    int
+	scrollbar   Scrollbar
+	hscrollbar  HScrollbar
 }
 
 func NewDiffViewWidget(filePath string, fd diff.FileDiff) *DiffViewWidget {
+	lines := fd.AllLines()
+	maxW := 0
+	for _, dl := range lines {
+		if lw := len([]rune(dl.Left.Text)); lw > maxW {
+			maxW = lw
+		}
+		if rw := len([]rune(dl.Right.Text)); rw > maxW {
+			maxW = rw
+		}
+	}
 	return &DiffViewWidget{
 		FilePath:    filePath,
-		Lines:       fd.AllLines(),
+		Lines:       lines,
 		Highlighter: highlight.New(filePath),
+		maxLineW:    maxW,
 	}
 }
 
@@ -47,14 +63,29 @@ func (d *DiffViewWidget) gutterWidth() int {
 
 func (d *DiffViewWidget) Render(surface *RenderSurface) {
 	w, h := surface.Size()
-	d.viewH = h
+	r := d.GetRect()
 
 	gutterW := d.gutterWidth()
+
+	showVScroll := len(d.Lines) > h
+	contentW := (w - 1) / 2 - gutterW
+	showHScroll := d.maxLineW > contentW
+
+	if showHScroll {
+		h--
+	}
+	if showVScroll {
+		w--
+	}
+
+	d.viewH = h
+
 	dividerX := (w - 1) / 2
 	leftStart := gutterW
 	leftW := dividerX - gutterW
 	rightStart := dividerX + 1 + gutterW
 	rightW := w - rightStart
+	d.contentW = leftW
 
 	if leftW < 1 || rightW < 1 {
 		return
@@ -94,6 +125,38 @@ func (d *DiffViewWidget) Render(surface *RenderSurface) {
 		d.renderSide(surface, leftStart, y, leftW, dl.Left.Text, leftStyle, leftSpans)
 		d.renderSide(surface, rightStart, y, rightW, dl.Right.Text, rightStyle, rightSpans)
 	}
+
+	if showVScroll {
+		d.scrollbar.X = r.X + w
+		d.scrollbar.Y = r.Y
+		d.scrollbar.Height = h
+		d.scrollbar.TotalItems = len(d.Lines)
+		d.scrollbar.TopItem = d.TopLine
+		d.scrollbar.Render(surface, w, 0)
+	}
+
+	if showHScroll {
+		d.hscrollbar.X = r.X + leftStart
+		d.hscrollbar.Y = r.Y + h
+		d.hscrollbar.Width = leftW
+		d.hscrollbar.TotalCols = d.maxLineW
+		d.hscrollbar.LeftCol = d.LeftCol
+		d.hscrollbar.Render(surface, leftStart, h)
+
+		for x := 0; x < gutterW; x++ {
+			surface.SetCell(x, h, term.Cell{Ch: ' '})
+		}
+		surface.SetCell(dividerX, h, term.Cell{Ch: '│', Style: term.StyleBorder})
+		for x := dividerX + 1; x < rightStart; x++ {
+			surface.SetCell(x, h, term.Cell{Ch: ' '})
+		}
+
+		rhscroll := HScrollbar{
+			X: r.X + rightStart, Y: r.Y + h,
+			Width: rightW, TotalCols: d.maxLineW, LeftCol: d.LeftCol,
+		}
+		rhscroll.Render(surface, rightStart, h)
+	}
 }
 
 func (d *DiffViewWidget) renderGutter(surface *RenderSurface, x, y, w int, sl diff.SideLine, style term.Style) {
@@ -113,13 +176,14 @@ func (d *DiffViewWidget) renderGutter(surface *RenderSurface, x, y, w int, sl di
 func (d *DiffViewWidget) renderSide(surface *RenderSurface, x, y, w int, text string, baseStyle term.Style, spans []highlight.Span) {
 	runes := []rune(text)
 	for i := 0; i < w; i++ {
+		colIdx := d.LeftCol + i
 		ch := ' '
-		if i < len(runes) {
-			ch = runes[i]
+		if colIdx < len(runes) {
+			ch = runes[colIdx]
 		}
 		style := term.StyleDefault
 		for _, sp := range spans {
-			if i >= sp.Start && i < sp.End {
+			if colIdx >= sp.Start && colIdx < sp.End {
 				style = sp.Style
 				break
 			}
@@ -143,7 +207,29 @@ func kindToStyle(k diff.LineKind) term.Style {
 	}
 }
 
+func (d *DiffViewWidget) clampLeftCol() {
+	max := d.maxLineW - d.contentW
+	if max < 0 {
+		max = 0
+	}
+	if d.LeftCol > max {
+		d.LeftCol = max
+	}
+	if d.LeftCol < 0 {
+		d.LeftCol = 0
+	}
+}
+
 func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
+	if newTop, consumed := d.scrollbar.HandleEvent(ev); consumed {
+		d.TopLine = newTop
+		return EventConsumed
+	}
+	if newLeft, consumed := d.hscrollbar.HandleEvent(ev); consumed {
+		d.LeftCol = newLeft
+		return EventConsumed
+	}
+
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
 		switch tev.Key() {
@@ -160,6 +246,15 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			if d.TopLine < max {
 				d.TopLine++
 			}
+			return EventConsumed
+		case tcell.KeyLeft:
+			if d.LeftCol > 0 {
+				d.LeftCol--
+			}
+			return EventConsumed
+		case tcell.KeyRight:
+			d.LeftCol++
+			d.clampLeftCol()
 			return EventConsumed
 		case tcell.KeyPgUp:
 			d.TopLine -= d.viewH
@@ -179,6 +274,7 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		case tcell.KeyHome:
 			d.TopLine = 0
+			d.LeftCol = 0
 			return EventConsumed
 		case tcell.KeyEnd:
 			max := len(d.Lines) - d.viewH
@@ -190,22 +286,47 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 	case *tcell.EventMouse:
 		btn := tev.Buttons()
+		mod := tev.Modifiers()
 		if btn&tcell.WheelUp != 0 {
-			d.TopLine -= 3
-			if d.TopLine < 0 {
-				d.TopLine = 0
+			if mod&tcell.ModShift != 0 {
+				d.LeftCol -= 4
+				if d.LeftCol < 0 {
+					d.LeftCol = 0
+				}
+			} else {
+				d.TopLine -= 3
+				if d.TopLine < 0 {
+					d.TopLine = 0
+				}
 			}
 			return EventConsumed
 		}
 		if btn&tcell.WheelDown != 0 {
-			max := len(d.Lines) - d.viewH
-			if max < 0 {
-				max = 0
+			if mod&tcell.ModShift != 0 {
+				d.LeftCol += 4
+				d.clampLeftCol()
+			} else {
+				max := len(d.Lines) - d.viewH
+				if max < 0 {
+					max = 0
+				}
+				d.TopLine += 3
+				if d.TopLine > max {
+					d.TopLine = max
+				}
 			}
-			d.TopLine += 3
-			if d.TopLine > max {
-				d.TopLine = max
+			return EventConsumed
+		}
+		if btn&tcell.WheelLeft != 0 {
+			d.LeftCol -= 4
+			if d.LeftCol < 0 {
+				d.LeftCol = 0
 			}
+			return EventConsumed
+		}
+		if btn&tcell.WheelRight != 0 {
+			d.LeftCol += 4
+			d.clampLeftCol()
 			return EventConsumed
 		}
 	}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -38,6 +38,7 @@ type EditorPaneWidget struct {
 	clickCount    int
 	mouseDown     bool
 	scrollbar       Scrollbar
+	hscrollbar      HScrollbar
 	Diagnostics     []Diagnostic
 	OnChange        func()
 	Multi           *multicursor.MultiCursor
@@ -69,9 +70,21 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 	w, h := surface.Size()
 
 	totalLines := len(e.Buf.Lines)
-	showScrollbar := totalLines > h
 	gutterW := e.GutterWidth()
+
+	maxLineW := 0
+	for _, line := range e.Buf.Lines {
+		if lw := len([]rune(line)); lw > maxLineW {
+			maxLineW = lw
+		}
+	}
+
 	editorW := w - gutterW
+	showHScrollbar := maxLineW > editorW
+	if showHScrollbar {
+		h--
+	}
+	showScrollbar := totalLines > h
 	if showScrollbar {
 		editorW--
 	}
@@ -202,14 +215,29 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 		}
 	}
 
+	scrollbarCol := w - 1
+	if showHScrollbar {
+		scrollbarCol = w - 1
+	}
 	if showScrollbar {
 		r := e.GetRect()
-		e.scrollbar.X = r.X + w - 1
+		e.scrollbar.X = r.X + scrollbarCol
 		e.scrollbar.Y = r.Y
 		e.scrollbar.Height = h
 		e.scrollbar.TotalItems = totalLines + h - 1
 		e.scrollbar.TopItem = e.Viewport.TopLine
-		e.scrollbar.Render(surface, w-1, 0)
+		e.scrollbar.Render(surface, scrollbarCol, 0)
+	}
+
+	if showHScrollbar {
+		r := e.GetRect()
+		trackW := editorW
+		e.hscrollbar.X = r.X + gutterW
+		e.hscrollbar.Y = r.Y + h
+		e.hscrollbar.Width = trackW
+		e.hscrollbar.TotalCols = maxLineW
+		e.hscrollbar.LeftCol = e.Viewport.LeftCol
+		e.hscrollbar.Render(surface, gutterW, h)
 	}
 
 	r := e.GetRect()
@@ -341,23 +369,53 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		if e.scrollbar.IsDragging() {
 			return EventConsumed
 		}
+		if newLeft, consumed := e.hscrollbar.HandleEvent(ev); consumed {
+			e.Viewport.LeftCol = newLeft
+			return EventConsumed
+		}
+		if e.hscrollbar.IsDragging() {
+			return EventConsumed
+		}
 
+		mod := mev.Modifiers()
 		if btn&tcell.WheelUp != 0 {
-			e.Viewport.TopLine -= 3
-			if e.Viewport.TopLine < 0 {
-				e.Viewport.TopLine = 0
+			if mod&tcell.ModShift != 0 {
+				e.Viewport.LeftCol -= 4
+				if e.Viewport.LeftCol < 0 {
+					e.Viewport.LeftCol = 0
+				}
+			} else {
+				e.Viewport.TopLine -= 3
+				if e.Viewport.TopLine < 0 {
+					e.Viewport.TopLine = 0
+				}
 			}
 			return EventConsumed
 		}
 		if btn&tcell.WheelDown != 0 {
-			max := len(e.Buf.Lines) - 1
-			if max < 0 {
-				max = 0
+			if mod&tcell.ModShift != 0 {
+				e.Viewport.LeftCol += 4
+			} else {
+				max := len(e.Buf.Lines) - 1
+				if max < 0 {
+					max = 0
+				}
+				e.Viewport.TopLine += 3
+				if e.Viewport.TopLine > max {
+					e.Viewport.TopLine = max
+				}
 			}
-			e.Viewport.TopLine += 3
-			if e.Viewport.TopLine > max {
-				e.Viewport.TopLine = max
+			return EventConsumed
+		}
+		if btn&tcell.WheelLeft != 0 {
+			e.Viewport.LeftCol -= 4
+			if e.Viewport.LeftCol < 0 {
+				e.Viewport.LeftCol = 0
 			}
+			return EventConsumed
+		}
+		if btn&tcell.WheelRight != 0 {
+			e.Viewport.LeftCol += 4
 			return EventConsumed
 		}
 		if btn&tcell.Button1 != 0 {

--- a/internal/ui/scrollbar.go
+++ b/internal/ui/scrollbar.go
@@ -45,7 +45,7 @@ func (s *Scrollbar) Render(surface *RenderSurface, rx, ry int) {
 		if y >= thumbTop && y < thumbTop+thumbH {
 			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbarThumb})
 		} else {
-			surface.SetCell(rx, ry+y, term.Cell{Ch: ' ', Style: term.StyleScrollbar})
+			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbar})
 		}
 	}
 }
@@ -110,4 +110,110 @@ func (s *Scrollbar) posToTopItem(thumbTop int) int {
 		top = scrollable
 	}
 	return top
+}
+
+type HScrollbar struct {
+	X         int
+	Y         int
+	Width     int
+	TotalCols int
+	LeftCol   int
+	dragging  bool
+	dragOffset int
+}
+
+func (s *HScrollbar) Visible() bool {
+	return s.TotalCols > s.Width && s.Width > 0
+}
+
+func (s *HScrollbar) ThumbPos() (left, width int) {
+	if s.TotalCols <= s.Width {
+		return 0, s.Width
+	}
+	width = s.Width * s.Width / s.TotalCols
+	if width < 1 {
+		width = 1
+	}
+	scrollable := s.TotalCols - s.Width
+	left = s.LeftCol * (s.Width - width) / scrollable
+	if left+width > s.Width {
+		left = s.Width - width
+	}
+	return
+}
+
+func (s *HScrollbar) Render(surface *RenderSurface, rx, ry int) {
+	if !s.Visible() {
+		return
+	}
+	thumbLeft, thumbW := s.ThumbPos()
+	for x := 0; x < s.Width; x++ {
+		if x >= thumbLeft && x < thumbLeft+thumbW {
+			surface.SetCell(rx+x, ry, term.Cell{Ch: '▄', Style: term.StyleScrollbarThumb})
+		} else {
+			surface.SetCell(rx+x, ry, term.Cell{Ch: '▄', Style: term.StyleScrollbar})
+		}
+	}
+}
+
+func (s *HScrollbar) HandleEvent(ev tcell.Event) (newLeftCol int, consumed bool) {
+	mev, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return s.LeftCol, false
+	}
+
+	mx, my := mev.Position()
+	btn := mev.Buttons()
+
+	if s.dragging {
+		if btn == tcell.ButtonNone {
+			s.dragging = false
+			return s.LeftCol, false
+		}
+		if btn&tcell.Button1 != 0 {
+			relX := mx - s.X
+			return s.posToLeftCol(relX - s.dragOffset), true
+		}
+	}
+
+	if btn&tcell.Button1 != 0 && my == s.Y && mx >= s.X && mx < s.X+s.Width {
+		relX := mx - s.X
+		thumbLeft, thumbW := s.ThumbPos()
+
+		s.dragging = true
+		if relX >= thumbLeft && relX < thumbLeft+thumbW {
+			s.dragOffset = relX - thumbLeft
+		} else {
+			s.dragOffset = thumbW / 2
+			return s.posToLeftCol(relX - s.dragOffset), true
+		}
+		return s.LeftCol, true
+	}
+
+	return s.LeftCol, false
+}
+
+func (s *HScrollbar) IsDragging() bool { return s.dragging }
+
+func (s *HScrollbar) posToLeftCol(thumbLeft int) int {
+	_, thumbW := s.ThumbPos()
+	maxThumbLeft := s.Width - thumbW
+	if maxThumbLeft <= 0 {
+		return 0
+	}
+	if thumbLeft < 0 {
+		thumbLeft = 0
+	}
+	if thumbLeft > maxThumbLeft {
+		thumbLeft = maxThumbLeft
+	}
+	scrollable := s.TotalCols - s.Width
+	left := thumbLeft * scrollable / maxThumbLeft
+	if left < 0 {
+		left = 0
+	}
+	if left > scrollable {
+		left = scrollable
+	}
+	return left
 }


### PR DESCRIPTION
## Summary
- Add reusable `HScrollbar` widget for horizontal scroll indication (lower half block `▄` character)
- Diff view: horizontal scrolling (arrow keys, mouse wheel, Shift+wheel), vertical scrollbar, and dual horizontal scrollbars (one per side, synced)
- Editor: horizontal scrollbar when content overflows viewport width, Shift+wheel and WheelLeft/WheelRight support
- Scrollbar track now uses block characters (`█` vertical, `▄` horizontal) instead of spaces for cleaner look

## Test plan
- [ ] Open a diff with long lines — Left/Right arrows scroll horizontally, both sides stay in sync
- [ ] Diff vertical scrollbar appears when content exceeds height, click/drag works
- [ ] Diff horizontal scrollbars appear under both sides when lines exceed width
- [ ] Editor shows horizontal scrollbar when lines exceed viewport width
- [ ] Shift+WheelUp/Down scrolls horizontally in both editor and diff view
- [ ] Scrollbar click and drag works for both vertical and horizontal

🤖 Generated with [Claude Code](https://claude.com/claude-code)