### PR TITLE
fix: add .claude/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules/
 docs-web/dist/
 
 # Editor files
+.claude/
 .vscode/
 .idea/
 *.swp


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` to prevent Claude Code worktrees from showing as untracked files in the Changes panel

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)