### PR TITLE
feat: add upper, lower, and title case transforms

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -467,6 +467,19 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "editor.upperCase", Title: "Transform to Upper Case",
+		Handler: func() { app.EditorGroup.UpperCase() },
+	})
+	reg.Register(command.Command{
+		ID: "editor.lowerCase", Title: "Transform to Lower Case",
+		Handler: func() { app.EditorGroup.LowerCase() },
+	})
+	reg.Register(command.Command{
+		ID: "editor.titleCase", Title: "Transform to Title Case",
+		Handler: func() { app.EditorGroup.TitleCase() },
+	})
+
+	reg.Register(command.Command{
 		ID: "editor.quit", Title: "Quit",
 		Handler: app.Quit,
 	})

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -467,15 +467,15 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.upperCase", Title: "Transform to Upper Case",
+		ID: "editor.upperCase", Title: "Transform to Uppercase",
 		Handler: func() { app.EditorGroup.UpperCase() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.lowerCase", Title: "Transform to Lower Case",
+		ID: "editor.lowerCase", Title: "Transform to Lowercase",
 		Handler: func() { app.EditorGroup.LowerCase() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.titleCase", Title: "Transform to Title Case",
+		ID: "editor.titleCase", Title: "Transform to Titlecase",
 		Handler: func() { app.EditorGroup.TitleCase() },
 	})
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -639,7 +639,6 @@ func (g *EditorGroupWidget) SetDiagnostics(path string, diags []Diagnostic) {
 	}
 }
 
-
 func (g *EditorGroupWidget) FindNext() {
 	if !g.IsEditorActive() || len(g.Editor.SearchMatches) == 0 {
 		return
@@ -816,6 +815,24 @@ func (g *EditorGroupWidget) SplitSelectionToLines() {
 	if g.IsEditorActive() {
 		g.Editor.SplitSelectionToLines()
 		g.saveMultiState()
+	}
+}
+
+func (g *EditorGroupWidget) UpperCase() {
+	if g.IsEditorActive() {
+		g.Editor.UpperCase()
+	}
+}
+
+func (g *EditorGroupWidget) LowerCase() {
+	if g.IsEditorActive() {
+		g.Editor.LowerCase()
+	}
+}
+
+func (g *EditorGroupWidget) TitleCase() {
+	if g.IsEditorActive() {
+		g.Editor.TitleCase()
 	}
 }
 

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -2206,7 +2206,7 @@ func (e *EditorPaneWidget) TitleCase() {
 				} else {
 					runes[i] = unicode.ToLower(r)
 				}
-			} else {
+			} else if !(inWord && r == '\'') {
 				inWord = false
 			}
 		}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -2121,3 +2121,95 @@ func (e *EditorPaneWidget) SplitSelectionToLines() {
 	e.syncFromMulti()
 	e.scrollViewport()
 }
+
+
+// transformSelection replaces the selected text with the result of applying fn.
+// It preserves the selection after transformation.
+func (e *EditorPaneWidget) transformSelection(fn func(string) string) {
+	if e.Selection == nil || !e.Selection.Active {
+		return
+	}
+	text := e.Selection.Text(e.Buf.Lines, e.Cursor.Line, e.Cursor.Col)
+	if text == "" {
+		return
+	}
+	transformed := fn(text)
+	if transformed == text {
+		return
+	}
+
+	start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
+
+	if e.Undo != nil {
+		e.Undo.BreakGroup()
+	}
+
+	// Delete the selection
+	delCmd := &undo.DeleteSelectionCommand{
+		StartLine: start.Line, StartCol: start.Col,
+		EndLine: end.Line, EndCol: end.Col,
+	}
+	e.exec(delCmd)
+
+	// Insert the transformed text
+	tLines := strings.Split(transformed, "\n")
+	if len(tLines) == 1 {
+		e.exec(&undo.InsertStringCommand{Line: start.Line, Col: start.Col, Text: tLines[0]})
+	} else {
+		currentLine := []rune(e.Buf.Lines[start.Line])
+		col := start.Col
+		if col > len(currentLine) {
+			col = len(currentLine)
+		}
+		suffix := string(currentLine[col:])
+		e.exec(&undo.PasteCommand{
+			Line:   start.Line,
+			Col:    col,
+			Text:   transformed,
+			Suffix: suffix,
+		})
+	}
+
+	// Restore the selection so the user sees the transformed range
+	newEndLine := start.Line + len(tLines) - 1
+	var newEndCol int
+	if len(tLines) == 1 {
+		newEndCol = start.Col + len([]rune(tLines[0]))
+	} else {
+		newEndCol = len([]rune(tLines[len(tLines)-1]))
+	}
+
+	e.Selection.Start(start.Line, start.Col)
+	e.Cursor.Line = newEndLine
+	e.Cursor.Col = newEndCol
+	e.clampCursor()
+	e.scrollViewport()
+}
+
+func (e *EditorPaneWidget) UpperCase() {
+	e.transformSelection(strings.ToUpper)
+}
+
+func (e *EditorPaneWidget) LowerCase() {
+	e.transformSelection(strings.ToLower)
+}
+
+func (e *EditorPaneWidget) TitleCase() {
+	e.transformSelection(func(s string) string {
+		runes := []rune(s)
+		inWord := false
+		for i, r := range runes {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) {
+				if !inWord {
+					runes[i] = unicode.ToUpper(r)
+					inWord = true
+				} else {
+					runes[i] = unicode.ToLower(r)
+				}
+			} else {
+				inWord = false
+			}
+		}
+		return string(runes)
+	})
+}

