### PR TITLE
perf: optimize large file rendering

### DIFF
--- a/cmd/ttt/commands.go
+++ b/cmd/ttt/commands.go
@@ -562,6 +562,12 @@ func registerSearchCommands(reg *command.Registry, app *App) {
 			}
 			findBar := ui.NewFindBarWidget()
 			findBar.Borders = app.borders
+			if len(app.editorGroup.Editor.Buf.Lines) > 5000 {
+				findBar.Debounce.DelayMs = app.settings.Search.Debounce
+			}
+			findBar.Debounce.OnFinish = func() {
+				app.screen.PostEvent(tcell.NewEventInterrupt(nil))
+			}
 			findBar.OnSearch = func(query string, opts ui.SearchOptions) []ui.FindMatch {
 				matches, err := ui.FindInLines(app.editorGroup.Editor.Buf.Lines, query, opts)
 				if err != nil {
@@ -1203,6 +1209,7 @@ func registerWidgetCallbacks(reg *command.Registry, app *App) {
 	app.search.PostEvent = func() {
 		app.screen.PostEvent(tcell.NewEventInterrupt(nil))
 	}
+	app.search.Debounce.OnFinish = app.search.PostEvent
 	app.search.DiffSources = func() []ui.DiffSearchSource {
 		seen := map[string]bool{}
 		sources := app.editorGroup.DiffTabSources()

--- a/cmd/ttt/widgets.go
+++ b/cmd/ttt/widgets.go
@@ -116,7 +116,7 @@ func buildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	explorer := ui.NewExplorerWidget(cfg.Settings.Explorer, ws.Paths()...)
 	search := ui.NewSearchWidget()
 	search.SetWorkDirs(ws.Paths())
-	search.DebounceMs = cfg.Settings.Search.Debounce
+	search.Debounce.DelayMs = cfg.Settings.Search.Debounce
 	changes := ui.NewChangesWidget(ws.Paths()...)
 
 	sidebar := ui.NewSidebarWidget()

--- a/internal/ui/debouncer.go
+++ b/internal/ui/debouncer.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"sync"
+	"time"
+)
+
+type Debouncer struct {
+	DelayMs   int
+	OnFinish  func()
+	timer     *time.Timer
+	mu        sync.Mutex
+	gen       uint64
+}
+
+func (d *Debouncer) Schedule(fn func()) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	delay := d.DelayMs
+	if delay <= 0 {
+		fn()
+		return
+	}
+	d.gen++
+	gen := d.gen
+	d.timer = time.AfterFunc(time.Duration(delay)*time.Millisecond, func() {
+		d.mu.Lock()
+		if gen != d.gen {
+			d.mu.Unlock()
+			return
+		}
+		d.mu.Unlock()
+		fn()
+		if d.OnFinish != nil {
+			d.OnFinish()
+		}
+	})
+}
+
+func (d *Debouncer) Stop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	d.gen++
+}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -441,6 +441,7 @@ func (g *EditorGroupWidget) Undo() {
 			g.Editor.Cursor.Line = pos.Line
 			g.Editor.Cursor.Col = pos.Col
 		}
+		g.Editor.InvalidateMaxLineWidth()
 	}
 }
 
@@ -454,6 +455,7 @@ func (g *EditorGroupWidget) Redo() {
 			g.Editor.Cursor.Line = pos.Line
 			g.Editor.Cursor.Col = pos.Col
 		}
+		g.Editor.InvalidateMaxLineWidth()
 	}
 }
 
