### PR TITLE
feat: add three new themes

### DIFF
--- a/internal/config/themes/chiclet.json
+++ b/internal/config/themes/chiclet.json
@@ -1,0 +1,219 @@
+{
+  "default": {
+    "fg": "#4e4460",
+    "bg": "#faf5f0"
+  },
+  "muted": {
+    "fg": "#a898b4"
+  },
+  "success": {
+    "fg": "#56b685"
+  },
+  "danger": {
+    "fg": "#e86080"
+  },
+  "warning": {
+    "fg": "#d49840"
+  },
+  "border": {
+    "fg": "#d8c8e0"
+  },
+  "statusBar": {
+    "fg": "#4e4460",
+    "bg": "#e8daf0"
+  },
+  "tabs": {
+    "active": {
+      "fg": "#4e4460",
+      "bg": "#ede0f4",
+      "bold": true
+    },
+    "inactive": {
+      "fg": "#a898b4"
+    }
+  },
+  "sidebar": {
+    "header": {
+      "fg": "#4e4460",
+      "bold": true
+    },
+    "item": {
+      "fg": "#605070"
+    },
+    "selected": {
+      "fg": "#4e4460",
+      "bg": "#e4d6ee"
+    }
+  },
+  "dialog": {
+    "input": {
+      "fg": "#4e4460",
+      "bg": "#f0e8f4"
+    },
+    "item": {
+      "fg": "#605070"
+    },
+    "selected": {
+      "fg": "#4e4460",
+      "bg": "#e4d6ee"
+    },
+    "muted": {
+      "fg": "#a898b4"
+    }
+  },
+  "editor": {
+    "lineNumber": {
+      "fg": "#c0b0cc"
+    },
+    "activeLine": {
+      "bg": "#f2ecf6"
+    },
+    "selection": {
+      "bg": "#d6e8f8"
+    },
+    "searchMatch": {
+      "bg": "#ffd070",
+      "fg": "#4e4460"
+    },
+    "searchActive": {
+      "bg": "#f090b0",
+      "fg": "#ffffff"
+    },
+    "bracketMatch": {
+      "bg": "#e0d0ea"
+    },
+    "diagnostics": {
+      "error": {
+        "fg": "#e86080"
+      },
+      "warning": {
+        "fg": "#d49840"
+      },
+      "info": {
+        "fg": "#6098cc"
+      },
+      "hint": {
+        "fg": "#a898b4"
+      }
+    }
+  },
+  "menu": {
+    "item": {
+      "fg": "#4e4460",
+      "bg": "#f0e8f4"
+    },
+    "active": {
+      "fg": "#4e4460",
+      "bg": "#e4d6ee",
+      "bold": true
+    }
+  },
+  "input": {
+    "item": {
+      "fg": "#4e4460",
+      "bg": "#f0e8f4"
+    },
+    "placeholder": {
+      "fg": "#a898b4",
+      "bg": "#f0e8f4"
+    },
+    "action": {
+      "fg": "#a898b4",
+      "bg": "#f0e8f4"
+    }
+  },
+  "hover": {
+    "bold": {
+      "fg": "#4e4460",
+      "bold": true
+    },
+    "code": {
+      "fg": "#56b685"
+    }
+  },
+  "diff": {
+    "added": {
+      "bg": "#d8f4e4"
+    },
+    "deleted": {
+      "bg": "#f8d8d8"
+    },
+    "modified": {
+      "bg": "#f4f0d4"
+    }
+  },
+  "scrollbar": {
+    "fg": "#d0c0dc",
+    "bg": "#f0e8f4"
+  },
+  "syntax": {
+    "comment": {
+      "fg": "#b8a8c8"
+    },
+    "string": {
+      "fg": "#56b685"
+    },
+    "keyword": {
+      "fg": "#b070d0"
+    },
+    "number": {
+      "fg": "#e88050"
+    },
+    "operator": {
+      "fg": "#7a6890"
+    },
+    "function": {
+      "fg": "#5098cc"
+    },
+    "type": {
+      "fg": "#e06888"
+    },
+    "builtin": {
+      "fg": "#e06888"
+    },
+    "variable": {
+      "fg": "#6080b0"
+    },
+    "punctuation": {
+      "fg": "#7a6890"
+    },
+    "tag": {
+      "fg": "#b070d0"
+    },
+    "attribute": {
+      "fg": "#50a0b0"
+    }
+  },
+  "terminal": {
+    "foreground": "#4e4460",
+    "background": "#faf5f0",
+    "black": "#4e4460",
+    "red": "#e86080",
+    "green": "#56b685",
+    "yellow": "#d49840",
+    "blue": "#5098cc",
+    "magenta": "#b070d0",
+    "cyan": "#50a0b0",
+    "white": "#f0e8f0",
+    "brightBlack": "#a898b4",
+    "brightRed": "#f080a0",
+    "brightGreen": "#70c89a",
+    "brightYellow": "#e0b060",
+    "brightBlue": "#70b0e0",
+    "brightMagenta": "#c898e0",
+    "brightCyan": "#68b8c8",
+    "brightWhite": "#faf5f0"
+  },
+  "borders": {
+    "horizontal": "─",
+    "vertical": "│",
+    "topLeft": "╭",
+    "topRight": "╮",
+    "bottomLeft": "╰",
+    "bottomRight": "╯",
+    "topTee": "┬",
+    "bottomTee": "┴",
+    "leftTee": "├",
+    "rightTee": "┤"
+  }
+}

