### PR TITLE
fix: restore editor cursor when non-modal overlay loses focus

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -283,7 +283,14 @@ func (r *Root) CursorPosition() (x, y int, visible bool) {
 	if len(r.Overlays) > 0 {
 		top := r.Overlays[len(r.Overlays)-1]
 		if cp, ok := top.Widget.(CursorProvider); ok {
-			return cp.CursorPosition()
+			if x, y, vis := cp.CursorPosition(); vis {
+				return x, y, true
+			}
+			// non-modal overlays (e.g. find bar) may lose focus to the editor;
+			// fall through so the focused widget can show its cursor instead
+			if top.Modal {
+				return 0, 0, false
+			}
 		}
 	}
 	if r.Focused != nil {


### PR DESCRIPTION
## Summary
- When a non-modal overlay (e.g. find bar) was open and the user clicked into the editor, the cursor disappeared despite the editor having focus and accepting keystrokes
- `Root.CursorPosition()` unconditionally returned the overlay's cursor result — when the find bar reported `visible=false` (because it lost focus), it never fell through to the focused editor widget
- Now non-modal overlays that return `visible=false` fall through to `r.Focused`, while modal overlays still block as before

## Test plan
- [ ] Open a file, press Ctrl+F to open find bar
- [ ] Click into the editor — cursor should be visible and blink
- [ ] Type text — cursor should follow as expected
- [ ] Click back into the find bar — cursor should appear in the input field
- [ ] Open a modal dialog (e.g. Ctrl+K Q for quick open) — cursor should stay in the dialog only

🤖 Generated with [Claude Code](https://claude.com/claude-code)