### PR TITLE
fix: reset sidebar width to default when reopening after collapse

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -99,6 +99,9 @@ func formatKeyDisplay(key string) string {
 func (a *App) ShowSidebar() {
 	a.Sidebar.Visible = true
 	a.SplitPanel.ShowLeft = true
+	if a.SplitPanel.DividerPos < ui.MinSidebarWidth {
+		a.SplitPanel.DividerPos = ui.DefaultSidebarWidth
+	}
 	a.applySearchHighlights()
 }
 

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -132,7 +132,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	splitPanel.Left = sidebar
 	splitPanel.Right = contentSplit
 	splitPanel.Borders = borders
-	splitPanel.DividerPos = 30
+	splitPanel.DividerPos = ui.DefaultSidebarWidth
 	splitPanel.ShowLeft = sidebar.Visible
 	splitPanel.RightBorderStartY = 2
 	contentSplit.RightBorderStartY = &splitPanel.RightBorderStartY

--- a/internal/ui/split_panel.go
+++ b/internal/ui/split_panel.go
@@ -7,6 +7,13 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
+const DefaultSidebarWidth = 30
+
+// MinSidebarWidth is the minimum width below which the sidebar resets to
+// DefaultSidebarWidth when toggled back on. This prevents the sidebar from
+// reopening at an unusably small width after being dragged nearly closed.
+const MinSidebarWidth = 10
+
 type SplitPanelWidget struct {
 	BaseWidget
 	Left              Widget
@@ -25,7 +32,7 @@ type SplitPanelWidget struct {
 
 func NewSplitPanelWidget() *SplitPanelWidget {
 	return &SplitPanelWidget{
-		DividerPos: 30,
+		DividerPos: DefaultSidebarWidth,
 		ShowLeft:   true,
 	}
 }

--- a/tests/e2e/sidebar_test.go
+++ b/tests/e2e/sidebar_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"strings"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
 )
 
 func TestSidebarTabClick(t *testing.T) {
@@ -134,5 +136,41 @@ func TestSidebarTabOverflow(t *testing.T) {
 
 	if len(h.app.Sidebar.TabBar.HiddenTabs) != 0 {
 		t.Errorf("expected 0 hidden tabs with default sidebar, got %d", len(h.app.Sidebar.TabBar.HiddenTabs))
+	}
+}
+
+func TestSidebarCollapseWidthReset(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	// Simulate dragging sidebar to a very small width (below MinSidebarWidth)
+	h.app.SetSidebarWidth(2)
+	if h.app.SplitPanel.DividerPos != 2 {
+		t.Fatalf("expected divider at 2, got %d", h.app.SplitPanel.DividerPos)
+	}
+
+	// Toggle sidebar off
+	h.exec("sidebar.toggle")
+	if h.app.Sidebar.Visible {
+		t.Fatal("sidebar should be hidden after toggle")
+	}
+
+	// Toggle sidebar back on — width should reset to default
+	h.exec("sidebar.toggle")
+	if !h.app.Sidebar.Visible {
+		t.Fatal("sidebar should be visible after second toggle")
+	}
+	if h.app.SplitPanel.DividerPos != ui.DefaultSidebarWidth {
+		t.Errorf("expected sidebar width to reset to %d after collapse, got %d",
+			ui.DefaultSidebarWidth, h.app.SplitPanel.DividerPos)
+	}
+
+	// Verify a width at or above the minimum is preserved
+	h.app.SetSidebarWidth(ui.MinSidebarWidth)
+	h.exec("sidebar.toggle")
+	h.exec("sidebar.toggle")
+	if h.app.SplitPanel.DividerPos != ui.MinSidebarWidth {
+		t.Errorf("expected sidebar width %d to be preserved, got %d",
+			ui.MinSidebarWidth, h.app.SplitPanel.DividerPos)
 	}
 }

--- a/tests/functional/sidebar-toggle.test.js
+++ b/tests/functional/sidebar-toggle.test.js
@@ -30,6 +30,33 @@ describe("sidebar toggle", () => {
     expect(snap2).toContain("Explore");
   });
 
+  it("should reset sidebar width after being narrowed below minimum", () => {
+    dir = createTempDir();
+    createTempFile(dir, "width.txt", "Width reset test");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    // Narrow sidebar to near-zero width using the command palette
+    for (let i = 0; i < 25; i++) {
+      tui.exec("Decrease Sidebar Width");
+      tui.waitStable(50);
+    }
+
+    // Toggle sidebar off
+    tui.press("ctrl+b");
+    tui.waitStable();
+    const hidden = tui.snapshot();
+    expect(hidden).not.toContain("Explore");
+
+    // Toggle sidebar back on — should reset to usable default width
+    tui.press("ctrl+b");
+    tui.waitFor("Explore");
+
+    const restored = tui.snapshot();
+    expect(restored).toContain("Explore");
+  });
+
   it("should switch sidebar panels with chord keys", () => {
     dir = createTempDir();
     createTempFile(dir, "panels.txt", "Panel test");


### PR DESCRIPTION
## Summary
- When the sidebar was dragged to a very small width (1-2 columns), then toggled off with Ctrl+B and back on, it reopened at the tiny width instead of a usable size
- `ShowSidebar()` now checks if `DividerPos` is below `MinSidebarWidth` (10) and resets it to `DefaultSidebarWidth` (30)
- Extracted magic number `30` into named constants `DefaultSidebarWidth` and `MinSidebarWidth` in `internal/ui/split_panel.go`

## Test plan
- [x] E2E test: `TestSidebarCollapseWidthReset` verifies width resets to default after collapse, and preserves width at/above the minimum
- [x] Functional test: narrows sidebar via command palette, toggles off/on, verifies "Explore" text is visible
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)