### PR TITLE
fix: use ASCII x for tab close button

### DIFF
--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -49,7 +49,7 @@ func (t *TabBarWidget) tabLabel(tab Tab) string {
 	}
 	label += name
 	if tab.Active && tab.Closable {
-		label += " ✖"
+		label += " x"
 	}
 	label += " "
 	return label


### PR DESCRIPTION
## Summary
- The ✖ (U+2716) character renders as double-width in Ghostty, causing the tab close button to appear oversized and misalign the tab bar layout
- Replaced with ASCII `x` which has consistent single-cell width across all terminals

## Test plan
- [ ] Open multiple files so tabs are visible
- [ ] Verify the close button renders as a single-width `x` on the active tab
- [ ] Test in Ghostty — should no longer appear oversized
- [ ] Click the `x` to close a tab — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)