### PR TITLE
feat: add Ctrl+K J keybinding for panel toggle

### DIFF
--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -189,6 +189,7 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "alt+backspace", Command: "editor.deleteWordLeft"},
 		{Key: "alt+delete", Command: "editor.deleteWordRight"},
 		{Key: "ctrl+delete", Command: "editor.deleteWordRight"},
+		{Key: "ctrl+k j", Command: "panel.toggle"},
 		{Key: "ctrl+t", Command: "terminal.toggle"},
 		{Key: "alt+t", Command: "terminal.fullscreen"},
 		{Key: "f10", Command: "menu.file"},


### PR DESCRIPTION
## Summary
- Add `Ctrl+K J` chord to toggle the bottom panel
- The `panel.toggle` command already existed but had no keybinding
- `J` = "down" (vim convention), matching VS Code's `Ctrl+J` panel toggle

## Test plan
- [ ] Press `Ctrl+K J` — bottom panel should toggle visibility
- [ ] Verify `Ctrl+T` still opens/toggles terminal as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)