### PR TITLE
feat: line-ending detection and preservation (LF/CRLF)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,16 @@ Language server support lives in `internal/lsp/`. Servers are configured per-lan
 
 Async completions and signature help use the same `PostEvent(EventInterrupt)` pattern as git blame. Document sync is full-document (not incremental). Auto-completion triggers on every text change with a configurable debounce timer (`autocomplete.debounce` in settings.json, default 150ms). Signature help triggers on `(` and `,` characters, dismissed on `)`.
 
+### Testing
+
+The project has three levels of testing:
+
+**Unit tests** (`internal/*/`) — Standard Go tests for individual packages. The core layer is fully testable without any terminal dependency. Run with `go test ./internal/core/buffer/` or `make test` for all.
+
+**E2E tests** (`tests/e2e/`) — Go tests that wire up the full `App` with a `tcell.SimulationScreen`. The `testHarness` (`harness_test.go`) creates a temp directory with sample files, builds the complete app (config, commands, keybindings, renderer), and provides helpers: `pressKey()`, `pressRune()`, `click()`, `exec()`, `screenText()`, `assertContains()`. The watcher-aware `waitForFileChange()` helper blocks on `PollEvent` to receive real fsnotify events and dispatches them through the reconciliation path. These tests run single-threaded (no event loop goroutine) — the test drives events and redraws manually.
+
+**Functional blackbox tests** (`tests/functional/`) — JavaScript tests using vitest + `tui-use` CLI that drive the real compiled `bin/ttt` binary in a real terminal. The `tui.js` wrapper provides: `start()` (launches the binary), `snapshot()` (captures screen), `type()` / `press()` / `pressChord()` (input), `waitFor()` (poll until text appears), `waitStable()` (wait for screen to settle), `exec()` (open command palette and run a command). These tests catch integration issues that the Go-level tests miss (e.g., launch-time watcher sync was caught here). Run with `cd tests/functional && pnpm test`. The binary must be built first (`make build`). Tests run sequentially (`fileParallelism: false`) and each test kills any leftover tui-use sessions in `beforeEach`.
+
 ### Dependencies
 
 Key external dependencies beyond the Go standard library:

--- a/internal/app/commands_palette.go
+++ b/internal/app/commands_palette.go
@@ -105,6 +105,26 @@ func (a *App) ShowIndentPicker() {
 	})
 }
 
+func (a *App) ShowEolPicker() {
+	cmds := []command.Command{
+		{ID: "lf", Title: "LF"},
+		{ID: "crlf", Title: "CRLF"},
+	}
+	a.ShowPicker(cmds, func(id string) {
+		buf := a.EditorGroup.ActiveBuffer()
+		if buf == nil {
+			return
+		}
+		switch id {
+		case "lf":
+			buf.LineEnding = "\n"
+		case "crlf":
+			buf.LineEnding = "\r\n"
+		}
+		buf.Dirty = true
+	})
+}
+
 func registerPaletteCommands(app *App) {
 	reg := app.Reg
 
@@ -129,10 +149,16 @@ func registerPaletteCommands(app *App) {
 	})
 
 	app.StatusBar.OnIndentClick = app.ShowIndentPicker
