### PR TITLE
fix: add mouse capture to prevent cross-widget drag interference

### DIFF
--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -19,6 +19,7 @@ type ContentSplitWidget struct {
 	RightBorderStartY  *int
 	dragging           bool
 	wasPressed         bool
+	capturedChild      Widget
 }
 
 func NewContentSplitWidget() *ContentSplitWidget {
@@ -106,10 +107,23 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 			if cs.OnResize != nil {
 				cs.OnResize(newH)
 			}
-			return EventConsumed
+			return EventCaptured
 		}
 		cs.dragging = false
 		return EventIgnored
+	}
+
+	if cs.capturedChild != nil {
+		if btn == tcell.ButtonNone {
+			cs.capturedChild.HandleEvent(ev)
+			cs.capturedChild = nil
+			return EventConsumed
+		}
+		result := cs.capturedChild.HandleEvent(ev)
+		if result == EventCaptured {
+			return EventCaptured
+		}
+		return EventConsumed
 	}
 
 	if cs.ShowBottom {
@@ -133,16 +147,23 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 				return EventConsumed
 			}
 			cs.dragging = true
-			return EventConsumed
+			return EventCaptured
 		}
 
 		if freshClick && my >= divY-1 && my <= divY && mx < r.X+r.W-1 {
 			cs.dragging = true
-			return EventConsumed
+			return EventCaptured
 		}
 
 		if my > divY && cs.Bottom != nil {
 			result := cs.Bottom.HandleEvent(ev)
+			if result == EventCaptured {
+				cs.capturedChild = cs.Bottom
+				if cs.OnBottomClick != nil {
+					cs.OnBottomClick()
+				}
+				return EventCaptured
+			}
 			if result == EventConsumed && btn&tcell.Button1 != 0 && cs.OnBottomClick != nil {
 				cs.OnBottomClick()
 			}
@@ -151,12 +172,19 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 	} else {
 		if freshClick && my == r.Y+r.H {
 			cs.dragging = true
-			return EventConsumed
+			return EventCaptured
 		}
 	}
 
 	if cs.Top != nil {
 		result := cs.Top.HandleEvent(ev)
+		if result == EventCaptured {
+			cs.capturedChild = cs.Top
+			if cs.OnTopClick != nil {
+				cs.OnTopClick()
+			}
+			return EventCaptured
+		}
 		if result == EventConsumed && btn&tcell.Button1 != 0 && cs.OnTopClick != nil {
 			cs.OnTopClick()
 		}

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -368,14 +368,23 @@ func (d *DiffViewWidget) clampLeftCol() {
 func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 	if newTop, consumed := d.scrollbar.HandleEvent(ev); consumed {
 		d.TopLine = newTop
+		if d.scrollbar.IsDragging() {
+			return EventCaptured
+		}
 		return EventConsumed
 	}
 	if newLeft, consumed := d.hscrollbar.HandleEvent(ev); consumed {
 		d.LeftCol = newLeft
+		if d.hscrollbar.IsDragging() {
+			return EventCaptured
+		}
 		return EventConsumed
 	}
 	if newLeft, consumed := d.rhscrollbar.HandleEvent(ev); consumed {
 		d.LeftCol = newLeft
+		if d.rhscrollbar.IsDragging() {
+			return EventCaptured
+		}
 		return EventConsumed
 	}
 

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -407,17 +407,23 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 
 		if newTop, consumed := e.scrollbar.HandleEvent(ev); consumed {
 			e.Viewport.TopLine = newTop
+			if e.scrollbar.IsDragging() {
+				return EventCaptured
+			}
 			return EventConsumed
 		}
 		if e.scrollbar.IsDragging() {
-			return EventConsumed
+			return EventCaptured
 		}
 		if newLeft, consumed := e.hscrollbar.HandleEvent(ev); consumed {
 			e.Viewport.LeftCol = newLeft
+			if e.hscrollbar.IsDragging() {
+				return EventCaptured
+			}
 			return EventConsumed
 		}
 		if e.hscrollbar.IsDragging() {
-			return EventConsumed
+			return EventCaptured
 		}
 
 		mod := mev.Modifiers()
@@ -476,7 +482,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 				e.Multi.Add(line, col)
 				e.syncFromMulti()
 				e.scrollViewport()
-				return EventConsumed
+				return EventCaptured
 			}
 
 			if !e.mouseDown {
@@ -515,7 +521,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 				e.Cursor.Col = col
 			}
 			e.scrollViewport()
-			return EventConsumed
+			return EventCaptured
 		}
 		if btn == tcell.ButtonNone && e.mouseDown {
 			e.mouseDown = false

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -42,6 +42,7 @@ type Root struct {
 	OnRightClick      func(mx, my int)
 	EscapeDismissers  []func() bool
 	EscapeFallback    func()
+	capturedWidget    Widget
 }
 
 func NewRoot(main Widget) *Root {
@@ -82,6 +83,10 @@ func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 				return EventConsumed
 			}
 		}
