### PR TITLE
feat: debounce global search and fix highlight issues

### DIFF
--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -13,6 +13,8 @@ import (
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/ui"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 func registerCommands(reg *command.Registry, app *App, running *bool, quitPending *bool) {
@@ -1204,6 +1206,9 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 		app.root.SetFocus(app.editorGroup)
 	}
 
+	app.search.PostEvent = func() {
+		app.screen.PostEvent(tcell.NewEventInterrupt(nil))
+	}
 	app.search.DiffSources = func() []ui.DiffSearchSource {
 		seen := map[string]bool{}
 		sources := app.editorGroup.DiffTabSources()

--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -658,6 +658,7 @@ func registerSearchCommands(reg *command.Registry, app *App) {
 			app.search.FlatList = nil
 			app.search.Selected = 0
 			app.search.ScrollTop = 0
+			app.editorGroup.ClearSearch()
 		},
 	})
 }
@@ -1160,6 +1161,14 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 	}
 
 	app.sidebar.OnPanelChange = func(id string) {
+		if id == "search" {
+			if app.search.Input.Text != "" {
+				matches, _ := ui.FindInLines(app.editorGroup.Editor.Buf.Lines, app.search.Input.Text, app.search.Options)
+				app.editorGroup.SetSearch(app.search.Input.Text, matches)
+			}
+		} else {
+			app.editorGroup.ClearSearch()
+		}
 		if id == "changes" {
 			app.changes.Refresh()
 		}
@@ -1206,6 +1215,9 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 		app.root.SetFocus(app.editorGroup)
 	}
 
+	app.search.OnClear = func() {
+		app.editorGroup.ClearSearch()
+	}
 	app.search.PostEvent = func() {
 		app.screen.PostEvent(tcell.NewEventInterrupt(nil))
 	}

--- a/cmd/ttt/widgets.go
+++ b/cmd/ttt/widgets.go
@@ -122,6 +122,7 @@ func buildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	explorer := ui.NewExplorerWidget(cfg.Settings.Explorer, ws.Paths()...)
 	search := ui.NewSearchWidget()
 	search.SetWorkDirs(ws.Paths())
+	search.DebounceMs = cfg.Settings.Search.Debounce
 	changes := ui.NewChangesWidget(ws.Paths()...)
 
 	sidebar := ui.NewSidebarWidget()

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -67,6 +67,16 @@ func DefaultLSPSettings() LSPSettings {
 	}
 }
 