--- a/internal/config/themes/neon-chaos.json
+++ b/internal/config/themes/neon-chaos.json
@@ -1,0 +1,219 @@
+{
+  "default": {
+    "fg": "#e0e0e0",
+    "bg": "#0a0a12"
+  },
+  "muted": {
+    "fg": "#606888"
+  },
+  "success": {
+    "fg": "#39ff14"
+  },
+  "danger": {
+    "fg": "#ff2060"
+  },
+  "warning": {
+    "fg": "#ff9500"
+  },
+  "border": {
+    "fg": "#ff00ff"
+  },
+  "statusBar": {
+    "fg": "#0a0a12",
+    "bg": "#ff00ff"
+  },
+  "tabs": {
+    "active": {
+      "fg": "#0a0a12",
+      "bg": "#00ffff",
+      "bold": true
+    },
+    "inactive": {
+      "fg": "#ff00ff"
+    }
+  },
+  "sidebar": {
+    "header": {
+      "fg": "#00ffff",
+      "bold": true
+    },
+    "item": {
+      "fg": "#b0b8d0"
+    },
+    "selected": {
+      "fg": "#0a0a12",
+      "bg": "#ff00ff"
+    }
+  },
+  "dialog": {
+    "input": {
+      "fg": "#e0e0e0",
+      "bg": "#18182a"
+    },
+    "item": {
+      "fg": "#b0b8d0"
+    },
+    "selected": {
+      "fg": "#0a0a12",
+      "bg": "#00ffff"
+    },
+    "muted": {
+      "fg": "#606888"
+    }
+  },
+  "editor": {
+    "lineNumber": {
+      "fg": "#383858"
+    },
+    "activeLine": {
+      "bg": "#12122a"
+    },
+    "selection": {
+      "bg": "#38185a"
+    },
+    "searchMatch": {
+      "bg": "#ff9500",
+      "fg": "#0a0a12"
+    },
+    "searchActive": {
+      "bg": "#39ff14",
+      "fg": "#0a0a12"
+    },
+    "bracketMatch": {
+      "bg": "#302060"
+    },
+    "diagnostics": {
+      "error": {
+        "fg": "#ff2060"
+      },
+      "warning": {
+        "fg": "#ff9500"
+      },
+      "info": {
+        "fg": "#00ccff"
+      },
+      "hint": {
+        "fg": "#606888"
+      }
+    }
+  },
+  "menu": {
+    "item": {
+      "fg": "#e0e0e0",
+      "bg": "#18182a"
+    },
+    "active": {
+      "fg": "#0a0a12",
+      "bg": "#ff00ff",
+      "bold": true
+    }
+  },
+  "input": {
+    "item": {
+      "fg": "#e0e0e0",
+      "bg": "#18182a"
+    },
+    "placeholder": {
+      "fg": "#606888",
+      "bg": "#18182a"
+    },
+    "action": {
+      "fg": "#ff00ff",
+      "bg": "#18182a"
+    }
+  },
+  "hover": {
+    "bold": {
+      "fg": "#00ffff",
+      "bold": true
+    },
+    "code": {
+      "fg": "#39ff14"
+    }
+  },
+  "diff": {
+    "added": {
+      "bg": "#0a2a10"
+    },
+    "deleted": {
+      "bg": "#300a14"
+    },
+    "modified": {
+      "bg": "#2a2a0a"
+    }
+  },
+  "scrollbar": {
+    "fg": "#ff00ff",
+    "bg": "#18182a"
+  },
+  "syntax": {
+    "comment": {
+      "fg": "#484878"
+    },
+    "string": {
+      "fg": "#39ff14"
+    },
+    "keyword": {
+      "fg": "#ff00ff"
+    },
+    "number": {
+      "fg": "#ff9500"
+    },
+    "operator": {
+      "fg": "#00ffff"
+    },
+    "function": {
+      "fg": "#ffff00"
+    },
+    "type": {
+      "fg": "#ff6ec7"
+    },
+    "builtin": {
+      "fg": "#00ccff"
+    },
+    "variable": {
+      "fg": "#b894f6"
+    },
+    "punctuation": {
+      "fg": "#00ffff"
+    },
+    "tag": {
+      "fg": "#ff2060"
+    },
+    "attribute": {
+      "fg": "#ffff00"
+    }
+  },
+  "terminal": {
+    "foreground": "#e0e0e0",
+    "background": "#0a0a12",
+    "black": "#0a0a12",
+    "red": "#ff2060",
+    "green": "#39ff14",
+    "yellow": "#ffff00",
+    "blue": "#00ccff",
+    "magenta": "#ff00ff",
+    "cyan": "#00ffff",
+    "white": "#e0e0e0",
+    "brightBlack": "#484878",
+    "brightRed": "#ff5080",
+    "brightGreen": "#70ff50",
+    "brightYellow": "#ffff66",
+    "brightBlue": "#50e0ff",
+    "brightMagenta": "#ff66ff",
+    "brightCyan": "#66ffff",
+    "brightWhite": "#ffffff"
+  },
+  "borders": {
+    "horizontal": "░",
+    "vertical": "▓",
+    "topLeft": "◆",
+    "topRight": "◆",
+    "bottomLeft": "◆",
+    "bottomRight": "◆",
+    "topTee": "●",
+    "bottomTee": "●",
+    "leftTee": "◢",
+    "rightTee": "◣"
+  }
+}