+	app.StatusBar.OnEolClick = app.ShowEolPicker
 
 	reg.Register(command.Command{
 		ID: "editor.indentation", Title: "Change Indentation",
 		Handler: app.ShowIndentPicker,
+	})
+
+	reg.Register(command.Command{
+		ID: "editor.lineEnding", Title: "Change Line Ending",
+		Handler: app.ShowEolPicker,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -45,6 +45,11 @@ func RunEventLoop(
 		app.Status.Col = col
 		app.Status.Dirty = app.EditorGroup.IsDirty()
 		app.Status.CursorCount = app.EditorGroup.MultiCursorCount()
+		if buf := app.EditorGroup.ActiveBuffer(); buf != nil {
+			app.Status.LineEnding = buf.LineEnding
+		} else {
+			app.Status.LineEnding = "\n"
+		}
 		app.Explorer.ActiveFile = filePath
 		app.SyncWatched()
 

--- a/internal/core/buffer/buffer.go
+++ b/internal/core/buffer/buffer.go
@@ -73,6 +73,7 @@ type Buffer struct {
 	Lines              []string
 	Dirty              bool
 	InsertFinalNewline bool
+	LineEnding         string // "\n" (LF) or "\r\n" (CRLF); defaults to "\n"
 
 	// diskModTime and diskSize record the state of the file on disk the last
 	// time we loaded or saved it, so we can detect external modifications

--- a/internal/core/buffer/io.go
+++ b/internal/core/buffer/io.go
@@ -2,6 +2,7 @@ package buffer
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,6 +15,10 @@ func (b *Buffer) LoadFile(filename string) error {
 		return err
 	}
 	defer f.Close()
+
+	b.LineEnding = detectLineEnding(f)
+	f.Seek(0, io.SeekStart)
+
 	var lines []string
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -34,6 +39,17 @@ func (b *Buffer) LoadFile(filename string) error {
 		b.recordDiskInfo(info)
 	}
 	return nil
+}
+
+// detectLineEnding reads up to 64KB of a file to determine its line ending.
+// Returns "\r\n" if CRLF is found, "\n" otherwise.
+func detectLineEnding(r io.Reader) string {
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	if n > 0 && bytes.Contains(buf[:n], []byte("\r\n")) {
+		return "\r\n"
+	}
+	return "\n"
 }
 
 // recordDiskInfo stores the file's modification time and size so a later save
@@ -121,12 +137,16 @@ func (b *Buffer) SaveFile(filename string) error {
 }
 
 func (b *Buffer) writeLines(w io.Writer) error {
+	eol := b.LineEnding
+	if eol == "" {
+		eol = "\n"
+	}
 	for i, line := range b.Lines {
 		if _, err := io.WriteString(w, line); err != nil {
 			return err
 		}
 		if i < len(b.Lines)-1 {
-			if _, err := io.WriteString(w, "\n"); err != nil {
+			if _, err := io.WriteString(w, eol); err != nil {
 				return err
 			}
 		}

--- a/internal/core/buffer/io_test.go
+++ b/internal/core/buffer/io_test.go
@@ -123,6 +123,71 @@ func TestDiskChangedNewBuffer(t *testing.T) {
 	}
 }
 
+func TestLoadDetectsLF(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "lf.txt")
+	os.WriteFile(fname, []byte("line1\nline2\nline3\n"), 0644)
+	b := &Buffer{}
+	if err := b.LoadFile(fname); err != nil {
+		t.Fatal(err)
+	}
+	if b.LineEnding != "\n" {
+		t.Errorf("expected LF, got %q", b.LineEnding)
+	}
+}
+
+func TestLoadDetectsCRLF(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "crlf.txt")
+	os.WriteFile(fname, []byte("line1\r\nline2\r\nline3\r\n"), 0644)
+	b := &Buffer{}
+	if err := b.LoadFile(fname); err != nil {
+		t.Fatal(err)
+	}
+	if b.LineEnding != "\r\n" {
+		t.Errorf("expected CRLF, got %q", b.LineEnding)
+	}
+}
+
+func TestSavePreservesLF(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "lf.txt")
+	os.WriteFile(fname, []byte("a\nb"), 0644)
+	b := &Buffer{}
+	b.LoadFile(fname)
+	b.Lines[0] = "edited"
+	b.SaveFile(fname)
+	data, _ := os.ReadFile(fname)
+	if string(data) != "edited\nb" {
+		t.Errorf("expected LF preserved, got %q", string(data))
+	}
+}
+
+func TestSavePreservesCRLF(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "crlf.txt")
+	os.WriteFile(fname, []byte("a\r\nb"), 0644)
+	b := &Buffer{}
+	b.LoadFile(fname)
+	b.Lines[0] = "edited"
+	b.SaveFile(fname)
+	data, _ := os.ReadFile(fname)
+	if string(data) != "edited\r\nb" {
+		t.Errorf("expected CRLF preserved, got %q", string(data))
+	}
+}
+
+func TestNewBufferDefaultsToLF(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "new.txt")
+	b := &Buffer{Lines: []string{"hello", "world"}}
+	b.SaveFile(fname)
+	data, _ := os.ReadFile(fname)
+	if string(data) != "hello\nworld" {
+		t.Errorf("expected LF default, got %q", string(data))
+	}
+}
+
 func TestSaveDoesNotLeaveTempFiles(t *testing.T) {
 	dir := t.TempDir()
 	fname := filepath.Join(dir, "file.txt")

--- a/internal/ui/statusbar_widget.go
+++ b/internal/ui/statusbar_widget.go
@@ -16,7 +16,9 @@ type StatusBarWidget struct {
 	BaseWidget
 	Status         *view.StatusBar
 	OnIndentClick  func()
+	OnEolClick     func()
 	indentSpan     statusBarSpan
+	eolSpan        statusBarSpan
 	okSpan         statusBarSpan
 	actionSpan     statusBarSpan
 	secondarySpan  statusBarSpan
@@ -67,7 +69,11 @@ func (s *StatusBarWidget) Render(surface *RenderSurface) {
 		right = append(right, segment{fmt.Sprintf("Spaces: %d", st.TabSize), "indent"})
 	}
 	right = append(right, segment{"UTF-8", "encoding"})
-	right = append(right, segment{"LF", "eol"})
+	eolLabel := "LF"
+	if st.LineEnding == "\r\n" {
+		eolLabel = "CRLF"
+	}
+	right = append(right, segment{eolLabel, "eol"})
 	if st.Language != "" {
 		lang := st.Language
 		if st.LSP {
@@ -97,6 +103,9 @@ func (s *StatusBarWidget) Render(surface *RenderSurface) {
 			segLen := len([]rune(seg.text))
 			if seg.id == "indent" {
 				s.indentSpan = statusBarSpan{r.X + pos, r.X + pos + segLen}
+			}
+			if seg.id == "eol" {
+				s.eolSpan = statusBarSpan{r.X + pos, r.X + pos + segLen}
 			}
 			s.drawText(surface, pos, seg.text, term.StyleStatusBar)
 			pos += segLen
@@ -188,6 +197,10 @@ func (s *StatusBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 	if mx >= s.indentSpan.start && mx < s.indentSpan.end && s.OnIndentClick != nil {
 		s.OnIndentClick()
+		return EventConsumed
+	}
+	if mx >= s.eolSpan.start && mx < s.eolSpan.end && s.OnEolClick != nil {
+		s.OnEolClick()
 		return EventConsumed
 	}
 	return EventIgnored

--- a/internal/view/statusbar.go
+++ b/internal/view/statusbar.go
@@ -35,6 +35,7 @@ type StatusBar struct {
 	Language     string
 	LSP          bool
 	TabSize      int
+	LineEnding   string
 	CursorCount  int
 	Notification string
 	NotifyLevel  NotifyLevel

--- a/tests/functional/line-endings.test.js
+++ b/tests/functional/line-endings.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, cleanupDir } from "./helpers.js";
+import { writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("line ending detection and preservation", () => {
+  it("shows LF in status bar for LF files", () => {
+    dir = createTempDir();
+    const file = join(dir, "lf.txt");
+    writeFileSync(file, "line1\nline2\nline3\n");
+
+    tui.start(file);
+    tui.waitFor("line1");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("LF");
+    expect(snap).not.toContain("CRLF");
+  });
+
+  it("shows CRLF in status bar for CRLF files", () => {
+    dir = createTempDir();
+    const file = join(dir, "crlf.txt");
+    writeFileSync(file, "line1\r\nline2\r\nline3\r\n");
+
+    tui.start(file);
+    tui.waitFor("line1");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("CRLF");
+  });
+
+  it("preserves LF endings on save", () => {
+    dir = createTempDir();
+    const file = join(dir, "lf.txt");
+    writeFileSync(file, "hello\nworld");
+
+    tui.start(file);
+    tui.waitFor("hello");
+    tui.press("end");
+    tui.type(" edited");
+    tui.waitFor("hello edited");
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const raw = readFileSync(file);
+    expect(raw.includes(Buffer.from("\r\n"))).toBe(false);
+    const content = raw.toString();
+    expect(content).toContain("hello edited\nworld");
+    expect(content.includes("\r\n")).toBe(false);
+  });
+
+  it("switches from LF to CRLF via command palette", () => {
+    dir = createTempDir();
+    const file = join(dir, "lf.txt");
+    writeFileSync(file, "aaa\nbbb");
+
+    tui.start(file);
+    tui.waitFor("aaa");
+    tui.waitStable();
+
+    let snap = tui.snapshot();
+    expect(snap).not.toContain("CRLF");
+
+    tui.exec("Change Line Ending");
+    tui.waitStable();
+    tui.type("CRLF");
+    tui.waitStable();
+    tui.press("enter");
+    tui.waitStable();
+
+    snap = tui.snapshot();
+    expect(snap).toContain("CRLF");
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const raw = readFileSync(file);
+    expect(raw.toString()).toContain("aaa\r\nbbb");
+  });
+
+  it("switches from CRLF to LF via command palette", () => {
+    dir = createTempDir();
+    const file = join(dir, "crlf.txt");
+    writeFileSync(file, "aaa\r\nbbb");
+
+    tui.start(file);
+    tui.waitFor("aaa");
+    tui.waitFor("CRLF");
+
+    tui.exec("Change Line Ending");
+    tui.waitStable();
+    tui.type("LF");
+    tui.waitStable();
+    tui.press("enter");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("LF");
+    expect(snap).not.toContain("CRLF");
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const raw = readFileSync(file);
+    const content = raw.toString();
+    expect(content).toContain("aaa\nbbb");
+    expect(content.includes("\r\n")).toBe(false);
+  });
+
+  it("preserves CRLF endings on save", () => {
+    dir = createTempDir();
+    const file = join(dir, "crlf.txt");
+    writeFileSync(file, "hello\r\nworld");
+
+    tui.start(file);
+    tui.waitFor("hello");
+    tui.press("end");
+    tui.type(" edited");
+    tui.waitFor("hello edited");
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const raw = readFileSync(file);
+    const content = raw.toString();
+    expect(content).toContain("hello edited\r\nworld");
+    // Verify no mixed line endings — only CRLF, no bare LF
+    const withoutCRLF = content.replace(/\r\n/g, "");
+    expect(withoutCRLF.includes("\n")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Detect CRLF vs LF on file load (reads first 64KB), preserve original line endings on save
- Status bar shows dynamic LF/CRLF label instead of hardcoded "LF"
- Clickable EOL label in status bar opens a picker to switch between LF and CRLF
- "Change Line Ending" command available in the command palette
- Documents the three testing levels (unit, e2e, functional) in CLAUDE.md

## Test plan
- [x] Unit tests: detect LF, detect CRLF, preserve LF on save, preserve CRLF on save, new buffer defaults to LF
- [x] Functional blackbox tests: status bar shows LF for LF files, CRLF for CRLF files, preserves each on save, switch LF→CRLF and CRLF→LF via command palette
- [x] Full Go test suite passes (`go test ./...`)
- [x] All existing functional tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)