### PR TITLE
feat: bind Ctrl+/ to toggle comment, selection-aware

### DIFF
--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -179,6 +179,7 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "alt+shift+up", Command: "editor.duplicateLine"},
 		{Key: "alt+shift+down", Command: "editor.duplicateLine"},
 		{Key: "ctrl+k k", Command: "editor.deleteLine"},
+		{Key: "ctrl+/", Command: "editor.toggleComment"},
 		{Key: "ctrl+enter", Command: "editor.insertLineBelow"},
 		{Key: "ctrl+left", Command: "editor.moveWordLeft"},
 		{Key: "ctrl+right", Command: "editor.moveWordRight"},

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -1164,7 +1164,7 @@ func (e *EditorPaneWidget) InsertLineAbove() {
 	e.scrollViewport()
 }
 
-func (e *EditorPaneWidget) ToggleLineComment() {
+func (e *EditorPaneWidget) commentPrefix() string {
 	prefix := "//"
 	if e.Highlighter != nil {
 		lang := strings.ToLower(e.Highlighter.Language())
@@ -1177,27 +1177,80 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 			prefix = "<!--"
 		}
 	}
-	line := e.Cursor.Line
-	runes := []rune(e.Buf.Lines[line])
-	trimmed := strings.TrimLeft(string(runes), " \t")
-	if strings.HasPrefix(trimmed, prefix) {
-		indent := len(runes) - len([]rune(trimmed))
-		removeLen := len([]rune(prefix))
-		if indent+removeLen < len(runes) && runes[indent+removeLen] == ' ' {
-			removeLen++
+	return prefix
+}
+
+func (e *EditorPaneWidget) ToggleLineComment() {
+	prefix := e.commentPrefix()
+
+	startLine, endLine := e.Cursor.Line, e.Cursor.Line
+	if e.Selection != nil && e.Selection.Active {
+		start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
+		startLine = start.Line
+		endLine = end.Line
+		if end.Col == 0 && endLine > startLine {
+			endLine--
 		}
-		e.exec(&undo.DeleteSelectionCommand{
-			StartLine: line, StartCol: indent,
-			EndLine: line, EndCol: indent + removeLen,
-		})
-		e.Cursor.Col -= removeLen
-		if e.Cursor.Col < 0 {
-			e.Cursor.Col = 0
+	}
+
+	allCommented := true
+	for l := startLine; l <= endLine; l++ {
+		trimmed := strings.TrimLeft(e.Buf.Lines[l], " \t")
+		if trimmed == "" {
+			continue
 		}
-	} else {
+		if !strings.HasPrefix(trimmed, prefix) {
+			allCommented = false
+			break
+		}
+	}
+
+	var cmds []undo.EditCommand
+	cursorDelta := 0
+
+	for l := startLine; l <= endLine; l++ {
+		runes := []rune(e.Buf.Lines[l])
+		trimmed := strings.TrimLeft(string(runes), " \t")
+		if trimmed == "" {
+			continue
+		}
 		indent := len(runes) - len([]rune(trimmed))
-		e.exec(&undo.InsertStringCommand{Line: line, Col: indent, Text: prefix + " "})
-		e.Cursor.Col += len([]rune(prefix)) + 1
+
+		if allCommented {
+			removeLen := len([]rune(prefix))
+			if indent+removeLen < len(runes) && runes[indent+removeLen] == ' ' {
+				removeLen++
+			}
+			cmd := &undo.DeleteSelectionCommand{
+				StartLine: l, StartCol: indent,
+				EndLine: l, EndCol: indent + removeLen,
+			}
+			cmd.Apply(e.Buf)
+			cmds = append(cmds, cmd)
+			if l == e.Cursor.Line {
+				cursorDelta = -removeLen
+			}
+		} else {
+			cmd := &undo.InsertStringCommand{Line: l, Col: indent, Text: prefix + " "}
+			cmd.Apply(e.Buf)
+			cmds = append(cmds, cmd)
+			if l == e.Cursor.Line {
+				cursorDelta = len([]rune(prefix)) + 1
+			}
+		}
+	}
+
+	if len(cmds) > 0 && e.Undo != nil {
+		e.Undo.Push(&undo.BatchCommand{Commands: cmds})
+		e.maxLineWidthDirty = true
+		if e.OnChange != nil {
+			e.OnChange()
+		}
+	}
+
+	e.Cursor.Col += cursorDelta
+	if e.Cursor.Col < 0 {
+		e.Cursor.Col = 0
 	}
 	e.clampCursor()
 	e.scrollViewport()

--- a/tests/functional/toggle-comment.test.js
+++ b/tests/functional/toggle-comment.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, cleanupDir } from "./helpers.js";
+import { writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("toggle line comment", () => {
+  it("comments a single line via command palette", () => {
+    dir = createTempDir();
+    const file = join(dir, "test.go");
+    writeFileSync(file, "package main\n\nfunc main() {\n}\n");
+
+    tui.start(file);
+    tui.waitFor("package main");
+
+    tui.exec("Toggle Line Comment");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    expect(content).toContain("// package main");
+  });
+
+  it("uncomments a commented line", () => {
+    dir = createTempDir();
+    const file = join(dir, "test.go");
+    writeFileSync(file, "// package main\n\nfunc main() {\n}\n");
+
+    tui.start(file);
+    tui.waitFor("// package main");
+
+    tui.exec("Toggle Line Comment");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    const firstLine = content.split("\n")[0];
+    expect(firstLine).toBe("package main");
+  });
+
+  it("comments all lines when selecting all", () => {
+    dir = createTempDir();
+    const file = join(dir, "test.go");
+    writeFileSync(file, "line1\nline2\nline3\n");
+
+    tui.start(file);
+    tui.waitFor("line1");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Toggle Line Comment");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    expect(content).toContain("// line1");
+    expect(content).toContain("// line2");
+    expect(content).toContain("// line3");
+  });
+
+  it("uncomments all lines when selecting all commented lines", () => {
+    dir = createTempDir();
+    const file = join(dir, "test.go");
+    writeFileSync(file, "// line1\n// line2\n// line3\n");
+
+    tui.start(file);
+    tui.waitFor("// line1");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Toggle Line Comment");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    const lines = content.split("\n");
+    expect(lines[0]).toBe("line1");
+    expect(lines[1]).toBe("line2");
+    expect(lines[2]).toBe("line3");
+  });
+
+  it("uses # prefix for Python files", () => {
+    dir = createTempDir();
+    const file = join(dir, "test.py");
+    writeFileSync(file, 'print("hello")\nx = 1\n');
+
+    tui.start(file);
+    tui.waitFor("print");
+
+    tui.exec("Toggle Line Comment");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFileSync(file, "utf8");
+    expect(content).toContain('# print("hello")');
+  });
+});


### PR DESCRIPTION
## Summary
- Bind `Ctrl+/` to `editor.toggleComment` (was unbound)
- Make toggle comment selection-aware: when multiple lines are selected, all are toggled as a group
- If all selected lines are commented, uncomment them all; otherwise comment them all
- Multi-line toggle is a single undo step (`BatchCommand`)
- Extracted `commentPrefix()` helper for per-language comment prefix lookup

## Test plan
- [x] Functional tests: comment single line, uncomment single line, comment all via select-all, uncomment all via select-all, Python `#` prefix
- [x] Full Go test suite passes
- [x] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)