### PR TITLE
fix: prevent divider grab zone from capturing hscrollbar clicks

### DIFF
--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -136,7 +136,6 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 			divY = r.Y
 		}
 
-		// divY±1: extend grab zone 1 row above and below divider for easier targeting
 		// r.W-1: exclude last column to avoid colliding with editor scrollbar
 		// For divY+1 (tab bar row), let the bottom panel handle clicks first
 		if freshClick && my == divY+1 && mx < r.X+r.W-1 && cs.Bottom != nil {
@@ -150,7 +149,7 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventCaptured
 		}
 
-		if freshClick && my >= divY-1 && my <= divY && mx < r.X+r.W-1 {
+		if freshClick && my == divY && mx < r.X+r.W-1 {
 			cs.dragging = true
 			return EventCaptured
 		}


### PR DESCRIPTION
## Summary
- The content split divider grab zone extended 1 row above (`divY-1`) into the editor's last row, which is where the horizontal scrollbar is rendered
- This made horizontal scrolling impossible when the bottom panel (terminal) was open
- Narrowed the above-divider grab zone to just the divider row itself (`divY`); the tab bar row below (`divY+1`) still doubles as a drag handle

## Test plan
- [ ] Open a file with long lines so the horizontal scrollbar appears
- [ ] Open the bottom panel (terminal)
- [ ] Verify clicking/dragging the horizontal scrollbar works
- [ ] Verify dragging the divider row still resizes the bottom panel
- [ ] Verify dragging from the tab bar gap still resizes the bottom panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)