+type SearchSettings struct {
+	Debounce int `json:"debounce"`
+}
+
+func DefaultSearchSettings() SearchSettings {
+	return SearchSettings{
+		Debounce: 350,
+	}
+}
+
 type ExplorerSettings struct {
 	ShowHidden     bool `json:"showHidden"`
 	ShowGitIgnored bool `json:"showGitIgnored"`
@@ -92,6 +102,7 @@ type Settings struct {
 	DebugMode      bool             `json:"debugMode,omitempty"`
 	FormatOnSave       bool             `json:"formatOnSave"`
 	InsertFinalNewline bool             `json:"insertFinalNewline"`
+	Search         SearchSettings       `json:"search,omitzero"`
 	Explorer       ExplorerSettings     `json:"explorer,omitzero"`
 	Terminal       TerminalSettings     `json:"terminal,omitzero"`
 	LSP            LSPSettings          `json:"lsp,omitzero"`
@@ -108,6 +119,7 @@ func DefaultSettings() Settings {
 		SidebarVisible: true,
 		SidebarWidth:   30,
 		InsertFinalNewline: true,
+		Search:         DefaultSearchSettings(),
 		Explorer:       DefaultExplorerSettings(),
 		Terminal:       DefaultTerminalSettings(),
 		LSP:            DefaultLSPSettings(),

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -710,8 +710,11 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 
 			startY := s.resultsStartY()
-			if len(s.Groups) > 0 {
+			if s.debouncing || s.Searching {
 				startY++
+			}
+			if len(s.Groups) > 0 {
+				startY += 2
 			}
 
 			idx := s.ScrollTop + (localY - startY)

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -6,6 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
+
 	"github.com/eugenioenko/ttt/internal/term"
 
 	"github.com/gdamore/tcell/v2"
@@ -54,6 +57,13 @@ type SearchWidget struct {
 	OnReplace    func(filePath string, matches []SearchMatch, replacement string, opts SearchOptions)
 	OnReplaceAll func(allMatches map[string][]SearchMatch, replacement string, opts SearchOptions)
 	OnPreview    func(filePath string, matches []SearchMatch, replacement string, opts SearchOptions)
+	PostEvent     func()
+	DebounceMs    int
+	debounceTimer *time.Timer
+	debounceMu    sync.Mutex
+	debouncing    bool
+	searchGen     uint64
+	searchMu      sync.Mutex
 }
 
 type searchItem struct {
@@ -72,7 +82,7 @@ func NewSearchWidget() *SearchWidget {
 	s.Exclude.Placeholder = "files to exclude"
 	s.ReplaceInput = NewInputWidget()
 	s.ReplaceInput.Placeholder = "Replace"
-	onChange := func(string) { s.runSearch() }
+	onChange := func(string) { s.scheduleSearch() }
 	s.Input.OnChange = onChange
 	s.Include.OnChange = onChange
 	s.Exclude.OnChange = onChange
@@ -180,6 +190,41 @@ func (s *SearchWidget) inputY(inp *InputWidget) int {
 		return base + 2
 	}
 	return 0
+}
+
+func (s *SearchWidget) scheduleSearch() {
+	s.debounceMu.Lock()
+	defer s.debounceMu.Unlock()
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+	}
+	s.debouncing = true
+	s.searchGen++
+	gen := s.searchGen
+	delay := s.DebounceMs
+	if delay <= 0 {
+		delay = 350
+	}
+	s.debounceTimer = time.AfterFunc(time.Duration(delay)*time.Millisecond, func() {
+		s.searchMu.Lock()
+		defer s.searchMu.Unlock()
+
+		s.debounceMu.Lock()
+		if gen != s.searchGen {
+			s.debounceMu.Unlock()
+			if s.PostEvent != nil {
+				s.PostEvent()
+			}
+			return
+		}
+		s.debouncing = false
+		s.debounceMu.Unlock()
+
+		s.runSearch()
+		if s.PostEvent != nil {
+			s.PostEvent()
+		}
+	})
 }
 
 func (s *SearchWidget) runSearch() {
@@ -419,7 +464,7 @@ func (s *SearchWidget) Render(surface *RenderSurface) {
 		return
 	}
 
-	if s.Input.Text != "" && len(s.FlatList) == 0 && !s.Searching {
+	if s.Input.Text != "" && len(s.FlatList) == 0 && !s.Searching && !s.debouncing {
 		msg := "No results"
 		for i, ch := range msg {
 			if i < w {
@@ -427,6 +472,19 @@ func (s *SearchWidget) Render(surface *RenderSurface) {
 			}
 		}
 		return
+	}
+
+	if s.debouncing || s.Searching {
+		msg := "Searching..."
+		for i, ch := range msg {
+			if i < w {
+				surface.SetCell(i, startY, term.Cell{Ch: ch, Style: term.StyleMuted})
+			}
+		}
+		if len(s.FlatList) == 0 {
+			return
+		}
+		startY++
 	}
 
 	if len(s.Groups) > 0 {

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -57,6 +57,7 @@ type SearchWidget struct {
 	OnReplace    func(filePath string, matches []SearchMatch, replacement string, opts SearchOptions)
 	OnReplaceAll func(allMatches map[string][]SearchMatch, replacement string, opts SearchOptions)
 	OnPreview    func(filePath string, matches []SearchMatch, replacement string, opts SearchOptions)
+	OnClear      func()
 	PostEvent     func()
 	DebounceMs    int
 	debounceTimer *time.Timer
@@ -82,8 +83,18 @@ func NewSearchWidget() *SearchWidget {
 	s.Exclude.Placeholder = "files to exclude"
 	s.ReplaceInput = NewInputWidget()
 	s.ReplaceInput.Placeholder = "Replace"
+	s.Input.OnChange = func(text string) {
+		if text == "" {
+			s.cancelSearch()
+			s.runSearch()
+			if s.OnClear != nil {
+				s.OnClear()
+			}
+			return
+		}
+		s.scheduleSearch()
+	}
 	onChange := func(string) { s.scheduleSearch() }
-	s.Input.OnChange = onChange
 	s.Include.OnChange = onChange
 	s.Exclude.OnChange = onChange
 	s.Input.Actions = []InputAction{
@@ -190,6 +201,16 @@ func (s *SearchWidget) inputY(inp *InputWidget) int {
 		return base + 2
 	}
 	return 0
+}
+
+func (s *SearchWidget) cancelSearch() {
+	s.debounceMu.Lock()
+	defer s.debounceMu.Unlock()
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+	}
+	s.debouncing = false
+	s.searchGen++
 }
 
 func (s *SearchWidget) scheduleSearch() {

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -65,6 +65,7 @@ type SearchWidget struct {
 	debouncing    bool
 	searchGen     uint64
 	searchMu      sync.Mutex
+	resultStartY  int
 }
 
 type searchItem struct {
@@ -164,17 +165,6 @@ func (s *SearchWidget) SetWorkDirs(dirs []string) {
 }
 
 func (s *SearchWidget) Focusable() bool { return true }
-
-func (s *SearchWidget) resultsStartY() int {
-	base := 2
-	if s.showReplace {
-		base += 2
-	}
-	if s.showFilters {
-		base += 4
-	}
-	return base
-}
 
 func (s *SearchWidget) CursorPosition() (int, int, bool) {
 	r := s.GetRect()
@@ -526,6 +516,7 @@ func (s *SearchWidget) Render(surface *RenderSurface) {
 		startY++
 	}
 
+	s.resultStartY = startY
 	visibleH := h - startY
 	if visibleH <= 0 {
 		return
@@ -709,15 +700,7 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 				}
 			}
 
-			startY := s.resultsStartY()
-			if s.debouncing || s.Searching {
-				startY++
-			}
-			if len(s.Groups) > 0 {
-				startY += 2
-			}
-
-			idx := s.ScrollTop + (localY - startY)
+			idx := s.ScrollTop + (localY - s.resultStartY)
 			if idx >= 0 && idx < len(s.FlatList) {
 				item := s.FlatList[idx]
 				if s.showReplace && s.ReplaceInput.Text != "" && item.IsFile {


### PR DESCRIPTION
## Summary
- Debounce global search input (350ms default, configurable via `search.debounce` in settings.json) so ripgrep only runs after the user stops typing
- Uses generation counter and mutex to prevent concurrent searches from racing
- Clear editor search highlights when erasing search text or switching away from search panel; re-apply highlights when switching back without re-running ripgrep
- Fix off-by-one click offset in search results caused by miscounted header rows
- Store computed `resultStartY` from Render as single source of truth for click handling

## Test plan
- [ ] Type in global search, verify search only triggers after pause (not per keystroke)
- [ ] Erase search text, verify editor highlights are cleared immediately
- [ ] Switch from search panel to explorer, verify highlights clear; switch back, verify they re-appear
- [ ] Click on search results with collapsed/expanded file groups, verify correct item is selected
- [ ] Verify `search.debounce` setting in settings.json overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)