### PR TITLE
feat: dismiss LSP availability notification, fix status bar icon

### DIFF
--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -1057,13 +1057,19 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 	serverCfg := a.lspManager.ServerConfig(serverKey)
 	if len(serverCfg.Command) > 0 {
 		if _, err := exec.LookPath(serverCfg.Command[0]); err != nil {
-			if !a.lspNotified[serverKey] {
+			if !a.lspNotified[serverKey] && a.settings.LSP.ShouldNotifyAvailability() {
 				a.lspNotified[serverKey] = true
 				msg := fmt.Sprintf("%s autocomplete support is available. Click Docs for installation instructions.", lang)
 				anchor := serverKey
 				a.status.SetNotificationWithAction(msg, view.NotifyWarning, 10*time.Second, "Docs", func() {
 					openURL("https://tttedit.dev/guides/lsp/#" + anchor)
 				})
+				a.status.SecondaryLabel = "Don't show again"
+				a.status.SecondaryAction = func() {
+					v := false
+					a.settings.LSP.NotifyAvailability = &v
+					config.SaveSettings(*a.settings)
+				}
 				time.AfterFunc(10*time.Second, func() {
 					a.screen.PostEvent(tcell.NewEventInterrupt(nil))
 				})

--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os/exec"
+
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
@@ -43,7 +45,14 @@ func runEventLoop(
 		if app.editorGroup.Editor != nil && app.editorGroup.Editor.Highlighter != nil {
 			lang := app.editorGroup.Editor.Highlighter.Language()
 			app.status.Language = lang
-			_, _, lspOk := app.lspResolve(filePath, lang)
+			serverKey, _, lspOk := app.lspResolve(filePath, lang)
+			if lspOk {
+				serverCfg := app.lspManager.ServerConfig(serverKey)
+				if len(serverCfg.Command) > 0 {
+					_, err := exec.LookPath(serverCfg.Command[0])
+					lspOk = err == nil
+				}
+			}
 			app.status.LSP = lspOk
 		} else {
 			app.status.Language = ""

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -42,11 +42,16 @@ type LSPServerConfig struct {
 }
 
 type LSPSettings struct {
-	Enabled          *bool                      `json:"enabled,omitempty"`
-	Servers          map[string]LSPServerConfig `json:"servers,omitempty"`
-	SaveOnRename     bool                       `json:"saveOnRename"`
-	CodeActionsOnSave []string                  `json:"codeActionsOnSave,omitempty"`
-	HoverDelay       int                        `json:"hoverDelay,omitempty"`
+	Enabled            *bool                      `json:"enabled,omitempty"`
+	Servers            map[string]LSPServerConfig `json:"servers,omitempty"`
+	SaveOnRename       bool                       `json:"saveOnRename"`
+	CodeActionsOnSave  []string                   `json:"codeActionsOnSave,omitempty"`
+	HoverDelay         int                        `json:"hoverDelay,omitempty"`
+	NotifyAvailability *bool                      `json:"notifyAvailability,omitempty"`
+}
+
+func (l LSPSettings) ShouldNotifyAvailability() bool {
+	return l.NotifyAvailability == nil || *l.NotifyAvailability
 }
 
 func (l LSPSettings) IsEnabled() bool {
@@ -75,6 +80,7 @@ func DefaultExplorerSettings() ExplorerSettings {
 }
 
 type Settings struct {
+	Version        int              `json:"version"`
 	TabSize        int              `json:"tabSize"`
 	InsertSpaces   bool             `json:"insertSpaces"`
 	WordWrap       bool             `json:"wordWrap"`
@@ -94,6 +100,7 @@ type Settings struct {
 
 func DefaultSettings() Settings {
 	return Settings{
+		Version:        1,
 		TabSize:        4,
 		InsertSpaces:   true,
 		WordWrap:       false,

--- a/internal/ui/statusbar_widget.go
+++ b/internal/ui/statusbar_widget.go
@@ -19,6 +19,7 @@ type StatusBarWidget struct {
 	indentSpan     statusBarSpan
 	okSpan         statusBarSpan
 	actionSpan     statusBarSpan
+	secondarySpan  statusBarSpan
 }
 
 func NewStatusBarWidget(status *view.StatusBar) *StatusBarWidget {
@@ -116,6 +117,7 @@ func (s *StatusBarWidget) renderNotification(surface *RenderSurface, w int) {
 	x += s.drawText(surface, x, s.Status.Notification, style)
 
 	s.actionSpan = statusBarSpan{}
+	s.secondarySpan = statusBarSpan{}
 	s.okSpan = statusBarSpan{}
 	rightX := w - 1
 
@@ -126,6 +128,17 @@ func (s *StatusBarWidget) renderNotification(surface *RenderSurface, w int) {
 			s.actionSpan = statusBarSpan{r.X + actionX, r.X + actionX + len([]rune(actionLabel))}
 			for i, ch := range actionLabel {
 				surface.SetCell(actionX+i, 0, term.Cell{Ch: ch, Style: style})
+			}
+			rightX = actionX
+		}
+		if s.Status.SecondaryLabel != "" && s.Status.SecondaryAction != nil {
+			secLabel := " [" + s.Status.SecondaryLabel + "] "
+			secX := rightX - len([]rune(secLabel))
+			if secX > x+2 {
+				s.secondarySpan = statusBarSpan{r.X + secX, r.X + secX + len([]rune(secLabel))}
+				for i, ch := range secLabel {
+					surface.SetCell(secX+i, 0, term.Cell{Ch: ch, Style: style})
+				}
 			}
 		}
 	} else {
@@ -161,6 +174,13 @@ func (s *StatusBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		if s.actionSpan.start != s.actionSpan.end && mx >= s.actionSpan.start && mx < s.actionSpan.end {
 			if s.Status.NotifyAction != nil {
 				s.Status.NotifyAction()
+			}
+			s.Status.DismissNotification()
+			return EventConsumed
+		}
+		if s.secondarySpan.start != s.secondarySpan.end && mx >= s.secondarySpan.start && mx < s.secondarySpan.end {
+			if s.Status.SecondaryAction != nil {
+				s.Status.SecondaryAction()
 			}
 			s.Status.DismissNotification()
 			return EventConsumed

--- a/internal/view/statusbar.go
+++ b/internal/view/statusbar.go
@@ -39,8 +39,10 @@ type StatusBar struct {
 	Notification string
 	NotifyLevel  NotifyLevel
 	NotifyExpiry time.Time
-	NotifyAction func()
-	ActionLabel  string
+	NotifyAction    func()
+	ActionLabel     string
+	SecondaryAction func()
+	SecondaryLabel  string
 }
 
 func (s *StatusBar) SetNotification(msg string, level NotifyLevel, duration time.Duration) {
@@ -64,6 +66,8 @@ func (s *StatusBar) DismissNotification() {
 	s.NotifyExpiry = time.Time{}
 	s.NotifyAction = nil
 	s.ActionLabel = ""
+	s.SecondaryAction = nil
+	s.SecondaryLabel = ""
 }
 
 func (s *StatusBar) IsNotificationActive() bool {


### PR DESCRIPTION
## Summary
- Add "Don't show again" button to the LSP autocomplete availability notification, persisted via `lsp.notifyAvailability` in settings.json
- Fix LSP ⊕ icon in status bar — only shows when the server binary is installed, not just configured
- Add `version` field to settings (starts at 1)
- Add secondary action button support to the status bar notification system

Closes #23

## Test plan
- [ ] Open a file with a configured but uninstalled LSP server (e.g. `.svelte`) — notification should show with [Docs] and [Don't show again] buttons
- [ ] Click "Don't show again" — notification dismisses, `notifyAvailability: false` appears in settings.json
- [ ] Restart ttt — notification should not reappear
- [ ] Set `notifyAvailability` back to `true` — notification reappears on next open
- [ ] LSP ⊕ icon should NOT appear for configured-but-uninstalled servers
- [ ] LSP ⊕ icon should appear for installed servers (e.g. Go with gopls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)