### PR TITLE
fix: clear commit input after successful commit

### DIFF
--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -1445,6 +1445,11 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 		if err := git.Commit(dir, message); err != nil {
 			app.StatusError("Commit failed: " + err.Error())
 		} else {
+			for i := range app.changes.Groups {
+				if app.changes.Groups[i].Dir == dir {
+					app.changes.Groups[i].Input.Clear()
+				}
+			}
 			app.StatusNotify("Committed: " + message)
 			app.changes.Refresh()
 		}


### PR DESCRIPTION
## Summary
- Clear the commit message input field after a successful git commit from the changes panel
- Show a status bar notification confirming the commit

## Test plan
- [ ] Open changes panel, stage files, type a commit message, commit
- [ ] Verify the input field is cleared after success
- [ ] Verify the status bar shows "Committed: <message>"
- [ ] Verify failed commits still show the error and keep the input text

🤖 Generated with [Claude Code](https://claude.com/claude-code)