### PR TITLE
feat: extended diff view (full file side-by-side)

### DIFF
--- a/audit.md
+++ b/audit.md
@@ -1,95 +1,129 @@
 # ttt Feature Audit — Gaps to a Daily-Driver Professional Editor
 
-Audit date: 2026-06-10. Scope: essential quality-of-life features for daily professional use,
-compared against editors like VS Code. **Explicitly out of scope: LSP-depth features and DAP.**
+Audit date: 2026-06-10. Updated: 2026-06-11 with cross-reference against VS Code, Zed, Sublime
+Text, and developer community feedback (HN, Reddit, Lobsters).
+
+Scope: essential features for daily professional use. **Out of scope: DAP (debugger).**
 
 ## Verdict
 
-The foundation is strong: multi-cursor, find/replace (in-file and project-wide with ripgrep),
-fuzzy file open, command palette, git changes panel with PR review, integrated terminal with
-tabs, EditorConfig, themes, menus, and context menus all exist and work. The gaps cluster into
-three areas: **data safety** (no external-change detection, non-atomic saves, no session
-restore), **navigation memory** (no back/forward history, no recent files), and **git depth**
-(no gutter indicators, no branch switching, no conflict resolution).
+The foundation is strong: multi-cursor, find/replace (in-file + project-wide with ripgrep),
+fuzzy file open, command palette, LSP (completions, hover, go-to-def, references, rename, format,
+diagnostics), git integration (stage/unstage/commit/diff/blame/PR review), integrated terminal,
+EditorConfig, themes, menus, context menus, sidebar panels, and syntax highlighting all exist.
 
