### PR TITLE
fix: make chord key matching case-insensitive for caps lock

### DIFF
--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"log/slog"
+	"unicode"
+
 	"github.com/eugenioenko/ttt/internal/term"
 
 	"github.com/gdamore/tcell/v2"
@@ -13,10 +15,10 @@ type Overlay struct {
 }
 
 type GlobalKeyBinding struct {
-	Key      tcell.Key
-	Mod      tcell.ModMask
-	Rune     rune
-	Handler  func()
+	Key     tcell.Key
+	Mod     tcell.ModMask
+	Rune    rune
+	Handler func()
 }
 
 type ChordKeyBinding struct {
@@ -30,19 +32,19 @@ type chordState struct {
 }
 
 type Root struct {
-	Main              Widget
-	Overlays          []Overlay
-	Focused           Widget
-	Width             int
-	Height            int
-	GlobalKeys        []GlobalKeyBinding
-	ForceKeys         []GlobalKeyBinding // checked even when focused widget wants raw keys
-	ChordKeys         []ChordKeyBinding
-	chord             *chordState
-	OnRightClick      func(mx, my int)
-	EscapeDismissers  []func() bool
-	EscapeFallback    func()
-	capturedWidget    Widget
+	Main             Widget
+	Overlays         []Overlay
+	Focused          Widget
+	Width            int
+	Height           int
+	GlobalKeys       []GlobalKeyBinding
+	ForceKeys        []GlobalKeyBinding // checked even when focused widget wants raw keys
+	ChordKeys        []ChordKeyBinding
+	chord            *chordState
+	OnRightClick     func(mx, my int)
+	EscapeDismissers []func() bool
+	EscapeFallback   func()
+	capturedWidget   Widget
 }
 
 func NewRoot(main Widget) *Root {
@@ -72,6 +74,18 @@ func matchKey(kev *tcell.EventKey, gk GlobalKeyBinding) bool {
 		return kev.Key() == gk.Key && kev.Modifiers() == gk.Mod
 	}
 	return kev.Key() == tcell.KeyRune && kev.Rune() == gk.Rune && kev.Modifiers() == gk.Mod
+}
+
+// matchKeyChord is like matchKey but compares rune keys case-insensitively.
+// This handles caps lock being on: e.g. chord "ctrl+k j" still matches when
+// caps lock sends uppercase "J" as the second key.
+func matchKeyChord(kev *tcell.EventKey, gk GlobalKeyBinding) bool {
+	if gk.Key != tcell.KeyRune {
+		return kev.Key() == gk.Key && kev.Modifiers() == gk.Mod
+	}
+	return kev.Key() == tcell.KeyRune &&
+		unicode.ToLower(kev.Rune()) == unicode.ToLower(gk.Rune) &&
+		kev.Modifiers() == gk.Mod
 }
 
 func (r *Root) HandleEvent(ev tcell.Event) EventResult {
@@ -189,7 +203,7 @@ func (r *Root) handleChord(kev *tcell.EventKey) EventResult {
 		var next []int
 		for _, ci := range r.chord.candidates {
 			chord := r.ChordKeys[ci]
-			if r.chord.stepIdx < len(chord.Steps) && matchKey(kev, chord.Steps[r.chord.stepIdx]) {
+			if r.chord.stepIdx < len(chord.Steps) && matchKeyChord(kev, chord.Steps[r.chord.stepIdx]) {
 				if r.chord.stepIdx+1 == len(chord.Steps) {
 					r.chord = nil
 					chord.Handler()
@@ -208,7 +222,7 @@ func (r *Root) handleChord(kev *tcell.EventKey) EventResult {
 
 	var candidates []int
 	for i, chord := range r.ChordKeys {
-		if len(chord.Steps) > 1 && matchKey(kev, chord.Steps[0]) {
+		if len(chord.Steps) > 1 && matchKeyChord(kev, chord.Steps[0]) {
 			candidates = append(candidates, i)
 		}
 	}

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -9,11 +9,11 @@ import (
 
 type mockWidget struct {
 	BaseWidget
-	lastEvent    tcell.Event
-	eventCount   int
-	rendered     bool
-	focusable    bool
-	renderChar   rune
+	lastEvent  tcell.Event
+	eventCount int
+	rendered   bool
+	focusable  bool
+	renderChar rune
 }
 
 func (m *mockWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -202,6 +202,55 @@ func TestChordSharedPrefix(t *testing.T) {
 	}
 	if !firedB {
 		t.Fatal("chord B should have fired")
+	}
+}
+
+func TestChordMatchesCaseInsensitive(t *testing.T) {
+	root := NewRoot(&mockWidget{})
+	root.SetSize(80, 24)
+	root.SetFocus(&mockWidget{focusable: true})
+
+	fired := false
+	// Register chord with lowercase rune second key: ctrl+k, j
+	root.AddChordKey([]GlobalKeyBinding{
+		{Key: tcell.KeyCtrlK, Mod: tcell.ModCtrl},
+		{Key: tcell.KeyRune, Rune: 'j'},
+	}, func() { fired = true })
+
+	// First step: ctrl+k
+	root.HandleEvent(makeKeyEvent(tcell.KeyCtrlK, tcell.ModCtrl))
+	if fired {
+		t.Fatal("chord should not fire after first key")
+	}
+
+	// Second step: uppercase J (simulating caps lock)
+	ev := tcell.NewEventKey(tcell.KeyRune, 'J', tcell.ModNone)
+	root.HandleEvent(ev)
+	if !fired {
+		t.Fatal("chord should fire with uppercase second key (caps lock)")
+	}
+}
+
+func TestChordMatchesCaseInsensitiveReverse(t *testing.T) {
+	root := NewRoot(&mockWidget{})
+	root.SetSize(80, 24)
+	root.SetFocus(&mockWidget{focusable: true})
+
+	fired := false
+	// Register chord with uppercase rune second key: ctrl+k, J
+	root.AddChordKey([]GlobalKeyBinding{
+		{Key: tcell.KeyCtrlK, Mod: tcell.ModCtrl},
+		{Key: tcell.KeyRune, Rune: 'J'},
+	}, func() { fired = true })
+
+	// First step: ctrl+k
+	root.HandleEvent(makeKeyEvent(tcell.KeyCtrlK, tcell.ModCtrl))
+
+	// Second step: lowercase j (caps lock off)
+	ev := tcell.NewEventKey(tcell.KeyRune, 'j', tcell.ModNone)
+	root.HandleEvent(ev)
+	if !fired {
+		t.Fatal("chord should fire with lowercase second key when registered as uppercase")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `matchKeyChord()` function that compares rune keys case-insensitively using `unicode.ToLower`, fixing chord bindings (e.g. `ctrl+k j`) failing when caps lock sends uppercase runes
- Only chord matching uses the case-insensitive variant; global keys and force keys remain case-sensitive
- Adds two unit tests: lowercase-registered chord matched with uppercase input, and vice versa

Closes #110

## Test plan
- [x] `TestChordMatchesCaseInsensitive` — registers chord with lowercase `j`, triggers with uppercase `J`
- [x] `TestChordMatchesCaseInsensitiveReverse` — registers chord with uppercase `J`, triggers with lowercase `j`
- [x] All existing chord tests continue to pass (exact-case matching still works)
- [x] `go build ./...` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)