### PR TITLE
refactor: default input prefix to ❯

### DIFF
--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -102,7 +102,7 @@ func (c *ChangesWidget) Refresh() {
 				unstaged = append(unstaged, f)
 			}
 		}
-		input := NewInputWidget(" > ")
+		input := NewInputWidget()
 		input.Placeholder = "Message"
 		expanded := !c.multiRoot
 		stagedExpanded := true

--- a/internal/ui/findbar_widget.go
+++ b/internal/ui/findbar_widget.go
@@ -29,7 +29,7 @@ type FindBarWidget struct {
 
 func NewFindBarWidget() *FindBarWidget {
 	f := &FindBarWidget{focused: true}
-	f.Input = NewInputWidget(" > ")
+	f.Input = NewInputWidget()
 	f.Input.Placeholder = "Search"
 	f.Input.OnChange = func(string) {
 		f.Current = 0

--- a/internal/ui/input_widget.go
+++ b/internal/ui/input_widget.go
@@ -24,9 +24,9 @@ type InputWidget struct {
 	OnChange     func(text string)
 }
 
-func NewInputWidget(prefix string) *InputWidget {
+func NewInputWidget() *InputWidget {
 	return &InputWidget{
-		Prefix: prefix,
+		Prefix: " ❯ ",
 		Style:  term.StyleInput,
 	}
 }

--- a/internal/ui/inputdialog_widget.go
+++ b/internal/ui/inputdialog_widget.go
@@ -23,7 +23,7 @@ type InputDialogWidget struct {
 func NewInputDialogWidget(title, placeholder, initial string) *InputDialogWidget {
 	d := &InputDialogWidget{
 		Title: title,
-		Input: InputWidget{Prefix: " > ", Style: term.StylePaletteItem, Placeholder: placeholder},
+		Input: InputWidget{Prefix: " ❯ ", Style: term.StylePaletteItem, Placeholder: placeholder},
 	}
 	d.Input.SetText(initial)
 	return d

--- a/internal/ui/palette_widget.go
+++ b/internal/ui/palette_widget.go
@@ -53,7 +53,8 @@ func NewCommandPaletteWidget(commands []command.Command) *CommandPaletteWidget {
 	p := &CommandPaletteWidget{
 		Commands: commands,
 	}
-	p.Input = NewInputWidget(" ")
+	p.Input = NewInputWidget()
+	p.Input.Prefix = " "
 	p.Input.SetText(">")
 	p.Input.OnChange = func(text string) {
 		p.filter()

--- a/internal/ui/replacebar_widget.go
+++ b/internal/ui/replacebar_widget.go
@@ -28,7 +28,7 @@ type ReplaceBarWidget struct {
 
 func NewReplaceBarWidget() *ReplaceBarWidget {
 	r := &ReplaceBarWidget{}
-	r.SearchInput = NewInputWidget(" > ")
+	r.SearchInput = NewInputWidget()
 	r.SearchInput.Placeholder = "Search"
 	r.SearchInput.OnChange = func(string) {
 		r.Current = 0
@@ -49,7 +49,7 @@ func NewReplaceBarWidget() *ReplaceBarWidget {
 		}},
 	}
 
-	r.ReplaceInput = NewInputWidget(" > ")
+	r.ReplaceInput = NewInputWidget()
 	r.ReplaceInput.Placeholder = "Replace"
 	r.ReplaceInput.Actions = []InputAction{
 		{Label: "⟳", OnClick: func() {

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -64,13 +64,13 @@ type searchItem struct {
 
 func NewSearchWidget() *SearchWidget {
 	s := &SearchWidget{}
-	s.Input = NewInputWidget(" > ")
+	s.Input = NewInputWidget()
 	s.Input.Placeholder = "Search"
-	s.Include = NewInputWidget(" > ")
+	s.Include = NewInputWidget()
 	s.Include.Placeholder = "files to include"
-	s.Exclude = NewInputWidget(" > ")
+	s.Exclude = NewInputWidget()
 	s.Exclude.Placeholder = "files to exclude"
-	s.ReplaceInput = NewInputWidget(" > ")
+	s.ReplaceInput = NewInputWidget()
 	s.ReplaceInput.Placeholder = "Replace"
 	onChange := func(string) { s.runSearch() }
 	s.Input.OnChange = onChange


### PR DESCRIPTION
## Summary
- Change `NewInputWidget()` to take no arguments, defaulting prefix to `" ❯ "`
- All 9 callers that passed `" > "` now use the default
- Palette overrides to `" "` after construction (keeps its `>` as editable text for mode switching)
- Input dialog also updated to `" ❯ "`

## Test plan
- [ ] Open find bar (Ctrl+F) — verify `❯` prefix
- [ ] Open search sidebar (Ctrl+K F) — verify `❯` prefix on all inputs
- [ ] Open replace bar (Ctrl+R) — verify `❯` prefix
- [ ] Open command palette (Ctrl+P) — verify it still shows ` >` (space + editable `>`)
- [ ] Open Go To Line (Ctrl+G) — verify `❯` prefix
- [ ] Open changes panel, check commit input — verify `❯` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)