-## Priority 1 — Data safety & trust (blockers for daily driving)
+Since PR #55 was opened, several gaps have been closed:
+- Atomic save + permission/symlink preservation (PR #56)
+- External file change detection with silent reload (PR #58)
+- Line-ending detection/preservation with status bar toggle (PR #60)
+- Trim trailing whitespace on save (PR #61)
+- Toggle comment with Ctrl+/ and selection-aware multi-line support (PR #62)
 
-These are the features whose absence loses user data or breaks trust in the tool.
+The remaining gaps cluster into: **navigation & orientation** (no back/forward, no symbol outline,
+no code folding), **editor layout** (no split panes, no session restore), **LSP depth** (no code
+actions UI, no inlay hints, no snippets), and **visual polish** (no indent guides, no git gutter).
 
-| Feature | Status | Notes |
+## Feature Matrix
+
+Features are ranked by cross-source consensus (how many of VS Code, Zed, Sublime Text, HN/Reddit
+flagged them) and by impact in an **agent-driven workflow** where reviewing and navigating code
+matters more than writing it.
+
+### Tier 1 — High Impact (4-5 sources agree, transforms the editor)
+
+| Feature | Status | Consensus | Notes |
+|---|---|---|---|
+| Split editor panes | MISSING | VS Code, Zed, Sublime, HN, Reddit | Side-by-side viewing for comparing files, reviewing agent output. Fundamental layout feature. |
+| Code folding | MISSING | VS Code, Zed, Sublime, HN, Reddit | Collapse/expand code blocks. Indent-based works immediately; tree-sitter ideal long-term. |
+| Session restore | MISSING | VS Code, Zed, Sublime, HN, Reddit | Reopen with same tabs, cursors, scroll positions. `.ttt` workspace files are the persistence vehicle. |
+| Navigation history (back/forward) | MISSING | VS Code, Zed, Sublime, HN, Reddit | Alt+Left/Right after go-to-definition. Essential companion to existing LSP navigation. |
+| Go to Symbol (file + workspace) | MISSING | VS Code, Zed, Sublime, Reddit | Ctrl+Shift+O for file outline, Ctrl+T project-wide. Uses LSP `documentSymbol`/`workspace/symbol`. |
+| Code actions / lightbulb UI | MISSING | VS Code, Zed, HN, Reddit | Interactive quick-fix picker (Ctrl+.). LSP `textDocument/codeAction`. Have code actions on save, but no interactive UI. |
+
+### Tier 2 — Developer Expectations (3-4 sources, expected by power users)
+
+| Feature | Status | Consensus | Notes |
+|---|---|---|---|
+| Inlay hints | MISSING | VS Code, Zed, HN, Reddit | Inline type/parameter annotations via LSP `textDocument/inlayHint`. High value for Go/TS/Rust. |
+| Snippet expansion | MISSING | VS Code, Zed, Sublime, Reddit | LSP completions return snippets with tab stops/placeholders. Without this, many completions are degraded. |
+| Indent guides | MISSING | VS Code, Zed, Sublime, Reddit | Vertical lines at indent levels. Pure rendering, no AST needed. Quick win. |
+| Git gutter indicators | MISSING | VS Code, Zed, HN, Reddit | Green/blue/red marks in gutter for added/modified/deleted lines vs HEAD. High visibility. |
+| Outline / symbol sidebar | MISSING | VS Code, Zed, Reddit | Tree of functions/classes in sidebar panel. Leverages existing LSP + sidebar. |
+| Column/box selection | MISSING | VS Code, Sublime, HN, Reddit | Rectangular selection with Ctrl+Alt+Up/Down. Complements existing multi-cursor. |
+| Macro recording/playback | MISSING | Sublime, HN, Reddit | Record/replay editing sequences. Covers sequential cases multi-cursor can't. |
+
+### Tier 3 — Differentiators (2-3 sources, sets ttt apart)
+
+| Feature | Status | Consensus | Notes |
+|---|---|---|---|
+| Sticky scroll | MISSING | VS Code, Reddit | Pin enclosing scope headers at viewport top. No terminal editor has this. |
+| Breadcrumbs | MISSING | VS Code, Zed, Reddit | File > Class > Method path showing current location. |
+| Semantic tokens | MISSING | VS Code, Zed | LSP `textDocument/semanticTokens` for accurate syntax highlighting beyond regex. |
+| Bracket pair colorization | MISSING | VS Code, Zed | Color-code nested bracket pairs. Readability improvement. |
+| Bookmarks / marks | MISSING | Sublime, HN | Toggle bookmarks on lines, jump between them. Simple but useful in large files. |
+| Word wrap rendering | PARTIAL | VS Code, Sublime, HN | `wordWrap` setting exists but is a no-op. Important for markdown/prose/logs. |
+| Merge conflict resolution UI | MISSING | VS Code, Zed | Inline accept current/incoming/both above conflict markers. |
+
+### Tier 4 — Polish & Nice-to-Have
+
+| Feature | Status | Consensus | Notes |
+|---|---|---|---|
+| Minimap | MISSING | VS Code, Zed, Sublime | Character-based code overview. Polarizing — some love, some hide. |
+| Zen/distraction-free mode | MISSING | VS Code, Sublime | Hide all chrome, center text. Simple to implement. |
+| Sort/reverse/unique lines | MISSING | Sublime | Small text manipulation commands. Quick wins. |
+| Case transforms (upper/lower/title) | MISSING | Sublime | Ctrl+K Ctrl+U/L. Quick wins. |
+| Join lines | MISSING | VS Code, Sublime | Ctrl+J to merge next line up. |
+| Split selection into lines | MISSING | Sublime | Ctrl+Shift+L — selection to per-line cursors. |
+| Goto matching bracket | MISSING | VS Code, Sublime | `findMatchingBracket()` exists but no navigation command. |
+| Recent files / reopen closed tab | MISSING | VS Code, Zed | MRU list, Ctrl+Shift+T. |
+| Relative line numbers | MISSING | Zed, Sublime | Useful for vim-style workflows. |
+| Vim keybindings mode | MISSING | Zed, Sublime, HN | Large audience but massive implementation effort. |
+| Autosave | MISSING | VS Code, Zed | Save on focus change, timer, etc. |
+| Settings hot reload | MISSING | Zed, Reddit | Change settings without restart. |
+| Preview/transient tabs | MISSING | VS Code, Zed, Sublime | Single-click opens preview; editing pins the tab. |
+| Task runner | MISSING | VS Code, Zed | Run build/test commands with error parsing. Terminal covers most of this. |
+| Plugin/extension system | MISSING | HN, Reddit | Long-term multiplier but massive effort. |
+| AI inline completion (ghost text) | MISSING | HN, Reddit | Growing expectation; integration point for Ollama/OpenAI. |
+| Tree-sitter integration | MISSING | HN, Reddit | Architectural investment. Unlocks accurate highlighting, text objects, structural editing. |
+
+### Completed (since original audit)
+
+| Feature | Status | PR |
 |---|---|---|
-| External file change detection | MISSING | No fsnotify/polling. `git checkout`, formatters, or other tools editing a file silently desync the buffer. Editing then saving overwrites external changes. |
-| Atomic save + permission preservation | MISSING | `SaveFile()` uses `os.Create()` directly (`internal/core/buffer/io.go:39`) — truncate-then-write loses data on crash mid-save, and resets file permissions to 0644. |
-| Hot exit / session restore | MISSING | Open tabs, cursor positions, and unsaved changes are lost on quit/crash. Only workspace folder paths persist (`.ttt` files). |
-| Line-ending preservation | MISSING | Loader strips endings via `bufio.Scanner`, saver always writes LF. Opening and saving a CRLF file silently rewrites every line. Status bar hardcodes "LF". |
-| Read-only file handling | MISSING | No permission check before save; failure surfaces as a raw error. |
-| Crash recovery / backup files | PARTIAL | Crash stack trace logged to `crash.log`, but no buffer recovery. |
-| Autosave | MISSING | No setting, no timer, no focus-loss save. |
-| Large file handling | RISK | Whole file loaded into `[]string`; no guard or special casing for very large files. |
+| Atomic save + permission/symlink preservation | DONE | #56 |
+| External file change detection + silent reload | DONE | #58 |
+| Line-ending detection/preservation + status bar toggle | DONE | #60 |
+| Trim trailing whitespace on save | DONE | #61 |
+| Toggle comment (Ctrl+/, selection-aware, multi-language) | DONE | #62 |
 
-## Priority 2 — Navigation memory (the "feels slow without it" tier)
+### Already Existed (confirmed working)
 
-| Feature | Status | Notes |
-|---|---|---|
-| Back/forward cursor history (Alt+Left/Right) | MISSING | No location stack. After go-to-definition or a search jump, there is no way back. |
-| Recent files / reopen closed tab | MISSING | No MRU list, no Ctrl+Shift+T equivalent. |
-| Reveal active file in tree | PARTIAL | Active file highlights if visible, but parent folders don't auto-expand; no explicit "reveal" command. |
-| Bookmarks / marks | MISSING | |
-| Outline / symbol list | MISSING | No outline view, even regex-based. |
-| Breadcrumbs | MISSING | |
+Multi-cursor (Ctrl+D, Alt+Click, select all occurrences), find/replace (in-file + project-wide),
+fuzzy file open, command palette, LSP suite, git (stage/unstage/commit/diff/blame/PR review),
+integrated terminal, EditorConfig, themes, auto-indent, auto-pair, smart home, move/dup/delete
+line, indent/dedent selection, double/triple-click, menus, context menus, sidebar panels,
+problems panel, bracket highlighting.
 
-## Priority 3 — Editing polish
+## Recommended Next Steps
 
-| Feature | Status | Notes |
-|---|---|---|
-| Toggle line comment keybinding | PARTIAL | `ToggleLineComment()` exists (`internal/ui/editor_widget.go:1167`) with per-language prefixes, but is **unbound** (no Ctrl+/) and only handles a single line, not a selection. |
-| Trim trailing whitespace on save | PARTIAL | EditorConfig `trim_trailing_whitespace` is parsed but never applied on save. |
-| Word wrap | PARTIAL | `wordWrap` setting exists but rendering never wraps — setting is a no-op. |
-| Whole-word toggle in find | MISSING | Find bar has case + regex toggles, but no whole-word. |
-| Jump to matching bracket | MISSING | Highlighting exists (`findMatchingBracket()`), but no navigation command. |
-| Add cursor above/below | MISSING | Alt+Click, Ctrl+D, select-all-occurrences exist; column-wise cursor stacking does not. |
-| Column/block selection | MISSING | Selection model is linear anchor-to-cursor only. |
-| Wrap selection in quotes/brackets | MISSING | Typing `"` with a selection replaces it instead of surrounding it. |
-| Case transforms / join lines / sort lines | MISSING | None of the classic text commands exist. |
-| Per-language indent settings | MISSING | Only global settings + EditorConfig. |
-| Smart-home, auto-indent, auto-pair, indent/dedent selection, move/dup/delete line, double/triple-click selection | EXISTS | Solid coverage. |
+Prioritized for an agent-driven workflow (reviewing and navigating > writing):
 
-## Priority 4 — Git depth
+1. **Split editor panes** — side-by-side review of agent output vs existing code
+2. **Code folding** (indent-based) — collapse irrelevant sections in large files
+3. **Session restore** — resume context between sessions via `.ttt` workspace files
+4. **Navigation history** (back/forward) — jump around code without losing position
+5. **Go to Symbol** — quickly orient in unfamiliar/generated code
+6. **Indent guides** — quick visual win, pure rendering
+7. **Git gutter indicators** — high-visibility improvement, diff infra exists
+8. **Code actions UI** (Ctrl+.) — interactive quick-fix picker
+9. **Inlay hints** — inline type/parameter annotations
+10. **Snippet expansion** — fix degraded LSP completions
 
-| Feature | Status | Notes |
-|---|---|---|
-| Gutter change indicators | MISSING | No modified/added/deleted marks next to line numbers — one of the most-looked-at signals in VS Code. |
-| Branch switching / creation UI | MISSING | Branch shows in status bar but isn't clickable; no checkout/create commands. |
-| Merge conflict detection & resolution | MISSING | No conflict marker highlighting, no accept ours/theirs. |
-| Commit history / log view | MISSING | |
-| Stash support | MISSING | |
-| Stage/unstage/discard/commit, push/pull/sync, diff views, PR review, inline blame | EXISTS | Comprehensive. |
+## Sources
 
-## Priority 5 — Workbench
-
-| Feature | Status | Notes |
-|---|---|---|
-| Side-by-side editor splits | DEFERRED | Current splits are sidebar/editor and editor/terminal only. As a terminal editor, side-by-side is well served by tmux/multiplexer panes running separate instances. More fundamentally, terminal real estate doesn't support it: a typical 80–120 column window split in half leaves ~40–60 columns per side — below readable code width, before subtracting the sidebar. Not worth the structural lift. |
-| Tab drag-reorder / move between splits | MISSING | Tabs scroll and pin, but can't be reordered. |
-| Move files in explorer | MISSING | Create/rename/delete exist; no move (and delete is permanent — `os.RemoveAll`, no trash). |
-| Settings hot reload | MISSING | `settings.json` edits require restart. |
-| Zen / distraction-free mode | MISSING | Terminal has fullscreen; editor doesn't. |
-| Minimap | MISSING | Arguably optional in a terminal editor. |
-| Explorer file watching | MISSING | Tree only updates on manual refresh. |
-| Menus, context menus, command palette, sidebar panels, problems panel, terminal tabs+selection | EXISTS | Comprehensive. |
-
-## Suggested attack order
-
-1. **Atomic save + permission preservation** — small, contained (`internal/core/buffer/io.go`), eliminates the worst data-loss risk.
-2. **External change detection** (fsnotify or stat-on-focus) with reload prompt — the other half of data trust.
-3. **Line-ending detection/preservation** — quiet correctness fix; status bar already has the slot.
-4. **Bind Ctrl+/ and make toggle-comment selection-aware** — the code is 90% there.
-5. **Back/forward navigation history** — touches cursor/jump paths but is self-contained state.
-6. **Session restore (open tabs + cursor positions)** — workspace files already provide the persistence vehicle.
-7. **Recent files / reopen closed tab** — small, pairs with quick-open.
-8. **Git gutter indicators** — high visibility payoff; diff infrastructure already exists.
-9. **Trim trailing whitespace on save** — parser already reads the flag; just apply it.
-
-Editor side-by-side splits are intentionally deferred: tmux panes with separate instances cover
-the terminal-native workflow, typical terminal widths can't fit two readable code columns anyway,
-and the structural cost inside the editor is the highest on this list.
+- VS Code official documentation and feature comparison
+- Zed editor documentation and blog posts
+- Sublime Text documentation and feature pages
+- Hacker News discussions on terminal editors (2024-2026)
+- Reddit, Lobsters, and developer blog posts on editor wishlists
+- Helix, Kakoune, and Micro editor comparisons

--- a/audit.md
+++ b/audit.md
@@ -1,0 +1,92 @@
+# ttt Feature Audit — Gaps to a Daily-Driver Professional Editor
+
+Audit date: 2026-06-10. Scope: essential quality-of-life features for daily professional use,
+compared against editors like VS Code. **Explicitly out of scope: LSP-depth features and DAP.**
+
+## Verdict
+
+The foundation is strong: multi-cursor, find/replace (in-file and project-wide with ripgrep),
+fuzzy file open, command palette, git changes panel with PR review, integrated terminal with
+tabs, EditorConfig, themes, menus, and context menus all exist and work. The gaps cluster into
+three areas: **data safety** (no external-change detection, non-atomic saves, no session
+restore), **navigation memory** (no back/forward history, no recent files), and **git depth**
+(no gutter indicators, no branch switching, no conflict resolution).
+
+## Priority 1 — Data safety & trust (blockers for daily driving)
+
+These are the features whose absence loses user data or breaks trust in the tool.
+
+| Feature | Status | Notes |
+|---|---|---|
+| External file change detection | MISSING | No fsnotify/polling. `git checkout`, formatters, or other tools editing a file silently desync the buffer. Editing then saving overwrites external changes. |
+| Atomic save + permission preservation | MISSING | `SaveFile()` uses `os.Create()` directly (`internal/core/buffer/io.go:39`) — truncate-then-write loses data on crash mid-save, and resets file permissions to 0644. |
+| Hot exit / session restore | MISSING | Open tabs, cursor positions, and unsaved changes are lost on quit/crash. Only workspace folder paths persist (`.ttt` files). |
+| Line-ending preservation | MISSING | Loader strips endings via `bufio.Scanner`, saver always writes LF. Opening and saving a CRLF file silently rewrites every line. Status bar hardcodes "LF". |
+| Read-only file handling | MISSING | No permission check before save; failure surfaces as a raw error. |
+| Crash recovery / backup files | PARTIAL | Crash stack trace logged to `crash.log`, but no buffer recovery. |
+| Autosave | MISSING | No setting, no timer, no focus-loss save. |
+| Large file handling | RISK | Whole file loaded into `[]string`; no guard or special casing for very large files. |
+
+## Priority 2 — Navigation memory (the "feels slow without it" tier)
+
+| Feature | Status | Notes |
+|---|---|---|
+| Back/forward cursor history (Alt+Left/Right) | MISSING | No location stack. After go-to-definition or a search jump, there is no way back. |
+| Recent files / reopen closed tab | MISSING | No MRU list, no Ctrl+Shift+T equivalent. |
+| Reveal active file in tree | PARTIAL | Active file highlights if visible, but parent folders don't auto-expand; no explicit "reveal" command. |
+| Bookmarks / marks | MISSING | |
+| Outline / symbol list | MISSING | No outline view, even regex-based. |
+| Breadcrumbs | MISSING | |
+
+## Priority 3 — Editing polish
+
+| Feature | Status | Notes |
+|---|---|---|
+| Toggle line comment keybinding | PARTIAL | `ToggleLineComment()` exists (`internal/ui/editor_widget.go:1167`) with per-language prefixes, but is **unbound** (no Ctrl+/) and only handles a single line, not a selection. |
+| Trim trailing whitespace on save | PARTIAL | EditorConfig `trim_trailing_whitespace` is parsed but never applied on save. |
+| Word wrap | PARTIAL | `wordWrap` setting exists but rendering never wraps — setting is a no-op. |
+| Whole-word toggle in find | MISSING | Find bar has case + regex toggles, but no whole-word. |
+| Jump to matching bracket | MISSING | Highlighting exists (`findMatchingBracket()`), but no navigation command. |
+| Add cursor above/below | MISSING | Alt+Click, Ctrl+D, select-all-occurrences exist; column-wise cursor stacking does not. |
+| Column/block selection | MISSING | Selection model is linear anchor-to-cursor only. |
+| Wrap selection in quotes/brackets | MISSING | Typing `"` with a selection replaces it instead of surrounding it. |
+| Case transforms / join lines / sort lines | MISSING | None of the classic text commands exist. |
+| Per-language indent settings | MISSING | Only global settings + EditorConfig. |
+| Smart-home, auto-indent, auto-pair, indent/dedent selection, move/dup/delete line, double/triple-click selection | EXISTS | Solid coverage. |
+
+## Priority 4 — Git depth
+
+| Feature | Status | Notes |
+|---|---|---|
+| Gutter change indicators | MISSING | No modified/added/deleted marks next to line numbers — one of the most-looked-at signals in VS Code. |
+| Branch switching / creation UI | MISSING | Branch shows in status bar but isn't clickable; no checkout/create commands. |
+| Merge conflict detection & resolution | MISSING | No conflict marker highlighting, no accept ours/theirs. |
+| Commit history / log view | MISSING | |
+| Stash support | MISSING | |
+| Stage/unstage/discard/commit, push/pull/sync, diff views, PR review, inline blame | EXISTS | Comprehensive. |
+
+## Priority 5 — Workbench
+
+| Feature | Status | Notes |
+|---|---|---|
+| Side-by-side editor splits | MISSING | Current splits are sidebar/editor and editor/terminal only; no two-files-side-by-side editing. |
+| Tab drag-reorder / move between splits | MISSING | Tabs scroll and pin, but can't be reordered. |
+| Move files in explorer | MISSING | Create/rename/delete exist; no move (and delete is permanent — `os.RemoveAll`, no trash). |
+| Settings hot reload | MISSING | `settings.json` edits require restart. |
+| Zen / distraction-free mode | MISSING | Terminal has fullscreen; editor doesn't. |
+| Minimap | MISSING | Arguably optional in a terminal editor. |
+| Explorer file watching | MISSING | Tree only updates on manual refresh. |
+| Menus, context menus, command palette, sidebar panels, problems panel, terminal tabs+selection | EXISTS | Comprehensive. |
+
+## Suggested attack order
+
+1. **Atomic save + permission preservation** — small, contained (`internal/core/buffer/io.go`), eliminates the worst data-loss risk.
+2. **External change detection** (fsnotify or stat-on-focus) with reload prompt — the other half of data trust.
+3. **Line-ending detection/preservation** — quiet correctness fix; status bar already has the slot.
+4. **Bind Ctrl+/ and make toggle-comment selection-aware** — the code is 90% there.
+5. **Back/forward navigation history** — touches cursor/jump paths but is self-contained state.
+6. **Session restore (open tabs + cursor positions)** — workspace files already provide the persistence vehicle.
+7. **Recent files / reopen closed tab** — small, pairs with quick-open.
+8. **Git gutter indicators** — high visibility payoff; diff infrastructure already exists.
+9. **Trim trailing whitespace on save** — parser already reads the flag; just apply it.
+10. **Editor side-by-side split** — biggest structural lift in the list; schedule deliberately.

--- a/audit.md
+++ b/audit.md
@@ -69,7 +69,7 @@ These are the features whose absence loses user data or breaks trust in the tool
 
 | Feature | Status | Notes |
 |---|---|---|
-| Side-by-side editor splits | DEFERRED | Current splits are sidebar/editor and editor/terminal only. As a terminal editor, side-by-side is well served by tmux/multiplexer panes running separate instances; in-editor splits only add value for same-file dual views and shared buffer state. Not worth the structural lift now. |
+| Side-by-side editor splits | DEFERRED | Current splits are sidebar/editor and editor/terminal only. As a terminal editor, side-by-side is well served by tmux/multiplexer panes running separate instances. More fundamentally, terminal real estate doesn't support it: a typical 80–120 column window split in half leaves ~40–60 columns per side — below readable code width, before subtracting the sidebar. Not worth the structural lift. |
 | Tab drag-reorder / move between splits | MISSING | Tabs scroll and pin, but can't be reordered. |
 | Move files in explorer | MISSING | Create/rename/delete exist; no move (and delete is permanent — `os.RemoveAll`, no trash). |
 | Settings hot reload | MISSING | `settings.json` edits require restart. |
@@ -91,4 +91,5 @@ These are the features whose absence loses user data or breaks trust in the tool
 9. **Trim trailing whitespace on save** — parser already reads the flag; just apply it.
 
 Editor side-by-side splits are intentionally deferred: tmux panes with separate instances cover
-the terminal-native workflow, and the structural cost inside the editor is the highest on this list.
+the terminal-native workflow, typical terminal widths can't fit two readable code columns anyway,
+and the structural cost inside the editor is the highest on this list.

--- a/audit.md
+++ b/audit.md
@@ -69,7 +69,7 @@ These are the features whose absence loses user data or breaks trust in the tool
 
 | Feature | Status | Notes |
 |---|---|---|
-| Side-by-side editor splits | MISSING | Current splits are sidebar/editor and editor/terminal only; no two-files-side-by-side editing. |
+| Side-by-side editor splits | DEFERRED | Current splits are sidebar/editor and editor/terminal only. As a terminal editor, side-by-side is well served by tmux/multiplexer panes running separate instances; in-editor splits only add value for same-file dual views and shared buffer state. Not worth the structural lift now. |
 | Tab drag-reorder / move between splits | MISSING | Tabs scroll and pin, but can't be reordered. |
 | Move files in explorer | MISSING | Create/rename/delete exist; no move (and delete is permanent — `os.RemoveAll`, no trash). |
 | Settings hot reload | MISSING | `settings.json` edits require restart. |
@@ -89,4 +89,6 @@ These are the features whose absence loses user data or breaks trust in the tool
 7. **Recent files / reopen closed tab** — small, pairs with quick-open.
 8. **Git gutter indicators** — high visibility payoff; diff infrastructure already exists.
 9. **Trim trailing whitespace on save** — parser already reads the flag; just apply it.
-10. **Editor side-by-side split** — biggest structural lift in the list; schedule deliberately.
+
+Editor side-by-side splits are intentionally deferred: tmux panes with separate instances cover
+the terminal-native workflow, and the structural cost inside the editor is the highest on this list.

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -237,22 +237,36 @@ func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus) {
 
 func (a *App) fetchPRFileContent(dv *ui.DiffViewWidget, owner, repo, baseSHA, headSHA, path string) {
 	if owner == "" || baseSHA == "" {
+		dv.Loading = false
 		return
 	}
-	if content, err := github.FetchFileContent(owner, repo, path, baseSHA); err == nil {
-		lines := strings.Split(content, "\n")
-		if len(lines) > 0 && lines[len(lines)-1] == "" {
-			lines = lines[:len(lines)-1]
+	tabName := path + " (diff)"
+	go func() {
+		var oldLines, newLines []string
+		var fetchErr error
+		if content, err := github.FetchFileContent(owner, repo, path, baseSHA); err == nil {
+			oldLines = strings.Split(content, "\n")
+			if len(oldLines) > 0 && oldLines[len(oldLines)-1] == "" {
+				oldLines = oldLines[:len(oldLines)-1]
+			}
+		} else {
+			fetchErr = err
 		}
-		dv.SetOldLines(lines)
-	}
-	if content, err := github.FetchFileContent(owner, repo, path, headSHA); err == nil {
-		lines := strings.Split(content, "\n")
-		if len(lines) > 0 && lines[len(lines)-1] == "" {
-			lines = lines[:len(lines)-1]
+		if content, err := github.FetchFileContent(owner, repo, path, headSHA); err == nil {
+			newLines = strings.Split(content, "\n")
+			if len(newLines) > 0 && newLines[len(newLines)-1] == "" {
+				newLines = newLines[:len(newLines)-1]
+			}
+		} else if fetchErr == nil {
+			fetchErr = err
 		}
-		dv.SetNewLines(lines)
-	}
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&DiffContentResult{
+			TabName:  tabName,
+			OldLines: oldLines,
+			NewLines: newLines,
+			Err:      fetchErr,
+		}))
+	}()
 }
 
 func (a *App) ShowPRGroupMenu(group *ui.ChangesGroup, sx, sy int) {

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/ui"
 
 	"github.com/gdamore/tcell/v2"
@@ -226,7 +227,32 @@ func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus) {
 		return
 	}
 	a.EditorGroup.OpenDiff(status.Path, parsed, nil, nil, false)
+	if dv := a.EditorGroup.ActiveDiffWidget(); dv != nil {
+		dv.OnFetchExtended = func(dv *ui.DiffViewWidget) {
+			a.fetchPRFileContent(dv, group.PROwner, group.PRRepo, group.PRBaseSHA, group.PRHeadSHA, status.Path)
+		}
+	}
 	a.Root.SetFocus(a.EditorGroup)
+}
+
+func (a *App) fetchPRFileContent(dv *ui.DiffViewWidget, owner, repo, baseSHA, headSHA, path string) {
+	if owner == "" || baseSHA == "" {
+		return
+	}
+	if content, err := github.FetchFileContent(owner, repo, path, baseSHA); err == nil {
+		lines := strings.Split(content, "\n")
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+		dv.SetOldLines(lines)
+	}
+	if content, err := github.FetchFileContent(owner, repo, path, headSHA); err == nil {
+		lines := strings.Split(content, "\n")
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+		dv.SetNewLines(lines)
+	}
 }
 
 func (a *App) ShowPRGroupMenu(group *ui.ChangesGroup, sx, sy int) {

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -491,6 +491,10 @@ func registerWidgetCallbacks(app *App) {
 		}
 	}
 
+	app.Changes.OnOpenFile = func(path string) {
+		app.EditorGroup.OpenFile(path)
+		app.Root.SetFocus(app.EditorGroup)
+	}
 	app.Changes.OnOpenDiff = func(dir string, status git.FileStatus, extended bool) {
 		app.OpenChangeDiff(dir, status, extended)
 	}

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -171,7 +171,22 @@ func (a *App) ApplySearchReplaceAll(allMatches map[string][]ui.SearchMatch, repl
 	})
 }
 
-func (a *App) OpenChangeDiff(dir string, status git.FileStatus) {
+func (a *App) openSelectedDiff(extended bool) {
+	g := a.Changes.SelectedGroup()
+	if g != nil && g.IsPR {
+		_, status, ok := a.Changes.SelectedFile()
+		if ok && a.Changes.OnOpenPRDiff != nil {
+			a.Changes.OnOpenPRDiff(g, status, extended)
+		}
+	} else {
+		dir, status, ok := a.Changes.SelectedFile()
+		if ok && a.Changes.OnOpenDiff != nil {
+			a.Changes.OnOpenDiff(dir, status, extended)
+		}
+	}
+}
+
+func (a *App) OpenChangeDiff(dir string, status git.FileStatus, extended bool) {
 	fullPath := filepath.Join(dir, status.Path)
 	if status.Status == "?" {
 		a.EditorGroup.OpenFile(fullPath)
@@ -211,11 +226,11 @@ func (a *App) OpenChangeDiff(dir string, status git.FileStatus) {
 			newLines = newLines[:len(newLines)-1]
 		}
 	}
-	a.EditorGroup.OpenDiff(status.Path, parsed, oldLines, newLines, a.Settings.DiffView == "extended")
+	a.EditorGroup.OpenDiff(status.Path, parsed, oldLines, newLines, extended)
 	a.Root.SetFocus(a.EditorGroup)
 }
 
-func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus) {
+func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
 	diffText, ok := group.PRDiffs[status.Path]
 	if !ok || diffText == "" {
 		a.StatusWarn("No diff available for " + status.Path)
@@ -226,7 +241,7 @@ func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus) {
 		a.StatusWarn("Empty diff for " + status.Path)
 		return
 	}
-	a.EditorGroup.OpenDiff(status.Path, parsed, nil, nil, false)
+	a.EditorGroup.OpenDiff(status.Path, parsed, nil, nil, extended)
 	if dv := a.EditorGroup.ActiveDiffWidget(); dv != nil {
 		dv.OnFetchExtended = func(dv *ui.DiffViewWidget) {
 			a.fetchPRFileContent(dv, group.PROwner, group.PRRepo, group.PRBaseSHA, group.PRHeadSHA, status.Path)
@@ -424,13 +439,15 @@ func registerWidgetCallbacks(app *App) {
 			{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
 		}
 		if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
+			cmd := "diff.extendedView"
 			label := "Extended Diff"
 			if dv.IsExtended() {
+				cmd = "diff.compactView"
 				label = "Compact Diff"
 			}
 			tabContextMenu = append(tabContextMenu,
 				ui.MenuSep(),
-				ui.ContextMenuItem{Label: label, Command: "diff.toggleExtended"},
+				ui.ContextMenuItem{Label: label, Command: cmd},
 			)
 		}
 		openContextMenu(app, tabContextMenu, sx, sy)
@@ -474,8 +491,12 @@ func registerWidgetCallbacks(app *App) {
 		}
 	}
 
-	app.Changes.OnOpenDiff = app.OpenChangeDiff
-	app.Changes.OnOpenPRDiff = app.OpenPRDiff
+	app.Changes.OnOpenDiff = func(dir string, status git.FileStatus, extended bool) {
+		app.OpenChangeDiff(dir, status, extended)
+	}
+	app.Changes.OnOpenPRDiff = func(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
+		app.OpenPRDiff(group, status, extended)
+	}
 	app.Changes.OnPRGroupMenu = app.ShowPRGroupMenu
 	app.Changes.OnRefreshPR = app.FetchAndOpenPR
 	app.Changes.OnGroupMenu = app.ShowGroupMenu

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -66,7 +66,7 @@ func (a *App) DiffSearchSources() []ui.DiffSearchSource {
 				continue
 			}
 			fd := diff.Parse(diffText)
-			dv := ui.NewDiffViewWidget(path, fd)
+			dv := ui.NewDiffViewWidget(path, fd, nil, nil, false)
 			sources = append(sources, ui.DiffSearchSource{TabName: tabName, Lines: dv.CombinedLines()})
 		}
 	}
@@ -82,7 +82,7 @@ func (a *App) NavigateToSearchMatch(path string, line, col int) {
 					continue
 				}
 				if diffText, ok := g.PRDiffs[filePath]; ok {
-					a.EditorGroup.OpenDiff(filePath, diff.Parse(diffText))
+					a.EditorGroup.OpenDiff(filePath, diff.Parse(diffText), nil, nil, false)
 					break
 				}
 			}
@@ -114,7 +114,7 @@ func (a *App) PreviewSearchReplace(filePath string, matches []ui.SearchMatch, re
 		lines = lines[:len(lines)-1]
 	}
 	fd := ui.BuildReplaceDiff(filepath.Base(filePath), lines, matches, replacement, opts)
-	a.EditorGroup.OpenDiff(filePath, fd)
+	a.EditorGroup.OpenDiff(filePath, fd, nil, nil, false)
 	a.Root.SetFocus(a.EditorGroup)
 }
 
