### PR TITLE
fix: remove flawed auto-pair bracket/quote insertion

### DIFF
--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -972,23 +972,9 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 				if multi {
 					e.multiExecRune(r)
 				} else if hasSel {
-					if closing, ok := autoPairs[r]; ok {
-						e.deleteSelection()
-						e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: r})
-						e.Cursor.Col++
-						e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: closing})
-					} else {
-						e.deleteSelection()
-						e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: r})
-						e.Cursor.Col++
-					}
-				} else if closing, skip := autoCloseSkip[r]; skip && e.charAtCursor() == r {
-					_ = closing
-					e.Cursor.Col++
-				} else if closing, ok := autoPairs[r]; ok {
+					e.deleteSelection()
 					e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: r})
 					e.Cursor.Col++
-					e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: closing})
 				} else {
 					e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: r})
 					e.Cursor.Col++
@@ -1132,27 +1118,6 @@ func leadingWhitespace(s string) string {
 		}
 	}
 	return s
-}
-
-var autoPairs = map[rune]rune{
-	'(': ')', '{': '}', '[': ']',
-	'"': '"', '\'': '\'', '`': '`',
-}
-
-var autoCloseSkip = map[rune]bool{
-	')': true, '}': true, ']': true,
-	'"': true, '\'': true, '`': true,
-}
-
-func (e *EditorPaneWidget) charAtCursor() rune {
-	if e.Cursor.Line >= len(e.Buf.Lines) {
-		return 0
-	}
-	runes := []rune(e.Buf.Lines[e.Cursor.Line])
-	if e.Cursor.Col >= len(runes) {
-		return 0
-	}
-	return runes[e.Cursor.Col]
 }
 
 var bracketPairs = map[rune]rune{


### PR DESCRIPTION
## Summary
- Remove auto-pair logic that inserted matching closing characters (e.g. `"` → `""`, `(` → `()`)
- The implementation had no context awareness — it would double-insert when editing inside existing pairs, and the skip-closing logic silently swallowed characters
- Typing brackets and quotes now inserts exactly what you type

## Test plan
- [x] `go test ./...` passes
- [x] Manual: type `"`, `(`, `[`, `{` — each inserts only the typed character

🤖 Generated with [Claude Code](https://claude.com/claude-code)