### PR TITLE
feat: crash recovery, search race fix, and UX improvements

### DIFF
--- a/cmd/ttt/app.go
+++ b/cmd/ttt/app.go
@@ -95,11 +95,28 @@ func formatKeyDisplay(key string) string {
 func (a *App) ShowSidebar() {
 	a.sidebar.Visible = true
 	a.splitPanel.ShowLeft = true
+	a.applySearchHighlights()
 }
 
 func (a *App) HideSidebar() {
 	a.sidebar.Visible = false
 	a.splitPanel.ShowLeft = false
+	a.editorGroup.ClearSearch()
+}
+
+func (a *App) applySearchHighlights() {
+	if a.sidebar.ActivePanel == "search" && a.search.Input.Text != "" {
+		matches, _ := ui.FindInLines(a.editorGroup.Editor.Buf.Lines, a.search.Input.Text, a.search.Options)
+		a.editorGroup.SetSearch(a.search.Input.Text, matches)
+	}
+}
+
+func (a *App) ShowPanel(id string, widget ui.Widget) {
+	a.sidebar.SetActivePanel(id)
+	if !a.sidebar.Visible {
+		a.ShowSidebar()
+	}
+	a.root.SetFocus(widget)
 }
 
 func (a *App) ToggleSidebar() {

--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -40,22 +40,14 @@ func registerViewCommands(reg *command.Registry, app *App) {
 		ID: "sidebar.explorer", Title: "Show Explorer",
 		Handler: func() {
 			app.explorer.Reload()
-			app.sidebar.SetActivePanel("explorer")
-			if !app.sidebar.Visible {
-				app.ShowSidebar()
-			}
-			app.root.SetFocus(app.explorer)
+			app.ShowPanel("explorer", app.explorer)
 		},
 	})
 
 	reg.Register(command.Command{
 		ID: "sidebar.search", Title: "Show Search",
 		Handler: func() {
-			app.sidebar.SetActivePanel("search")
-			if !app.sidebar.Visible {
-				app.ShowSidebar()
-			}
-			app.root.SetFocus(app.search)
+			app.ShowPanel("search", app.search)
 		},
 	})
 
@@ -66,10 +58,7 @@ func registerViewCommands(reg *command.Registry, app *App) {
 				app.search.ToggleReplaceMode()
 			} else {
 				app.search.SetReplaceMode(true)
-				app.sidebar.SetActivePanel("search")
-				if !app.sidebar.Visible {
-					app.ShowSidebar()
-				}
+				app.ShowPanel("search", app.search)
 			}
 			app.root.SetFocus(app.search)
 		},
@@ -79,11 +68,7 @@ func registerViewCommands(reg *command.Registry, app *App) {
 		ID: "sidebar.changes", Title: "Show Changes",
 		Handler: func() {
 			app.changes.Refresh()
-			app.sidebar.SetActivePanel("changes")
-			if !app.sidebar.Visible {
-				app.ShowSidebar()
-			}
-			app.root.SetFocus(app.changes)
+			app.ShowPanel("changes", app.changes)
 		},
 	})
 
@@ -1162,10 +1147,7 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 
 	app.sidebar.OnPanelChange = func(id string) {
 		if id == "search" {
-			if app.search.Input.Text != "" {
-				matches, _ := ui.FindInLines(app.editorGroup.Editor.Buf.Lines, app.search.Input.Text, app.search.Options)
-				app.editorGroup.SetSearch(app.search.Input.Text, matches)
-			}
+			app.applySearchHighlights()
 		} else {
 			app.editorGroup.ClearSearch()
 		}

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
+	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
@@ -25,11 +26,7 @@ func initLogger(debug bool) *os.File {
 		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
 		return nil
 	}
-	logPath := "ttt.log"
-	if home, err := os.UserHomeDir(); err == nil {
-		logPath = filepath.Join(home, ".config", "ttt", "ttt.log")
-		os.MkdirAll(filepath.Dir(logPath), 0755)
-	}
+	logPath := config.ConfigFilePath("ttt.log")
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
@@ -37,6 +34,24 @@ func initLogger(debug bool) *os.File {
 	}
 	slog.SetDefault(slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	return f
+}
+
+func handlePanic(screen *term.TcellScreen) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	if screen != nil {
+		screen.Fini()
+	}
+	stack := debug.Stack()
+	crashMsg := fmt.Sprintf("ttt crashed: %v\n\n%s", r, stack)
+	crashPath := config.ConfigFilePath("crash.log")
+	header := fmt.Sprintf("ttt crash report — %s\nVersion: %s\n\n", time.Now().Format(time.RFC3339), version)
+	os.WriteFile(crashPath, []byte(header+crashMsg), 0644)
+	fmt.Fprintf(os.Stderr, "ttt crashed. Crash log saved to %s\n", crashPath)
+	fmt.Fprintln(os.Stderr, crashMsg)
+	os.Exit(1)
 }
 
 func findConfigFlag() string {
@@ -98,6 +113,7 @@ Docs: https://tttedit.dev
 		panic(err)
 	}
 	defer screen.Fini()