@@ -195,7 +195,22 @@ func (a *App) OpenChangeDiff(dir string, status git.FileStatus) {
 		a.Root.SetFocus(a.EditorGroup)
 		return
 	}
-	a.EditorGroup.OpenDiff(status.Path, parsed)
+	var oldLines, newLines []string
+	oldContent, err := git.ShowFile(dir, status.Path, "HEAD")
+	if err == nil {
+		oldLines = strings.Split(oldContent, "\n")
+		if len(oldLines) > 0 && oldLines[len(oldLines)-1] == "" {
+			oldLines = oldLines[:len(oldLines)-1]
+		}
+	}
+	newData, err := os.ReadFile(fullPath)
+	if err == nil {
+		newLines = strings.Split(string(newData), "\n")
+		if len(newLines) > 0 && newLines[len(newLines)-1] == "" {
+			newLines = newLines[:len(newLines)-1]
+		}
+	}
+	a.EditorGroup.OpenDiff(status.Path, parsed, oldLines, newLines, a.Settings.DiffView == "extended")
 	a.Root.SetFocus(a.EditorGroup)
 }
 
@@ -210,7 +225,7 @@ func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus) {
 		a.StatusWarn("Empty diff for " + status.Path)
 		return
 	}
-	a.EditorGroup.OpenDiff(status.Path, parsed)
+	a.EditorGroup.OpenDiff(status.Path, parsed, nil, nil, false)
 	a.Root.SetFocus(a.EditorGroup)
 }
 
