### PR TITLE
feat: add minimal gutter style and default to compact

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -87,7 +87,7 @@ func DefaultEditorSettings() EditorSettings {
 		InsertSpaces:       true,
 		LineNumbers:        true,
 		InsertFinalNewline: true,
-		GutterStyle:        "extended",
+		GutterStyle:        "compact",
 	}
 }
 

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -74,10 +74,14 @@ func (e *EditorPaneWidget) GutterWidth() int {
 	if digits < 2 {
 		digits = 2
 	}
-	if e.GutterStyle == "compact" {
+	switch e.GutterStyle {
+	case "minimal":
+		return digits + 1
+	case "compact":
 		return digits + 3
+	default:
+		return digits + 5
 	}
-	return digits + 5
 }
 
 func (e *EditorPaneWidget) computeMaxLineWidth() int {
@@ -213,11 +217,13 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 			if lineIdx < totalLines {
 				numStr = strconv.Itoa(lineIdx + 1)
 			}
-			compact := e.GutterStyle == "compact"
 			var padded string
-			if compact {
+			switch e.GutterStyle {
+			case "minimal":
+				padded = strings.Repeat(" ", gutterW-1-len(numStr)) + numStr + " "
+			case "compact":
 				padded = " " + strings.Repeat(" ", gutterW-3-len(numStr)) + numStr + "  "
-			} else {
+			default:
 				padded = "  " + strings.Repeat(" ", gutterW-5-len(numStr)) + numStr + "   "
 			}
 			for i, ch := range padded {
@@ -226,10 +232,17 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 			if e.Folds != nil && lineIdx < totalLines {
 				if fr := e.Folds.FoldAt(lineIdx); fr != nil {
 					chevronCol := gutterW - 2
+					collapsedCh := '▶'
+					expandedCh := '▼'
+					if e.GutterStyle == "minimal" {
+						chevronCol = gutterW - 1
+						collapsedCh = '▸'
+						expandedCh = '▾'
+					}
 					if e.Folds.IsCollapsed(lineIdx) {
-						surface.SetCell(chevronCol, y, term.Cell{Ch: '▶', Style: gutterStyle})
+						surface.SetCell(chevronCol, y, term.Cell{Ch: collapsedCh, Style: gutterStyle})
 					} else if e.gutterHover {
-						surface.SetCell(chevronCol, y, term.Cell{Ch: '▼', Style: gutterStyle})
+						surface.SetCell(chevronCol, y, term.Cell{Ch: expandedCh, Style: gutterStyle})
 					}
 				}
 			}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -68,6 +68,9 @@ func (e *EditorPaneWidget) Focusable() bool { return true }
 
 func (e *EditorPaneWidget) GutterWidth() int {
 	if !e.LineNumbers {
+		if e.GutterStyle != "minimal" {
+			return 1
+		}
 		return 0
 	}
 	digits := len(strconv.Itoa(len(e.Buf.Lines)))
@@ -213,18 +216,22 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 			if lineIdx < totalLines && lineIdx == e.Cursor.Line {
 				gutterStyle = term.StyleActiveLine
 			}
-			numStr := ""
-			if lineIdx < totalLines {
-				numStr = strconv.Itoa(lineIdx + 1)
-			}
 			var padded string
-			switch e.GutterStyle {
-			case "minimal":
-				padded = strings.Repeat(" ", gutterW-1-len(numStr)) + numStr + " "
-			case "compact":
-				padded = " " + strings.Repeat(" ", gutterW-3-len(numStr)) + numStr + "  "
-			default:
-				padded = "  " + strings.Repeat(" ", gutterW-5-len(numStr)) + numStr + "   "
+			if !e.LineNumbers {
+				padded = strings.Repeat(" ", gutterW)
+			} else {
+				numStr := ""
+				if lineIdx < totalLines {
+					numStr = strconv.Itoa(lineIdx + 1)
+				}
+				switch e.GutterStyle {
+				case "minimal":
+					padded = strings.Repeat(" ", gutterW-1-len(numStr)) + numStr + " "
+				case "compact":
+					padded = " " + strings.Repeat(" ", gutterW-3-len(numStr)) + numStr + "  "
+				default:
+					padded = "  " + strings.Repeat(" ", gutterW-5-len(numStr)) + numStr + "   "
+				}
 			}
 			for i, ch := range padded {
 				surface.SetCell(i, y, term.Cell{Ch: ch, Style: gutterStyle})


### PR DESCRIPTION
## Summary
- Add new `"minimal"` gutter style with tightest spacing (digits + 1 col), no left padding, and small fold chevrons (▸/▾)
- Change default `gutterStyle` from `"extended"` to `"compact"`
- Three gutter modes now available: `minimal` → `compact` → `extended`

## Test plan
- [ ] Set `gutterStyle` to `"minimal"` and verify line numbers render with no left padding and 1 space right
- [ ] Verify fold chevrons in minimal mode use small triangles (▸/▾) at the rightmost gutter column
- [ ] Verify compact and extended modes render unchanged (▶/▼ chevrons)
- [ ] Confirm new default is compact when no `gutterStyle` is set in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)