+	defer handlePanic(screen)
 
 	screen.SetStyleMap(buildStyleMap(cfg.Theme))
 	screen.SetCursorStyle(term.ParseCursorStyle(cfg.Settings.CursorStyle))

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -86,8 +86,7 @@ func NewSearchWidget() *SearchWidget {
 	s.ReplaceInput.Placeholder = "Replace"
 	s.Input.OnChange = func(text string) {
 		if text == "" {
-			s.cancelSearch()
-			s.runSearch()
+			s.runSearchSync()
 			if s.OnClear != nil {
 				s.OnClear()
 			}
@@ -102,12 +101,12 @@ func NewSearchWidget() *SearchWidget {
 		{Label: "Aa", OnClick: func() {
 			s.Options.CaseSensitive = !s.Options.CaseSensitive
 			s.syncOptionActions()
-			s.runSearch()
+			s.runSearchSync()
 		}},
 		{Label: ".*", OnClick: func() {
 			s.Options.UseRegex = !s.Options.UseRegex
 			s.syncOptionActions()
-			s.runSearch()
+			s.runSearchSync()
 		}},
 	}
 	s.ReplaceInput.Actions = []InputAction{
@@ -138,7 +137,7 @@ func (s *SearchWidget) ToggleReplaceMode() {
 }
 
 func (s *SearchWidget) Refresh() {
-	s.runSearch()
+	s.runSearchSync()
 }
 
 func (s *SearchWidget) visibleInputs() []*InputWidget {
@@ -217,25 +216,35 @@ func (s *SearchWidget) scheduleSearch() {
 		delay = 350
 	}
 	s.debounceTimer = time.AfterFunc(time.Duration(delay)*time.Millisecond, func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.Error = fmt.Sprintf("%v", r)
+			}
+			if s.PostEvent != nil {
+				s.PostEvent()
+			}
+		}()
+
 		s.searchMu.Lock()
 		defer s.searchMu.Unlock()
 
 		s.debounceMu.Lock()
 		if gen != s.searchGen {
 			s.debounceMu.Unlock()
-			if s.PostEvent != nil {
-				s.PostEvent()
-			}
 			return
 		}
 		s.debouncing = false
 		s.debounceMu.Unlock()
 
 		s.runSearch()
-		if s.PostEvent != nil {
-			s.PostEvent()
-		}
 	})
+}
+
+func (s *SearchWidget) runSearchSync() {
+	s.cancelSearch()
+	s.searchMu.Lock()
+	defer s.searchMu.Unlock()
+	s.runSearch()
 }
 
 func (s *SearchWidget) runSearch() {
@@ -742,12 +751,12 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 			case 'c':
 				s.Options.CaseSensitive = !s.Options.CaseSensitive
 				s.syncOptionActions()
-				s.runSearch()
+				s.runSearchSync()
 				return EventConsumed
 			case 'r':
 				s.Options.UseRegex = !s.Options.UseRegex
 				s.syncOptionActions()
-				s.runSearch()
+				s.runSearchSync()
 				return EventConsumed
 			}
 		}
@@ -766,7 +775,7 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		case tcell.KeyEnter:
 			if s.focusIdx == 0 && len(s.FlatList) == 0 {
-				s.runSearch()
+				s.runSearchSync()
 			} else {
 				s.activateSelected()
 			}

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -790,12 +790,6 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 				s.Selected++
 			}
 			return EventConsumed
-		case tcell.KeyLeft:
-			s.collapseSelected()
-			return EventConsumed
-		case tcell.KeyRight:
-			s.expandSelected()
-			return EventConsumed
 		default:
 			if s.focusedInput().HandleEvent(ev) == EventConsumed {
 				return EventConsumed
@@ -859,27 +853,5 @@ func (s *SearchWidget) activateSelected() {
 				s.OnOpenMatch(m.FilePath, m.LineNum, m.ColStart)
 			}
 		}
-	}
-}
-
-func (s *SearchWidget) collapseSelected() {
-	if s.Selected < 0 || s.Selected >= len(s.FlatList) {
-		return
-	}
-	item := s.FlatList[s.Selected]
-	if item.IsFile {
-		s.Groups[item.Group].Expanded = false
-		s.flatten()
-	}
-}
-
-func (s *SearchWidget) expandSelected() {
-	if s.Selected < 0 || s.Selected >= len(s.FlatList) {
-		return
-	}
-	item := s.FlatList[s.Selected]
-	if item.IsFile {
-		s.Groups[item.Group].Expanded = true
-		s.flatten()
 	}
 }


### PR DESCRIPTION
## Summary
- Save crash log to `~/.config/ttt/crash.log` on panic with timestamp and version, restore terminal from raw mode
- Fix search race condition: all `runSearch` callers now go through `runSearchSync` which serializes with the debounce goroutine via `searchMu`
- Add `recover` in debounce goroutine so search panics show as errors instead of crashing
- Let Left/Right keys move cursor in search input instead of collapse/expand (Enter still toggles sections)
- Clear/re-apply search highlights when sidebar is toggled (not just panel switched)
- Extract `ShowPanel` and `applySearchHighlights` helpers to reduce duplication

## Test plan
- [ ] Type `|d` with regex enabled, delete back to `|` — should not crash
- [ ] Toggle sidebar while search highlights are active — highlights clear and re-apply
- [ ] Left/Right arrow keys move cursor in search input field
- [ ] Enter still collapses/expands file groups in search results
- [ ] Force a panic (e.g. nil pointer) — terminal restores, crash log written to `~/.config/ttt/crash.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)