### PR TITLE
fix: correct functional test failures for case transforms and LSP

### DIFF
--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -67,12 +67,24 @@ type InitializeResult struct {
 type ServerCapabilities struct {
 	CompletionProvider              *CompletionOptions       `json:"completionProvider,omitempty"`
 	TextDocumentSync                *TextDocumentSyncOptions `json:"textDocumentSync,omitempty"`
-	DocumentFormattingProvider      bool                     `json:"documentFormattingProvider,omitempty"`
-	DocumentRangeFormattingProvider bool                     `json:"documentRangeFormattingProvider,omitempty"`
+	DocumentFormattingProvider      BoolOrObject `json:"documentFormattingProvider,omitempty"`
+	DocumentRangeFormattingProvider BoolOrObject `json:"documentRangeFormattingProvider,omitempty"`
 }
 
 type CompletionOptions struct {
 	TriggerCharacters []string `json:"triggerCharacters,omitempty"`
+}
+
+type BoolOrObject bool
+
+func (b *BoolOrObject) UnmarshalJSON(data []byte) error {
+	var v bool
+	if err := json.Unmarshal(data, &v); err == nil {
+		*b = BoolOrObject(v)
+		return nil
+	}
+	*b = true
+	return nil
 }
 
 type TextDocumentSyncOptions struct {

--- a/tests/functional/case-transform.test.js
+++ b/tests/functional/case-transform.test.js
@@ -20,7 +20,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Upper Case");
+    tui.exec("Transform to Uppercase");
     tui.waitStable();
 
     const snap = tui.snapshot();
@@ -37,7 +37,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Lower Case");
+    tui.exec("Transform to Lowercase");
     tui.waitStable();
 
     const snap = tui.snapshot();
@@ -54,7 +54,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Title Case");
+    tui.exec("Transform to Titlecase");
     tui.waitStable();
 
     const snap = tui.snapshot();
@@ -71,7 +71,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Upper Case");
+    tui.exec("Transform to Uppercase");
     tui.waitStable();
 
     let snap = tui.snapshot();


### PR DESCRIPTION
## Summary
- Fix case-transform functional tests: command names didn't match registered names (`"Upper Case"` → `"Uppercase"`, `"Lower Case"` → `"Lowercase"`, `"Title Case"` → `"Titlecase"`)
- Fix LSP protocol parsing: `documentRangeFormattingProvider` and `documentFormattingProvider` now accept both `bool` and object values (LSP spec allows either; `clangd` sends an object)

## Test plan
- [x] All 122 functional tests pass (8 skipped for missing LSP servers)
- [x] Case-transform tests verified with correct command names
- [x] LSP C tests pass with clangd

🤖 Generated with [Claude Code](https://claude.com/claude-code)