+	}
+
+	if !isKey && r.capturedWidget != nil {
+		return r.handleMouse(ev)
 	}
 
 	if res := r.handleOverlay(ev); res == EventConsumed {
@@ -144,16 +149,37 @@ func (r *Root) handleOverlay(ev tcell.Event) EventResult {
 }
 
 func (r *Root) handleMouse(ev tcell.Event) EventResult {
-	if mev, ok := ev.(*tcell.EventMouse); ok {
-		btn := mev.Buttons()
-		if btn&tcell.Button2 != 0 && r.OnRightClick != nil {
-			mx, my := mev.Position()
-			slog.Debug("root", "action", "rightClick", "x", mx, "y", my)
-			r.OnRightClick(mx, my)
+	mev, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return EventIgnored
+	}
+	btn := mev.Buttons()
+
+	if r.capturedWidget != nil {
+		if btn == tcell.ButtonNone {
+			r.capturedWidget.HandleEvent(ev)
+			r.capturedWidget = nil
+			slog.Debug("root", "action", "mouseCapture", "state", "released")
 			return EventConsumed
 		}
+		r.capturedWidget.HandleEvent(ev)
+		slog.Debug("root", "action", "mouseCapture", "state", "active")
+		return EventConsumed
 	}
+
+	if btn&tcell.Button2 != 0 && r.OnRightClick != nil {
+		mx, my := mev.Position()
+		slog.Debug("root", "action", "rightClick", "x", mx, "y", my)
+		r.OnRightClick(mx, my)
+		return EventConsumed
+	}
+
 	result := r.Main.HandleEvent(ev)
+	if result == EventCaptured {
+		r.capturedWidget = r.Main
+		slog.Debug("root", "action", "mouseCapture", "state", "set")
+		return EventConsumed
+	}
 	slog.Debug("root", "action", "mouseToMain", "result", result)
 	return result
 }

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -621,6 +621,9 @@ func (s *SearchWidget) toggleRow() int {
 func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 	if newTop, consumed := s.scrollbar.HandleEvent(ev); consumed {
 		s.ScrollTop = newTop
+		if s.scrollbar.IsDragging() {
+			return EventCaptured
+		}
 		return EventConsumed
 	}
 	switch tev := ev.(type) {

--- a/internal/ui/split_panel.go
+++ b/internal/ui/split_panel.go
@@ -20,6 +20,7 @@ type SplitPanelWidget struct {
 	OnRightClick      func()
 	dragging          bool
 	wasPressed        bool
+	capturedChild     Widget
 }
 
 func NewSplitPanelWidget() *SplitPanelWidget {
@@ -184,10 +185,23 @@ func (s *SplitPanelWidget) HandleEvent(ev tcell.Event) EventResult {
 				newWidth := mx - r.X - 1
 				s.OnResize(newWidth)
 			}
-			return EventConsumed
+			return EventCaptured
 		}
 		s.dragging = false
 		return EventIgnored
+	}
+
+	if s.capturedChild != nil {
+		if btn == tcell.ButtonNone {
+			s.capturedChild.HandleEvent(ev)
+			s.capturedChild = nil
+			return EventConsumed
+		}
+		result := s.capturedChild.HandleEvent(ev)
+		if result == EventCaptured {
+			return EventCaptured
+		}
+		return EventConsumed
 	}
 
 	if !inBounds {
@@ -202,12 +216,19 @@ func (s *SplitPanelWidget) HandleEvent(ev tcell.Event) EventResult {
 		// divX to divX+1: grab zone extends right only to avoid overlapping the scrollbar
 		if freshClick && mx >= divX && mx <= divX+1 && s.OnResize != nil {
 			s.dragging = true
-			return EventConsumed
+			return EventCaptured
 		}
 		if mx < divX {
 			if s.Left != nil {
 				result := s.Left.HandleEvent(ev)
 				slog.Debug("splitPanel", "action", "leftChild", "result", result)
+				if result == EventCaptured {
+					s.capturedChild = s.Left
+					if s.OnLeftClick != nil {
+						s.OnLeftClick()
+					}
+					return EventCaptured
+				}
 				if result == EventConsumed && isClick && s.OnLeftClick != nil {
 					s.OnLeftClick()
 				}
@@ -217,6 +238,13 @@ func (s *SplitPanelWidget) HandleEvent(ev tcell.Event) EventResult {
 			if s.Right != nil {
 				result := s.Right.HandleEvent(ev)
 				slog.Debug("splitPanel", "action", "rightChild", "result", result)
+				if result == EventCaptured {
+					s.capturedChild = s.Right
+					if s.OnRightClick != nil {
+						s.OnRightClick()
+					}
+					return EventCaptured
+				}
 				if result == EventConsumed && isClick && s.OnRightClick != nil {
 					s.OnRightClick()
 				}
@@ -226,10 +254,17 @@ func (s *SplitPanelWidget) HandleEvent(ev tcell.Event) EventResult {
 	} else {
 		if freshClick && mx == r.X {
 			s.dragging = true
-			return EventConsumed
+			return EventCaptured
 		}
 		if s.Right != nil {
 			result := s.Right.HandleEvent(ev)
+			if result == EventCaptured {
+				s.capturedChild = s.Right
+				if s.OnRightClick != nil {
+					s.OnRightClick()
+				}
+				return EventCaptured
+			}
 			if result == EventConsumed && isClick && s.OnRightClick != nil {
 				s.OnRightClick()
 			}

--- a/internal/ui/terminal_widget.go
+++ b/internal/ui/terminal_widget.go
@@ -286,6 +286,9 @@ func (tw *TerminalWidget) HandleEvent(ev tcell.Event) EventResult {
 			if tw.scrollOffset < 0 {
 				tw.scrollOffset = 0
 			}
+			if tw.scrollbar.IsDragging() {
+				return EventCaptured
+			}
 			return EventConsumed
 		}
 		btn := tev.Buttons()
@@ -308,7 +311,7 @@ func (tw *TerminalWidget) HandleEvent(ev tcell.Event) EventResult {
 			} else {
 				tw.selCurrent = pos
 			}
-			return EventConsumed
+			return EventCaptured
 		}
 		if tw.selecting {
 			tw.selecting = false

--- a/internal/ui/widget.go
+++ b/internal/ui/widget.go
@@ -12,6 +12,7 @@ const (
 	EventIgnored   EventResult = iota
 	EventConsumed
 	EventDismissed
+	EventCaptured
 )
 
 type ConstraintType int


### PR DESCRIPTION
## Summary
- Adds an `EventCaptured` result type that widgets return when starting a drag operation (text selection, scrollbar drag, divider resize)
- Container widgets (`SplitPanel`, `ContentSplit`) track which child initiated capture and route all subsequent mouse events to it until release
- `Root` captures at the top level, bypassing overlays and right-click handling during active drags
- Fixes UX bugs where dragging a selection in the editor could trigger sidebar clicks, panel switches, or dropdown interactions

## Test plan
- [ ] Start a text selection in the editor and drag the mouse over the sidebar — sidebar should not react
- [ ] Drag a selection over the bottom panel divider — panel should not resize or switch focus
- [ ] Drag the sidebar divider — should still work correctly
- [ ] Drag the bottom panel divider — should still work correctly
- [ ] Scrollbar thumb dragging should work in editor, terminal, diff, and search widgets
- [ ] Double-click and triple-click word/line selection should still work
- [ ] Alt+click multi-cursor should still work
- [ ] Terminal text selection should not leak to other widgets
- [ ] Right-click context menu should still work when not dragging

🤖 Generated with [Claude Code](https://claude.com/claude-code)