### PR TITLE
docs: update design principles and search docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,10 @@ The codebase follows a strict layered architecture: **core → view → render �
 
 - **`cmd/ttt/main.go`** — Entry point with event loop. Wires all components together, handles key dispatch, viewport scrolling, and redraw. Accepts a `--workspace <file>` flag to open a saved workspace, or folder/file paths as positional arguments.
 
-### Design Philosophy
+### Design Principles
 
-- **UX comes first.** When making design decisions, prioritize user experience over implementation simplicity. If a feature needs good navigation, discoverability, or interaction patterns, invest in that rather than taking shortcuts.
+1. **UX comes first.** Implement the UI feel and look first, then the functionality. When making design decisions, prioritize user experience over implementation simplicity. If a feature needs good navigation, discoverability, or interaction patterns, invest in that rather than taking shortcuts.
+2. **Single source of truth for layout.** When Render computes layout values (positions, offsets), store them on the struct so event handlers reuse them directly instead of recalculating — divergent calculations cause click offset bugs.
 
 ### Key Design Constraints
 
@@ -64,6 +65,7 @@ The codebase follows a strict layered architecture: **core → view → render �
 - The diff view layers syntax highlighting on top of diff background colors using `BgStyle` layering.
 - **RawKeyConsumer interface**: when the integrated terminal is focused, all key events are routed directly to the PTY. Only force-keys (Ctrl+`) bypass this to allow toggling the terminal panel.
 - Async PTY output wakes the event loop via `PostEvent`/`EventInterrupt`.
+- **Global search** (`search_widget.go`) shells out to `rg` (ripgrep) with debounced input (`search.debounce` in settings.json, default 350ms). Uses a generation counter and mutex to prevent concurrent searches from racing. Editor search highlights are tied to the search panel lifecycle — cleared when switching away, re-applied from existing results when switching back.
 
 ### Keybinding System & tcell Key Mapping
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -623,6 +623,8 @@ This should be built as part of Phase 2 (widget framework, step 3 — event rout
 - [x] Search results grouped by file, showing matching line with context
 - [x] Click result to open file at that line
 - [x] Respect .gitignore patterns (via ripgrep)
+- [x] Debounced search input (`search.debounce` in settings.json, default 350ms) with generation counter and mutex to prevent concurrent races
+- [x] Editor search highlights tied to search panel lifecycle — cleared when switching away, re-applied from existing results when switching back (no re-run)
 - [ ] Find and replace across files (with preview/confirmation)
 
 ---
@@ -987,8 +989,10 @@ One thing the core needs to support: `editor/openFile` must accept absolute path
 
 ## Design Principles
 
-1. **Core stays terminal-free.** `internal/core/` must compile and test without tcell. All terminal interaction goes through the `Screen` interface.
-2. **Composition over inheritance.** Windows, panes, dialogs, and sidebar are all composed from the same primitives: Rect, Viewport, Buffer, Renderer.
-3. **Test without a terminal.** MockScreen exists for this reason. New UI components should be testable against it.
-4. **Render efficiently.** The diff-based renderer exists from day one. Never rebuild the full screen when a partial update will do.
-5. **Rune-correct.** Cursor positions, selections, and display widths are always rune-based, not byte-based. CJK and emoji support is a goal, not an afterthought.
+1. **UX comes first.** Implement the UI feel and look first, then the functionality. When making design decisions, prioritize user experience over implementation simplicity. If a feature needs good navigation, discoverability, or interaction patterns, invest in that rather than taking shortcuts.
+2. **Core stays terminal-free.** `internal/core/` must compile and test without tcell. All terminal interaction goes through the `Screen` interface.
+3. **Composition over inheritance.** Windows, panes, dialogs, and sidebar are all composed from the same primitives: Rect, Viewport, Buffer, Renderer.
+4. **Single source of truth for layout.** When Render computes layout values (positions, offsets), store them on the struct so event handlers reuse them directly instead of recalculating — divergent calculations cause click offset bugs.
+5. **Test without a terminal.** MockScreen exists for this reason. New UI components should be testable against it.
+6. **Render efficiently.** The diff-based renderer exists from day one. Never rebuild the full screen when a partial update will do.
+7. **Rune-correct.** Cursor positions, selections, and display widths are always rune-based, not byte-based. CJK and emoji support is a goal, not an afterthought.


### PR DESCRIPTION
## Summary
- Add "UX comes first" as the primary design principle in CLAUDE.md and PROJECT.md
- Add "single source of truth for layout" principle (learned from click offset bugs)
- Document search debounce and highlight lifecycle as completed items in Phase 14

## Test plan
- [ ] Review doc changes for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)