### PR TITLE
feat: add clipboard, selection, and word navigation to InputWidget

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,44 +31,44 @@ type TerminalTab struct {
 }
 
 type App struct {
-	Root              *ui.Root
-	EditorGroup       *ui.EditorGroupWidget
-	Sidebar           *ui.SidebarWidget
-	SplitPanel        *ui.SplitPanelWidget
-	ContentSplit      *ui.ContentSplitWidget
-	BottomPanel       *ui.BottomPanelWidget
-	Explorer          *ui.ExplorerWidget
-	Search            *ui.SearchWidget
-	Changes           *ui.ChangesWidget
-	MenuBar           *ui.MenuBarWidget
-	StatusBar         *ui.StatusBarWidget
-	Status            *view.StatusBar
-	Borders           *term.BorderSet
-	Screen            *term.TcellScreen
-	Renderer          *render.Renderer
-	Settings          *config.Settings
-	Workspace         *workspace.Workspace
-	Palette           *ui.TerminalColorPalette
-	TerminalPanel     *ui.TerminalPanelWidget
-	Terminals         []TerminalTab
-	LspManager        *lsp.Manager
-	DocVersionsMu     sync.Mutex
-	DocVersions       map[string]int
-	CompletionItems   []ui.CompletionItem
+	Root               *ui.Root
+	EditorGroup        *ui.EditorGroupWidget
+	Sidebar            *ui.SidebarWidget
+	SplitPanel         *ui.SplitPanelWidget
+	ContentSplit       *ui.ContentSplitWidget
+	BottomPanel        *ui.BottomPanelWidget
+	Explorer           *ui.ExplorerWidget
+	Search             *ui.SearchWidget
+	Changes            *ui.ChangesWidget
+	MenuBar            *ui.MenuBarWidget
+	StatusBar          *ui.StatusBarWidget
+	Status             *view.StatusBar
+	Borders            *term.BorderSet
+	Screen             *term.TcellScreen
+	Renderer           *render.Renderer
+	Settings           *config.Settings
+	Workspace          *workspace.Workspace
+	Palette            *ui.TerminalColorPalette
+	TerminalPanel      *ui.TerminalPanelWidget
+	Terminals          []TerminalTab
+	LspManager         *lsp.Manager
+	DocVersionsMu      sync.Mutex
+	DocVersions        map[string]int
+	CompletionItems    []ui.CompletionItem
 	LspCompletionItems []lsp.CompletionItem
-	AutocompleteTimer *time.Timer
-	HoverTimer        *time.Timer
-	HoverGen          uint64
-	LastHoverLine     int
-	LastHoverCol      int
-	Problems          *ui.ProblemsWidget
-	References        *ui.ReferencesWidget
-	AllDiagnostics    map[string][]ui.Diagnostic
-	Keybindings       []config.KeyBinding
-	LspNotified       map[string]bool
-	Reg               *command.Registry
-	Running           *bool
-	QuitPending       *bool
+	AutocompleteTimer  *time.Timer
+	HoverTimer         *time.Timer
+	HoverGen           uint64
+	LastHoverLine      int
+	LastHoverCol       int
+	Problems           *ui.ProblemsWidget
+	References         *ui.ReferencesWidget
+	AllDiagnostics     map[string][]ui.Diagnostic
+	Keybindings        []config.KeyBinding
+	LspNotified        map[string]bool
+	Reg                *command.Registry
+	Running            *bool
+	QuitPending        *bool
 }
 
 func (a *App) KeyFor(cmd string) string {
@@ -425,6 +425,36 @@ func OpenURL(url string) {
 		cmd = exec.Command("xdg-open", url)
 	}
 	cmd.Start()
+}
+
+func (a *App) Copy() {
+	if holder, ok := a.Root.Focused.(ui.InputHolder); ok {
+		if inp := holder.FocusedInput(); inp != nil {
+			inp.CopySelection()
+			return
+		}
+	}
+	a.EditorGroup.Copy()
+}
+
+func (a *App) Cut() {
+	if holder, ok := a.Root.Focused.(ui.InputHolder); ok {
+		if inp := holder.FocusedInput(); inp != nil {
+			inp.CutSelection()
+			return
+		}
+	}
+	a.EditorGroup.Cut()
+}
+
+func (a *App) Paste() {
+	if holder, ok := a.Root.Focused.(ui.InputHolder); ok {
+		if inp := holder.FocusedInput(); inp != nil {
+			inp.PasteClipboard()
+			return
+		}
+	}
+	a.EditorGroup.Paste()
 }
 
 func (a *App) ShowDialog(w ui.Widget) {

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -282,17 +282,17 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "editor.copy", Title: "Copy",
-		Handler: func() { app.EditorGroup.Copy() },
+		Handler: app.Copy,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.cut", Title: "Cut",
-		Handler: func() { app.EditorGroup.Cut() },
+		Handler: app.Cut,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.paste", Title: "Paste",
-		Handler: func() { app.EditorGroup.Paste() },
+		Handler: app.Paste,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -56,6 +56,7 @@ var menuBarMenus = [][]ui.ContextMenuItem{
 		ui.MenuSep(),
 		{Label: "Explore", Command: "sidebar.explorer"},
 		{Label: "Find", Command: "sidebar.search"},
+		{Label: "Replace", Command: "sidebar.searchReplace"},
 		{Label: "Changes", Command: "sidebar.changes"},
 		ui.MenuSep(),
 		{Label: "Toggle Sidebar", Command: "sidebar.toggle"},

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -2,9 +2,9 @@ package ui
 
 import (
 	"fmt"
-	"path/filepath"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/term"
+	"path/filepath"
 
 	"github.com/gdamore/tcell/v2"
 )
@@ -44,11 +44,11 @@ type changesItem struct {
 type ChangesWidget struct {
 	BaseWidget
 	SelectableList
-	Dirs         []string
-	Groups       []ChangesGroup
-	items        []changesItem
-	multiRoot    bool
-	inputFocused bool
+	Dirs             []string
+	Groups           []ChangesGroup
+	items            []changesItem
+	multiRoot        bool
+	inputFocused     bool
 	Loading          bool
 	OnOpenDiff       func(dir string, status git.FileStatus)
 	OnOpenPRDiff     func(group *ChangesGroup, status git.FileStatus)
@@ -450,6 +450,19 @@ func (c *ChangesWidget) CursorPosition() (int, int, bool) {
 		}
 	}
 	return 0, 0, false
+}
+
+func (c *ChangesWidget) FocusedInput() *InputWidget {
+	if !c.inputFocused {
+		return nil
+	}
+	if c.Selected >= 0 && c.Selected < len(c.items) {
+		item := c.items[c.Selected]
+		if item.kind == itemInput {
+			return c.Groups[item.groupIndex].Input
+		}
+	}
+	return nil
 }
 
 func (c *ChangesWidget) HandleEvent(ev tcell.Event) EventResult {

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -531,6 +531,12 @@ func (c *ChangesWidget) HandleEvent(ev tcell.Event) EventResult {
 						return EventConsumed
 					}
 				}
+				if item.kind == itemInput {
+					c.Selected = idx
+					c.inputFocused = true
+					c.Groups[item.groupIndex].Input.HandleTextClick(mx)
+					return EventConsumed
+				}
 				if item.kind == itemFile && mx >= r.X+r.W-3 {
 					c.Selected = idx
 					c.handleFileAction(item)

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -534,7 +534,7 @@ func (c *ChangesWidget) HandleEvent(ev tcell.Event) EventResult {
 				if item.kind == itemInput {
 					c.Selected = idx
 					c.inputFocused = true
-					c.Groups[item.groupIndex].Input.HandleTextClick(mx)
+					c.Groups[item.groupIndex].Input.HandleClick(mx, my)
 					return EventConsumed
 				}
 				if item.kind == itemFile && mx >= r.X+r.W-3 {

--- a/internal/ui/findbar_widget.go
+++ b/internal/ui/findbar_widget.go
@@ -185,9 +185,7 @@ func (f *FindBarWidget) HandleEvent(ev tcell.Event) EventResult {
 				f.focused = true
 				row := barY + 1
 				if localY == row && localX >= barX+1 && localX < barX+1+barW-2 {
-					if !f.Input.HandleMouseClick(localX, localY) {
-						f.Input.HandleTextClick(mx)
-					}
+					f.Input.HandleClick(mx, my)
 				}
 				if f.btnPrev.Contains(mx, my) {
 					if len(f.Matches) > 0 {

--- a/internal/ui/findbar_widget.go
+++ b/internal/ui/findbar_widget.go
@@ -185,7 +185,9 @@ func (f *FindBarWidget) HandleEvent(ev tcell.Event) EventResult {
 				f.focused = true
 				row := barY + 1
 				if localY == row && localX >= barX+1 && localX < barX+1+barW-2 {
-					f.Input.HandleMouseClick(localX, localY)
+					if !f.Input.HandleMouseClick(localX, localY) {
+						f.Input.HandleTextClick(mx)
+					}
 				}
 				if f.btnPrev.Contains(mx, my) {
 					if len(f.Matches) > 0 {

--- a/internal/ui/input_widget.go
+++ b/internal/ui/input_widget.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"strings"
+	"time"
+	"unicode"
 
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/term"
@@ -16,17 +18,21 @@ type InputAction struct {
 }
 
 type InputWidget struct {
-	Text         string
-	Prefix       string
-	Placeholder  string
-	CursorPos    int
-	scrollOffset int
-	selStart     int // -1 means no selection
-	selEnd       int
-	Style        term.Style
-	Actions      []InputAction
-	ActionHits   []HitRegion
-	OnChange     func(text string)
+	Text          string
+	Prefix        string
+	Placeholder   string
+	CursorPos     int
+	scrollOffset  int
+	selStart      int // -1 means no selection
+	selEnd        int
+	lastClickTime int64
+	lastClickPos  int
+	clickCount    int
+	renderX       int // screen X of the text area, set during Render
+	Style         term.Style
+	Actions       []InputAction
+	ActionHits    []HitRegion
+	OnChange      func(text string)
 }
 
 func NewInputWidget() *InputWidget {
@@ -68,6 +74,7 @@ func (inp *InputWidget) Render(surface *RenderSurface, x, y, w int) {
 	prefixW := len(prefixRunes)
 	textW := w - actionsW - prefixW
 
+	inp.renderX = x + prefixW
 	for i, ch := range prefixRunes {
 		surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: inp.Style})
 	}
@@ -177,9 +184,12 @@ func (inp *InputWidget) HandleEvent(ev tcell.Event) EventResult {
 			inp.deleteSelection()
 		} else if inp.CursorPos > 0 {
 			runes := []rune(inp.Text)
-			runes = append(runes[:inp.CursorPos-1], runes[inp.CursorPos:]...)
-			inp.Text = string(runes)
-			inp.CursorPos--
+			newPos := inp.CursorPos - 1
+			if kev.Modifiers()&tcell.ModCtrl != 0 {
+				newPos = inp.wordLeft()
+			}
+			inp.Text = string(append(runes[:newPos], runes[inp.CursorPos:]...))
+			inp.CursorPos = newPos
 			inp.notify()
 		}
 		return EventConsumed
@@ -189,17 +199,23 @@ func (inp *InputWidget) HandleEvent(ev tcell.Event) EventResult {
 		} else {
 			runes := []rune(inp.Text)
 			if inp.CursorPos < len(runes) {
-				runes = append(runes[:inp.CursorPos], runes[inp.CursorPos+1:]...)
-				inp.Text = string(runes)
+				end := inp.CursorPos + 1
+				if kev.Modifiers()&tcell.ModCtrl != 0 {
+					end = inp.wordRight()
+				}
+				inp.Text = string(append(runes[:inp.CursorPos], runes[end:]...))
 				inp.notify()
 			}
 		}
 		return EventConsumed
 	case tcell.KeyLeft:
+		ctrl := kev.Modifiers()&tcell.ModCtrl != 0
 		if shift {
 			inp.startSel()
 		}
-		if inp.CursorPos > 0 {
+		if ctrl {
+			inp.CursorPos = inp.wordLeft()
+		} else if inp.CursorPos > 0 {
 			inp.CursorPos--
 		}
 		if shift {
@@ -209,10 +225,13 @@ func (inp *InputWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		return EventConsumed
 	case tcell.KeyRight:
+		ctrl := kev.Modifiers()&tcell.ModCtrl != 0
 		if shift {
 			inp.startSel()
 		}
-		if inp.CursorPos < len([]rune(inp.Text)) {
+		if ctrl {
+			inp.CursorPos = inp.wordRight()
+		} else if inp.CursorPos < len([]rune(inp.Text)) {
 			inp.CursorPos++
 		}
 		if shift {
@@ -291,6 +310,118 @@ func (inp *InputWidget) CutSelection() {
 	}
 	inp.CopySelection()
 	inp.deleteSelection()
+}
+
+func isWordRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+func (inp *InputWidget) wordLeft() int {
+	runes := []rune(inp.Text)
+	pos := inp.CursorPos - 1
+	if pos >= len(runes) {
+		pos = len(runes) - 1
+	}
+	if pos < 0 {
+		return 0
+	}
+	if unicode.IsSpace(runes[pos]) {
+		for pos > 0 && unicode.IsSpace(runes[pos-1]) {
+			pos--
+		}
+	} else if isWordRune(runes[pos]) {
+		for pos > 0 && isWordRune(runes[pos-1]) {
+			pos--
+		}
+	} else {
+		for pos > 0 && !isWordRune(runes[pos-1]) && !unicode.IsSpace(runes[pos-1]) {
+			pos--
+		}
+	}
+	return pos
+}
+
+func (inp *InputWidget) wordRight() int {
+	runes := []rune(inp.Text)
+	pos := inp.CursorPos
+	if pos >= len(runes) {
+		return len(runes)
+	}
+	if unicode.IsSpace(runes[pos]) {
+		for pos < len(runes) && unicode.IsSpace(runes[pos]) {
+			pos++
+		}
+	} else if isWordRune(runes[pos]) {
+		for pos < len(runes) && isWordRune(runes[pos]) {
+			pos++
+		}
+	} else {
+		for pos < len(runes) && !isWordRune(runes[pos]) && !unicode.IsSpace(runes[pos]) {
+			pos++
+		}
+	}
+	return pos
+}
+
+func (inp *InputWidget) selectWordAt(pos int) {
+	runes := []rune(inp.Text)
+	if pos < 0 || pos >= len(runes) {
+		return
+	}
+	lo, hi := pos, pos
+	if isWordRune(runes[pos]) {
+		for lo > 0 && isWordRune(runes[lo-1]) {
+			lo--
+		}
+		for hi < len(runes) && isWordRune(runes[hi]) {
+			hi++
+		}
+	} else if !unicode.IsSpace(runes[pos]) {
+		for lo > 0 && !isWordRune(runes[lo-1]) && !unicode.IsSpace(runes[lo-1]) {
+			lo--
+		}
+		for hi < len(runes) && !isWordRune(runes[hi]) && !unicode.IsSpace(runes[hi]) {
+			hi++
+		}
+	} else {
+		for lo > 0 && unicode.IsSpace(runes[lo-1]) {
+			lo--
+		}
+		for hi < len(runes) && unicode.IsSpace(runes[hi]) {
+			hi++
+		}
+	}
+	inp.selStart = lo
+	inp.selEnd = hi
+	inp.CursorPos = hi
+}
+
+// HandleTextClick handles a mouse click on the input. screenX is the
+// absolute screen coordinate; the text offset is derived from the render
+// position stored during the last Render call.
+func (inp *InputWidget) HandleTextClick(screenX int) bool {
+	pos := inp.scrollOffset + (screenX - inp.renderX)
+	runes := []rune(inp.Text)
+	if pos > len(runes) {
+		pos = len(runes)
+	}
+
+	now := time.Now().UnixMilli()
+	if now-inp.lastClickTime < 400 && pos == inp.lastClickPos {
+		inp.clickCount++
+	} else {
+		inp.clickCount = 1
+	}
+	inp.lastClickTime = now
+	inp.lastClickPos = pos
+
+	if inp.clickCount == 2 {
+		inp.selectWordAt(pos)
+	} else {
+		inp.CursorPos = pos
+		inp.clearSel()
+	}
+	return true
 }
 
 // InputHolder is implemented by widgets that host an InputWidget so global

--- a/internal/ui/input_widget.go
+++ b/internal/ui/input_widget.go
@@ -1,6 +1,9 @@
 package ui
 
 import (
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/term"
 
 	"github.com/gdamore/tcell/v2"
@@ -18,6 +21,8 @@ type InputWidget struct {
 	Placeholder  string
 	CursorPos    int
 	scrollOffset int
+	selStart     int // -1 means no selection
+	selEnd       int
 	Style        term.Style
 	Actions      []InputAction
 	ActionHits   []HitRegion
@@ -26,9 +31,35 @@ type InputWidget struct {
 
 func NewInputWidget() *InputWidget {
 	return &InputWidget{
-		Prefix: " ❯ ",
-		Style:  term.StyleInput,
+		Prefix:   " ❯ ",
+		Style:    term.StyleInput,
+		selStart: -1,
 	}
+}
+
+func (inp *InputWidget) HasSelection() bool {
+	return inp.selStart >= 0 && inp.selStart != inp.selEnd
+}
+
+func (inp *InputWidget) selRange() (int, int) {
+	if inp.selStart < inp.selEnd {
+		return inp.selStart, inp.selEnd
+	}
+	return inp.selEnd, inp.selStart
+}
+
+func (inp *InputWidget) clearSel() {
+	inp.selStart = -1
+	inp.selEnd = -1
+}
+
+func (inp *InputWidget) deleteSelection() {
+	lo, hi := inp.selRange()
+	runes := []rune(inp.Text)
+	inp.Text = string(append(runes[:lo], runes[hi:]...))
+	inp.CursorPos = lo
+	inp.clearSel()
+	inp.notify()
 }
 
 func (inp *InputWidget) Render(surface *RenderSurface, x, y, w int) {
@@ -52,6 +83,11 @@ func (inp *InputWidget) Render(surface *RenderSurface, x, y, w int) {
 			inp.scrollOffset = inp.CursorPos - textW + 1
 		}
 
+		selLo, selHi := -1, -1
+		if inp.HasSelection() {
+			selLo, selHi = inp.selRange()
+		}
+
 		if showPlaceholder {
 			phRunes := []rune(inp.Placeholder)
 			for i := 0; i < textW; i++ {
@@ -68,7 +104,11 @@ func (inp *InputWidget) Render(surface *RenderSurface, x, y, w int) {
 				if ri < len(textRunes) {
 					ch = textRunes[ri]
 				}
-				surface.SetCell(x+prefixW+i, y, term.Cell{Ch: ch, Style: inp.Style})
+				style := inp.Style
+				if selLo >= 0 && ri >= selLo && ri < selHi {
+					style = term.StyleSelection
+				}
+				surface.SetCell(x+prefixW+i, y, term.Cell{Ch: ch, Style: style})
 			}
 		}
 	}
@@ -119,8 +159,13 @@ func (inp *InputWidget) HandleEvent(ev tcell.Event) EventResult {
 	if !ok {
 		return EventIgnored
 	}
+	shift := kev.Modifiers()&tcell.ModShift != 0
+
 	switch kev.Key() {
 	case tcell.KeyRune:
+		if inp.HasSelection() {
+			inp.deleteSelection()
+		}
 		runes := []rune(inp.Text)
 		runes = append(runes[:inp.CursorPos], append([]rune{kev.Rune()}, runes[inp.CursorPos:]...)...)
 		inp.Text = string(runes)
@@ -128,7 +173,9 @@ func (inp *InputWidget) HandleEvent(ev tcell.Event) EventResult {
 		inp.notify()
 		return EventConsumed
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
-		if inp.CursorPos > 0 {
+		if inp.HasSelection() {
+			inp.deleteSelection()
+		} else if inp.CursorPos > 0 {
 			runes := []rune(inp.Text)
 			runes = append(runes[:inp.CursorPos-1], runes[inp.CursorPos:]...)
 			inp.Text = string(runes)
@@ -137,42 +184,158 @@ func (inp *InputWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		return EventConsumed
 	case tcell.KeyDelete:
-		runes := []rune(inp.Text)
-		if inp.CursorPos < len(runes) {
-			runes = append(runes[:inp.CursorPos], runes[inp.CursorPos+1:]...)
-			inp.Text = string(runes)
-			inp.notify()
+		if inp.HasSelection() {
+			inp.deleteSelection()
+		} else {
+			runes := []rune(inp.Text)
+			if inp.CursorPos < len(runes) {
+				runes = append(runes[:inp.CursorPos], runes[inp.CursorPos+1:]...)
+				inp.Text = string(runes)
+				inp.notify()
+			}
 		}
 		return EventConsumed
 	case tcell.KeyLeft:
+		if shift {
+			inp.startSel()
+		}
 		if inp.CursorPos > 0 {
 			inp.CursorPos--
 		}
+		if shift {
+			inp.selEnd = inp.CursorPos
+		} else {
+			inp.clearSel()
+		}
 		return EventConsumed
 	case tcell.KeyRight:
+		if shift {
+			inp.startSel()
+		}
 		if inp.CursorPos < len([]rune(inp.Text)) {
 			inp.CursorPos++
 		}
+		if shift {
+			inp.selEnd = inp.CursorPos
+		} else {
+			inp.clearSel()
+		}
 		return EventConsumed
 	case tcell.KeyHome:
+		if shift {
+			inp.startSel()
+		}
 		inp.CursorPos = 0
+		if shift {
+			inp.selEnd = inp.CursorPos
+		} else {
+			inp.clearSel()
+		}
 		return EventConsumed
 	case tcell.KeyEnd:
+		if shift {
+			inp.startSel()
+		}
 		inp.CursorPos = len([]rune(inp.Text))
+		if shift {
+			inp.selEnd = inp.CursorPos
+		} else {
+			inp.clearSel()
+		}
+		return EventConsumed
+	case tcell.KeyCtrlV:
+		inp.PasteClipboard()
+		return EventConsumed
+	case tcell.KeyCtrlA:
+		inp.SelectAll()
+		return EventConsumed
+	case tcell.KeyCtrlC:
+		inp.CopySelection()
+		return EventConsumed
+	case tcell.KeyCtrlX:
+		inp.CutSelection()
 		return EventConsumed
 	}
 	return EventIgnored
 }
 
+func (inp *InputWidget) startSel() {
+	if inp.selStart < 0 {
+		inp.selStart = inp.CursorPos
+		inp.selEnd = inp.CursorPos
+	}
+}
+
+func (inp *InputWidget) SelectAll() {
+	runes := []rune(inp.Text)
+	if len(runes) == 0 {
+		return
+	}
+	inp.selStart = 0
+	inp.selEnd = len(runes)
+	inp.CursorPos = len(runes)
+}
+
+func (inp *InputWidget) CopySelection() {
+	if !inp.HasSelection() {
+		return
+	}
+	lo, hi := inp.selRange()
+	runes := []rune(inp.Text)
+	clipboard.Set(string(runes[lo:hi]))
+}
+
+func (inp *InputWidget) CutSelection() {
+	if !inp.HasSelection() {
+		return
+	}
+	inp.CopySelection()
+	inp.deleteSelection()
+}
+
+// InputHolder is implemented by widgets that host an InputWidget so global
+// clipboard commands can be routed to the focused input. FocusedInput may
+// return nil when no input is currently focused.
+type InputHolder interface {
+	FocusedInput() *InputWidget
+}
+
+// PasteClipboard inserts clipboard text at the cursor, replacing any
+// selection. Newlines are flattened for single-line inputs.
+func (inp *InputWidget) PasteClipboard() {
+	if inp.HasSelection() {
+		inp.deleteSelection()
+	}
+	text := sanitizePaste(clipboard.Get())
+	if text == "" {
+		return
+	}
+	runes := []rune(inp.Text)
+	pasted := []rune(text)
+	runes = append(runes[:inp.CursorPos], append(pasted, runes[inp.CursorPos:]...)...)
+	inp.Text = string(runes)
+	inp.CursorPos += len(pasted)
+	inp.notify()
+}
+
+func sanitizePaste(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	text = strings.TrimRight(text, "\n")
+	return strings.ReplaceAll(text, "\n", " ")
+}
+
 func (inp *InputWidget) SetText(text string) {
 	inp.Text = text
 	inp.CursorPos = len([]rune(text))
+	inp.clearSel()
 	inp.notify()
 }
 
 func (inp *InputWidget) Clear() {
 	inp.Text = ""
 	inp.CursorPos = 0
+	inp.clearSel()
 	inp.notify()
 }
 

--- a/internal/ui/input_widget.go
+++ b/internal/ui/input_widget.go
@@ -28,7 +28,8 @@ type InputWidget struct {
 	lastClickTime int64
 	lastClickPos  int
 	clickCount    int
-	renderX       int // screen X of the text area, set during Render
+	renderX       int // screen-absolute X of the text area start
+	renderY       int // screen-absolute Y of the input row
 	Style         term.Style
 	Actions       []InputAction
 	ActionHits    []HitRegion
@@ -74,7 +75,9 @@ func (inp *InputWidget) Render(surface *RenderSurface, x, y, w int) {
 	prefixW := len(prefixRunes)
 	textW := w - actionsW - prefixW
 
-	inp.renderX = x + prefixW
+	ox, oy := surface.Origin()
+	inp.renderX = ox + x + prefixW
+	inp.renderY = oy + y
 	for i, ch := range prefixRunes {
 		surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: inp.Style})
 	}
@@ -128,7 +131,7 @@ func (inp *InputWidget) Render(surface *RenderSurface, x, y, w int) {
 			style = term.StyleDefault
 		}
 		labelW := len([]rune(action.Label))
-		inp.ActionHits = append(inp.ActionHits, HitRegion{X: ax, Y: y, W: labelW})
+		inp.ActionHits = append(inp.ActionHits, HitRegion{X: ox + ax, Y: inp.renderY, W: labelW})
 		for _, ch := range action.Label {
 			if ax < x+w {
 				surface.SetCell(ax, y, term.Cell{Ch: ch, Style: style})
@@ -396,12 +399,28 @@ func (inp *InputWidget) selectWordAt(pos int) {
 	inp.CursorPos = hi
 }
 
-// HandleTextClick handles a mouse click on the input. screenX is the
-// absolute screen coordinate; the text offset is derived from the render
-// position stored during the last Render call.
-func (inp *InputWidget) HandleTextClick(screenX int) bool {
+// HandleClick handles a mouse click at screen-absolute coordinates.
+// It checks action buttons first, then positions the cursor or selects
+// a word on double-click.
+func (inp *InputWidget) HandleClick(screenX, screenY int) bool {
+	for i, hit := range inp.ActionHits {
+		if screenX >= hit.X && screenX < hit.X+hit.W && screenY == hit.Y {
+			if i < len(inp.Actions) && inp.Actions[i].OnClick != nil {
+				inp.Actions[i].OnClick()
+			}
+			return true
+		}
+	}
+
+	if screenY != inp.renderY {
+		return false
+	}
+
 	pos := inp.scrollOffset + (screenX - inp.renderX)
 	runes := []rune(inp.Text)
+	if pos < 0 {
+		pos = 0
+	}
 	if pos > len(runes) {
 		pos = len(runes)
 	}
@@ -470,17 +489,6 @@ func (inp *InputWidget) Clear() {
 	inp.notify()
 }
 
-func (inp *InputWidget) HandleMouseClick(localX, localY int) bool {
-	for i, hit := range inp.ActionHits {
-		if localX >= hit.X && localX < hit.X+hit.W && localY == hit.Y {
-			if i < len(inp.Actions) && inp.Actions[i].OnClick != nil {
-				inp.Actions[i].OnClick()
-			}
-			return true
-		}
-	}
-	return false
-}
 
 func (inp *InputWidget) notify() {
 	if inp.OnChange != nil {

--- a/internal/ui/inputdialog_widget.go
+++ b/internal/ui/inputdialog_widget.go
@@ -122,6 +122,7 @@ func (d *InputDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 			if my == d.boxY+3 {
 				d.focusedBtn = 0
+				d.Input.HandleTextClick(mx)
 			}
 		}
 		return EventConsumed

--- a/internal/ui/inputdialog_widget.go
+++ b/internal/ui/inputdialog_widget.go
@@ -122,7 +122,7 @@ func (d *InputDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 			if my == d.boxY+3 {
 				d.focusedBtn = 0
-				d.Input.HandleTextClick(mx)
+				d.Input.HandleClick(mx, my)
 			}
 		}
 		return EventConsumed

--- a/internal/ui/palette_widget.go
+++ b/internal/ui/palette_widget.go
@@ -196,6 +196,16 @@ func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
 }
 
 func (p *CommandPaletteWidget) HandleEvent(ev tcell.Event) EventResult {
+	if mev, ok := ev.(*tcell.EventMouse); ok {
+		if mev.Buttons()&tcell.Button1 != 0 {
+			mx, my := mev.Position()
+			if my == p.inputY {
+				p.Input.HandleTextClick(mx)
+			}
+		}
+		return EventConsumed
+	}
+
 	kev, ok := ev.(*tcell.EventKey)
 	if !ok {
 		return EventConsumed

--- a/internal/ui/palette_widget.go
+++ b/internal/ui/palette_widget.go
@@ -200,7 +200,7 @@ func (p *CommandPaletteWidget) HandleEvent(ev tcell.Event) EventResult {
 		if mev.Buttons()&tcell.Button1 != 0 {
 			mx, my := mev.Position()
 			if my == p.inputY {
-				p.Input.HandleTextClick(mx)
+				p.Input.HandleClick(mx, my)
 			}
 		}
 		return EventConsumed

--- a/internal/ui/replacebar_widget.go
+++ b/internal/ui/replacebar_widget.go
@@ -200,19 +200,13 @@ func (r *ReplaceBarWidget) HandleEvent(ev tcell.Event) EventResult {
 			replRow := barY + 2
 
 			if localY == findRow && localX >= barX+1 && localX < barX+1+barW-2 {
-				if r.SearchInput.HandleMouseClick(localX, localY) {
-					return EventConsumed
-				}
 				r.focusRow = 0
-				r.SearchInput.HandleTextClick(mx)
+				r.SearchInput.HandleClick(mx, my)
 				return EventConsumed
 			}
 			if localY == replRow && localX >= barX+1 && localX < barX+1+barW-2 {
-				if r.ReplaceInput.HandleMouseClick(localX, localY) {
-					return EventConsumed
-				}
 				r.focusRow = 1
-				r.ReplaceInput.HandleTextClick(mx)
+				r.ReplaceInput.HandleClick(mx, my)
 				return EventConsumed
 			}
 

--- a/internal/ui/replacebar_widget.go
+++ b/internal/ui/replacebar_widget.go
@@ -204,6 +204,7 @@ func (r *ReplaceBarWidget) HandleEvent(ev tcell.Event) EventResult {
 					return EventConsumed
 				}
 				r.focusRow = 0
+				r.SearchInput.HandleTextClick(mx)
 				return EventConsumed
 			}
 			if localY == replRow && localX >= barX+1 && localX < barX+1+barW-2 {
@@ -211,6 +212,7 @@ func (r *ReplaceBarWidget) HandleEvent(ev tcell.Event) EventResult {
 					return EventConsumed
 				}
 				r.focusRow = 1
+				r.ReplaceInput.HandleTextClick(mx)
 				return EventConsumed
 			}
 

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -734,6 +734,7 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 					return EventConsumed
 				}
 				s.focusIdx = 0
+				s.Input.HandleTextClick(mx)
 				return EventConsumed
 			}
 
@@ -748,6 +749,7 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 						break
 					}
 				}
+				s.ReplaceInput.HandleTextClick(mx)
 				return EventConsumed
 			}
 

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -157,7 +157,7 @@ func (s *SearchWidget) visibleInputs() []*InputWidget {
 	return inputs
 }
 
-func (s *SearchWidget) focusedInput() *InputWidget {
+func (s *SearchWidget) FocusedInput() *InputWidget {
 	inputs := s.visibleInputs()
 	if s.focusIdx >= 0 && s.focusIdx < len(inputs) {
 		return inputs[s.focusIdx]
@@ -173,7 +173,7 @@ func (s *SearchWidget) Focusable() bool { return true }
 
 func (s *SearchWidget) CursorPosition() (int, int, bool) {
 	r := s.GetRect()
-	inp := s.focusedInput()
+	inp := s.FocusedInput()
 	y := s.inputY(inp)
 	return inp.CursorX(r.X), r.Y + y, true
 }
@@ -438,8 +438,8 @@ func (s *SearchWidget) streamFiles(ctx context.Context, gen uint64, groups *[]Se
 }
 
 type rgMessage struct {
-	Type string         `json:"type"`
-	Data rgMatchData    `json:"data"`
+	Type string      `json:"type"`
+	Data rgMatchData `json:"data"`
 }
 
 type rgMatchData struct {
@@ -856,7 +856,7 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 			return EventConsumed
 		default:
-			if s.focusedInput().HandleEvent(ev) == EventConsumed {
+			if s.FocusedInput().HandleEvent(ev) == EventConsumed {
 				return EventConsumed
 			}
 		}

--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -730,18 +730,12 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 			localY := my - r.Y
 
 			if localY == 0 {
-				if s.Input.HandleMouseClick(localX, localY) {
-					return EventConsumed
-				}
 				s.focusIdx = 0
-				s.Input.HandleTextClick(mx)
+				s.Input.HandleClick(mx, my)
 				return EventConsumed
 			}
 
 			if s.showReplace && localY == 2 {
-				if s.ReplaceInput.HandleMouseClick(localX, localY) {
-					return EventConsumed
-				}
 				inputs := s.visibleInputs()
 				for i, inp := range inputs {
 					if inp == s.ReplaceInput {
@@ -749,7 +743,7 @@ func (s *SearchWidget) HandleEvent(ev tcell.Event) EventResult {
 						break
 					}
 				}
-				s.ReplaceInput.HandleTextClick(mx)
+				s.ReplaceInput.HandleClick(mx, my)
 				return EventConsumed
 			}
 

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -15,6 +15,10 @@ func (s *RenderSurface) Size() (w, h int) {
 	return s.clip.W, s.clip.H
 }
 
+func (s *RenderSurface) Origin() (x, y int) {
+	return s.clip.X, s.clip.Y
+}
+
 func (s *RenderSurface) SetCell(x, y int, c term.Cell) {
 	absX := s.clip.X + x
 	absY := s.clip.Y + y


### PR DESCRIPTION
## Summary
- **Clipboard support**: Ctrl+C/X/V now work in all InputWidget instances (dialogs, search panel, commit message, find/replace bar, command palette). Global `editor.copy`/`cut`/`paste` commands route through focused inputs via the `InputHolder` interface before falling back to the editor.
- **Text selection**: Shift+Left/Right/Home/End extends selection, Ctrl+A selects all. Selected text renders with `StyleSelection`. Typing, backspace, delete, and paste replace the active selection.
- **Word navigation**: Ctrl+Left/Right jumps by word boundary, Ctrl+Shift+Left/Right selects by word, Ctrl+Backspace/Delete deletes word.
- **Mouse improvements**: Single click positions cursor in text, double-click selects word. Consolidated `HandleMouseClick` and `HandleTextClick` into a single `HandleClick(screenX, screenY)` method — the input stores its screen position during Render so callers just pass raw screen coordinates.

## Test plan
- [ ] Open Save As dialog, paste a URL with Ctrl+V
- [ ] Open Review PR dialog, paste a URL with Ctrl+V
- [ ] In search panel, Ctrl+A to select all, Ctrl+C to copy, Ctrl+V to paste
- [ ] In commit message input, type text, Shift+Left to select, Ctrl+X to cut
- [ ] Ctrl+Left/Right word jumps in any input
- [ ] Ctrl+Backspace deletes word in any input
- [ ] Double-click selects word in search, find bar, command palette, dialogs
- [ ] Action buttons (case sensitive, regex toggles) still work in search/find bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)