--- a/internal/config/themes/zenith.json
+++ b/internal/config/themes/zenith.json
@@ -1,0 +1,219 @@
+{
+  "default": {
+    "fg": "#c8ccd4",
+    "bg": "#23272e"
+  },
+  "muted": {
+    "fg": "#636d83"
+  },
+  "success": {
+    "fg": "#8ebd6b"
+  },
+  "danger": {
+    "fg": "#e06c75"
+  },
+  "warning": {
+    "fg": "#d4a959"
+  },
+  "border": {
+    "fg": "#3e4451"
+  },
+  "statusBar": {
+    "fg": "#abb2bf",
+    "bg": "#1e2227"
+  },
+  "tabs": {
+    "active": {
+      "fg": "#e2e6ed",
+      "bg": "#2c313a",
+      "bold": true
+    },
+    "inactive": {
+      "fg": "#636d83"
+    }
+  },
+  "sidebar": {
+    "header": {
+      "fg": "#e2e6ed",
+      "bold": true
+    },
+    "item": {
+      "fg": "#abb2bf"
+    },
+    "selected": {
+      "fg": "#e2e6ed",
+      "bg": "#2c313a"
+    }
+  },
+  "dialog": {
+    "input": {
+      "fg": "#c8ccd4",
+      "bg": "#1e2227"
+    },
+    "item": {
+      "fg": "#abb2bf"
+    },
+    "selected": {
+      "fg": "#e2e6ed",
+      "bg": "#2c313a"
+    },
+    "muted": {
+      "fg": "#636d83"
+    }
+  },
+  "editor": {
+    "lineNumber": {
+      "fg": "#495162"
+    },
+    "activeLine": {
+      "bg": "#2c313a"
+    },
+    "selection": {
+      "bg": "#334060"
+    },
+    "searchMatch": {
+      "bg": "#5c4a1e",
+      "fg": "#e2e6ed"
+    },
+    "searchActive": {
+      "bg": "#d4a959",
+      "fg": "#1e2227"
+    },
+    "bracketMatch": {
+      "bg": "#3a3f4b"
+    },
+    "diagnostics": {
+      "error": {
+        "fg": "#e06c75"
+      },
+      "warning": {
+        "fg": "#d4a959"
+      },
+      "info": {
+        "fg": "#7ab0df"
+      },
+      "hint": {
+        "fg": "#636d83"
+      }
+    }
+  },
+  "menu": {
+    "item": {
+      "fg": "#abb2bf",
+      "bg": "#1e2227"
+    },
+    "active": {
+      "fg": "#e2e6ed",
+      "bg": "#2c313a",
+      "bold": true
+    }
+  },
+  "input": {
+    "item": {
+      "fg": "#c8ccd4",
+      "bg": "#1e2227"
+    },
+    "placeholder": {
+      "fg": "#636d83",
+      "bg": "#1e2227"
+    },
+    "action": {
+      "fg": "#636d83",
+      "bg": "#1e2227"
+    }
+  },
+  "hover": {
+    "bold": {
+      "fg": "#e2e6ed",
+      "bold": true
+    },
+    "code": {
+      "fg": "#8ebd6b"
+    }
+  },
+  "diff": {
+    "added": {
+      "bg": "#1e2e1e"
+    },
+    "deleted": {
+      "bg": "#2e1e1e"
+    },
+    "modified": {
+      "bg": "#2e2e1e"
+    }
+  },
+  "scrollbar": {
+    "fg": "#495162",
+    "bg": "#2c313a"
+  },
+  "syntax": {
+    "comment": {
+      "fg": "#636d83"
+    },
+    "string": {
+      "fg": "#8ebd6b"
+    },
+    "keyword": {
+      "fg": "#7ab0df"
+    },
+    "number": {
+      "fg": "#d4a959"
+    },
+    "operator": {
+      "fg": "#9da5b4"
+    },
+    "function": {
+      "fg": "#dbc074"
+    },
+    "type": {
+      "fg": "#6db3a8"
+    },
+    "builtin": {
+      "fg": "#6db3a8"
+    },
+    "variable": {
+      "fg": "#c0a6e8"
+    },
+    "punctuation": {
+      "fg": "#9da5b4"
+    },
+    "tag": {
+      "fg": "#e06c75"
+    },
+    "attribute": {
+      "fg": "#d4a959"
+    }
+  },
+  "terminal": {
+    "foreground": "#c8ccd4",
+    "background": "#1e2227",
+    "black": "#1e2227",
+    "red": "#e06c75",
+    "green": "#8ebd6b",
+    "yellow": "#d4a959",
+    "blue": "#7ab0df",
+    "magenta": "#c0a6e8",
+    "cyan": "#6db3a8",
+    "white": "#c8ccd4",
+    "brightBlack": "#636d83",
+    "brightRed": "#e8838b",
+    "brightGreen": "#a5d48a",
+    "brightYellow": "#e0be78",
+    "brightBlue": "#92c2e8",
+    "brightMagenta": "#d0bbef",
+    "brightCyan": "#89c8be",
+    "brightWhite": "#e2e6ed"
+  },
+  "borders": {
+    "horizontal": "─",
+    "vertical": "│",
+    "topLeft": "┌",
+    "topRight": "┐",
+    "bottomLeft": "└",
+    "bottomRight": "┘",
+    "topTee": "┬",
+    "bottomTee": "┴",
+    "leftTee": "├",
+    "rightTee": "┤"
+  }
+}


### PR DESCRIPTION
## Summary
- **Zenith**: Clean, low-contrast dark theme optimized for long coding sessions. Muted colors on a dark gray background with soft blues, greens, and muted oranges. Professional and easy on the eyes.
- **Chiclet**: Playful pastel theme inspired by candy keyboard aesthetics. Light background with soft pinks, lavenders, teals, and warm yellows. Uses rounded border corners (╭╮╰╯) for a softer feel.
- **Neon Chaos**: Experimental theme pushing visual boundaries. Neon magenta, electric cyan, acid green, and hot pink on deep dark background. Uses unusual Unicode border characters (░ ▓ ◆ ● ◢ ◣) for a striking, unconventional look.

All three themes include the full schema: `input` styles with matching `bg` for `placeholder` and `action`, `hover` styles, `terminal` colors, `diagnostics`, and `bracketMatch`.

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] Switch to each theme via command palette and verify rendering
- [ ] Verify input fields maintain consistent background when typing
- [ ] Check terminal panel colors render correctly with each theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)