### PR TITLE
feat: quit confirmation dialog for unsaved changes

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -128,10 +128,8 @@ Docs: https://tttedit.dev
 
 	editor.Keybindings = cfg.Keybindings
 	editor.Reg = cmdRegistry
-	quitPending := false
 	running := true
 	editor.Running = &running
-	editor.QuitPending = &quitPending
 	app.RegisterCommands(editor)
 	app.BindKeys(editor.Root, cmdRegistry, cfg.Keybindings)
 
@@ -150,5 +148,5 @@ Docs: https://tttedit.dev
 	w, h := screen.Size()
 	editor.Root.SetSize(w, h)
 
-	app.RunEventLoop(screen, renderer, editor, &running, &quitPending, editor.CloseTerminal)
+	app.RunEventLoop(screen, renderer, editor, &running, editor.CloseTerminal)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -69,7 +69,7 @@ type App struct {
 	LspNotified        map[string]bool
 	Reg                *command.Registry
 	Running            *bool
-	QuitPending        *bool
+	quitPending        bool
 	Watcher            *watcher.Watcher
 }
 

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -155,16 +155,23 @@ func (a *App) doSaveFile() {
 	}
 }
 
+func (a *App) forceQuit() {
+	for _, tt := range a.Terminals {
+		tt.Term.Close()
+	}
+	*a.Running = false
+}
+
 func (a *App) Quit() {
-	if !a.EditorGroup.AnyDirty() || *a.QuitPending {
-		for _, tt := range a.Terminals {
-			tt.Term.Close()
-		}
-		*a.Running = false
+	if a.quitPending || !a.EditorGroup.AnyDirty() {
+		a.forceQuit()
 		return
 	}
-	*a.QuitPending = true
-	a.StatusWarn("Unsaved changes. Press Ctrl+Q again to quit.")
+	a.quitPending = true
+	a.ShowConfirmDialog("Unsaved changes! Press Ctrl+Q to force quit", []string{"Cancel", "Quit"}, []func(){
+		func() { a.quitPending = false; a.DismissDialog() },
+		func() { a.forceQuit() },
+	})
 }
 
 func registerEditorCommands(app *App) {

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -23,7 +23,6 @@ func RunEventLoop(
 	renderer *render.Renderer,
 	app *App,
 	running *bool,
-	quitPending *bool,
 	closeTerminal func(panelID string),
 ) {
 	if app.Watcher != nil {
@@ -132,10 +131,6 @@ func RunEventLoop(
 		ev := screen.PollEvent()
 		switch tev := ev.(type) {
 		case *tcell.EventKey:
-			if *quitPending && !(tev.Key() == tcell.KeyCtrlQ) {
-				*quitPending = false
-				app.Status.DismissNotification()
-			}
 			if app.EditorGroup.SignatureHelp != nil {
 				switch tev.Key() {
 				case tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -66,10 +66,8 @@ func newTestHarness(t *testing.T, w, h int) *testHarness {
 
 	reg := command.NewRegistry()
 	editor.Reg = reg
-	quitPending := false
 	running := true
 	editor.Running = &running
-	editor.QuitPending = &quitPending
 	app.RegisterCommands(editor)
 	app.BindKeys(editor.Root, reg, cfg.Keybindings)
 


### PR DESCRIPTION
## Summary
- Replace the status bar warning with a modal confirm dialog when quitting with unsaved changes
- Dialog shows "Cancel" and "Quit" buttons with keyboard shortcuts (first letter underlined)
- A second Ctrl+Q force quits directly from the dialog
- Remove `quitPending` from public API and event loop parameter

## Test plan
- [ ] Open a file, make changes, press Ctrl+Q — confirm dialog appears
- [ ] Press Cancel or C — dialog dismisses, editor stays open
- [ ] Press Quit or Q — editor quits without saving
- [ ] Press Ctrl+Q again while dialog is showing — force quits
- [ ] Press Ctrl+Q with no unsaved changes — quits immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)