### PR TITLE
fix: don't open folder tree when opening individual files

### DIFF
--- a/cmd/ttt/eventloop.go
+++ b/cmd/ttt/eventloop.go
@@ -29,7 +29,9 @@ func runEventLoop(
 	lastBlameFile := ""
 	lastBranchDir := app.workspace.Primary()
 	blameGen := 0
-	app.status.Branch = git.BranchName(lastBranchDir)
+	if lastBranchDir != "" {
+		app.status.Branch = git.BranchName(lastBranchDir)
+	}
 	app.status.TabSize = app.settings.TabSize
 
 	syncStatus := func() {

--- a/cmd/ttt/widgets.go
+++ b/cmd/ttt/widgets.go
@@ -85,6 +85,7 @@ func buildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.InsertFinalNewline = cfg.Settings.InsertFinalNewline
 	for _, f := range openFiles {
 		editorGroup.OpenFile(f)
+		editorGroup.PinActiveTab()
 	}
 
 	terminalPanel := ui.NewTerminalPanelWidget()

--- a/cmd/ttt/widgets.go
+++ b/cmd/ttt/widgets.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"github.com/eugenioenko/ttt/internal/config"
-	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -53,12 +52,6 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 			folders = append(folders, absPath)
 		} else {
 			openFiles = append(openFiles, absPath)
-			dir := filepath.Dir(absPath)
-			if root := git.RepoRoot(dir); root != "" {
-				folders = append(folders, root)
-			} else {
-				folders = append(folders, dir)
-			}
 		}
 	}
 
@@ -73,7 +66,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 		}
 	}
 
-	if len(folders) == 0 && len(prURLs) == 0 {
+	if len(folders) == 0 && len(prURLs) == 0 && len(openFiles) == 0 {
 		cwd, _ := os.Getwd()
 		folders = append(folders, cwd)
 	}
@@ -129,7 +122,8 @@ func buildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	sidebar.AddPanel("explorer", "Explore", explorer)
 	sidebar.AddPanel("search", "Find", search)
 	sidebar.AddPanel("changes", "Changes", changes)
-	sidebar.Visible = cfg.Settings.SidebarVisible
+	hasFolders := len(ws.Paths()) > 0
+	sidebar.Visible = cfg.Settings.SidebarVisible && hasFolders
 	sidebar.Borders = borders
 
 	sidebarWidth := cfg.Settings.SidebarWidth

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -129,6 +129,12 @@ func (g *EditorGroupWidget) reportError(msg string) {
 	}
 }
 
+func (g *EditorGroupWidget) PinActiveTab() {
+	if t := g.activeTab(); t != nil {
+		t.Pinned = true
+	}
+}
+
 func (g *EditorGroupWidget) OpenFile(path string) {
 	for i := range g.tabs {
 		if g.tabs[i].FilePath == path {

--- a/tests/functional/command-palette.test.js
+++ b/tests/functional/command-palette.test.js
@@ -26,9 +26,9 @@ describe("command palette", () => {
 
   it("should execute a command from the palette", () => {
     dir = createTempDir();
-    const file = createTempFile(dir, "exec.txt", "Exec test");
+    createTempFile(dir, "exec.txt", "Exec test");
 
-    tui.start(file);
+    tui.start(dir);
     tui.waitFor("Explore");
 
     tui.exec("Toggle Sidebar");

--- a/tests/functional/sidebar-toggle.test.js
+++ b/tests/functional/sidebar-toggle.test.js
@@ -12,9 +12,9 @@ afterEach(() => {
 describe("sidebar toggle", () => {
   it("should toggle sidebar with ctrl+b", () => {
     dir = createTempDir();
-    const file = createTempFile(dir, "side.txt", "Sidebar test");
+    createTempFile(dir, "side.txt", "Sidebar test");
 
-    tui.start(file);
+    tui.start(dir);
     tui.waitFor("Explore");
 
     tui.press("ctrl+b");
@@ -32,9 +32,9 @@ describe("sidebar toggle", () => {
 
   it("should switch sidebar panels with chord keys", () => {
     dir = createTempDir();
-    const file = createTempFile(dir, "panels.txt", "Panel test");
+    createTempFile(dir, "panels.txt", "Panel test");
 
-    tui.start(file);
+    tui.start(dir);
     tui.waitFor("Explore");
 
     tui.pressChord("ctrl+k", "f");

--- a/tests/functional/tab-management.test.js
+++ b/tests/functional/tab-management.test.js
@@ -16,6 +16,7 @@ describe("tab management", () => {
     const file2 = createTempFile(dir, "second.txt", "Second file");
 
     tui.start(file1, file2);
+    tui.waitStable();
     tui.waitFor("second.txt");
 
     const snap = tui.snapshot();


### PR DESCRIPTION
## Summary
- File args (`ttt main.go`) no longer load the parent dir or git root into the sidebar
- Sidebar is hidden by default in file-only mode
- `ttt` with no args still opens the current directory as before
- PR-only mode (`ttt <pr-url>`) unaffected

## Test plan
- [ ] `ttt /tmp/somefile.go` — opens file, no sidebar, full editor width
- [ ] `ttt .` — opens current directory with sidebar as before
- [ ] `ttt` (no args) — opens cwd with sidebar as before
- [ ] `ttt file.go ~/project/` — opens file + folder, sidebar shows folder tree
- [ ] `ttt <pr-url>` — unchanged PR behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)