### PR TITLE
feat: live-reload files when they change on disk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.24.1
 	github.com/creack/pty v1.1.24
 	github.com/eugenioenko/vt10x v0.0.0-20260527232601-d49d2c8355db
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gdamore/tcell/v2 v2.13.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/eugenioenko/vt10x v0.0.0-20260527232601-d49d2c8355db h1:Qux7flgfL+6tbpg8gQWrEc0yAktZKu6jhqCT5JfJvyU=
 github.com/eugenioenko/vt10x v0.0.0-20260527232601-d49d2c8355db/go.mod h1:ScQ3ntuV4FsJ0tiQEsQKideTmj/vJT5KIo9xKB98Q/0=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.13.7 h1:yfHdeC7ODIYCc6dgRos8L1VujQtXHmUpU6UZotzD6os=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/terminal"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/view"
+	"github.com/eugenioenko/ttt/internal/watcher"
 	"github.com/eugenioenko/ttt/internal/workspace"
 
 	"github.com/gdamore/tcell/v2"
@@ -69,6 +70,7 @@ type App struct {
 	Reg                *command.Registry
 	Running            *bool
 	QuitPending        *bool
+	Watcher            *watcher.Watcher
 }
 
 func (a *App) KeyFor(cmd string) string {
@@ -353,6 +355,7 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	a.Screen = screen
 	a.Renderer = renderer
 	a.LspManager = lspManager
+	a.StartWatcher()
 
 	a.EditorGroup.OnError = func(msg string) {
 		a.StatusError(msg)

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -26,6 +26,10 @@ func RunEventLoop(
 	quitPending *bool,
 	closeTerminal func(panelID string),
 ) {
+	if app.Watcher != nil {
+		defer app.Watcher.Close()
+	}
+
 	lastBlameLine := -1
 	lastBlameFile := ""
 	lastBranchDir := app.Workspace.Primary()
@@ -42,6 +46,7 @@ func RunEventLoop(
 		app.Status.Dirty = app.EditorGroup.IsDirty()
 		app.Status.CursorCount = app.EditorGroup.MultiCursorCount()
 		app.Explorer.ActiveFile = filePath
+		app.SyncWatched()
 
 		if app.EditorGroup.Editor != nil && app.EditorGroup.Editor.Highlighter != nil {
 			lang := app.EditorGroup.Editor.Highlighter.Language()
@@ -225,6 +230,8 @@ func RunEventLoop(
 					app.AllDiagnostics[v.Path] = v.Diagnostics
 				}
 				app.refreshProblems()
+			case *FileChangedResult:
+				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:
 				app.Search.ApplyBatch(v)
 			case *PrFetchResult:

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -118,6 +118,9 @@ func RunEventLoop(
 		renderer.Render(screen)
 	}
 
+	// Populate the status bar and register file watches for any files opened at
+	// launch, before the first user interaction.
+	syncStatus()
 	redraw()
 
 	for *running {

--- a/internal/app/watch.go
+++ b/internal/app/watch.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/eugenioenko/ttt/internal/watcher"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// FileChangedResult is posted to the event loop when a watched file changes on
+// disk. It carries the path as tracked by the editor.
+type FileChangedResult struct {
+	Path string
+}
+
+// StartWatcher creates the file watcher. onChange runs on the watcher's
+// goroutine, so it only posts an event; the reconciliation happens on the main
+// loop in HandleFileChanged. a.Screen is read at call time so it is safe even
+// if the screen is wired up after Init.
+func (a *App) StartWatcher() {
+	w, err := watcher.New(func(path string) {
+		if a.Screen != nil {
+			a.Screen.PostEvent(tcell.NewEventInterrupt(&FileChangedResult{Path: path}))
+		}
+	})
+	if err != nil {
+		return
+	}
+	a.Watcher = w
+}
+
+// SyncWatched updates the watcher's tracked set to the currently open files.
+// It is cheap to call frequently — the watcher ignores paths it already tracks.
+func (a *App) SyncWatched() {
+	if a.Watcher == nil {
+		return
+	}
+	a.Watcher.Sync(a.EditorGroup.OpenFilePaths())
+}
+
+// HandleFileChanged reconciles an open buffer with a change detected on disk.
+// A clean buffer is reloaded silently; a buffer with unsaved edits is left
+// untouched (the save path still guards against clobbering) and the user is
+// warned. The recorded disk state of a dirty buffer is deliberately not
+// updated, so the save-time conflict check keeps working.
+func (a *App) HandleFileChanged(path string) {
+	buf := a.EditorGroup.BufferForPath(path)
+	if buf == nil {
+		return
+	}
+	if !buf.DiskChanged(path) {
+		// Our own save, or a change that doesn't affect the bytes we hold.
+		return
+	}
+	name := filepath.Base(path)
+	if _, err := os.Stat(path); err != nil {
+		a.StatusWarn(name + " was deleted on disk")
+		return
+	}
+	if buf.Dirty {
+		a.StatusWarn(name + " changed on disk; you have unsaved changes")
+		return
+	}
+	a.EditorGroup.ReloadFile(path)
+	a.StatusNotify(name + " reloaded (changed on disk)")
+}

--- a/internal/app/watch.go
+++ b/internal/app/watch.go
@@ -63,6 +63,8 @@ func (a *App) HandleFileChanged(path string) {
 		a.StatusWarn(name + " changed on disk; you have unsaved changes")
 		return
 	}
+	// Reload silently: a clean buffer picking up disk changes is the routine
+	// case (e.g. tailing a live log), and a notification on every change would
+	// be noise. Only the cases needing attention (conflict, deletion) warn.
 	a.EditorGroup.ReloadFile(path)
-	a.StatusNotify(name + " reloaded (changed on disk)")
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -224,12 +224,70 @@ func (g *EditorGroupWidget) ReloadFile(path string) {
 		if g.tabs[i].FilePath == path && g.tabs[i].Buf != nil {
 			g.tabs[i].Buf.LoadFile(path)
 			g.tabs[i].Buf.Dirty = false
+			g.clampCursor(&g.tabs[i])
 			if i == g.active {
 				g.syncTabs()
 			}
 			return
 		}
 	}
+}
+
+// clampCursor keeps a tab's cursor within the bounds of its buffer, which may
+// have shrunk after an external reload.
+func (g *EditorGroupWidget) clampCursor(t *editorTab) {
+	if t.Cur == nil || t.Buf == nil {
+		return
+	}
+	n := len(t.Buf.Lines)
+	if n == 0 {
+		t.Cur.Line, t.Cur.Col = 0, 0
+		return
+	}
+	if t.Cur.Line >= n {
+		t.Cur.Line = n - 1
+	}
+	if t.Cur.Line < 0 {
+		t.Cur.Line = 0
+	}
+	lineLen := len([]rune(t.Buf.Lines[t.Cur.Line]))
+	if t.Cur.Col > lineLen {
+		t.Cur.Col = lineLen
+	}
+}
+
+// OpenFilePaths returns the paths of all tabs backed by a real file on disk
+// (excluding untitled buffers and non-text content like diff views). The order
+// is unspecified.
+func (g *EditorGroupWidget) OpenFilePaths() []string {
+	var paths []string
+	for i := range g.tabs {
+		t := &g.tabs[i]
+		if t.Content != nil || t.Buf == nil {
+			continue
+		}
+		if t.FilePath == "" || t.FilePath == "untitled" {
+			continue
+		}
+		paths = append(paths, t.FilePath)
+	}
+	return paths
+}
+
+// BufferForPath returns the buffer of the tab with the given path, or nil.
+func (g *EditorGroupWidget) BufferForPath(path string) *buffer.Buffer {
+	for i := range g.tabs {
+		if g.tabs[i].FilePath == path {
+			return g.tabs[i].Buf
+		}
+	}
+	return nil
+}
+
+// IsDirtyPath reports whether the tab with the given path has unsaved changes.
+func (g *EditorGroupWidget) IsDirtyPath(path string) bool {
+	b := g.BufferForPath(path)
+	return b != nil && b.Dirty
 }
 
 func (g *EditorGroupWidget) IsEditorActive() bool {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,0 +1,174 @@
+// Package watcher reports when files open in the editor are modified on disk
+// by another process. It wraps fsnotify, watching the parent directories of
+// tracked files (the portable, rename-safe pattern) and debouncing bursts of
+// events into a single notification per file.
+package watcher
+
+import (
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// defaultDebounce coalesces the rapid bursts of events that a single logical
+// write produces (including the temp-file + rename pattern the editor itself
+// uses to save) into one notification.
+const defaultDebounce = 150 * time.Millisecond
+
+// Watcher tracks a set of files and invokes onChange when one of them changes
+// on disk. onChange is called from an internal goroutine with the same path
+// string that was passed to Sync, so callers can match it back to their own
+// bookkeeping.
+type Watcher struct {
+	fsw      *fsnotify.Watcher
+	onChange func(path string)
+	debounce time.Duration
+
+	mu     sync.Mutex
+	files  map[string]string // cleaned-abs path -> original path as tracked
+	dirs   map[string]int    // watched directory -> number of tracked files in it
+	timers map[string]*time.Timer
+	closed bool
+}
+
+// New creates a Watcher and starts its event loop. onChange must be safe to
+// call from another goroutine.
+func New(onChange func(path string)) (*Watcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	w := &Watcher{
+		fsw:      fsw,
+		onChange: onChange,
+		debounce: defaultDebounce,
+		files:    make(map[string]string),
+		dirs:     make(map[string]int),
+		timers:   make(map[string]*time.Timer),
+	}
+	go w.run()
+	return w, nil
+}
+
+// Sync reconciles the tracked set with paths, adding watches for newly opened
+// files and dropping them for closed ones. It is a no-op for paths already
+// tracked, so it is cheap to call frequently.
+func (w *Watcher) Sync(paths []string) {
+	want := make(map[string]string, len(paths))
+	for _, p := range paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		want[filepath.Clean(abs)] = p
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+	for key := range w.files {
+		if _, ok := want[key]; !ok {
+			w.untrackLocked(key)
+		}
+	}
+	for key, orig := range want {
+		if _, ok := w.files[key]; !ok {
+			w.trackLocked(key, orig)
+		}
+	}
+}
+
+func (w *Watcher) trackLocked(key, orig string) {
+	dir := filepath.Dir(key)
+	if w.dirs[dir] == 0 {
+		if err := w.fsw.Add(dir); err != nil {
+			return
+		}
+	}
+	w.dirs[dir]++
+	w.files[key] = orig
+}
+
+func (w *Watcher) untrackLocked(key string) {
+	if _, ok := w.files[key]; !ok {
+		return
+	}
+	delete(w.files, key)
+	if t := w.timers[key]; t != nil {
+		t.Stop()
+		delete(w.timers, key)
+	}
+	dir := filepath.Dir(key)
+	if w.dirs[dir] > 0 {
+		w.dirs[dir]--
+		if w.dirs[dir] == 0 {
+			delete(w.dirs, dir)
+			_ = w.fsw.Remove(dir)
+		}
+	}
+}
+
+func (w *Watcher) run() {
+	for {
+		select {
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			// Only Chmod-only events are uninteresting; writes, creates,
+			// renames and removes can all change the file's contents.
+			if ev.Op == fsnotify.Chmod {
+				continue
+			}
+			w.handle(filepath.Clean(ev.Name))
+		case _, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+func (w *Watcher) handle(key string) {
+	w.mu.Lock()
+	orig, tracked := w.files[key]
+	if !tracked || w.closed {
+		w.mu.Unlock()
+		return
+	}
+	if t := w.timers[key]; t != nil {
+		t.Stop()
+	}
+	w.timers[key] = time.AfterFunc(w.debounce, func() {
+		w.mu.Lock()
+		_, still := w.files[key]
+		delete(w.timers, key)
+		closed := w.closed
+		w.mu.Unlock()
+		if still && !closed {
+			w.onChange(orig)
+		}
+	})
+	w.mu.Unlock()
+}
+
+// Close stops watching and releases resources. The Watcher must not be used
+// afterwards.
+func (w *Watcher) Close() error {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return nil
+	}
+	w.closed = true
+	for key, t := range w.timers {
+		t.Stop()
+		delete(w.timers, key)
+	}
+	w.mu.Unlock()
+	return w.fsw.Close()
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,121 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// waitForChange blocks until a path is reported or the timeout elapses.
+func waitForChange(t *testing.T, ch <-chan string, timeout time.Duration) (string, bool) {
+	t.Helper()
+	select {
+	case p := <-ch:
+		return p, true
+	case <-time.After(timeout):
+		return "", false
+	}
+}
+
+func newTestWatcher(t *testing.T) (*Watcher, <-chan string) {
+	t.Helper()
+	ch := make(chan string, 8)
+	w, err := New(func(path string) { ch <- path })
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { w.Close() })
+	return w, ch
+}
+
+func TestWatcherDetectsChange(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "watched.txt")
+	if err := os.WriteFile(file, []byte("one\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, ch := newTestWatcher(t)
+	w.Sync([]string{file})
+
+	if err := os.WriteFile(file, []byte("two\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := waitForChange(t, ch, 3*time.Second)
+	if !ok {
+		t.Fatal("expected a change notification, got none")
+	}
+	if got != file {
+		t.Errorf("expected path %q, got %q", file, got)
+	}
+}
+
+func TestWatcherIgnoresUntrackedFiles(t *testing.T) {
+	dir := t.TempDir()
+	tracked := filepath.Join(dir, "tracked.txt")
+	other := filepath.Join(dir, "other.txt")
+	if err := os.WriteFile(tracked, []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(other, []byte("y\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, ch := newTestWatcher(t)
+	w.Sync([]string{tracked})
+
+	// Modifying a sibling that is not tracked must not notify.
+	if err := os.WriteFile(other, []byte("changed\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := waitForChange(t, ch, 500*time.Millisecond); ok {
+		t.Errorf("expected no notification for untracked file, got %q", got)
+	}
+}
+
+func TestWatcherStopsAfterUntrack(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "watched.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, ch := newTestWatcher(t)
+	w.Sync([]string{file})
+	w.Sync(nil) // untrack everything
+
+	if err := os.WriteFile(file, []byte("changed\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := waitForChange(t, ch, 500*time.Millisecond); ok {
+		t.Errorf("expected no notification after untracking, got %q", got)
+	}
+}
+
+func TestWatcherDebouncesBurst(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "watched.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, ch := newTestWatcher(t)
+	w.Sync([]string{file})
+
+	// Several rapid writes should coalesce into a single notification.
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(file, []byte("burst\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, ok := waitForChange(t, ch, 3*time.Second); !ok {
+		t.Fatal("expected at least one notification")
+	}
+	// No second notification should follow from the same burst.
+	if got, ok := waitForChange(t, ch, 500*time.Millisecond); ok {
+		t.Errorf("expected burst to be debounced, got extra notification %q", got)
+	}
+}

--- a/tests/e2e/file_reload_test.go
+++ b/tests/e2e/file_reload_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +10,55 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 )
+
+// TestWatcherReloadVisibleOnScreen is the fullest black-box test: it drives the
+// real TUI render pipeline and a real external process. It opens a file,
+// captures the rendered terminal screen, has a separate OS process overwrite
+// the file, then captures the screen again — asserting the painted cells now
+// show the new content and no longer show the old. This exercises the entire
+// chain: external process -> fsnotify -> reconcile -> render -> screen cells.
+func TestWatcherReloadVisibleOnScreen(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.app.StartWatcher()
+
+	path := filepath.Join(h.dir, "screen.txt")
+	if err := os.WriteFile(path, []byte("MARKER_BEFORE\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.app.SyncWatched()
+	h.redraw()
+
+	// Capture the rendered screen before the external change.
+	if !strings.Contains(h.screenText(), "MARKER_BEFORE") {
+		t.Fatalf("expected screen to show MARKER_BEFORE, got:\n%s", h.screenText())
+	}
+
+	// A genuinely separate process rewrites the file. The new content differs
+	// in length so the change is detected regardless of mtime resolution.
+	cmd := exec.Command("sh", "-c", "printf 'MARKER_AFTER_EXTERNAL\\n' > "+path)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("external write failed: %v (%s)", err, out)
+	}
+
+	if !h.waitForFileChange(3 * time.Second) {
+		t.Fatal("watcher never reported the external write")
+	}
+
+	// Capture the rendered screen after the change.
+	after := h.screenText()
+	if !strings.Contains(after, "MARKER_AFTER_EXTERNAL") {
+		t.Errorf("expected screen to show MARKER_AFTER_EXTERNAL after reload, got:\n%s", after)
+	}
+	if strings.Contains(after, "MARKER_BEFORE") {
+		t.Errorf("expected old content to be gone from screen, got:\n%s", after)
+	}
+}
 
 // TestWatcherUpdatesEditorOnDiskWrite is a black-box test of the whole feature:
 // it starts the real fsnotify watcher, opens a file, writes to that file as an

--- a/tests/e2e/file_reload_test.go
+++ b/tests/e2e/file_reload_test.go
@@ -1,0 +1,134 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// TestWatcherUpdatesEditorOnDiskWrite is a black-box test of the whole feature:
+// it starts the real fsnotify watcher, opens a file, writes to that file as an
+// external process would, and asserts the editor's view picks up the new
+// content — driven end to end through the watcher and the event dispatch.
+func TestWatcherUpdatesEditorOnDiskWrite(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.app.StartWatcher()
+
+	path := filepath.Join(h.dir, "live.txt")
+	if err := os.WriteFile(path, []byte("before the write\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.app.SyncWatched() // begin watching the open file
+	h.redraw()
+
+	if !strings.Contains(editorText(h), "before the write") {
+		t.Fatalf("expected initial content, got %q", editorText(h))
+	}
+
+	// An external process rewrites the file.
+	modifyOnDisk(t, path, "after the write\n")
+
+	if !h.waitForFileChange(3 * time.Second) {
+		t.Fatal("watcher never reported the external write")
+	}
+	if !strings.Contains(editorText(h), "after the write") {
+		t.Errorf("editor did not reflect the disk write, got %q", editorText(h))
+	}
+}
+
+// editorText returns the active buffer's contents joined by newlines.
+func editorText(h *testHarness) string {
+	return strings.Join(h.app.EditorGroup.Editor.Buf.Lines, "\n")
+}
+
+func TestExternalChangeReloadsCleanBuffer(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	path := filepath.Join(h.dir, "reload.txt")
+	if err := os.WriteFile(path, []byte("original\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	if !strings.Contains(editorText(h), "original") {
+		t.Fatalf("expected editor to show original content, got %q", editorText(h))
+	}
+
+	modifyOnDisk(t, path, "updated externally\n")
+	// Simulate the watcher firing for this path.
+	h.app.HandleFileChanged(path)
+	h.redraw()
+
+	if !strings.Contains(editorText(h), "updated externally") {
+		t.Errorf("expected clean buffer to auto-reload, got %q", editorText(h))
+	}
+}
+
+func TestExternalChangeKeepsDirtyBuffer(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	path := filepath.Join(h.dir, "dirty.txt")
+	if err := os.WriteFile(path, []byte("original\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.app.Root.SetFocus(h.app.EditorGroup)
+	h.redraw()
+
+	// Make an unsaved edit so the buffer is dirty.
+	h.pressRune('Z')
+	if !h.app.EditorGroup.IsDirtyPath(path) {
+		t.Fatalf("expected buffer to be dirty after typing")
+	}
+	dirtyBefore := editorText(h)
+
+	modifyOnDisk(t, path, "updated externally\n")
+	h.app.HandleFileChanged(path)
+	h.redraw()
+
+	// A dirty buffer must NOT be reloaded — the user's edits survive.
+	if editorText(h) != dirtyBefore {
+		t.Errorf("dirty buffer was overwritten by reload: %q", editorText(h))
+	}
+	if strings.Contains(editorText(h), "updated externally") {
+		t.Errorf("dirty buffer should not have picked up disk content")
+	}
+}
+
+func TestExternalChangeClampsCursor(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	path := filepath.Join(h.dir, "shrink.txt")
+	if err := os.WriteFile(path, []byte("line1\nline2\nline3\nline4\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(path)
+	h.app.Root.SetFocus(h.app.EditorGroup)
+	h.redraw()
+
+	// Move the cursor down to a line that will not exist after the reload.
+	for i := 0; i < 3; i++ {
+		h.pressKey(tcell.KeyDown, tcell.ModNone)
+	}
+
+	modifyOnDisk(t, path, "only one line\n")
+	h.app.HandleFileChanged(path)
+	h.redraw()
+
+	line, _ := h.app.EditorGroup.ActiveCursor()
+	if line >= len(h.app.EditorGroup.Editor.Buf.Lines) {
+		t.Errorf("cursor line %d out of bounds after reload (buffer has %d lines)",
+			line, len(h.app.EditorGroup.Editor.Buf.Lines))
+	}
+}

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/app"
 	"github.com/eugenioenko/ttt/internal/command"
@@ -179,6 +180,32 @@ func (h *testHarness) assertNotContains(text string) {
 	h.t.Helper()
 	if h.containsText(text) {
 		h.t.Errorf("expected screen NOT to contain %q, got:\n%s", text, h.screenText())
+	}
+}
+
+// waitForFileChange blocks until the file watcher posts a change notification
+// (or the timeout elapses), then dispatches it exactly as the real event loop
+// does. It returns true if a change was handled. This drives the full path:
+// real fsnotify watcher -> PostEvent -> reconcile -> editor update.
+func (h *testHarness) waitForFileChange(timeout time.Duration) bool {
+	h.t.Helper()
+	evCh := make(chan tcell.Event, 1)
+	go func() { evCh <- h.screen.PollEvent() }()
+	select {
+	case ev := <-evCh:
+		iev, ok := ev.(*tcell.EventInterrupt)
+		if !ok {
+			return false
+		}
+		fc, ok := iev.Data().(*app.FileChangedResult)
+		if !ok {
+			return false
+		}
+		h.app.HandleFileChanged(fc.Path)
+		h.redraw()
+		return true
+	case <-time.After(timeout):
+		return false
 	}
 }
 

--- a/tests/functional/external-change.test.js
+++ b/tests/functional/external-change.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync } from "node:fs";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("external file change detection", () => {
+  it("auto-reloads a clean buffer when the file changes on disk", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "reload.txt", "BEFORE_EXTERNAL_EDIT");
+
+    tui.start(file);
+    tui.waitFor("BEFORE_EXTERNAL_EDIT");
+
+    const before = tui.snapshot();
+    expect(before).toContain("BEFORE_EXTERNAL_EDIT");
+
+    // Modify the file from outside the editor, as another tool would.
+    writeFileSync(file, "AFTER_EXTERNAL_EDIT", "utf8");
+
+    // The editor should pick up the change on its own.
+    tui.waitFor("AFTER_EXTERNAL_EDIT");
+
+    const after = tui.snapshot();
+    expect(after).toContain("AFTER_EXTERNAL_EDIT");
+    expect(after).not.toContain("BEFORE_EXTERNAL_EDIT");
+  });
+
+  it("keeps unsaved edits when the file changes on disk", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "dirty.txt", "DISK_ORIGINAL");
+
+    tui.start(file);
+    tui.waitFor("DISK_ORIGINAL");
+
+    // Make an unsaved edit so the buffer is dirty.
+    tui.press("escape");
+    tui.press("end");
+    tui.type(" EDITED_IN_EDITOR");
+    tui.waitFor("DISK_ORIGINAL EDITED_IN_EDITOR");
+
+    // An external change must NOT clobber the user's unsaved work.
+    writeFileSync(file, "DISK_CHANGED_EXTERNALLY", "utf8");
+    tui.waitStable(400);
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("EDITED_IN_EDITOR");
+    expect(snap).not.toContain("DISK_CHANGED_EXTERNALLY");
+  });
+});


### PR DESCRIPTION
## Summary
Completes external change detection (the second half of audit item #2, after #57's save-time guard). The editor now **watches open files** and reacts to changes made by other tools — `git checkout`, formatters, codegen — instead of only noticing at save time. This is the VS Code behavior: switch branches and your open files update in place.

## How it works
- New `internal/watcher` package wraps **fsnotify**, watching the *parent directories* of open files (the portable, rename-safe pattern) with refcounting so a directory is watched once regardless of how many of its files are open.
- A per-file **debounce** coalesces the burst of events a single logical write produces — including the temp-file + atomic-rename pattern the editor's own save (#56) emits, so our own saves don't cause spurious reloads.
- Detection runs on the watcher goroutine and only **posts an event**; reconciliation happens on the main loop via the existing `PostEvent(EventInterrupt)` pattern (same as LSP/blame), so all buffer mutation stays single-threaded.

## Reconcile policy
| Buffer state | On external change |
|---|---|
| Clean | Reload silently; cursor clamped if the file shrank |
| Unsaved edits | Warn, **never** clobber. Recorded disk mtime is left untouched so the save-time conflict dialog (#57) still fires on save |
| Deleted on disk | Warn, keep the buffer |

The watch set is kept in sync with the open tabs from the event loop's `syncStatus`.

## Dependency
Adds `github.com/fsnotify/fsnotify` — its only dependency is `golang.org/x/sys`, already in the tree, so no new transitive weight.

## Tests
- **Watcher unit tests (real fsnotify):** detects a change, ignores untracked siblings in the same dir, stops after untracking, debounces a burst into one notification.
- **E2E reconcile tests:** clean buffer auto-reloads, dirty buffer is preserved, cursor is clamped when the file shrinks.
- **E2E black-box test:** starts the real watcher, writes a file as an external process would, and asserts the editor's view updates — driven end to end through fsnotify → PostEvent → reconcile.
- Full suite passes under `-race`.

## Not included
The save-time conflict dialog (already shipped in #57) and line-ending preservation (#3, next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)