### PR TITLE
fix: small UX fixes

### DIFF
--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -160,7 +160,6 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "ctrl+k p", Command: "command.palette"},
 		{Key: "ctrl+k q", Command: "file.quickOpen"},
 		{Key: "ctrl+k s", Command: "file.saveAs"},
-		{Key: "ctrl+k ctrl+t", Command: "theme.switch"},
 		{Key: "ctrl+u", Command: "editor.autocomplete"},
 		{Key: "ctrl+k i", Command: "editor.hover"},
 		{Key: "f2", Command: "editor.rename"},

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -195,6 +195,10 @@ func (s *SearchWidget) cancelSearch() {
 
 func (s *SearchWidget) scheduleSearch() {
 	s.debouncing = true
+	s.Groups = nil
+	s.FlatList = nil
+	s.Selected = 0
+	s.ScrollTop = 0
 	s.Debounce.Schedule(func() {
 		defer func() {
 			if r := recover(); r != nil {


### PR DESCRIPTION
## Summary
- Remove broken `ctrl+k ctrl+t` theme switch keybinding — `ctrl+t` is a force key (terminal.toggle) that fires before the chord system can match the second step. Theme switching remains available via the command palette.
- Clear global search results immediately when typing — previously stale results from the prior keystroke lingered during the debounce delay, making search appear one keystroke behind.

## Test plan
- [ ] Verify `ctrl+k` chords still work (e.g. `ctrl+k e` for explorer)
- [ ] Verify theme switching works via command palette
- [ ] Type slowly in global search — results should clear immediately on each keystroke, not show stale matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)