### PR TITLE
test: functional tests for quit confirmation dialog

### DIFF
--- a/tests/functional/quit-confirm.test.js
+++ b/tests/functional/quit-confirm.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("quit confirmation dialog", () => {
+  it("should quit immediately with no unsaved changes", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "clean.txt", "No changes here");
+
+    tui.start(file);
+    tui.waitFor("clean.txt");
+
+    tui.press("ctrl+q");
+    tui.waitStable(500);
+
+    const snap = tui.snapshot();
+    expect(snap).not.toContain("clean.txt");
+  });
+
+  it("should show confirm dialog when quitting with unsaved changes", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "dirty.txt", "Original");
+
+    tui.start(file);
+    tui.waitFor("dirty.txt");
+
+    tui.type("x");
+    tui.waitStable();
+
+    tui.press("ctrl+q");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("Unsaved changes");
+    expect(snap).toContain("Cancel");
+    expect(snap).toContain("Quit");
+  });
+
+  it("should dismiss dialog with Cancel", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "cancel.txt", "Keep editing");
+
+    tui.start(file);
+    tui.waitFor("cancel.txt");
+
+    tui.type("x");
+    tui.waitStable();
+
+    tui.press("ctrl+q");
+    tui.waitFor("Unsaved changes");
+
+    tui.type("c");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).not.toContain("Unsaved changes");
+    expect(snap).toContain("cancel.txt");
+  });
+
+  it("should quit when pressing Q in the dialog", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "quit-q.txt", "Will quit");
+
+    tui.start(file);
+    tui.waitFor("quit-q.txt");
+
+    tui.type("x");
+    tui.waitStable();
+
+    tui.press("ctrl+q");
+    tui.waitFor("Unsaved changes");
+
+    tui.type("q");
+    tui.waitStable(500);
+
+    const snap = tui.snapshot();
+    expect(snap).not.toContain("quit-q.txt");
+  });
+
+  it("should force quit with second Ctrl+Q", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "force.txt", "Force quit");
+
+    tui.start(file);
+    tui.waitFor("force.txt");
+
+    tui.type("x");
+    tui.waitStable();
+
+    tui.press("ctrl+q");
+    tui.waitFor("Unsaved changes");
+
+    tui.press("ctrl+q");
+    tui.waitStable(500);
+
+    const snap = tui.snapshot();
+    expect(snap).not.toContain("force.txt");
+  });
+});


### PR DESCRIPTION
## Summary
- Add functional blackbox tests for the quit confirmation dialog (PR #66)
- Tests cover: immediate quit (clean), dialog display, Cancel dismissal, Q key quit, and Ctrl+Q force quit

## Test plan
- [ ] All 5 tests pass locally with `cd tests/functional && pnpm test quit-confirm`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)