### PR TITLE
feat: add split selection into lines command

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -444,6 +444,10 @@ func registerEditorCommands(app *App) {
 		ID: "multicursor.undoCursor", Title: "Undo Last Cursor",
 		Handler: func() { app.EditorGroup.UndoLastCursor() },
 	})
+	reg.Register(command.Command{
+		ID: "editor.splitSelectionToLines", Title: "Split Selection into Lines",
+		Handler: func() { app.EditorGroup.SplitSelectionToLines() },
+	})
 
 	reg.Register(command.Command{
 		ID: "editor.quit", Title: "Quit",

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -788,6 +788,13 @@ func (g *EditorGroupWidget) UndoLastCursor() {
 	}
 }
 
+func (g *EditorGroupWidget) SplitSelectionToLines() {
+	if g.IsEditorActive() {
+		g.Editor.SplitSelectionToLines()
+		g.saveMultiState()
+	}
+}
+
 func (g *EditorGroupWidget) IsMultiCursorActive() bool {
 	return g.IsEditorActive() && g.Editor.isMultiActive()
 }

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -2001,3 +2001,48 @@ func (e *EditorPaneWidget) UndoLastCursor() {
 	}
 	e.scrollViewport()
 }
+
+func (e *EditorPaneWidget) SplitSelectionToLines() {
+	if e.Selection == nil || !e.Selection.Active {
+		return
+	}
+	start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
+	if start.Line == end.Line {
+		return
+	}
+	// If the selection ends at column 0 of the last line,
+	// exclude that line (cursor sits at the start, nothing selected there)
+	if end.Col == 0 && end.Line > start.Line {
+		end.Line--
+		end.Col = len([]rune(e.Buf.Lines[end.Line]))
+	}
+	if start.Line == end.Line {
+		e.Selection.Clear()
+		return
+	}
+	e.ensureMulti()
+	e.syncToMulti()
+	// Place the primary cursor at the end of the first selected line
+	firstLineLen := len([]rune(e.Buf.Lines[start.Line]))
+	col := firstLineLen
+	e.Multi.Cursors[e.Multi.Primary] = multicursor.CursorState{
+		Line: start.Line,
+		Col:  col,
+	}
+	// Add a cursor at the end of each subsequent line in the selection
+	for line := start.Line + 1; line <= end.Line; line++ {
+		lineLen := len([]rune(e.Buf.Lines[line]))
+		c := lineLen
+		if line == end.Line && end.Col < c {
+			c = end.Col
+		}
+		e.Multi.Add(line, c)
+	}
+	e.Selection.Clear()
+	// Clear selections on all cursors
+	for i := range e.Multi.Cursors {
+		e.Multi.Cursors[i].Sel.Clear()
+	}
+	e.syncFromMulti()
+	e.scrollViewport()
+}

