### PR TITLE
feat: refresh PR files with 'r' key in review context

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -412,6 +412,7 @@ func registerWidgetCallbacks(app *App) {
 	app.Changes.OnOpenDiff = app.OpenChangeDiff
 	app.Changes.OnOpenPRDiff = app.OpenPRDiff
 	app.Changes.OnPRGroupMenu = app.ShowPRGroupMenu
+	app.Changes.OnRefreshPR = app.FetchAndOpenPR
 	app.Changes.OnGroupMenu = app.ShowGroupMenu
 	app.Changes.OnCommit = app.CommitChanges
 	app.Changes.OnConfirmDiscard = app.ConfirmDiscard

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -56,6 +56,7 @@ type ChangesWidget struct {
 	OnCommit         func(dir string, message string)
 	OnGroupMenu      func(dir string, screenX, screenY int)
 	OnPRGroupMenu    func(group *ChangesGroup, screenX, screenY int)
+	OnRefreshPR      func(url string)
 	OnConfirmDiscard func(message string, onConfirm func())
 }
 
@@ -564,7 +565,15 @@ func (c *ChangesWidget) HandleEvent(ev tcell.Event) EventResult {
 		inPR := c.selectedInPR()
 		switch {
 		case tev.Key() == tcell.KeyRune && (tev.Rune() == 'r' || tev.Rune() == 'R'):
-			c.Refresh()
+			if inPR {
+				g := &c.Groups[c.items[c.Selected].groupIndex]
+				if c.OnRefreshPR != nil && g.PRURL != "" {
+					c.RemovePRGroup(g.Name)
+					c.OnRefreshPR(g.PRURL)
+				}
+			} else {
+				c.Refresh()
+			}
 			return EventConsumed
 		case !inPR && tev.Key() == tcell.KeyRune && tev.Rune() == ' ':
 			c.toggleStageSelected()


### PR DESCRIPTION
## Summary
- Pressing `r` while viewing a PR in the changes panel now re-fetches the PR files and diffs
- Local changes context still refreshes git status as before
- Added `OnRefreshPR` callback to `ChangesWidget`, wired to `FetchAndOpenPR`

## Test plan
- [ ] Open a PR for review, press `r` — should show loading state and reload PR files
- [ ] In local changes view, press `r` — should still refresh git status as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)