@@ -475,6 +477,7 @@ func (g *EditorGroupWidget) SetSearch(query string, matches []FindMatch) {
 	g.Editor.SearchQuery = query
 	g.Editor.SearchMatches = matches
 	g.Editor.SearchActive = 0
+	g.Editor.buildSearchIndex()
 }
 
 func (g *EditorGroupWidget) SetSearchActive(idx int) {
@@ -512,6 +515,7 @@ func (g *EditorGroupWidget) ClearSearch() {
 	g.Editor.SearchQuery = ""
 	g.Editor.SearchMatches = nil
 	g.Editor.SearchActive = 0
+	g.Editor.searchByLine = nil
 }
 
 func (g *EditorGroupWidget) SetDiagnostics(path string, diags []Diagnostic) {
@@ -520,6 +524,7 @@ func (g *EditorGroupWidget) SetDiagnostics(path string, diags []Diagnostic) {
 			g.tabs[i].Diagnostics = diags
 			if i == g.active {
 				g.Editor.Diagnostics = diags
+				g.Editor.buildDiagIndex()
 			}
 			return
 		}
@@ -734,6 +739,8 @@ func (g *EditorGroupWidget) syncTabs() {
 		g.Editor.Multi = t.Multi
 		g.Editor.Highlighter = t.Highlighter
 		g.Editor.Diagnostics = t.Diagnostics
+		g.Editor.buildDiagIndex()
+		g.Editor.InvalidateMaxLineWidth()
 		if t.TabSize > 0 {
 			g.Editor.TabSize = t.TabSize
 		}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -43,6 +43,10 @@ type EditorPaneWidget struct {
 	OnChange        func()
 	Multi           *multicursor.MultiCursor
 	multiSearchWord string
+	maxLineWidth      int
+	maxLineWidthDirty bool
+	searchByLine      map[int][]int
+	diagByLine        map[int][]int
 }
 
 func NewEditorPaneWidget(buf *buffer.Buffer, cur *cursor.Cursor, vp *view.Viewport) *EditorPaneWidget {
@@ -66,18 +70,48 @@ func (e *EditorPaneWidget) GutterWidth() int {
 	return digits + 3
 }
 
+func (e *EditorPaneWidget) computeMaxLineWidth() int {
+	if !e.maxLineWidthDirty && e.maxLineWidth > 0 {
+		return e.maxLineWidth
+	}
+	maxW := 0
+	for _, line := range e.Buf.Lines {
+		if lw := len([]rune(line)); lw > maxW {
+			maxW = lw
+		}
+	}
+	e.maxLineWidth = maxW
+	e.maxLineWidthDirty = false
+	return maxW
+}
+
+func (e *EditorPaneWidget) InvalidateMaxLineWidth() {
+	e.maxLineWidthDirty = true
+}
+
+func (e *EditorPaneWidget) buildSearchIndex() {
+	e.searchByLine = make(map[int][]int, len(e.SearchMatches))
+	for i, m := range e.SearchMatches {
+		e.searchByLine[m.Line] = append(e.searchByLine[m.Line], i)
+	}
+}
+
+func (e *EditorPaneWidget) buildDiagIndex() {
+	e.diagByLine = make(map[int][]int)
+	for i, d := range e.Diagnostics {
+		for line := d.StartLine; line <= d.EndLine; line++ {
+			e.diagByLine[line] = append(e.diagByLine[line], i)
+		}
+	}
+}
+
 func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 	w, h := surface.Size()
 
 	totalLines := len(e.Buf.Lines)
 	gutterW := e.GutterWidth()
 
-	maxLineW := 0
-	for _, line := range e.Buf.Lines {
-		if lw := len([]rune(line)); lw > maxLineW {
-			maxLineW = lw
-		}
-	}
+	maxLineW := e.computeMaxLineWidth()
 
 	editorW := w - gutterW
 	showHScrollbar := maxLineW > editorW
@@ -150,14 +184,17 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 					}
 				}
 				if hasSearch {
-					for mi, m := range e.SearchMatches {
-						if m.Line == lineIdx && colIdx >= m.Col && colIdx < m.Col+m.Len {
-							if mi == e.SearchActive {
-								style = term.StyleSearchActive
-							} else {
-								style = term.StyleSearchMatch
+					if indices, ok := e.searchByLine[lineIdx]; ok {
+						for _, mi := range indices {
+							m := e.SearchMatches[mi]
+							if colIdx >= m.Col && colIdx < m.Col+m.Len {
+								if mi == e.SearchActive {
+									style = term.StyleSearchActive
+								} else {
+									style = term.StyleSearchMatch
+								}
+								break
 							}
-							break
 						}
 					}
 				}
@@ -264,10 +301,12 @@ func (e *EditorPaneWidget) DiagnosticAt(line, col int) *Diagnostic {
 }
 
 func (e *EditorPaneWidget) diagStyleAt(line, col int) term.Style {
-	for _, d := range e.Diagnostics {
-		if line < d.StartLine || line > d.EndLine {
-			continue
-		}
+	indices, ok := e.diagByLine[line]
+	if !ok {
+		return 0
+	}
+	for _, i := range indices {
+		d := e.Diagnostics[i]
 		if line == d.StartLine && col < d.StartCol {
 			continue
 		}
@@ -295,6 +334,7 @@ func (e *EditorPaneWidget) exec(cmd undo.EditCommand) {
 	if e.Undo != nil {
 		e.Undo.Push(cmd)
 	}
+	e.maxLineWidthDirty = true
 	if e.OnChange != nil {
 		e.OnChange()
 	}

--- a/internal/ui/findbar_widget.go
+++ b/internal/ui/findbar_widget.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+
 	"github.com/eugenioenko/ttt/internal/term"
 
 	"github.com/gdamore/tcell/v2"
@@ -21,6 +22,7 @@ type FindBarWidget struct {
 	OnSearch   func(query string, opts SearchOptions) []FindMatch
 	OnNavigate func(match FindMatch)
 	OnDismiss  func()
+	Debounce   Debouncer
 	focused    bool
 	btnPrev    HitRegion
 	btnNext    HitRegion
@@ -147,6 +149,12 @@ func (f *FindBarWidget) currentDisplay() int {
 }
 
 func (f *FindBarWidget) search() {
+	f.Debounce.Schedule(func() {
+		f.doSearch()
+	})
+}
+
+func (f *FindBarWidget) doSearch() {
 	if f.OnSearch != nil {
 		f.Matches = f.OnSearch(f.Input.Text, f.Options)
 		if len(f.Matches) > 0 {

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/eugenioenko/ttt/internal/term"
 
@@ -58,14 +57,11 @@ type SearchWidget struct {
 	OnReplaceAll func(allMatches map[string][]SearchMatch, replacement string, opts SearchOptions)
 	OnPreview    func(filePath string, matches []SearchMatch, replacement string, opts SearchOptions)
 	OnClear      func()
-	PostEvent     func()
-	DebounceMs    int
-	debounceTimer *time.Timer
-	debounceMu    sync.Mutex
-	debouncing    bool
-	searchGen     uint64
-	searchMu      sync.Mutex
-	resultStartY  int
+	PostEvent    func()
+	Debounce     Debouncer
+	debouncing   bool
+	searchMu     sync.Mutex
+	resultStartY int
 }
 
 type searchItem struct {
@@ -193,49 +189,21 @@ func (s *SearchWidget) inputY(inp *InputWidget) int {
 }
 
 func (s *SearchWidget) cancelSearch() {
-	s.debounceMu.Lock()
-	defer s.debounceMu.Unlock()
-	if s.debounceTimer != nil {
-		s.debounceTimer.Stop()
-	}
+	s.Debounce.Stop()
 	s.debouncing = false
-	s.searchGen++
 }
 
 func (s *SearchWidget) scheduleSearch() {
-	s.debounceMu.Lock()
-	defer s.debounceMu.Unlock()
-	if s.debounceTimer != nil {
-		s.debounceTimer.Stop()
-	}
 	s.debouncing = true
-	s.searchGen++
-	gen := s.searchGen
-	delay := s.DebounceMs
-	if delay <= 0 {
-		delay = 350
-	}
-	s.debounceTimer = time.AfterFunc(time.Duration(delay)*time.Millisecond, func() {
+	s.Debounce.Schedule(func() {
 		defer func() {
 			if r := recover(); r != nil {
 				s.Error = fmt.Sprintf("%v", r)
 			}
-			if s.PostEvent != nil {
-				s.PostEvent()
-			}
 		}()
-
 		s.searchMu.Lock()
 		defer s.searchMu.Unlock()
-
-		s.debounceMu.Lock()
-		if gen != s.searchGen {
-			s.debounceMu.Unlock()
-			return
-		}
 		s.debouncing = false
-		s.debounceMu.Unlock()
-
 		s.runSearch()
 	})
 }


### PR DESCRIPTION
## Summary
- Cache max line width computation, invalidated on edits and tab switches instead of recalculating every render frame
- Index search matches and diagnostics by line number for O(1) lookup during render (replaces O(visible × matches) scans)
- Extract reusable `Debouncer` utility (`internal/ui/debouncer.go`) with thread-safe timer + generation counter
- Refactor `FindBarWidget` and `SearchWidget` to use `Debouncer` instead of duplicated timer logic
- Find bar debounce for large files (>5000 lines) uses `search.debounce` setting (350ms default) instead of hardcoded 200ms

## Test plan
- [x] `make build` compiles cleanly
- [x] `make test` — all unit tests pass
- [ ] Open a large file (100k+ lines), verify smooth typing in the editor
- [ ] Ctrl+F search in large file — input should remain responsive with debounced highlighting
- [ ] Global sidebar search (Ctrl+K F) — debounce behavior unchanged
- [ ] Verify search match highlighting and navigation still work correctly
- [ ] Undo/redo in editor doesn't cause stale max width or diagnostic display

🤖 Generated with [Claude Code](https://claude.com/claude-code)