### PR TITLE
fix: deduplicate git roots in changes panel

### DIFF
--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -86,10 +86,15 @@ func (c *ChangesWidget) Refresh() {
 		}
 	}
 	c.Groups = nil
+	seen := make(map[string]bool)
 	for _, dir := range c.Dirs {
 		if root := git.RepoRoot(dir); root != "" {
 			dir = root
 		}
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
 		files, err := git.StatusFiles(dir)
 		if err != nil {
 			files = nil

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -86,6 +86,7 @@ func (c *ChangesWidget) Refresh() {
 		}
 	}
 	c.Groups = nil
+	// multiple workspace folders may resolve to the same git root
 	seen := make(map[string]bool)
 	for _, dir := range c.Dirs {
 		if root := git.RepoRoot(dir); root != "" {


### PR DESCRIPTION
## Summary
- Deduplicate git roots in the changes panel when multiple workspace folders resolve to the same repo
- Prevents duplicate change groups when e.g. `.` and `cmd` are both in the workspace but share the same git root

## Test plan
- [ ] Open a workspace with overlapping folders (e.g. `.` and a subfolder) that share the same git repo
- [ ] Verify the changes panel shows only one group for that repo instead of duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)