--- a/tests/e2e/split_selection_test.go
+++ b/tests/e2e/split_selection_test.go
@@ -1,0 +1,132 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSplitSelectionToLines(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "split.txt")
+	os.WriteFile(f, []byte("line1\nline2\nline3\nline4\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	editor := h.app.EditorGroup.Editor
+	if editor == nil {
+		t.Fatal("editor is nil after opening file")
+	}
+
+	// Select lines 0-2 (first 3 lines): anchor at (0,0), cursor at (3,0)
+	editor.Cursor.Line = 3
+	editor.Cursor.Col = 0
+	editor.Selection.Start(0, 0)
+	h.redraw()
+
+	// Execute the split selection command
+	h.exec("editor.splitSelectionToLines")
+
+	// Should have created multi-cursors (one per line)
+	if editor.Multi == nil {
+		t.Fatal("expected multi-cursor to be active after split")
+	}
+	if len(editor.Multi.Cursors) != 3 {
+		t.Errorf("expected 3 cursors, got %d", len(editor.Multi.Cursors))
+	}
+	// Selection should be cleared
+	if editor.Selection.Active {
+		t.Error("expected selection to be cleared after split")
+	}
+}
+
+func TestSplitSelectionToLines_NoSelection(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "nosplit.txt")
+	os.WriteFile(f, []byte("line1\nline2\nline3\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	editor := h.app.EditorGroup.Editor
+
+	// No selection active — should be a no-op
+	h.exec("editor.splitSelectionToLines")
+
+	if editor.Multi != nil && editor.Multi.IsMulti() {
+		t.Error("expected no multi-cursor when no selection is active")
+	}
+}
+
+func TestSplitSelectionToLines_SingleLine(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "single.txt")
+	os.WriteFile(f, []byte("hello world\nline2\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	editor := h.app.EditorGroup.Editor
+
+	// Select within a single line
+	editor.Cursor.Line = 0
+	editor.Cursor.Col = 5
+	editor.Selection.Start(0, 0)
+	h.redraw()
+
+	h.exec("editor.splitSelectionToLines")
+
+	if editor.Multi != nil && editor.Multi.IsMulti() {
+		t.Error("expected no multi-cursor for single-line selection")
+	}
+}
+
+func TestSplitSelectionToLines_TypeAtAllCursors(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "typesplit.txt")
+	os.WriteFile(f, []byte("aaa\nbbb\nccc\nddd\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	editor := h.app.EditorGroup.Editor
+
+	// Select from start of line 0 to start of line 3 (covers lines 0,1,2)
+	editor.Cursor.Line = 3
+	editor.Cursor.Col = 0
+	editor.Selection.Start(0, 0)
+	h.redraw()
+
+	h.exec("editor.splitSelectionToLines")
+
+	// Verify 3 cursors at end of each line
+	if editor.Multi == nil {
+		t.Fatal("expected multi-cursor to be active")
+	}
+	if len(editor.Multi.Cursors) != 3 {
+		t.Fatalf("expected 3 cursors, got %d", len(editor.Multi.Cursors))
+	}
+
+	// Type a character — it should appear on all 3 cursor lines
+	h.pressRune('X')
+
+	// Check buffer content
+	if editor.Buf.Lines[0] != "aaaX" {
+		t.Errorf("expected line 0 to be 'aaaX', got %q", editor.Buf.Lines[0])
+	}
+	if editor.Buf.Lines[1] != "bbbX" {
+		t.Errorf("expected line 1 to be 'bbbX', got %q", editor.Buf.Lines[1])
+	}
+	if editor.Buf.Lines[2] != "cccX" {
+		t.Errorf("expected line 2 to be 'cccX', got %q", editor.Buf.Lines[2])
+	}
+	// Line 3 should be untouched
+	if editor.Buf.Lines[3] != "ddd" {
+		t.Errorf("expected line 3 to remain 'ddd', got %q", editor.Buf.Lines[3])
+	}
+}

--- a/tests/functional/split-selection.test.js
+++ b/tests/functional/split-selection.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("split selection into lines", () => {
+  it("should create per-line cursors from multi-line selection", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "aaa\nbbb\nccc");
+
+    tui.start(file);
+    tui.waitFor("aaa");
+
+    // Select all text (3 lines)
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Split Selection into Lines");
+    tui.waitStable();
+
+    // Type 'X' — should appear on each of the 3 lines with cursors
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    expect(content).toContain("aaaX");
+    expect(content).toContain("bbbX");
+    expect(content).toContain("cccX");
+  });
+
+  it("should do nothing with no selection", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "nosel.txt", "hello\nworld\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.exec("Split Selection into Lines");
+    tui.waitStable();
+
+    // Type 'Z' — should only appear once (single cursor)
+    tui.type("Z");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    const zCount = (content.match(/Z/g) || []).length;
+    expect(zCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `editor.splitSelectionToLines` command ("Split Selection into Lines") that converts a multi-line selection into per-line cursors
- Leverages the existing multi-cursor system — each line in the selection gets a cursor at its end
- Command palette only (no keybinding assigned)
- Handles edge cases: no selection, single-line selection, selection ending at column 0 of last line

## Test plan
- [x] E2E: multi-line selection creates correct number of cursors
- [x] E2E: no-op with no selection
- [x] E2E: no-op with single-line selection
- [x] E2E: typing after split affects all cursor lines
- [x] Functional: select-all + split + type inserts on all lines
- [x] Functional: no-op without selection (single cursor remains)
- [x] `make build` passes
- [x] `make test` passes

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)