### PR TITLE
feat: add sort, reverse, and unique lines commands

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -446,6 +446,23 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "editor.sortLinesAsc", Title: "Sort Lines Ascending",
+		Handler: func() { app.EditorGroup.SortLinesAsc() },
+	})
+	reg.Register(command.Command{
+		ID: "editor.sortLinesDesc", Title: "Sort Lines Descending",
+		Handler: func() { app.EditorGroup.SortLinesDesc() },
+	})
+	reg.Register(command.Command{
+		ID: "editor.reverseLines", Title: "Reverse Lines",
+		Handler: func() { app.EditorGroup.ReverseLines() },
+	})
+	reg.Register(command.Command{
+		ID: "editor.uniqueLines", Title: "Unique Lines",
+		Handler: func() { app.EditorGroup.UniqueLines() },
+	})
+
+	reg.Register(command.Command{
 		ID: "editor.quit", Title: "Quit",
 		Handler: app.Quit,
 	})

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -188,6 +188,7 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "alt+backspace", Command: "editor.deleteWordLeft"},
 		{Key: "alt+delete", Command: "editor.deleteWordRight"},
 		{Key: "ctrl+delete", Command: "editor.deleteWordRight"},
+		{Key: "ctrl+k o", Command: "editor.sortLinesAsc"},
 		{Key: "ctrl+k [", Command: "fold.toggle"},
 		{Key: "ctrl+k 0", Command: "fold.collapseAll"},
 		{Key: "ctrl+k 9", Command: "fold.expandAll"},

--- a/internal/core/undo/undo.go
+++ b/internal/core/undo/undo.go
@@ -547,6 +547,48 @@ func (c *BatchCommand) Undo(b *buffer.Buffer) {
 	}
 }
 
+// ReplaceLinesCommand replaces a contiguous range of buffer lines with new content.
+// Used by sort, reverse, and unique line operations.
+// The caller must set OldLines to the current buffer content being replaced
+// and NewLines to the desired replacement.
+type ReplaceLinesCommand struct {
+	Start    int      // first line index (inclusive)
+	OldLines []string // original lines (caller must populate before exec)
+	NewLines []string // replacement lines
+}
+
+func (c *ReplaceLinesCommand) Apply(b *buffer.Buffer) {
+	if c.Start < 0 || c.Start >= len(b.Lines) {
+		return
+	}
+	end := c.Start + len(c.OldLines)
+	if end > len(b.Lines) {
+		end = len(b.Lines)
+	}
+	newBuf := make([]string, 0, len(b.Lines)-len(c.OldLines)+len(c.NewLines))
+	newBuf = append(newBuf, b.Lines[:c.Start]...)
+	newBuf = append(newBuf, c.NewLines...)
+	newBuf = append(newBuf, b.Lines[end:]...)
+	b.Lines = newBuf
+	b.Dirty = true
+}
+
+func (c *ReplaceLinesCommand) Undo(b *buffer.Buffer) {
+	if c.Start < 0 || c.Start >= len(b.Lines) {
+		return
+	}
+	end := c.Start + len(c.NewLines)
+	if end > len(b.Lines) {
+		end = len(b.Lines)
+	}
+	newBuf := make([]string, 0, len(b.Lines)-len(c.NewLines)+len(c.OldLines))
+	newBuf = append(newBuf, b.Lines[:c.Start]...)
+	newBuf = append(newBuf, c.OldLines...)
+	newBuf = append(newBuf, b.Lines[end:]...)
+	b.Lines = newBuf
+	b.Dirty = true
+}
+
 func splitLines(s string) []string {
 	var lines []string
 	start := 0

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -743,6 +743,30 @@ func (g *EditorGroupWidget) ToggleLineComment() {
 	}
 }
 
