### PR TITLE
fix: make file save atomic and preserve permissions

### DIFF
--- a/internal/core/buffer/io.go
+++ b/internal/core/buffer/io.go
@@ -2,7 +2,9 @@ package buffer
 
 import (
 	"bufio"
+	"io"
 	"os"
+	"path/filepath"
 )
 
 // LoadFile loads a file into the buffer, replacing its contents.
@@ -31,30 +33,74 @@ func (b *Buffer) LoadFile(filename string) error {
 	return nil
 }
 
-// SaveFile writes the buffer contents to a file.
+// SaveFile writes the buffer contents to a file atomically: it writes to a
+// temporary file in the same directory, fsyncs it, then renames it over the
+// target. This guarantees the file on disk is always either the complete old
+// or complete new content, never a truncated partial write. The target's
+// permissions are preserved; symlinks are followed so the link is kept intact.
 func (b *Buffer) SaveFile(filename string) error {
 	if b.InsertFinalNewline && (len(b.Lines) == 0 || b.Lines[len(b.Lines)-1] != "") {
 		b.Lines = append(b.Lines, "")
 	}
-	f, err := os.Create(filename)
+
+	// Resolve symlinks so we write through to the real file rather than
+	// replacing the link itself with a regular file on rename.
+	target := filename
+	if resolved, err := filepath.EvalSymlinks(filename); err == nil {
+		target = resolved
+	}
+
+	dir := filepath.Dir(target)
+	mode := os.FileMode(0644)
+	if info, err := os.Stat(target); err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	tmp, err := os.CreateTemp(dir, ".ttt-*.tmp")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	w := bufio.NewWriter(f)
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail out before the rename succeeds.
+	defer os.Remove(tmpName)
+
+	w := bufio.NewWriter(tmp)
+	if err := b.writeLines(w); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := w.Flush(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		return err
+	}
+
+	b.Dirty = false
+	return nil
+}
+
+func (b *Buffer) writeLines(w io.Writer) error {
 	for i, line := range b.Lines {
-		if _, err := w.WriteString(line); err != nil {
+		if _, err := io.WriteString(w, line); err != nil {
 			return err
 		}
 		if i < len(b.Lines)-1 {
-			if err := w.WriteByte('\n'); err != nil {
+			if _, err := io.WriteString(w, "\n"); err != nil {
 				return err
 			}
 		}
 	}
-	if err := w.Flush(); err != nil {
-		return err
-	}
-	b.Dirty = false
 	return nil
 }

--- a/internal/core/buffer/io_test.go
+++ b/internal/core/buffer/io_test.go
@@ -2,6 +2,8 @@ package buffer
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -18,5 +20,81 @@ func TestLoadAndSaveFile(t *testing.T) {
 	}
 	if len(b.Lines) != 2 || b.Lines[0] != "hello" || b.Lines[1] != "world" {
 		t.Errorf("expected [hello world], got %v", b.Lines)
+	}
+}
+
+func TestSavePreservesPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not meaningful on Windows")
+	}
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "script.sh")
+	if err := os.WriteFile(fname, []byte("old\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	b := &Buffer{Lines: []string{"new", ""}}
+	if err := b.SaveFile(fname); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	info, err := os.Stat(fname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("expected mode 0755 preserved, got %o", info.Mode().Perm())
+	}
+}
+
+func TestSaveThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior differs on Windows")
+	}
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.txt")
+	link := filepath.Join(dir, "link.txt")
+	if err := os.WriteFile(realFile, []byte("old\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile, link); err != nil {
+		t.Fatal(err)
+	}
+	b := &Buffer{Lines: []string{"new", ""}}
+	if err := b.SaveFile(link); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	// The link must still be a symlink, and the real file must hold new content.
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("symlink was replaced with a regular file")
+	}
+	data, err := os.ReadFile(realFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new\n" {
+		t.Errorf("expected real file to contain %q, got %q", "new\n", string(data))
+	}
+}
+
+func TestSaveDoesNotLeaveTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "file.txt")
+	b := &Buffer{Lines: []string{"content", ""}}
+	if err := b.SaveFile(fname); err != nil {
+		t.Fatalf("SaveFile failed: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "file.txt" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only file.txt, got %v", names)
 	}
 }


### PR DESCRIPTION
## Summary
First of three file-save robustness fixes (atomic save → external-change detection → line-ending preservation).

`SaveFile` previously called `os.Create()` directly, which truncates the target file to zero bytes *before* writing the new content. A crash, `kill -9`, or full disk landing in that window left the file empty or partial with no recovery — the only intact copy was in the memory of a process that may have just died. It also reset file permissions to 0644 on every save.

Now `SaveFile`:
- writes to a temp file in the same directory
- flushes and `fsync`s it
- preserves the target's existing permission bits (so saving a `0755` script keeps it executable)
- follows symlinks, so a save through a symlinked dotfile keeps the link intact instead of replacing it with a regular file
- atomically renames the temp over the target — the on-disk file is always either fully old or fully new

## Tests
- `TestSavePreservesPermissions` — 0755 file stays 0755 after save
- `TestSaveThroughSymlink` — link stays a symlink, real file gets new content
- `TestSaveDoesNotLeaveTempFiles` — no `.ttt-*.tmp` residue on success
- Existing round-trip test still passes

## Test plan
- [ ] Save an executable script in the editor, confirm `ls -l` still shows the execute bit
- [ ] Save a file that's a symlink, confirm the link is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)