--- a/tests/e2e/case_transform_test.go
+++ b/tests/e2e/case_transform_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUpperCase(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "upper.txt")
+	os.WriteFile(f, []byte("Hello World\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.upperCase")
+	h.redraw()
+
+	got := h.app.EditorGroup.Editor.Buf.Lines[0]
+	if got != "HELLO WORLD" {
+		t.Errorf("expected 'HELLO WORLD', got %q", got)
+	}
+}
+
+func TestLowerCase(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "lower.txt")
+	os.WriteFile(f, []byte("Hello World\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.lowerCase")
+	h.redraw()
+
+	got := h.app.EditorGroup.Editor.Buf.Lines[0]
+	if got != "hello world" {
+		t.Errorf("expected 'hello world', got %q", got)
+	}
+}
+
+func TestTitleCase(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "title.txt")
+	os.WriteFile(f, []byte("hello world\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.titleCase")
+	h.redraw()
+
+	got := h.app.EditorGroup.Editor.Buf.Lines[0]
+	if got != "Hello World" {
+		t.Errorf("expected 'Hello World', got %q", got)
+	}
+}
+
+func TestCaseTransformNoSelection(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "nosel.txt")
+	os.WriteFile(f, []byte("Hello World\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	// Run transforms without selection - should be no-op
+	h.exec("editor.upperCase")
+	h.exec("editor.lowerCase")
+	h.exec("editor.titleCase")
+	h.redraw()
+
+	got := h.app.EditorGroup.Editor.Buf.Lines[0]
+	if got != "Hello World" {
+		t.Errorf("expected 'Hello World' (unchanged), got %q", got)
+	}
+}
+
+func TestUpperCaseMultiLine(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "multiupper.txt")
+	os.WriteFile(f, []byte("hello\nworld\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.upperCase")
+	h.redraw()
+
+	if h.app.EditorGroup.Editor.Buf.Lines[0] != "HELLO" {
+		t.Errorf("expected 'HELLO', got %q", h.app.EditorGroup.Editor.Buf.Lines[0])
+	}
+	if h.app.EditorGroup.Editor.Buf.Lines[1] != "WORLD" {
+		t.Errorf("expected 'WORLD', got %q", h.app.EditorGroup.Editor.Buf.Lines[1])
+	}
+}

--- a/tests/e2e/case_transform_test.go
+++ b/tests/e2e/case_transform_test.go
@@ -84,6 +84,44 @@ func TestCaseTransformNoSelection(t *testing.T) {
 	}
 }
 
+func TestTitleCaseApostrophe(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "apostrophe.txt")
+	os.WriteFile(f, []byte("don't stop\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.titleCase")
+	h.redraw()
+
+	got := h.app.EditorGroup.Editor.Buf.Lines[0]
+	if got != "Don't Stop" {
+		t.Errorf("expected \"Don't Stop\", got %q", got)
+	}
+}
+
+func TestTitleCaseHyphen(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "hyphen.txt")
+	os.WriteFile(f, []byte("self-aware\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.titleCase")
+	h.redraw()
+
+	got := h.app.EditorGroup.Editor.Buf.Lines[0]
+	if got != "Self-Aware" {
+		t.Errorf("expected \"Self-Aware\", got %q", got)
+	}
+}
+
 func TestUpperCaseMultiLine(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()

--- a/tests/functional/case-transform.test.js
+++ b/tests/functional/case-transform.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("case transforms", () => {
+  it("should transform to upper case", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello world\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Transform to Upper Case");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("HELLO WORLD");
+  });
+
+  it("should transform to lower case", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "HELLO WORLD\n");
+
+    tui.start(file);
+    tui.waitFor("HELLO");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Transform to Lower Case");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("hello world");
+  });
+
+  it("should transform to title case", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello world\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Transform to Title Case");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("Hello World");
+  });
+
+  it("should undo upper case transform", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello world\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Transform to Upper Case");
+    tui.waitStable();
+
+    let snap = tui.snapshot();
+    expect(snap).toContain("HELLO WORLD");
+
+    tui.press("ctrl+z");
+    tui.waitStable();
+    tui.press("ctrl+z");
+    tui.waitStable();
+
+    snap = tui.snapshot();
+    expect(snap).toContain("hello world");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds three case transform commands: Upper Case, Lower Case, Title Case
- Operates on selected text, command palette only (no keybindings)
- Includes E2E and functional tests

## Test plan
- [ ] Upper case transforms selection
- [ ] Lower case transforms selection
- [ ] Title case transforms selection
- [ ] No-op when no selection
- [ ] Multi-line selection transforms correctly
- [ ] Undo reverses the transform

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)