### PR TITLE
feat: trim trailing whitespace on save

### DIFF
--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -83,6 +83,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 
 	editorGroup := ui.NewEditorGroupWidget(borders, cfg.Settings.TabSize, cfg.Settings.LineNumbers)
 	editorGroup.InsertFinalNewline = cfg.Settings.InsertFinalNewline
+	editorGroup.TrimTrailingWhitespace = cfg.Settings.TrimTrailingWhitespace
 	for _, f := range openFiles {
 		editorGroup.OpenFile(f)
 		editorGroup.PinActiveTab()

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -101,7 +101,8 @@ type Settings struct {
 	Theme          string           `json:"theme,omitempty"`
 	DebugMode      bool             `json:"debugMode,omitempty"`
 	FormatOnSave       bool             `json:"formatOnSave"`
-	InsertFinalNewline bool             `json:"insertFinalNewline"`
+	InsertFinalNewline     bool         `json:"insertFinalNewline"`
+	TrimTrailingWhitespace bool       `json:"trimTrailingWhitespace"`
 	Search         SearchSettings       `json:"search,omitzero"`
 	Explorer       ExplorerSettings     `json:"explorer,omitzero"`
 	Terminal       TerminalSettings     `json:"terminal,omitzero"`

--- a/internal/core/buffer/buffer.go
+++ b/internal/core/buffer/buffer.go
@@ -72,8 +72,9 @@ func DetectIndent(lines []string) IndentInfo {
 type Buffer struct {
 	Lines              []string
 	Dirty              bool
-	InsertFinalNewline bool
-	LineEnding         string // "\n" (LF) or "\r\n" (CRLF); defaults to "\n"
+	InsertFinalNewline     bool
+	TrimTrailingWhitespace bool
+	LineEnding             string // "\n" (LF) or "\r\n" (CRLF); defaults to "\n"
 
 	// diskModTime and diskSize record the state of the file on disk the last
 	// time we loaded or saved it, so we can detect external modifications

--- a/internal/core/buffer/io.go
+++ b/internal/core/buffer/io.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // LoadFile loads a file into the buffer, replacing its contents.
@@ -81,6 +82,11 @@ func (b *Buffer) DiskChanged(filename string) bool {
 // or complete new content, never a truncated partial write. The target's
 // permissions are preserved; symlinks are followed so the link is kept intact.
 func (b *Buffer) SaveFile(filename string) error {
+	if b.TrimTrailingWhitespace {
+		for i, line := range b.Lines {
+			b.Lines[i] = strings.TrimRight(line, " \t")
+		}
+	}
 	if b.InsertFinalNewline && (len(b.Lines) == 0 || b.Lines[len(b.Lines)-1] != "") {
 		b.Lines = append(b.Lines, "")
 	}

--- a/internal/core/buffer/io_test.go
+++ b/internal/core/buffer/io_test.go
@@ -188,6 +188,33 @@ func TestNewBufferDefaultsToLF(t *testing.T) {
 	}
 }
 
+func TestSaveTrimsTrailingWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "trim.txt")
+	b := &Buffer{
+		Lines:                  []string{"hello   ", "world\t\t", "clean"},
+		TrimTrailingWhitespace: true,
+	}
+	b.SaveFile(fname)
+	data, _ := os.ReadFile(fname)
+	if string(data) != "hello\nworld\nclean" {
+		t.Errorf("expected trimmed output, got %q", string(data))
+	}
+}
+
+func TestSaveWithoutTrimPreservesWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	fname := filepath.Join(dir, "notrim.txt")
+	b := &Buffer{
+		Lines: []string{"hello   ", "world\t\t"},
+	}
+	b.SaveFile(fname)
+	data, _ := os.ReadFile(fname)
+	if string(data) != "hello   \nworld\t\t" {
+		t.Errorf("expected whitespace preserved, got %q", string(data))
+	}
+}
+
 func TestSaveDoesNotLeaveTempFiles(t *testing.T) {
 	dir := t.TempDir()
 	fname := filepath.Join(dir, "file.txt")

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -65,7 +65,8 @@ type EditorGroupWidget struct {
 	active       int
 	TabSize            int
 	LineNumbers        bool
-	InsertFinalNewline bool
+	InsertFinalNewline     bool
+	TrimTrailingWhitespace bool
 	Borders      *term.BorderSet
 	OnFileOpen   func(path, lang, text string)
 	OnFileChange func(path, lang, text string)
@@ -146,10 +147,13 @@ func (g *EditorGroupWidget) OpenFile(path string) {
 			return
 		}
 	}
-	newBuf := &buffer.Buffer{Lines: []string{""}, InsertFinalNewline: g.InsertFinalNewline}
+	newBuf := &buffer.Buffer{Lines: []string{""}, InsertFinalNewline: g.InsertFinalNewline, TrimTrailingWhitespace: g.TrimTrailingWhitespace}
 	ec := config.LoadEditorConfig(path)
 	if ec.InsertFinalNLSet {
 		newBuf.InsertFinalNewline = ec.InsertFinalNewline
+	}
+	if ec.TrimTrailingWSSet {
+		newBuf.TrimTrailingWhitespace = ec.TrimTrailingWS
 	}
 	if err := newBuf.LoadFile(path); err != nil {
 		g.reportError(fmt.Sprintf("Failed to open %s: %v", path, err))

--- a/tests/functional/trim-whitespace.test.js
+++ b/tests/functional/trim-whitespace.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, cleanupDir } from "./helpers.js";
+import { writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("trim trailing whitespace on save", () => {
+  it("trims trailing whitespace when editorconfig enables it", () => {
+    dir = createTempDir();
+    writeFileSync(join(dir, ".editorconfig"), [
+      "root = true",
+      "",
+      "[*]",
+      "trim_trailing_whitespace = true",
+    ].join("\n"));
+    const file = join(dir, "code.txt");
+    writeFileSync(file, "hello   \nworld\t\t\nclean\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    expect(content).toBe("hello\nworld\nclean\n");
+  });
+
+  it("trims trailing whitespace when --config enables it", () => {
+    dir = createTempDir();
+    const configFile = join(dir, "settings.json");
+    writeFileSync(configFile, JSON.stringify({ trimTrailingWhitespace: true }));
+    const file = join(dir, "code.txt");
+    writeFileSync(file, "foo   \nbar\t\nclean\n");
+
+    tui.start("--config", configFile, file);
+    tui.waitFor("foo");
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    expect(content).toBe("foo\nbar\nclean\n");
+  });
+
+  it("preserves trailing whitespace without the setting", () => {
+    dir = createTempDir();
+    const file = join(dir, "code.txt");
+    writeFileSync(file, "hello   \nworld\t\t\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    expect(content).toBe("hello   \nworld\t\t\n");
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `trim_trailing_whitespace` support from `.editorconfig` and `settings.json`
- Strips trailing spaces and tabs from all lines before writing to disk
- Wired through the full stack: `Settings` → `EditorGroupWidget` → `Buffer` → `SaveFile`
- EditorConfig per-file override takes precedence over global setting

## Test plan
- [x] Unit tests: trims whitespace when enabled, preserves when disabled
- [x] Functional blackbox tests: trims with `.editorconfig` enabled, preserves without it
- [x] Full Go test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)