### PR TITLE
fix: prevent search scroll snapping back after drag

### DIFF
--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -54,6 +54,7 @@ type SearchWidget struct {
 	Groups       []SearchFileGroup
 	FlatList     []searchItem
 	Selected     int
+	lastSelected int
 	ScrollTop    int
 	scrollbar    Scrollbar
 	WorkDirs     []string
@@ -591,7 +592,8 @@ func (s *SearchWidget) Render(surface *RenderSurface) {
 		return
 	}
 
-	if !s.scrollbar.IsDragging() {
+	if s.Selected != s.lastSelected {
+		s.lastSelected = s.Selected
 		if s.Selected < s.ScrollTop {
 			s.ScrollTop = s.Selected
 		}


### PR DESCRIPTION
## Summary
- Only auto-scroll to the selected search result when the selection changes, not on every render
- Prevents the viewport from jumping back after scrollbar drag or mouse wheel scrolling

## Test plan
- [ ] Search for something with many results
- [ ] Drag the scrollbar to scroll down — scroll position should stay after release
- [ ] Use mouse wheel to scroll — should not snap back
- [ ] Use keyboard arrows to change selection — should still auto-scroll to keep selection visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)