+func (g *EditorGroupWidget) SortLinesAsc() {
+	if g.IsEditorActive() {
+		g.Editor.SortLinesAsc()
+	}
+}
+
+func (g *EditorGroupWidget) SortLinesDesc() {
+	if g.IsEditorActive() {
+		g.Editor.SortLinesDesc()
+	}
+}
+
+func (g *EditorGroupWidget) ReverseLines() {
+	if g.IsEditorActive() {
+		g.Editor.ReverseLines()
+	}
+}
+
+func (g *EditorGroupWidget) UniqueLines() {
+	if g.IsEditorActive() {
+		g.Editor.UniqueLines()
+	}
+}
+
 func (g *EditorGroupWidget) MoveWordLeft(shift bool) {
 	if g.IsEditorActive() {
 		g.Editor.MoveWordLeft(shift)

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/core/undo"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/view"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1516,6 +1517,80 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 	e.Cursor.Col += cursorDelta
 	if e.Cursor.Col < 0 {
 		e.Cursor.Col = 0
+	}
+	e.clampCursor()
+	e.scrollViewport()
+}
+
+// lineRange returns the start and end line indices for the current selection,
+// or the full buffer range if no selection is active.
+func (e *EditorPaneWidget) lineRange() (int, int) {
+	if e.Selection != nil && e.Selection.Active {
+		start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
+		endLine := end.Line
+		if end.Col == 0 && endLine > start.Line {
+			endLine--
+		}
+		return start.Line, endLine
+	}
+	return 0, len(e.Buf.Lines) - 1
+}
+
+// copyLines returns a copy of the buffer lines in the given range (inclusive).
+func (e *EditorPaneWidget) copyLines(start, end int) []string {
+	lines := make([]string, end-start+1)
+	copy(lines, e.Buf.Lines[start:end+1])
+	return lines
+}
+
+func (e *EditorPaneWidget) SortLinesAsc() {
+	start, end := e.lineRange()
+	old := e.copyLines(start, end)
+	sorted := make([]string, len(old))
+	copy(sorted, old)
+	sort.Strings(sorted)
+	e.exec(&undo.ReplaceLinesCommand{Start: start, OldLines: old, NewLines: sorted})
+	e.clampCursor()
+	e.scrollViewport()
+}
+
+func (e *EditorPaneWidget) SortLinesDesc() {
+	start, end := e.lineRange()
+	old := e.copyLines(start, end)
+	sorted := make([]string, len(old))
+	copy(sorted, old)
+	sort.Sort(sort.Reverse(sort.StringSlice(sorted)))
+	e.exec(&undo.ReplaceLinesCommand{Start: start, OldLines: old, NewLines: sorted})
+	e.clampCursor()
+	e.scrollViewport()
+}
+
+func (e *EditorPaneWidget) ReverseLines() {
+	start, end := e.lineRange()
+	old := e.copyLines(start, end)
+	reversed := make([]string, len(old))
+	for i, line := range old {
+		reversed[len(old)-1-i] = line
+	}
+	e.exec(&undo.ReplaceLinesCommand{Start: start, OldLines: old, NewLines: reversed})
+	e.clampCursor()
+	e.scrollViewport()
+}
+
+func (e *EditorPaneWidget) UniqueLines() {
+	start, end := e.lineRange()
+	old := e.copyLines(start, end)
+	seen := make(map[string]bool)
+	var unique []string
+	for _, line := range old {
+		if !seen[line] {
+			seen[line] = true
+			unique = append(unique, line)
+		}
+	}
+	e.exec(&undo.ReplaceLinesCommand{Start: start, OldLines: old, NewLines: unique})
+	if e.Cursor.Line >= len(e.Buf.Lines) {
+		e.Cursor.Line = len(e.Buf.Lines) - 1
 	}
 	e.clampCursor()
 	e.scrollViewport()

--- a/tests/e2e/sort_lines_test.go
+++ b/tests/e2e/sort_lines_test.go
@@ -1,0 +1,149 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSortLinesAsc(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "sort.txt")
+	os.WriteFile(f, []byte("cherry\napple\nbanana\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	// Select all then sort ascending
+	h.exec("editor.selectAll")
+	h.exec("editor.sortLinesAsc")
+
+	lines := h.app.EditorGroup.Editor.Buf.Lines
+	// selectAll excludes the trailing empty line (end.Col==0 adjustment),
+	// so only lines 0-2 are sorted; line 3 ("") stays.
+	if lines[0] != "apple" || lines[1] != "banana" || lines[2] != "cherry" || lines[3] != "" {
+		t.Errorf("expected [apple, banana, cherry, ''], got %v", lines)
+	}
+}
+
+func TestSortLinesAscNoSelection(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "sortall.txt")
+	os.WriteFile(f, []byte("cherry\napple\nbanana\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	// No selection — sorts all lines including the trailing empty line
+	h.exec("editor.sortLinesAsc")
+
+	lines := h.app.EditorGroup.Editor.Buf.Lines
+	if lines[0] != "" || lines[1] != "apple" || lines[2] != "banana" || lines[3] != "cherry" {
+		t.Errorf("expected ['', apple, banana, cherry], got %v", lines)
+	}
+}
+
+func TestSortLinesDesc(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "sortdesc.txt")
+	os.WriteFile(f, []byte("apple\ncherry\nbanana\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.sortLinesDesc")
+
+	lines := h.app.EditorGroup.Editor.Buf.Lines
+	// selectAll excludes trailing empty line: sorts lines 0-2 descending
+	if lines[0] != "cherry" || lines[1] != "banana" || lines[2] != "apple" || lines[3] != "" {
+		t.Errorf("expected [cherry, banana, apple, ''], got %v", lines)
+	}
+}
+
+func TestReverseLines(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "reverse.txt")
+	os.WriteFile(f, []byte("first\nsecond\nthird\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.reverseLines")
+
+	lines := h.app.EditorGroup.Editor.Buf.Lines
+	// selectAll excludes trailing empty line: reverses lines 0-2
+	if lines[0] != "third" || lines[1] != "second" || lines[2] != "first" || lines[3] != "" {
+		t.Errorf("expected [third, second, first, ''], got %v", lines)
+	}
+}
+
+func TestReverseLinesNoSelection(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "revall.txt")
+	os.WriteFile(f, []byte("first\nsecond\nthird\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	// No selection — reverses all lines including trailing empty line
+	h.exec("editor.reverseLines")
+
+	lines := h.app.EditorGroup.Editor.Buf.Lines
+	if lines[0] != "" || lines[1] != "third" || lines[2] != "second" || lines[3] != "first" {
+		t.Errorf("expected ['', third, second, first], got %v", lines)
+	}
+}
+
+func TestUniqueLines(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "unique.txt")
+	os.WriteFile(f, []byte("apple\nbanana\napple\ncherry\nbanana\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("editor.selectAll")
+	h.exec("editor.uniqueLines")
+
+	lines := h.app.EditorGroup.Editor.Buf.Lines
+	// selectAll excludes trailing empty line: deduplicates lines 0-4
+	// ["apple","banana","apple","cherry","banana"] -> ["apple","banana","cherry"]
+	// trailing empty line stays at end
+	if len(lines) != 4 || lines[0] != "apple" || lines[1] != "banana" || lines[2] != "cherry" || lines[3] != "" {
+		t.Errorf("expected [apple, banana, cherry, ''], got %v", lines)
+	}
+}
+
+func TestSortLinesUndo(t *testing.T) {
+	h := newTestHarness(t, 80, 30)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "sortundo.txt")
+	os.WriteFile(f, []byte("cherry\napple\nbanana\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	// No selection — sort all lines
+	h.exec("editor.sortLinesAsc")
+
+	lines := h.app.EditorGroup.Editor.Buf.Lines
+	if lines[0] != "" {
+		t.Errorf("expected first line '' after sort, got %q", lines[0])
+	}
+
+	// Undo should restore original order
+	h.exec("editor.undo")
+
+	lines = h.app.EditorGroup.Editor.Buf.Lines
+	if lines[0] != "cherry" || lines[1] != "apple" || lines[2] != "banana" || lines[3] != "" {
+		t.Errorf("expected [cherry, apple, banana, ''] after undo, got %v", lines)
+	}
+}

--- a/tests/functional/sort-lines.test.js
+++ b/tests/functional/sort-lines.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("sort lines", () => {
+  it("should sort lines ascending via command palette", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "sort.txt", "cherry\napple\nbanana\n");
+
+    tui.start(file);
+    tui.waitFor("cherry");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Sort Lines Ascending");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    const lines = content.split("\n").filter((l) => l !== "");
+    expect(lines).toEqual(["apple", "banana", "cherry"]);
+  });
+
+  it("should sort lines descending via command palette", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "sortdesc.txt", "apple\ncherry\nbanana\n");
+
+    tui.start(file);
+    tui.waitFor("apple");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Sort Lines Descending");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    const lines = content.split("\n").filter((l) => l !== "");
+    expect(lines).toEqual(["cherry", "banana", "apple"]);
+  });
+
+  it("should reverse lines via command palette", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "reverse.txt", "first\nsecond\nthird\n");
+
+    tui.start(file);
+    tui.waitFor("first");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Reverse Lines");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    const lines = content.split("\n").filter((l) => l !== "");
+    expect(lines).toEqual(["third", "second", "first"]);
+  });
+
+  it("should remove duplicate lines via command palette", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "unique.txt",
+      "apple\nbanana\napple\ncherry\nbanana\n"
+    );
+
+    tui.start(file);
+    tui.waitFor("apple");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Unique Lines");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    const lines = content.split("\n").filter((l) => l !== "");
+    expect(lines).toEqual(["apple", "banana", "cherry"]);
+  });
+
+  it("should sort lines ascending with ctrl+k o chord", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "sortchord.txt", "cherry\napple\nbanana\n");
+
+    tui.start(file);
+    tui.waitFor("cherry");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.pressChord("ctrl+k", "o");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    const lines = content.split("\n").filter((l) => l !== "");
+    expect(lines).toEqual(["apple", "banana", "cherry"]);
+  });
+
+  it("should undo sort with ctrl+z", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "sortundo.txt", "cherry\napple\nbanana\n");
+
+    tui.start(file);
+    tui.waitFor("cherry");
+
+    tui.press("ctrl+a");
+    tui.waitStable();
+
+    tui.exec("Sort Lines Ascending");
+    tui.waitStable();
+
+    // Undo
+    tui.press("ctrl+z");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    const lines = content.split("\n").filter((l) => l !== "");
+    expect(lines).toEqual(["cherry", "apple", "banana"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds four text manipulation commands: Sort Lines Ascending, Sort Lines Descending, Reverse Lines, Unique Lines
- Operates on selected lines (or all lines if no selection)
- `ctrl+k o` keybinding for sort ascending, rest are command palette only
- Introduces `ReplaceLinesCommand` in the undo system for atomic line range replacement with full undo/redo
- Includes E2E and functional tests

## Test plan
- [x] Sort ascending with keybinding ctrl+k o
- [x] Sort ascending via command palette
- [x] Sort descending via command palette
- [x] Reverse lines via command palette
- [x] Unique lines removes duplicates preserving order
- [x] Works on selection and on entire buffer (no selection)
- [x] Undo restores original line order
- [x] All existing tests pass

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)