### PR TITLE
feat: render markdown with syntax highlighting in hover widget

### DIFF
--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -315,6 +315,15 @@ func (a *App) ShowHover(text string, anchorX, anchorY int) {
 	a.editorGroup.Hover = ui.NewHoverWidget(text, anchorX, anchorY)
 }
 
+func (a *App) isMouseOverHover(mx, my int) bool {
+	h := a.editorGroup.Hover
+	if h == nil {
+		return false
+	}
+	r := h.GetRect()
+	return mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H
+}
+
 func (a *App) DismissHover() {
 	a.editorGroup.Hover = nil
 	a.cancelHoverTimer()

--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -144,7 +144,7 @@ func runEventLoop(
 				if btn == 0 {
 					app.checkMouseHover(mx, my)
 				}
-			} else if !app.isMouseOverHover(mx, my) && btn != 0 {
+			} else if !app.isMouseOverHover(mx, my) && btn != 0 && !app.editorGroup.Hover.IsDragging() {
 				app.DismissHover()
 			}
 			app.root.HandleEvent(tev)

--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -140,9 +140,11 @@ func runEventLoop(
 			btn := tev.Buttons()
 			slog.Debug("mouse", "x", mx, "y", my, "btn", btn)
 			app.DismissSignatureHelp()
-			if btn == 0 {
-				app.checkMouseHover(mx, my)
-			} else {
+			if app.editorGroup.Hover == nil {
+				if btn == 0 {
+					app.checkMouseHover(mx, my)
+				}
+			} else if !app.isMouseOverHover(mx, my) && btn != 0 {
 				app.DismissHover()
 			}
 			app.root.HandleEvent(tev)

--- a/cmd/ttt/theme.go
+++ b/cmd/ttt/theme.go
@@ -58,6 +58,8 @@ func buildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	applyStyleDef(&m, term.StyleInput, theme.Input.Item)
 	applyStyleDef(&m, term.StyleInputPlaceholder, theme.Input.Placeholder)
 	applyStyleDef(&m, term.StyleInputAction, theme.Input.Action)
+	applyStyleDef(&m, term.StyleHoverBold, theme.Hover.Bold)
+	applyStyleDef(&m, term.StyleHoverCode, theme.Hover.Code)
 	applyStyleDef(&m, term.StyleMuted, theme.Muted)
 	applyStyleDef(&m, term.StyleSuccess, theme.Success)
 	applyStyleDef(&m, term.StyleDanger, theme.Danger)

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -138,6 +138,11 @@ func (tc TerminalColors) ANSIPalette() [16]string {
 	}
 }
 
+type HoverStyles struct {
+	Bold StyleDef `json:"bold"`
+	Code StyleDef `json:"code"`
+}
+
 type ThemeConfig struct {
 	Default StyleDef `json:"default"`
 	Muted   StyleDef `json:"muted"`
@@ -151,6 +156,7 @@ type ThemeConfig struct {
 	Editor          EditorStyles `json:"editor"`
 	Menu            MenuStyles  `json:"menu"`
 	Input           InputStyles `json:"input"`
+	Hover           HoverStyles `json:"hover"`
 	Border          StyleDef    `json:"border"`
 	Diff            DiffStyles  `json:"diff"`
 	Scrollbar       StyleDef    `json:"scrollbar"`
@@ -243,6 +249,11 @@ func (t *ThemeConfig) ResolveColors() {
 	fillFg(&t.Editor.Diagnostics.Warning, t.Warning.Fg)
 	fillFg(&t.Editor.Diagnostics.Info, t.Default.Fg)
 	fillFg(&t.Editor.Diagnostics.Hint, t.Default.Fg)
+	if !t.Hover.Bold.Bold {
+		t.Hover.Bold.Bold = true
+	}
+	fillFg(&t.Hover.Bold, t.Default.Fg)
+	fillFg(&t.Hover.Code, t.Syntax.String.Fg)
 }
 
 func fillFg(s *StyleDef, color string) {

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -1,0 +1,190 @@
+package markdown
+
+import (
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/core/highlight"
+	"github.com/eugenioenko/ttt/internal/term"
+)
+
+type Span struct {
+	Text  string
+	Style term.Style
+}
+
+type Line struct {
+	Spans []Span
+}
+
+func (l Line) Text() string {
+	var b strings.Builder
+	for _, s := range l.Spans {
+		b.WriteString(s.Text)
+	}
+	return b.String()
+}
+
+func Render(text string) []Line {
+	raw := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	var lines []Line
+	i := 0
+	for i < len(raw) {
+		line := raw[i]
+		if lang, ok := strings.CutPrefix(line, "```"); ok {
+			lang = strings.TrimSpace(lang)
+			var block []string
+			i++
+			for i < len(raw) && !strings.HasPrefix(raw[i], "```") {
+				block = append(block, raw[i])
+				i++
+			}
+			if i < len(raw) {
+				i++
+			}
+			lines = append(lines, renderCodeBlock(block, lang)...)
+			continue
+		}
+		if line == "---" {
+			lines = append(lines, Line{Spans: []Span{{Text: "---", Style: term.StyleBorder}}})
+			i++
+			continue
+		}
+		lines = append(lines, renderInline(line))
+		i++
+	}
+	return lines
+}
+
+func renderCodeBlock(block []string, lang string) []Line {
+	var h *highlight.Highlighter
+	if lang != "" {
+		h = highlight.New("file." + lang)
+	}
+	lines := make([]Line, len(block))
+	for i, text := range block {
+		if h != nil {
+			spans := h.HighlightLine(text)
+			lines[i] = highlightToLine(text, spans)
+		} else {
+			lines[i] = Line{Spans: []Span{{Text: text, Style: term.StyleHoverCode}}}
+		}
+	}
+	return lines
+}
+
+func highlightToLine(text string, spans []highlight.Span) Line {
+	if len(spans) == 0 {
+		return Line{Spans: []Span{{Text: text, Style: term.StyleHoverCode}}}
+	}
+	runes := []rune(text)
+	var result []Span
+	pos := 0
+	for _, s := range spans {
+		if s.Start > pos {
+			result = append(result, Span{Text: string(runes[pos:s.Start]), Style: term.StyleHoverCode})
+		}
+		result = append(result, Span{Text: string(runes[s.Start:s.End]), Style: s.Style})
+		pos = s.End
+	}
+	if pos < len(runes) {
+		result = append(result, Span{Text: string(runes[pos:]), Style: term.StyleHoverCode})
+	}
+	return Line{Spans: result}
+}
+
+func renderInline(text string) Line {
+	if text == "" {
+		return Line{Spans: []Span{{Text: "", Style: term.StylePaletteItem}}}
+	}
+	var spans []Span
+	runes := []rune(text)
+	i := 0
+	var buf []rune
+	flush := func(style term.Style) {
+		if len(buf) > 0 {
+			spans = append(spans, Span{Text: string(buf), Style: style})
+			buf = nil
+		}
+	}
+	for i < len(runes) {
+		ch := runes[i]
+		if ch == '`' {
+			flush(term.StylePaletteItem)
+			end := indexOf(runes, '`', i+1)
+			if end == -1 {
+				buf = append(buf, ch)
+				i++
+				continue
+			}
+			spans = append(spans, Span{Text: string(runes[i+1 : end]), Style: term.StyleHoverCode})
+			i = end + 1
+			continue
+		}
+		if ch == '*' && i+1 < len(runes) && runes[i+1] == '*' {
+			flush(term.StylePaletteItem)
+			end := indexOfDouble(runes, '*', i+2)
+			if end == -1 {
+				buf = append(buf, ch)
+				i++
+				continue
+			}
+			spans = append(spans, Span{Text: string(runes[i+2 : end]), Style: term.StyleHoverBold})
+			i = end + 2
+			continue
+		}
+		if ch == '*' || ch == '_' {
+			flush(term.StylePaletteItem)
+			end := indexOf(runes, ch, i+1)
+			if end == -1 || end == i+1 {
+				buf = append(buf, ch)
+				i++
+				continue
+			}
+			spans = append(spans, Span{Text: string(runes[i+1 : end]), Style: term.StyleHoverBold})
+			i = end + 1
+			continue
+		}
+		if ch == '[' {
+			flush(term.StylePaletteItem)
+			closeBracket := indexOf(runes, ']', i+1)
+			if closeBracket != -1 && closeBracket+1 < len(runes) && runes[closeBracket+1] == '(' {
+				closeParen := indexOf(runes, ')', closeBracket+2)
+				if closeParen != -1 {
+					linkText := string(runes[i+1 : closeBracket])
+					inner := renderInline(linkText)
+					spans = append(spans, inner.Spans...)
+					i = closeParen + 1
+					continue
+				}
+			}
+			buf = append(buf, ch)
+			i++
+			continue
+		}
+		buf = append(buf, ch)
+		i++
+	}
+	flush(term.StylePaletteItem)
+	if len(spans) == 0 {
+		spans = []Span{{Text: "", Style: term.StylePaletteItem}}
+	}
+	return Line{Spans: spans}
+}
+
+func indexOf(runes []rune, ch rune, from int) int {
+	for i := from; i < len(runes); i++ {
+		if runes[i] == ch {
+			return i
+		}
+	}
+	return -1
+}
+
+func indexOfDouble(runes []rune, ch rune, from int) int {
+	for i := from; i+1 < len(runes); i++ {
+		if runes[i] == ch && runes[i+1] == ch {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -1,11 +1,16 @@
 package markdown
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/eugenioenko/ttt/internal/core/highlight"
 	"github.com/eugenioenko/ttt/internal/term"
 )
+
+// Strip blank lines adjacent to --- dividers (LSP hover content often has extra newlines around them)
+var reDividerBlanks = regexp.MustCompile(`\n+---`)
+var reDividerBlanksAfter = regexp.MustCompile(`---\n+`)
 
 type Span struct {
 	Text  string
@@ -27,7 +32,10 @@ func (l Line) Text() string {
 const WrapWidth = 60
 
 func Render(text string) []Line {
-	raw := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	text = strings.TrimRight(text, "\n")
+	text = reDividerBlanks.ReplaceAllString(text, "\n---")
+	text = reDividerBlanksAfter.ReplaceAllString(text, "---\n")
+	raw := strings.Split(text, "\n")
 	var lines []Line
 	i := 0
 	for i < len(raw) {

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -24,6 +24,8 @@ func (l Line) Text() string {
 	return b.String()
 }
 
+const WrapWidth = 60
+
 func Render(text string) []Line {
 	raw := strings.Split(strings.TrimRight(text, "\n"), "\n")
 	var lines []Line
@@ -49,10 +51,66 @@ func Render(text string) []Line {
 			i++
 			continue
 		}
-		lines = append(lines, renderInline(line))
+		parsed := renderInline(line)
+		lines = append(lines, wrapLine(parsed, WrapWidth)...)
 		i++
 	}
 	return lines
+}
+
+func wrapLine(line Line, width int) []Line {
+	text := line.Text()
+	if len([]rune(text)) <= width {
+		return []Line{line}
+	}
+	styles := flattenStyles(line)
+	runes := []rune(text)
+	var result []Line
+	for len(runes) > 0 {
+		end := width
+		if end > len(runes) {
+			end = len(runes)
+		}
+		if end < len(runes) {
+			// break at last space within width
+			bp := -1
+			for j := end - 1; j > 0; j-- {
+				if runes[j] == ' ' {
+					bp = j
+					break
+				}
+			}
+			if bp > 0 {
+				end = bp + 1
+			}
+		}
+		var spans []Span
+		pos := 0
+		chunk := runes[:end]
+		chunkStyles := styles[:end]
+		for pos < len(chunk) {
+			st := chunkStyles[pos]
+			start := pos
+			for pos < len(chunk) && chunkStyles[pos] == st {
+				pos++
+			}
+			spans = append(spans, Span{Text: string(chunk[start:pos]), Style: st})
+		}
+		result = append(result, Line{Spans: spans})
+		runes = runes[end:]
+		styles = styles[end:]
+	}
+	return result
+}
+
+func flattenStyles(line Line) []term.Style {
+	var styles []term.Style
+	for _, span := range line.Spans {
+		for range []rune(span.Text) {
+			styles = append(styles, span.Style)
+		}
+	}
+	return styles
 }
 
 func renderCodeBlock(block []string, lang string) []Line {

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -1,0 +1,130 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+)
+
+func TestRenderPlainText(t *testing.T) {
+	lines := Render("hello world")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if lines[0].Text() != "hello world" {
+		t.Errorf("expected 'hello world', got %q", lines[0].Text())
+	}
+}
+
+func TestRenderInlineCode(t *testing.T) {
+	lines := Render("use `fmt.Println` here")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if lines[0].Text() != "use fmt.Println here" {
+		t.Errorf("expected 'use fmt.Println here', got %q", lines[0].Text())
+	}
+	found := false
+	for _, s := range lines[0].Spans {
+		if s.Text == "fmt.Println" && s.Style == term.StyleHoverCode {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected inline code span with StyleHoverCode")
+	}
+}
+
+func TestRenderBold(t *testing.T) {
+	lines := Render("this is **bold** text")
+	if lines[0].Text() != "this is bold text" {
+		t.Errorf("expected 'this is bold text', got %q", lines[0].Text())
+	}
+	found := false
+	for _, s := range lines[0].Spans {
+		if s.Text == "bold" && s.Style == term.StyleHoverBold {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected bold span with StyleHoverBold")
+	}
+}
+
+func TestRenderLink(t *testing.T) {
+	lines := Render("see [docs](https://example.com) here")
+	if lines[0].Text() != "see docs here" {
+		t.Errorf("expected 'see docs here', got %q", lines[0].Text())
+	}
+}
+
+func TestRenderCodeBlock(t *testing.T) {
+	input := "before\n```go\nfunc main() {}\n```\nafter"
+	lines := Render(input)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	if lines[0].Text() != "before" {
+		t.Errorf("line 0: expected 'before', got %q", lines[0].Text())
+	}
+	if lines[1].Text() != "func main() {}" {
+		t.Errorf("line 1: expected 'func main() {}', got %q", lines[1].Text())
+	}
+	if lines[2].Text() != "after" {
+		t.Errorf("line 2: expected 'after', got %q", lines[2].Text())
+	}
+}
+
+func TestRenderDivider(t *testing.T) {
+	lines := Render("above\n---\nbelow")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	if lines[1].Spans[0].Style != term.StyleBorder {
+		t.Error("expected divider line to have StyleBorder")
+	}
+}
+
+func TestRenderMultilineCodeBlock(t *testing.T) {
+	input := "```\nline1\nline2\nline3\n```"
+	lines := Render(input)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	for i, expected := range []string{"line1", "line2", "line3"} {
+		if lines[i].Text() != expected {
+			t.Errorf("line %d: expected %q, got %q", i, expected, lines[i].Text())
+		}
+	}
+}
+
+func TestRenderItalic(t *testing.T) {
+	lines := Render("this is *italic* text")
+	if lines[0].Text() != "this is italic text" {
+		t.Errorf("expected 'this is italic text', got %q", lines[0].Text())
+	}
+}
+
+func TestRenderLinkWithInlineCode(t *testing.T) {
+	lines := Render("[`string` on pkg.go.dev](https://pkg.go.dev/builtin#string)")
+	text := lines[0].Text()
+	if text != "string on pkg.go.dev" {
+		t.Errorf("expected 'string on pkg.go.dev', got %q", text)
+	}
+	found := false
+	for _, s := range lines[0].Spans {
+		if s.Text == "string" && s.Style == term.StyleHoverCode {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected inline code span inside link")
+	}
+}
+
+func TestRenderEmptyText(t *testing.T) {
+	lines := Render("")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+}

--- a/internal/term/screen.go
+++ b/internal/term/screen.go
@@ -47,6 +47,8 @@ const (
 	StyleInput
 	StyleInputPlaceholder
 	StyleInputAction
+	StyleHoverBold
+	StyleHoverCode
 )
 
 // DirectColor holds an RGBA color for terminal emulator output.

--- a/internal/term/tcell_screen.go
+++ b/internal/term/tcell_screen.go
@@ -4,7 +4,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
-const StyleCount = 46
+const StyleCount = 48
 
 type StyleMap [StyleCount]tcell.Style
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -792,6 +792,9 @@ func (g *EditorGroupWidget) HandleEvent(ev tcell.Event) EventResult {
 		if result == EventDismissed {
 			g.Hover = nil
 		}
+		if result == EventConsumed {
+			return EventConsumed
+		}
 	}
 	if g.SignatureHelp != nil {
 		if kev, ok := ev.(*tcell.EventKey); ok && kev.Key() == tcell.KeyEscape && g.Autocomplete == nil {

--- a/internal/ui/hover_widget.go
+++ b/internal/ui/hover_widget.go
@@ -148,8 +148,8 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 	}
 
 	if hasVScroll {
-		h.vscrollbar.X = x + menuW - 2
-		h.vscrollbar.Y = y + 1
+		h.vscrollbar.X = h.OffsetX + x + menuW - 2
+		h.vscrollbar.Y = h.OffsetY + y + 1
 		h.vscrollbar.Height = visLines
 		h.vscrollbar.TotalItems = len(h.Lines)
 		h.vscrollbar.TopItem = h.scrollTop
@@ -161,15 +161,15 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 		if hasVScroll {
 			trackW--
 		}
-		h.hscrollbar.X = x + 1
-		h.hscrollbar.Y = y + menuH - 2
+		h.hscrollbar.X = h.OffsetX + x + 1
+		h.hscrollbar.Y = h.OffsetY + y + menuH - 2
 		h.hscrollbar.Width = trackW
 		h.hscrollbar.TotalCols = h.maxLineW
 		h.hscrollbar.LeftCol = h.scrollLeft
 		h.hscrollbar.Render(surface, x+1, y+menuH-2)
 	}
 
-	h.SetRect(Rect{X: x, Y: y, W: menuW, H: menuH})
+	h.SetRect(Rect{X: h.OffsetX + x, Y: h.OffsetY + y, W: menuW, H: menuH})
 }
 
 func (h *HoverWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -239,6 +239,10 @@ func (h *HoverWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 	}
 	return EventIgnored
+}
+
+func (h *HoverWidget) IsDragging() bool {
+	return h.vscrollbar.IsDragging() || h.hscrollbar.IsDragging()
 }
 
 func (h *HoverWidget) contentWidth() int {

--- a/internal/ui/hover_widget.go
+++ b/internal/ui/hover_widget.go
@@ -186,42 +186,48 @@ func (h *HoverWidget) HandleEvent(ev tcell.Event) EventResult {
 	case *tcell.EventKey:
 		return EventDismissed
 	case *tcell.EventMouse:
+		mx, my := tev.Position()
+		r := h.GetRect()
+		inside := mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H
 		btn := tev.Buttons()
-		if btn&tcell.WheelUp != 0 {
-			if h.scrollTop > 0 {
-				h.scrollTop--
-			}
-			return EventConsumed
-		}
-		if btn&tcell.WheelDown != 0 {
-			max := len(h.Lines) - h.visibleLines()
-			if max < 0 {
-				max = 0
-			}
-			if h.scrollTop < max {
-				h.scrollTop++
-			}
-			return EventConsumed
-		}
-		if btn&tcell.WheelLeft != 0 {
-			if h.scrollLeft > 0 {
-				h.scrollLeft -= 4
-				if h.scrollLeft < 0 {
-					h.scrollLeft = 0
+		if inside {
+			if btn&tcell.WheelUp != 0 {
+				if h.scrollTop > 0 {
+					h.scrollTop--
 				}
+				return EventConsumed
 			}
-			return EventConsumed
-		}
-		if btn&tcell.WheelRight != 0 {
-			max := h.maxLineW - h.contentWidth()
-			if max < 0 {
-				max = 0
-			}
-			if h.scrollLeft < max {
-				h.scrollLeft += 4
-				if h.scrollLeft > max {
-					h.scrollLeft = max
+			if btn&tcell.WheelDown != 0 {
+				max := len(h.Lines) - h.visibleLines()
+				if max < 0 {
+					max = 0
 				}
+				if h.scrollTop < max {
+					h.scrollTop++
+				}
+				return EventConsumed
+			}
+			if btn&tcell.WheelLeft != 0 {
+				if h.scrollLeft > 0 {
+					h.scrollLeft -= 4
+					if h.scrollLeft < 0 {
+						h.scrollLeft = 0
+					}
+				}
+				return EventConsumed
+			}
+			if btn&tcell.WheelRight != 0 {
+				max := h.maxLineW - h.contentWidth()
+				if max < 0 {
+					max = 0
+				}
+				if h.scrollLeft < max {
+					h.scrollLeft += 4
+					if h.scrollLeft > max {
+						h.scrollLeft = max
+					}
+				}
+				return EventConsumed
 			}
 			return EventConsumed
 		}

--- a/internal/ui/hover_widget.go
+++ b/internal/ui/hover_widget.go
@@ -11,15 +11,17 @@ const hoverMaxVisibleLines = 12
 
 type HoverWidget struct {
 	BaseWidget
-	Lines     []markdown.Line
-	AnchorX   int
-	AnchorY   int
-	OffsetX   int
-	OffsetY   int
-	Borders   *term.BorderSet
+	Lines      []markdown.Line
+	AnchorX    int
+	AnchorY    int
+	OffsetX    int
+	OffsetY    int
+	Borders    *term.BorderSet
 	scrollTop  int
 	scrollLeft int
 	maxLineW   int
+	vscrollbar Scrollbar
+	hscrollbar HScrollbar
 }
 
 func NewHoverWidget(text string, x, y int) *HoverWidget {
@@ -146,49 +148,40 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 	}
 
 	if hasVScroll {
-		sb := Scrollbar{
-			X:          x + menuW - 2,
-			Y:          y + 1,
-			Height:     visLines,
-			TotalItems: len(h.Lines),
-			TopItem:    h.scrollTop,
-		}
-		sb.Render(surface, x+menuW-2, y+1)
+		h.vscrollbar.X = x + menuW - 2
+		h.vscrollbar.Y = y + 1
+		h.vscrollbar.Height = visLines
+		h.vscrollbar.TotalItems = len(h.Lines)
+		h.vscrollbar.TopItem = h.scrollTop
+		h.vscrollbar.Render(surface, x+menuW-2, y+1)
 	}
 
 	if hasHScroll {
-		hScrollRow := y + menuH - 2
 		trackW := menuW - 2
 		if hasVScroll {
 			trackW--
 		}
-		maxScroll := h.maxLineW - contentW
-		if maxScroll < 1 {
-			maxScroll = 1
-		}
-		thumbW := trackW * contentW / h.maxLineW
-		if thumbW < 1 {
-			thumbW = 1
-		}
-		thumbX := 0
-		if maxScroll > 0 {
-			thumbX = h.scrollLeft * (trackW - thumbW) / maxScroll
-		}
-		for i := 0; i < trackW; i++ {
-			ch := ' '
-			style := term.StyleScrollbar
-			if i >= thumbX && i < thumbX+thumbW {
-				ch = '█'
-				style = term.StyleScrollbarThumb
-			}
-			surface.SetCell(x+1+i, hScrollRow, term.Cell{Ch: rune(ch), Style: style})
-		}
+		h.hscrollbar.X = x + 1
+		h.hscrollbar.Y = y + menuH - 2
+		h.hscrollbar.Width = trackW
+		h.hscrollbar.TotalCols = h.maxLineW
+		h.hscrollbar.LeftCol = h.scrollLeft
+		h.hscrollbar.Render(surface, x+1, y+menuH-2)
 	}
 
 	h.SetRect(Rect{X: x, Y: y, W: menuW, H: menuH})
 }
 
 func (h *HoverWidget) HandleEvent(ev tcell.Event) EventResult {
+	if newTop, consumed := h.vscrollbar.HandleEvent(ev); consumed {
+		h.scrollTop = newTop
+		return EventConsumed
+	}
+	if newLeft, consumed := h.hscrollbar.HandleEvent(ev); consumed {
+		h.scrollLeft = newLeft
+		return EventConsumed
+	}
+
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
 		return EventDismissed
@@ -220,8 +213,7 @@ func (h *HoverWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		}
 		if btn&tcell.WheelRight != 0 {
-			visW := h.visibleContentWidth()
-			max := h.maxLineW - visW
+			max := h.maxLineW - h.contentWidth()
 			if max < 0 {
 				max = 0
 			}
@@ -233,11 +225,23 @@ func (h *HoverWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 			return EventConsumed
 		}
+		if h.vscrollbar.IsDragging() || h.hscrollbar.IsDragging() {
+			return EventConsumed
+		}
 		if btn != tcell.ButtonNone {
 			return EventDismissed
 		}
 	}
 	return EventIgnored
+}
+
+func (h *HoverWidget) contentWidth() int {
+	r := h.GetRect()
+	w := r.W - 2
+	if len(h.Lines) > h.visibleLines() {
+		w--
+	}
+	return w
 }
 
 func buildStyleRuns(line markdown.Line) []term.Style {
@@ -248,13 +252,4 @@ func buildStyleRuns(line markdown.Line) []term.Style {
 		}
 	}
 	return styles
-}
-
-func (h *HoverWidget) visibleContentWidth() int {
-	sw, _ := h.GetRect().W, h.GetRect().H
-	w := sw - 2
-	if len(h.Lines) > h.visibleLines() {
-		w--
-	}
-	return w
 }

--- a/internal/ui/hover_widget.go
+++ b/internal/ui/hover_widget.go
@@ -1,8 +1,7 @@
 package ui
 
 import (
-	"strings"
-
+	"github.com/eugenioenko/ttt/internal/markdown"
 	"github.com/eugenioenko/ttt/internal/term"
 
 	"github.com/gdamore/tcell/v2"
@@ -12,7 +11,7 @@ const hoverMaxVisibleLines = 12
 
 type HoverWidget struct {
 	BaseWidget
-	Lines     []string
+	Lines     []markdown.Line
 	AnchorX   int
 	AnchorY   int
 	OffsetX   int
@@ -24,10 +23,10 @@ type HoverWidget struct {
 }
 
 func NewHoverWidget(text string, x, y int) *HoverWidget {
-	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	lines := markdown.Render(text)
 	maxW := 0
 	for _, line := range lines {
-		if w := len([]rune(line)); w > maxW {
+		if w := len([]rune(line.Text())); w > maxW {
 			maxW = w
 		}
 	}
@@ -122,7 +121,8 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 		if hasVScroll {
 			innerW--
 		}
-		if h.Lines[lineIdx] == "---" {
+		lineText := h.Lines[lineIdx].Text()
+		if lineText == "---" && len(h.Lines[lineIdx].Spans) == 1 && h.Lines[lineIdx].Spans[0].Style == term.StyleBorder {
 			surface.SetCell(x, row, term.Cell{Ch: b.LeftTee, Style: term.StyleBorder})
 			for bx := x + 1; bx < x+1+innerW; bx++ {
 				surface.SetCell(bx, row, term.Cell{Ch: b.Horizontal, Style: term.StyleBorder})
@@ -133,9 +133,15 @@ func (h *HoverWidget) Render(surface *RenderSurface) {
 		for bx := x + 1; bx < x+1+innerW; bx++ {
 			surface.SetCell(bx, row, term.Cell{Ch: ' ', Style: st})
 		}
-		runes := []rune(h.Lines[lineIdx])
+		styles := buildStyleRuns(h.Lines[lineIdx])
+		runes := []rune(lineText)
 		for j := 0; j < contentW && h.scrollLeft+j < len(runes); j++ {
-			surface.SetCell(x+1+j, row, term.Cell{Ch: runes[h.scrollLeft+j], Style: st})
+			idx := h.scrollLeft + j
+			cellStyle := st
+			if idx < len(styles) {
+				cellStyle = styles[idx]
+			}
+			surface.SetCell(x+1+j, row, term.Cell{Ch: runes[idx], Style: cellStyle})
 		}
 	}
 
@@ -232,6 +238,16 @@ func (h *HoverWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 	}
 	return EventIgnored
+}
+
+func buildStyleRuns(line markdown.Line) []term.Style {
+	var styles []term.Style
+	for _, span := range line.Spans {
+		for range []rune(span.Text) {
+			styles = append(styles, span.Style)
+		}
+	}
+	return styles
 }
 
 func (h *HoverWidget) visibleContentWidth() int {


### PR DESCRIPTION
## Summary
- Add `internal/markdown` package — lightweight markdown-to-styled-spans renderer handling code fences (with Chroma syntax highlighting), inline code, bold/italic, links, and horizontal rules
- Update `HoverWidget` to render `[]markdown.Line` with per-character styles instead of plain `[]string`
- Add `StyleHoverBold` and `StyleHoverCode` theme styles with sensible defaults (bold from default fg, code from string syntax color)
- Fix gopls link rendering — `` [`int` on pkg.go.dev](url) `` now shows "int on pkg.go.dev" with `int` styled as inline code

Closes #8

## Test plan
- [x] Unit tests for markdown parser (10 tests covering plain text, inline code, bold, italic, links, link with inline code, code blocks, dividers, empty text)
- [ ] Hover over Go symbols with gopls — verify code blocks are syntax highlighted
- [ ] Hover over TypeScript symbols — verify markdown formatting renders correctly
- [ ] Verify `---` dividers still render as border lines
- [ ] Verify scroll (vertical + horizontal) still works in hover widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)