@@ -367,6 +382,16 @@ func registerWidgetCallbacks(app *App) {
 			{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
 			{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
 			{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
+		}
+		if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
+			label := "Extended Diff"
+			if dv.IsExtended() {
+				label = "Compact Diff"
+			}
+			tabContextMenu = append(tabContextMenu,
+				ui.MenuSep(),
+				ui.ContextMenuItem{Label: label, Command: "diff.toggleExtended"},
+			)
 		}
 		openContextMenu(app, tabContextMenu, sx, sy)
 	}

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -270,10 +270,19 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "diff.toggleExtended", Title: "Toggle Extended Diff",
+		ID: "diff.extendedView", Title: "Git: Extended Diff",
 		Handler: func() {
 			if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
-				dv.SetExtended(!dv.IsExtended())
+				dv.SetExtended(true)
+			}
+		},
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.compactView", Title: "Git: Compact Diff",
+		Handler: func() {
+			if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
+				dv.SetExtended(false)
 			}
 		},
 	})

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -270,6 +270,15 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "diff.toggleExtended", Title: "Toggle Extended Diff",
+		Handler: func() {
+			if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
+				dv.SetExtended(!dv.IsExtended())
+			}
+		},
+	})
+
+	reg.Register(command.Command{
 		ID: "file.new", Title: "New File",
 		Handler: app.NewFile,
 	})

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -182,17 +182,21 @@ func registerGitCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "changes.openDiff", Title: "Open Diff",
+		ID: "changes.openDiff", Title: "Git: Open Compact Diff",
 		Handler: func() {
-			dir, status, ok := app.Changes.SelectedFile()
-			if ok && app.Changes.OnOpenDiff != nil {
-				app.Changes.OnOpenDiff(dir, status)
-			}
+			app.openSelectedDiff(false)
 		},
 	})
 
 	reg.Register(command.Command{
-		ID: "changes.openFile", Title: "Open File",
+		ID: "changes.openExtendedDiff", Title: "Git: Open Extended Diff",
+		Handler: func() {
+			app.openSelectedDiff(true)
+		},
+	})
+
+	reg.Register(command.Command{
+		ID: "changes.openFile", Title: "Git: Open File",
 		Handler: func() {
 			fullPath := app.Changes.SelectedFullPath()
 			if fullPath != "" {
@@ -203,12 +207,12 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "changes.refresh", Title: "Refresh Changes",
+		ID: "changes.refresh", Title: "Git: Refresh Changes",
 		Handler: func() { app.Changes.Refresh() },
 	})
 
 	reg.Register(command.Command{
-		ID: "changes.stage", Title: "Stage File",
+		ID: "changes.stage", Title: "Git: Stage File",
 		Handler: func() {
 			dir, status, ok := app.Changes.SelectedFile()
 			if ok && !status.Staged {
@@ -219,7 +223,7 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "changes.unstage", Title: "Unstage File",
+		ID: "changes.unstage", Title: "Git: Unstage File",
 		Handler: func() {
 			dir, status, ok := app.Changes.SelectedFile()
 			if ok && status.Staged {
@@ -230,7 +234,7 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "changes.discard", Title: "Discard Changes",
+		ID: "changes.discard", Title: "Git: Discard Changes",
 		Handler: app.DiscardSelected,
 	})
 
@@ -251,9 +255,9 @@ func registerGitCommands(app *App) {
 			},
 		})
 	}
-	registerGitCmd("git.pull", "Git Pull", []func(string) error{git.Pull}, "Pulled")
-	registerGitCmd("git.push", "Git Push", []func(string) error{git.Push}, "Pushed")
-	registerGitCmd("git.sync", "Git Sync", []func(string) error{git.Pull, git.Push}, "Synced")
+	registerGitCmd("git.pull", "Git: Pull", []func(string) error{git.Pull}, "Pulled")
+	registerGitCmd("git.push", "Git: Push", []func(string) error{git.Push}, "Pushed")
+	registerGitCmd("git.sync", "Git: Sync", []func(string) error{git.Pull, git.Push}, "Synced")
 }
 
 func registerWorkspaceCommands(app *App) {
@@ -289,11 +293,11 @@ func registerPRCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "pr.review", Title: "Review PR",
+		ID: "pr.review", Title: "Git: Review PR",
 		Handler: app.OpenPullRequestDialog,
 	})
 	reg.Register(command.Command{
-		ID: "pr.close", Title: "Close Pull Request",
+		ID: "pr.close", Title: "Git: Close PR",
 		Handler: func() { app.Changes.RemovePRGroups() },
 	})
 }

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -242,6 +242,20 @@ func RunEventLoop(
 				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:
 				app.Search.ApplyBatch(v)
+			case *DiffContentResult:
+				if v.Err != nil {
+					app.StatusError("Failed to fetch file content: " + v.Err.Error())
+					if dv := app.EditorGroup.DiffWidgetByTab(v.TabName); dv != nil {
+						dv.Loading = false
+						dv.SetExtended(false)
+					}
+				} else {
+					if dv := app.EditorGroup.DiffWidgetByTab(v.TabName); dv != nil {
+						dv.SetOldLines(v.OldLines)
+						dv.SetNewLines(v.NewLines)
+						dv.FinishLoading()
+					}
+				}
 			case *PrFetchResult:
 				app.Changes.Loading = false
 				if v.Err != nil {

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -255,7 +255,7 @@ func RunEventLoop(
 						})
 					}
 					groupName := fmt.Sprintf("PR #%d: %s", v.Info.Number, v.Info.Title)
