### PR TITLE
feat: detect external file changes before overwriting on save

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/eugenioenko/ttt/internal/command"
@@ -118,6 +120,23 @@ func (a *App) SaveFileAs() {
 }
 
 func (a *App) SaveFile() {
+	path := a.EditorGroup.ActiveFilePath()
+	buf := a.EditorGroup.ActiveBuffer()
+	if buf != nil && path != "untitled" && buf.DiskChanged(path) {
+		a.ShowConfirmDialog(
+			fmt.Sprintf("%s was modified on disk. Overwrite with your version?", filepath.Base(path)),
+			[]string{"Overwrite", "Cancel"},
+			[]func(){
+				func() { a.DismissDialog(); a.doSaveFile() },
+				func() { a.DismissDialog() },
+			},
+		)
+		return
+	}
+	a.doSaveFile()
+}
+
+func (a *App) doSaveFile() {
 	path, lang := a.editorPathLang()
 	if lang != "" {
 		a.RunCodeActionsOnSave(path, lang)

--- a/internal/core/buffer/buffer.go
+++ b/internal/core/buffer/buffer.go
@@ -1,5 +1,7 @@
 package buffer
 
+import "time"
+
 type IndentInfo struct {
 	UseTabs bool
 	Size    int
@@ -71,6 +73,14 @@ type Buffer struct {
 	Lines              []string
 	Dirty              bool
 	InsertFinalNewline bool
+
+	// diskModTime and diskSize record the state of the file on disk the last
+	// time we loaded or saved it, so we can detect external modifications
+	// before overwriting. diskInfoSet is false for buffers never backed by a
+	// file on disk (e.g. a new untitled buffer).
+	diskModTime time.Time
+	diskSize    int64
+	diskInfoSet bool
 }
 
 // InsertRune inserts a rune at the given line and column.

--- a/internal/core/buffer/io.go
+++ b/internal/core/buffer/io.go
@@ -30,7 +30,33 @@ func (b *Buffer) LoadFile(filename string) error {
 	}
 	b.Lines = lines
 	b.Dirty = false
+	if info, err := f.Stat(); err == nil {
+		b.recordDiskInfo(info)
+	}
 	return nil
+}
+
+// recordDiskInfo stores the file's modification time and size so a later save
+// can detect whether the file changed on disk in the meantime.
+func (b *Buffer) recordDiskInfo(info os.FileInfo) {
+	b.diskModTime = info.ModTime()
+	b.diskSize = info.Size()
+	b.diskInfoSet = true
+}
+
+// DiskChanged reports whether the file on disk has been modified since the
+// buffer last loaded or saved it. It returns false when there is no recorded
+// disk state (a new buffer never written to disk) or when the file no longer
+// exists — a missing file is handled by the save itself, which recreates it.
+func (b *Buffer) DiskChanged(filename string) bool {
+	if !b.diskInfoSet {
+		return false
+	}
+	info, err := os.Stat(filename)
+	if err != nil {
+		return false
+	}
+	return !info.ModTime().Equal(b.diskModTime) || info.Size() != b.diskSize
 }
 
 // SaveFile writes the buffer contents to a file atomically: it writes to a
@@ -88,6 +114,9 @@ func (b *Buffer) SaveFile(filename string) error {
 	}
 
 	b.Dirty = false
+	if info, err := os.Stat(target); err == nil {
+		b.recordDiskInfo(info)
+	}
 	return nil
 }
 

--- a/internal/core/buffer/io_test.go
+++ b/internal/core/buffer/io_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestLoadAndSaveFile(t *testing.T) {
@@ -76,6 +77,49 @@ func TestSaveThroughSymlink(t *testing.T) {
 	}
 	if string(data) != "new\n" {
 		t.Errorf("expected real file to contain %q, got %q", "new\n", string(data))
+	}
+}
+
+func TestDiskChanged(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(fname, []byte("one\ntwo\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Buffer{}
+	if err := b.LoadFile(fname); err != nil {
+		t.Fatal(err)
+	}
+	if b.DiskChanged(fname) {
+		t.Errorf("expected no change right after load")
+	}
+
+	// Simulate an external edit: different size and a later mtime.
+	if err := os.WriteFile(fname, []byte("changed externally\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(fname, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if !b.DiskChanged(fname) {
+		t.Errorf("expected change to be detected after external edit")
+	}
+
+	// Saving re-syncs our recorded disk state.
+	if err := b.SaveFile(fname); err != nil {
+		t.Fatal(err)
+	}
+	if b.DiskChanged(fname) {
+		t.Errorf("expected no change right after save")
+	}
+}
+
+func TestDiskChangedNewBuffer(t *testing.T) {
+	b := &Buffer{Lines: []string{"never saved"}}
+	if b.DiskChanged("/nonexistent/path") {
+		t.Errorf("a buffer with no recorded disk state should report no change")
 	}
 }
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -395,6 +395,16 @@ func (g *EditorGroupWidget) ActiveFilePath() string {
 	return ""
 }
 
+// ActiveBuffer returns the buffer backing the active tab, or nil if the active
+// tab is not a text buffer (e.g. a diff view).
+func (g *EditorGroupWidget) ActiveBuffer() *buffer.Buffer {
+	t := g.activeTab()
+	if t == nil || t.Content != nil {
+		return nil
+	}
+	return t.Buf
+}
+
 func (g *EditorGroupWidget) ActiveCursor() (line, col int) {
 	t := g.activeTab()
 	if t == nil || t.Content != nil {

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -24,6 +24,7 @@ type testHarness struct {
 	reg      *command.Registry
 	renderer *render.Renderer
 	running  bool
+	dir      string
 }
 
 func newTestHarness(t *testing.T, w, h int) *testHarness {
@@ -80,6 +81,7 @@ func newTestHarness(t *testing.T, w, h int) *testHarness {
 		reg:      reg,
 		renderer: editor.Renderer,
 		running:  running,
+		dir:      dir,
 	}
 	h2.redraw()
 	return h2

--- a/tests/e2e/save_conflict_test.go
+++ b/tests/e2e/save_conflict_test.go
@@ -1,0 +1,114 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// modifyOnDisk rewrites a file's contents and pushes its mtime forward so the
+// editor's recorded disk state is guaranteed to look stale, regardless of
+// filesystem timestamp resolution.
+func modifyOnDisk(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSaveConflictPromptsBeforeOverwrite(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	path := filepath.Join(h.dir, "conflict.txt")
+	if err := os.WriteFile(path, []byte("original\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	// Saving with no external change must not prompt.
+	h.exec("file.save")
+	if len(h.app.Root.Overlays) != 0 {
+		t.Fatalf("expected no dialog when file is unchanged on disk, got %d overlays", len(h.app.Root.Overlays))
+	}
+
+	// Now the file changes underneath us; saving must prompt first.
+	modifyOnDisk(t, path, "changed by another tool\n")
+	h.exec("file.save")
+	if len(h.app.Root.Overlays) != 1 {
+		t.Fatalf("expected a confirmation dialog after external change, got %d overlays", len(h.app.Root.Overlays))
+	}
+	h.assertContains("modified on disk")
+}
+
+func TestSaveConflictOverwrite(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	path := filepath.Join(h.dir, "conflict.txt")
+	if err := os.WriteFile(path, []byte("original\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	modifyOnDisk(t, path, "changed by another tool\n")
+	h.exec("file.save")
+	if len(h.app.Root.Overlays) != 1 {
+		t.Fatalf("expected confirmation dialog, got %d overlays", len(h.app.Root.Overlays))
+	}
+
+	// Overwrite is the default selection; Enter activates it.
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+	if len(h.app.Root.Overlays) != 0 {
+		t.Fatalf("expected dialog dismissed after Overwrite, got %d overlays", len(h.app.Root.Overlays))
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "original\n" {
+		t.Errorf("expected our buffer to overwrite the file, got %q", string(data))
+	}
+}
+
+func TestSaveConflictCancelKeepsDiskVersion(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	path := filepath.Join(h.dir, "conflict.txt")
+	if err := os.WriteFile(path, []byte("original\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	modifyOnDisk(t, path, "changed by another tool\n")
+	h.exec("file.save")
+	if len(h.app.Root.Overlays) != 1 {
+		t.Fatalf("expected confirmation dialog, got %d overlays", len(h.app.Root.Overlays))
+	}
+
+	// Cancel via its first-letter shortcut; the disk version must survive.
+	h.pressRune('c')
+	if len(h.app.Root.Overlays) != 0 {
+		t.Fatalf("expected dialog dismissed after Cancel, got %d overlays", len(h.app.Root.Overlays))
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "changed by another tool\n" {
+		t.Errorf("expected the disk version to be kept after Cancel, got %q", string(data))
+	}
+}


### PR DESCRIPTION
## Summary
Second of the file-save robustness fixes (after #56 atomic save). Closes the silent-overwrite gap: the editor never checked whether a file changed on disk before saving, so a `git checkout`, formatter, or other tool editing the file would be clobbered without warning.

Now the buffer records the file's mtime + size on load and after each save. At save time the app checks `DiskChanged`; on a conflict it shows a confirmation dialog before writing:

- **Overwrite** — proceed with the (atomic) save, replacing the on-disk version
- **Cancel** — abort, keeping the disk version

Reload is intentionally omitted: since the user just pressed Save, a Reload button that discards their edits would be a footgun.

The core `buffer` package stays UI-agnostic — it only exposes `DiskChanged(filename)`. The dialog and decision live in the app layer, consistent with the layered architecture.

## Tests
Unit (`internal/core/buffer`):
- `TestDiskChanged` — no change after load, detected after external edit, re-synced after save
- `TestDiskChangedNewBuffer` — a buffer never written to disk reports no change

E2E (`tests/e2e`, through the full app + simulation screen):
- `TestSaveConflictPromptsBeforeOverwrite` — no prompt when unchanged; prompt appears after an external change
- `TestSaveConflictOverwrite` — Overwrite writes our buffer's content
- `TestSaveConflictCancelKeepsDiskVersion` — Cancel leaves the disk version intact

Exposes the harness temp dir (`dir`) so e2e tests can open and externally mutate workspace files.

## Not included
Live auto-reload (fsnotify watcher) — the editor's view still only surfaces an external change at save time. That's a separate, larger piece tracked for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)