-					app.Changes.AddPRGroup(groupName, v.URL, files, v.Diffs)
+					app.Changes.AddPRGroup(groupName, v.URL, v.Info.Owner, v.Info.Repo, v.Info.BaseSHA, v.Info.HeadSHA, files, v.Diffs)
 					app.Sidebar.SetActivePanel("changes")
 					if !app.Sidebar.Visible {
 						app.ShowSidebar()

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -104,14 +104,16 @@ var diffContextMenu = []ui.ContextMenuItem{
 }
 
 var changesContextMenuStaged = []ui.ContextMenuItem{
-	{Label: "Open Diff", Command: "changes.openDiff"},
+	{Label: "Open Compact Diff", Command: "changes.openDiff"},
+	{Label: "Open Extended Diff", Command: "changes.openExtendedDiff"},
 	{Label: "Open File", Command: "changes.openFile"},
 	ui.MenuSep(),
 	{Label: "Unstage", Command: "changes.unstage"},
 }
 
 var changesContextMenuUnstaged = []ui.ContextMenuItem{
-	{Label: "Open Diff", Command: "changes.openDiff"},
+	{Label: "Open Compact Diff", Command: "changes.openDiff"},
+	{Label: "Open Extended Diff", Command: "changes.openExtendedDiff"},
 	{Label: "Open File", Command: "changes.openFile"},
 	ui.MenuSep(),
 	{Label: "Stage", Command: "changes.stage"},

--- a/internal/app/pr.go
+++ b/internal/app/pr.go
@@ -15,6 +15,13 @@ type PrFetchResult struct {
 	Err   error
 }
 
+type DiffContentResult struct {
+	TabName  string
+	OldLines []string
+	NewLines []string
+	Err      error
+}
+
 func (a *App) FetchAndOpenPR(url string) {
 	owner, repo, number, err := github.ParsePRURL(url)
 	if err != nil {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -103,6 +103,7 @@ type Settings struct {
 	FormatOnSave       bool             `json:"formatOnSave"`
 	InsertFinalNewline     bool         `json:"insertFinalNewline"`
 	TrimTrailingWhitespace bool       `json:"trimTrailingWhitespace"`
+	DiffView       string               `json:"diffView,omitempty"`
 	Search         SearchSettings       `json:"search,omitzero"`
 	Explorer       ExplorerSettings     `json:"explorer,omitzero"`
 	Terminal       TerminalSettings     `json:"terminal,omitzero"`

--- a/internal/core/diff/diff.go
+++ b/internal/core/diff/diff.go
@@ -50,6 +50,57 @@ func (f *FileDiff) AllLines() []DiffLine {
 	return lines
 }
 
+func FullDiffLines(oldLines, newLines []string) []DiffLine {
+	lcs := computeLCS(oldLines, newLines)
+	var lines []DiffLine
+	oi, ni, li := 0, 0, 0
+
+	for oi < len(oldLines) || ni < len(newLines) {
+		if li < len(lcs) && oi < len(oldLines) && ni < len(newLines) &&
+			oldLines[oi] == lcs[li] && newLines[ni] == lcs[li] {
+			lines = append(lines, DiffLine{
+				Left:  SideLine{Num: oi + 1, Text: oldLines[oi], Kind: Context},
+				Right: SideLine{Num: ni + 1, Text: newLines[ni], Kind: Context},
+			})
+			oi++
+			ni++
+			li++
+			continue
+		}
+
+		var delBuf []int
+		var addBuf []int
+		for oi < len(oldLines) && (li >= len(lcs) || oldLines[oi] != lcs[li]) {
+			delBuf = append(delBuf, oi)
+			oi++
+		}
+		for ni < len(newLines) && (li >= len(lcs) || newLines[ni] != lcs[li]) {
+			addBuf = append(addBuf, ni)
+			ni++
+		}
+
+		maxLen := len(delBuf)
+		if len(addBuf) > maxLen {
+			maxLen = len(addBuf)
+		}
+		for i := 0; i < maxLen; i++ {
+			dl := DiffLine{}
+			if i < len(delBuf) {
+				dl.Left = SideLine{Num: delBuf[i] + 1, Text: oldLines[delBuf[i]], Kind: Deleted}
+			} else {
+				dl.Left = SideLine{Kind: Blank}
+			}
+			if i < len(addBuf) {
+				dl.Right = SideLine{Num: addBuf[i] + 1, Text: newLines[addBuf[i]], Kind: Added}
+			} else {
+				dl.Right = SideLine{Kind: Blank}
+			}
+			lines = append(lines, dl)
+		}
+	}
+	return lines
+}
+
 func Parse(unified string) FileDiff {
 	var fd FileDiff
 	lines := strings.Split(unified, "\n")

--- a/internal/core/diff/diff_test.go
+++ b/internal/core/diff/diff_test.go
@@ -166,3 +166,72 @@ func TestGenerateAddition(t *testing.T) {
 		t.Error("expected added line 'b'")
 	}
 }
+
+func TestFullDiffLines(t *testing.T) {
+	old := []string{"a", "b", "c", "d"}
+	new := []string{"a", "x", "c", "d"}
+	lines := FullDiffLines(old, new)
+
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d", len(lines))
+	}
+	if lines[0].Left.Kind != Context || lines[0].Left.Text != "a" {
+		t.Errorf("line 0: expected context 'a', got %v", lines[0].Left)
+	}
+	if lines[1].Left.Kind != Deleted || lines[1].Left.Text != "b" {
+		t.Errorf("line 1 left: expected deleted 'b', got %v", lines[1].Left)
+	}
+	if lines[1].Right.Kind != Added || lines[1].Right.Text != "x" {
+		t.Errorf("line 1 right: expected added 'x', got %v", lines[1].Right)
+	}
+	if lines[2].Left.Kind != Context || lines[2].Left.Text != "c" {
+		t.Errorf("line 2: expected context 'c', got %v", lines[2].Left)
+	}
+	if lines[3].Left.Kind != Context || lines[3].Left.Text != "d" {
+		t.Errorf("line 3: expected context 'd', got %v", lines[3].Left)
+	}
+}
+
+func TestFullDiffLinesIdentical(t *testing.T) {
+	lines := FullDiffLines([]string{"a", "b"}, []string{"a", "b"})
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	for i, dl := range lines {
+		if dl.Left.Kind != Context || dl.Right.Kind != Context {
+			t.Errorf("line %d: expected both sides context", i)
+		}
+	}
+}
+
+func TestFullDiffLinesAddition(t *testing.T) {
+	old := []string{"a", "c"}
+	new := []string{"a", "b", "c"}
+	lines := FullDiffLines(old, new)
+
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	if lines[1].Left.Kind != Blank {
+		t.Errorf("line 1 left: expected blank, got %v", lines[1].Left.Kind)
+	}
+	if lines[1].Right.Kind != Added || lines[1].Right.Text != "b" {
+		t.Errorf("line 1 right: expected added 'b', got %v", lines[1].Right)
+	}
+}
+
+func TestFullDiffLinesDeletion(t *testing.T) {
+	old := []string{"a", "b", "c"}
+	new := []string{"a", "c"}
+	lines := FullDiffLines(old, new)
+
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	if lines[1].Left.Kind != Deleted || lines[1].Left.Text != "b" {
+		t.Errorf("line 1 left: expected deleted 'b', got %v", lines[1].Left)
+	}
+	if lines[1].Right.Kind != Blank {
+		t.Errorf("line 1 right: expected blank, got %v", lines[1].Right.Kind)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -226,6 +226,16 @@ func IgnoredFiles(dir string, paths []string) map[string]bool {
 	return result
 }
 
+func ShowFile(dir, path, ref string) (string, error) {
+	spec := ref + ":" + path
+	cmd := exec.Command("git", "-C", dir, "show", spec)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
 func DiffFile(dir, path string) (string, error) {
 	absPath := filepath.Join(dir, path)
 	cmd := exec.Command("git", "-C", dir, "diff", "--", absPath)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -14,11 +14,13 @@ type PRFile struct {
 }
 
 type PRInfo struct {
-	Owner  string
-	Repo   string
-	Number int
-	Title  string
-	Files  []PRFile
+	Owner   string
+	Repo    string
+	Number  int
+	Title   string
+	BaseSHA string
+	HeadSHA string
+	Files   []PRFile
 }
 
 func IsGHInstalled() bool {
@@ -49,15 +51,17 @@ func FetchPRInfo(owner, repo string, number int) (*PRInfo, error) {
 	repoArg := owner + "/" + repo
 	cmd := exec.Command("gh", "pr", "view", strconv.Itoa(number),
 		"--repo", repoArg,
-		"--json", "title,number,files")
+		"--json", "title,number,files,baseRefOid,headRefOid")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("gh pr view failed: %w", err)
 	}
 	var result struct {
-		Title  string `json:"title"`
-		Number int    `json:"number"`
-		Files  []struct {
+		Title      string `json:"title"`
+		Number     int    `json:"number"`
+		BaseRefOid string `json:"baseRefOid"`
+		HeadRefOid string `json:"headRefOid"`
+		Files      []struct {
 			Path   string `json:"path"`
 			Status string `json:"status"`
 		} `json:"files"`
@@ -66,10 +70,12 @@ func FetchPRInfo(owner, repo string, number int) (*PRInfo, error) {
 		return nil, fmt.Errorf("parse gh output: %w", err)
 	}
 	info := &PRInfo{
-		Owner:  owner,
-		Repo:   repo,
-		Number: result.Number,
-		Title:  result.Title,
+		Owner:   owner,
+		Repo:    repo,
+		Number:  result.Number,
+		Title:   result.Title,
+		BaseSHA: result.BaseRefOid,
+		HeadSHA: result.HeadRefOid,
 	}
 	for _, f := range result.Files {
 		status := "M"
@@ -94,6 +100,20 @@ func FetchPRDiff(owner, repo string, number int) (string, error) {
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("gh pr diff failed: %w", err)
+	}
+	return string(out), nil
+}
+
+func FetchFileContent(owner, repo, path, ref string) (string, error) {
+	repoArg := owner + "/" + repo
+	cmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/%s/contents/%s", repoArg, path),
+		"-H", "Accept: application/vnd.github.raw+json",
+		"--jq", ".",
+		"-f", "ref="+ref)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh api contents failed: %w", err)
 	}
 	return string(out), nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -49,19 +49,19 @@ func ParsePRURL(url string) (owner, repo string, number int, err error) {
 
 func FetchPRInfo(owner, repo string, number int) (*PRInfo, error) {
 	repoArg := owner + "/" + repo
-	cmd := exec.Command("gh", "pr", "view", strconv.Itoa(number),
+	numStr := strconv.Itoa(number)
+
+	cmd := exec.Command("gh", "pr", "view", numStr,
 		"--repo", repoArg,
-		"--json", "title,number,files,baseRefOid,headRefOid")
+		"--json", "title,number,files")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("gh pr view failed: %w", err)
 	}
 	var result struct {
-		Title      string `json:"title"`
-		Number     int    `json:"number"`
-		BaseRefOid string `json:"baseRefOid"`
-		HeadRefOid string `json:"headRefOid"`
-		Files      []struct {
+		Title  string `json:"title"`
+		Number int    `json:"number"`
+		Files  []struct {
 			Path   string `json:"path"`
 			Status string `json:"status"`
 		} `json:"files"`
@@ -69,13 +69,30 @@ func FetchPRInfo(owner, repo string, number int) (*PRInfo, error) {
 	if err := json.Unmarshal(out, &result); err != nil {
 		return nil, fmt.Errorf("parse gh output: %w", err)
 	}
+
+	query := fmt.Sprintf(`query { repository(owner: %q, name: %q) { pullRequest(number: %d) { baseRefOid headRefOid } } }`,
+		owner, repo, number)
+	gqlCmd := exec.Command("gh", "api", "graphql", "-f", "query="+query,
+		"--jq", ".data.repository.pullRequest")
+	gqlOut, err := gqlCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh graphql failed: %w", err)
+	}
+	var refs struct {
+		BaseRefOid string `json:"baseRefOid"`
+		HeadRefOid string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal(gqlOut, &refs); err != nil {
+		return nil, fmt.Errorf("parse graphql output: %w", err)
+	}
+
 	info := &PRInfo{
 		Owner:   owner,
 		Repo:    repo,
 		Number:  result.Number,
 		Title:   result.Title,
-		BaseSHA: result.BaseRefOid,
-		HeadSHA: result.HeadRefOid,
+		BaseSHA: refs.BaseRefOid,
+		HeadSHA: refs.HeadRefOid,
 	}
 	for _, f := range result.Files {
 		status := "M"
@@ -107,10 +124,8 @@ func FetchPRDiff(owner, repo string, number int) (string, error) {
 func FetchFileContent(owner, repo, path, ref string) (string, error) {
 	repoArg := owner + "/" + repo
 	cmd := exec.Command("gh", "api",
-		fmt.Sprintf("repos/%s/contents/%s", repoArg, path),
-		"-H", "Accept: application/vnd.github.raw+json",
-		"--jq", ".",
-		"-f", "ref="+ref)
+		fmt.Sprintf("repos/%s/contents/%s?ref=%s", repoArg, path, ref),
+		"-H", "Accept: application/vnd.github.raw+json")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("gh api contents failed: %w", err)

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -21,6 +21,10 @@ type ChangesGroup struct {
 	IsPR            bool
 	PRURL           string
 	PRDiffs         map[string]string
+	PROwner         string
+	PRRepo          string
+	PRBaseSHA       string
+	PRHeadSHA       string
 }
 
 type changesItemKind int
@@ -761,7 +765,7 @@ func (c *ChangesWidget) selectedInPR() bool {
 	return c.Groups[c.items[c.Selected].groupIndex].IsPR
 }
 
-func (c *ChangesWidget) AddPRGroup(name, url string, files []git.FileStatus, diffs map[string]string) {
+func (c *ChangesWidget) AddPRGroup(name, url, owner, repo, baseSHA, headSHA string, files []git.FileStatus, diffs map[string]string) {
 	c.Groups = append(c.Groups, ChangesGroup{
 		Dir:             "pr://" + name,
 		Name:            name,
@@ -771,6 +775,10 @@ func (c *ChangesWidget) AddPRGroup(name, url string, files []git.FileStatus, dif
 		IsPR:            true,
 		PRURL:           url,
 		PRDiffs:         diffs,
+		PROwner:         owner,
+		PRRepo:          repo,
+		PRBaseSHA:       baseSHA,
+		PRHeadSHA:       headSHA,
 	})
 	c.multiRoot = len(c.Groups) > 1
 	c.buildItems()

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -56,6 +56,7 @@ type ChangesWidget struct {
 	Loading          bool
 	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
 	OnOpenPRDiff     func(group *ChangesGroup, status git.FileStatus, extended bool)
+	OnOpenFile       func(path string)
 	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
 	OnCommit         func(dir string, message string)
 	OnGroupMenu      func(dir string, screenX, screenY int)
@@ -605,6 +606,19 @@ func (c *ChangesWidget) HandleEvent(ev tcell.Event) EventResult {
 		case !inPR && tev.Key() == tcell.KeyRune && tev.Rune() == 'D':
 			c.discardAllInGroup()
 			return EventConsumed
+		case tev.Key() == tcell.KeyRune && (tev.Rune() == 'o' || tev.Rune() == 'v'):
+			if c.OnOpenFile != nil {
+				if path := c.SelectedFullPath(); path != "" {
+					c.OnOpenFile(path)
+				}
+			}
+			return EventConsumed
+		case tev.Key() == tcell.KeyRune && tev.Rune() == 'c':
+			c.openSelectedDiff(false)
+			return EventConsumed
+		case tev.Key() == tcell.KeyRune && tev.Rune() == 'e':
+			c.openSelectedDiff(true)
+			return EventConsumed
 		}
 	}
 	return EventIgnored
@@ -664,6 +678,24 @@ func (c *ChangesWidget) stageAll() {
 		}
 	}
 	c.Refresh()
+}
+
+func (c *ChangesWidget) openSelectedDiff(extended bool) {
+	g := c.SelectedGroup()
+	if g == nil {
+		return
+	}
+	if g.IsPR {
+		_, status, ok := c.SelectedFile()
+		if ok && c.OnOpenPRDiff != nil {
+			c.OnOpenPRDiff(g, status, extended)
+		}
+	} else {
+		dir, status, ok := c.SelectedFile()
+		if ok && c.OnOpenDiff != nil {
+			c.OnOpenDiff(dir, status, extended)
+		}
+	}
 }
 
 func (c *ChangesWidget) activateSelected() {

--- a/internal/ui/changes_widget.go
+++ b/internal/ui/changes_widget.go
@@ -54,8 +54,8 @@ type ChangesWidget struct {
 	multiRoot        bool
 	inputFocused     bool
 	Loading          bool
-	OnOpenDiff       func(dir string, status git.FileStatus)
-	OnOpenPRDiff     func(group *ChangesGroup, status git.FileStatus)
+	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
+	OnOpenPRDiff     func(group *ChangesGroup, status git.FileStatus, extended bool)
 	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
 	OnCommit         func(dir string, message string)
 	OnGroupMenu      func(dir string, screenX, screenY int)
@@ -217,6 +217,17 @@ func (c *ChangesWidget) SelectedFile() (dir string, status git.FileStatus, ok bo
 		return g.Dir, g.Staged[item.fileIndex], true
 	}
 	return g.Dir, g.Unstaged[item.fileIndex], true
+}
+
+func (c *ChangesWidget) SelectedGroup() *ChangesGroup {
+	if c.Selected < 0 || c.Selected >= len(c.items) {
+		return nil
+	}
+	item := c.items[c.Selected]
+	if item.groupIndex < 0 || item.groupIndex >= len(c.Groups) {
+		return nil
+	}
+	return &c.Groups[item.groupIndex]
 }
 
 func (c *ChangesWidget) SelectedFullPath() string {
@@ -679,12 +690,12 @@ func (c *ChangesWidget) activateSelected() {
 		if g.IsPR {
 			_, status, ok := c.SelectedFile()
 			if ok && c.OnOpenPRDiff != nil {
-				c.OnOpenPRDiff(g, status)
+				c.OnOpenPRDiff(g, status, false)
 			}
 		} else {
 			dir, status, ok := c.SelectedFile()
 			if ok && c.OnOpenDiff != nil {
-				c.OnOpenDiff(dir, status)
+				c.OnOpenDiff(dir, status, false)
 			}
 		}
 	}

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -274,15 +274,10 @@ func (d *DiffViewWidget) Render(surface *RenderSurface) {
 	r := d.GetRect()
 
 	if d.Loading {
-		msg := "Loading full file..."
-		x := (w - len(msg)) / 2
-		y := h / 2
-		if x < 0 {
-			x = 0
-		}
+		msg := "Loading..."
 		for i, ch := range msg {
-			if x+i < w {
-				surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: term.StyleDefault})
+			if i < w {
+				surface.SetCell(i, 0, term.Cell{Ch: ch, Style: term.StyleDefault})
 			}
 		}
 		return

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -66,6 +66,8 @@ type DiffViewWidget struct {
 	fileDiff  diff.FileDiff
 	oldLines  []string
 	newLines  []string
+
+	OnFetchExtended func(dv *DiffViewWidget)
 }
 
 func NewDiffViewWidget(filePath string, fd diff.FileDiff, oldLines, newLines []string, extended bool) *DiffViewWidget {
@@ -82,11 +84,22 @@ func NewDiffViewWidget(filePath string, fd diff.FileDiff, oldLines, newLines []s
 	return dv
 }
 
+func (d *DiffViewWidget) SetOldLines(lines []string) {
+	d.oldLines = lines
+}
+
+func (d *DiffViewWidget) SetNewLines(lines []string) {
+	d.newLines = lines
+}
+
 func (d *DiffViewWidget) IsExtended() bool {
 	return d.extended
 }
 
 func (d *DiffViewWidget) SetExtended(extended bool) {
+	if extended && len(d.oldLines) == 0 && d.OnFetchExtended != nil {
+		d.OnFetchExtended(d)
+	}
 	d.extended = extended
 	d.rebuildLines()
 	d.TopLine = 0

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -68,6 +68,7 @@ type DiffViewWidget struct {
 	newLines  []string
 
 	OnFetchExtended func(dv *DiffViewWidget)
+	Loading         bool
 }
 
 func NewDiffViewWidget(filePath string, fd diff.FileDiff, oldLines, newLines []string, extended bool) *DiffViewWidget {
@@ -98,9 +99,21 @@ func (d *DiffViewWidget) IsExtended() bool {
 
 func (d *DiffViewWidget) SetExtended(extended bool) {
 	if extended && len(d.oldLines) == 0 && d.OnFetchExtended != nil {
+		d.Loading = true
+		d.extended = true
 		d.OnFetchExtended(d)
+		return
 	}
 	d.extended = extended
+	d.rebuildLines()
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSearch()
+	d.ClearSelection()
+}
+
+func (d *DiffViewWidget) FinishLoading() {
+	d.Loading = false
 	d.rebuildLines()
 	d.TopLine = 0
 	d.LeftCol = 0
@@ -259,6 +272,21 @@ func (d *DiffViewWidget) gutterWidth() int {
 func (d *DiffViewWidget) Render(surface *RenderSurface) {
 	w, h := surface.Size()
 	r := d.GetRect()
+
+	if d.Loading {
+		msg := "Loading full file..."
+		x := (w - len(msg)) / 2
+		y := h / 2
+		if x < 0 {
+			x = 0
+		}
+		for i, ch := range msg {
+			if x+i < w {
+				surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: term.StyleDefault})
+			}
+		}
+		return
+	}
 
 	gutterW := d.gutterWidth()
 

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -60,12 +60,49 @@ type DiffViewWidget struct {
 	searchMergedRefs   []diffMergedRef
 	searchActiveRight  bool
 	searchActiveSideIdx int
+
+	// extended diff mode
+	extended  bool
+	fileDiff  diff.FileDiff
+	oldLines  []string
+	newLines  []string
 }
 
-func NewDiffViewWidget(filePath string, fd diff.FileDiff) *DiffViewWidget {
-	lines := fd.AllLines()
+func NewDiffViewWidget(filePath string, fd diff.FileDiff, oldLines, newLines []string, extended bool) *DiffViewWidget {
+	dv := &DiffViewWidget{
+		FilePath:            filePath,
+		Highlighter:         highlight.New(filePath),
+		searchActiveSideIdx: -1,
+		fileDiff:            fd,
+		oldLines:            oldLines,
+		newLines:            newLines,
+		extended:            extended,
+	}
+	dv.rebuildLines()
+	return dv
+}
+
+func (d *DiffViewWidget) IsExtended() bool {
+	return d.extended
+}
+
+func (d *DiffViewWidget) SetExtended(extended bool) {
+	d.extended = extended
+	d.rebuildLines()
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSearch()
+	d.ClearSelection()
+}
+
+func (d *DiffViewWidget) rebuildLines() {
+	if d.extended && len(d.oldLines) > 0 {
+		d.Lines = diff.FullDiffLines(d.oldLines, d.newLines)
+	} else {
+		d.Lines = d.fileDiff.AllLines()
+	}
 	maxW := 0
-	for _, dl := range lines {
+	for _, dl := range d.Lines {
 		if lw := len([]rune(dl.Left.Text)); lw > maxW {
 			maxW = lw
 		}
@@ -73,13 +110,7 @@ func NewDiffViewWidget(filePath string, fd diff.FileDiff) *DiffViewWidget {
 			maxW = rw
 		}
 	}
-	return &DiffViewWidget{
-		FilePath:            filePath,
-		Lines:               lines,
-		Highlighter:         highlight.New(filePath),
-		maxLineW:            maxW,
-		searchActiveSideIdx: -1,
-	}
+	d.maxLineW = maxW
 }
 
 func (d *DiffViewWidget) Focusable() bool { return true }

--- a/internal/ui/diff_widget_test.go
+++ b/internal/ui/diff_widget_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDiffWidgetLeftRightLines(t *testing.T) {
 	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,3 +1,3 @@\n hello world\n-old line\n+new line\n context\n")
-	dv := NewDiffViewWidget("test.go", fd)
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
 
 	left := dv.LeftLines()
 	right := dv.RightLines()
@@ -45,7 +45,7 @@ func TestDiffWidgetLeftRightLines(t *testing.T) {
 
 func TestDiffWidgetSearchFindsMatches(t *testing.T) {
 	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,3 +1,3 @@\n hello world\n-old line\n+new line\n context\n")
-	dv := NewDiffViewWidget("test.go", fd)
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
 
 	leftMatches, err := FindInLines(dv.LeftLines(), "old", SearchOptions{})
 	if err != nil {
@@ -66,7 +66,7 @@ func TestDiffWidgetSearchFindsMatches(t *testing.T) {
 
 func TestDiffWidgetSetSearchMatches(t *testing.T) {
 	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,3 +1,3 @@\n hello world\n-old line\n+new line\n context\n")
-	dv := NewDiffViewWidget("test.go", fd)
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
 
 	leftMatches, _ := FindInLines(dv.LeftLines(), "line", SearchOptions{})
 	rightMatches, _ := FindInLines(dv.RightLines(), "line", SearchOptions{})
@@ -86,9 +86,35 @@ func TestDiffWidgetSetSearchMatches(t *testing.T) {
 	}
 }
 
+func TestDiffWidgetExtendedMode(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -2,3 +2,3 @@\n hello world\n-old line\n+new line\n context\n")
+	oldLines := []string{"first", "hello world", "old line", "context", "last line", "another"}
+	newLines := []string{"first", "hello world", "new line", "context", "last line", "another"}
+	dv := NewDiffViewWidget("test.go", fd, oldLines, newLines, false)
+
+	compactCount := len(dv.Lines)
+
+	dv.SetExtended(true)
+	if !dv.IsExtended() {
+		t.Error("expected extended mode to be true")
+	}
+	extendedCount := len(dv.Lines)
+	if extendedCount <= compactCount {
+		t.Errorf("extended should have more lines than compact: %d vs %d", extendedCount, compactCount)
+	}
+
+	dv.SetExtended(false)
+	if dv.IsExtended() {
+		t.Error("expected extended mode to be false")
+	}
+	if len(dv.Lines) != compactCount {
+		t.Errorf("compact line count changed: %d vs %d", len(dv.Lines), compactCount)
+	}
+}
+
 func TestDiffWidgetSearchContext(t *testing.T) {
 	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,3 +1,3 @@\n hello world\n-old line\n+new line\n context\n")
-	dv := NewDiffViewWidget("test.go", fd)
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
 
 	leftMatches, _ := FindInLines(dv.LeftLines(), "hello", SearchOptions{})
 	rightMatches, _ := FindInLines(dv.RightLines(), "hello", SearchOptions{})

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -205,17 +205,17 @@ func (g *EditorGroupWidget) OpenBuffer(path string, buf *buffer.Buffer) {
 	g.SwitchTab(len(g.tabs) - 1)
 }
 
-func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff) {
+func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, newLines []string, extended bool) {
 	tabName := path + " (diff)"
 	for i, t := range g.tabs {
 		if t.FilePath == tabName {
-			t.Content = NewDiffViewWidget(path, fd)
+			t.Content = NewDiffViewWidget(path, fd, oldLines, newLines, extended)
 			g.tabs[i] = t
 			g.SwitchTab(i)
 			return
 		}
 	}
-	widget := NewDiffViewWidget(path, fd)
+	widget := NewDiffViewWidget(path, fd, oldLines, newLines, extended)
 	g.tabs = append(g.tabs, editorTab{
 		FilePath: tabName,
 		Content:  widget,

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -310,6 +310,18 @@ func (g *EditorGroupWidget) ActiveDiffWidget() *DiffViewWidget {
 	return nil
 }
 
+func (g *EditorGroupWidget) DiffWidgetByTab(tabName string) *DiffViewWidget {
+	for _, t := range g.tabs {
+		if t.FilePath == tabName {
+			if dv, ok := t.Content.(*DiffViewWidget); ok {
+				return dv
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
 func (g *EditorGroupWidget) SwitchToTabByPath(path string) bool {
 	for i, t := range g.tabs {
 		if t.FilePath == path {


### PR DESCRIPTION
## Summary
- Adds toggle between **compact** (hunks only) and **extended** (full file) diff views
- Right-click a diff tab → "Extended Diff" / "Compact Diff" (only shows on diff tabs)
- New `diffView` setting in settings.json controls default ("compact" or "extended")
- Uses LCS algorithm to produce full-file side-by-side comparison with change highlighting

## Changes
- `internal/core/diff/diff.go` — new `FullDiffLines()` function
- `internal/git/git.go` — new `ShowFile()` to fetch file content from any git ref
- `internal/ui/diff_widget.go` — extended mode toggle with `SetExtended()`/`IsExtended()`
- `internal/app/callbacks.go` — fetches old/new file content, conditional tab menu item
- `internal/app/commands_editor.go` — `diff.toggleExtended` command
- `internal/config/settings.go` — `diffView` setting

## Test plan
- [x] Unit tests for `FullDiffLines` (modify, add, delete, identical)
- [x] Unit test for widget extended mode toggle
- [x] All existing diff widget tests pass
- [x] Full test suite passes (`make test`)
- [ ] Manual: open a changed file diff, right-click tab, toggle to extended, verify full file shows
- [ ] Manual: verify compact mode only shows hunks (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)