### PR TITLE
feat: add category prefixes to command palette entries

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -218,7 +218,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.rename", Title: "Editor: Rename Symbol",
+		ID: "editor.rename", Title: "Source: Rename Symbol",
 		Handler: app.RenameSymbol,
 	})
 
@@ -295,7 +295,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "fold.toggle", Title: "Fold: Toggle Fold",
+		ID: "fold.toggle", Title: "Editor: Toggle Fold",
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -308,7 +308,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "fold.collapseAll", Title: "Fold: Fold All",
+		ID: "fold.collapseAll", Title: "Editor: Fold All",
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -322,7 +322,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "fold.expandAll", Title: "Fold: Unfold All",
+		ID: "fold.expandAll", Title: "Editor: Unfold All",
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -178,17 +178,17 @@ func registerEditorCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "editor.focus", Title: "Focus Editor",
+		ID: "editor.focus", Title: "View: Focus Editor",
 		Handler: app.FocusEditor,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.autocomplete", Title: "Trigger Autocomplete",
+		ID: "editor.autocomplete", Title: "Editor: Trigger Autocomplete",
 		Handler: app.TriggerAutocomplete,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.hover", Title: "Show Hover",
+		ID: "editor.hover", Title: "Editor: Show Hover",
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			line, col := app.EditorGroup.ActiveCursor()
@@ -198,32 +198,32 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.goToDefinition", Title: "Go to Definition",
+		ID: "editor.goToDefinition", Title: "Navigate: Go to Definition",
 		Handler: func() { app.withEditorLSP(app.RequestDefinition) },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.goToImplementation", Title: "Go to Implementation",
+		ID: "editor.goToImplementation", Title: "Navigate: Go to Implementation",
 		Handler: func() { app.withEditorLSP(app.RequestImplementation) },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.goToTypeDefinition", Title: "Go to Type Definition",
+		ID: "editor.goToTypeDefinition", Title: "Navigate: Go to Type Definition",
 		Handler: func() { app.withEditorLSP(app.RequestTypeDefinition) },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.findReferences", Title: "Find All References",
+		ID: "editor.findReferences", Title: "Navigate: Find All References",
 		Handler: func() { app.withEditorLSP(app.RequestReferences) },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.rename", Title: "Rename Symbol",
+		ID: "editor.rename", Title: "Editor: Rename Symbol",
 		Handler: app.RenameSymbol,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.organizeImports", Title: "Source Action: Organize Imports",
+		ID: "editor.organizeImports", Title: "Source: Organize Imports",
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			app.RequestCodeAction(path, lang, "source.organizeImports")
@@ -231,7 +231,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.fixAll", Title: "Source Action: Fix All",
+		ID: "editor.fixAll", Title: "Source: Fix All",
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			app.RequestCodeAction(path, lang, "source.fixAll")
@@ -239,7 +239,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.formatDocument", Title: "Source Action: Format Document",
+		ID: "editor.formatDocument", Title: "Source: Format Document",
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			app.RequestFormatting(path, lang)
@@ -247,32 +247,32 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.formatSelection", Title: "Source Action: Format Selection",
+		ID: "editor.formatSelection", Title: "Source: Format Selection",
 		Handler: app.FormatSelection,
 	})
 
 	reg.Register(command.Command{
-		ID: "tab.next", Title: "Next Tab",
+		ID: "tab.next", Title: "Tab: Next Tab",
 		Handler: func() { app.EditorGroup.NextTab() },
 	})
 
 	reg.Register(command.Command{
-		ID: "tab.prev", Title: "Previous Tab",
+		ID: "tab.prev", Title: "Tab: Previous Tab",
 		Handler: func() { app.EditorGroup.PrevTab() },
 	})
 
 	reg.Register(command.Command{
-		ID: "tab.close", Title: "Close Tab",
+		ID: "tab.close", Title: "Tab: Close Tab",
 		Handler: app.CloseTab,
 	})
 
 	reg.Register(command.Command{
-		ID: "tab.closeOthers", Title: "Close Other Tabs",
+		ID: "tab.closeOthers", Title: "Tab: Close Other Tabs",
 		Handler: func() { app.EditorGroup.CloseOtherTabs() },
 	})
 
 	reg.Register(command.Command{
-		ID: "tab.closeAll", Title: "Close All Tabs",
+		ID: "tab.closeAll", Title: "Tab: Close All Tabs",
 		Handler: func() { app.EditorGroup.CloseAllTabs() },
 	})
 
@@ -295,7 +295,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "fold.toggle", Title: "Toggle Fold",
+		ID: "fold.toggle", Title: "Fold: Toggle Fold",
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -308,7 +308,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "fold.collapseAll", Title: "Fold All",
+		ID: "fold.collapseAll", Title: "Fold: Fold All",
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -322,7 +322,7 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "fold.expandAll", Title: "Unfold All",
+		ID: "fold.expandAll", Title: "Fold: Unfold All",
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -335,156 +335,156 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "file.new", Title: "New File",
+		ID: "file.new", Title: "File: New File",
 		Handler: app.NewFile,
 	})
 
 	reg.Register(command.Command{
-		ID: "file.save", Title: "Save File",
+		ID: "file.save", Title: "File: Save File",
 		Handler: app.SaveFile,
 	})
 
 	reg.Register(command.Command{
-		ID: "file.saveAs", Title: "Save As...",
+		ID: "file.saveAs", Title: "File: Save As...",
 		Handler: app.SaveFileAs,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.undo", Title: "Undo",
+		ID: "editor.undo", Title: "Editor: Undo",
 		Handler: func() { app.EditorGroup.Undo() },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.redo", Title: "Redo",
+		ID: "editor.redo", Title: "Editor: Redo",
 		Handler: func() { app.EditorGroup.Redo() },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.selectAll", Title: "Select All",
+		ID: "editor.selectAll", Title: "Editor: Select All",
 		Handler: func() { app.EditorGroup.SelectAll() },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.copy", Title: "Copy",
+		ID: "editor.copy", Title: "Editor: Copy",
 		Handler: app.Copy,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.cut", Title: "Cut",
+		ID: "editor.cut", Title: "Editor: Cut",
 		Handler: app.Cut,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.paste", Title: "Paste",
+		ID: "editor.paste", Title: "Editor: Paste",
 		Handler: app.Paste,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.moveLineUp", Title: "Move Line Up",
+		ID: "editor.moveLineUp", Title: "Editor: Move Line Up",
 		Handler: func() { app.EditorGroup.MoveLineUp() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.moveLineDown", Title: "Move Line Down",
+		ID: "editor.moveLineDown", Title: "Editor: Move Line Down",
 		Handler: func() { app.EditorGroup.MoveLineDown() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.duplicateLine", Title: "Duplicate Line",
+		ID: "editor.duplicateLine", Title: "Editor: Duplicate Line",
 		Handler: func() { app.EditorGroup.DuplicateLine() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.deleteLine", Title: "Delete Line",
+		ID: "editor.deleteLine", Title: "Editor: Delete Line",
 		Handler: func() { app.EditorGroup.DeleteLine() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.joinLines", Title: "Join Lines",
+		ID: "editor.joinLines", Title: "Editor: Join Lines",
 		Handler: func() { app.EditorGroup.JoinLines() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.insertLineBelow", Title: "Insert Line Below",
+		ID: "editor.insertLineBelow", Title: "Editor: Insert Line Below",
 		Handler: func() { app.EditorGroup.InsertLineBelow() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.insertLineAbove", Title: "Insert Line Above",
+		ID: "editor.insertLineAbove", Title: "Editor: Insert Line Above",
 		Handler: func() { app.EditorGroup.InsertLineAbove() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.toggleComment", Title: "Toggle Line Comment",
+		ID: "editor.toggleComment", Title: "Editor: Toggle Line Comment",
 		Handler: func() { app.EditorGroup.ToggleLineComment() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.moveWordLeft", Title: "Move Word Left",
+		ID: "editor.moveWordLeft", Title: "Editor: Move Word Left",
 		Handler: func() { app.EditorGroup.MoveWordLeft(false) },
 	})
 	reg.Register(command.Command{
-		ID: "editor.moveWordRight", Title: "Move Word Right",
+		ID: "editor.moveWordRight", Title: "Editor: Move Word Right",
 		Handler: func() { app.EditorGroup.MoveWordRight(false) },
 	})
 	reg.Register(command.Command{
-		ID: "editor.selectWordLeft", Title: "Select Word Left",
+		ID: "editor.selectWordLeft", Title: "Editor: Select Word Left",
 		Handler: func() { app.EditorGroup.MoveWordLeft(true) },
 	})
 	reg.Register(command.Command{
-		ID: "editor.selectWordRight", Title: "Select Word Right",
+		ID: "editor.selectWordRight", Title: "Editor: Select Word Right",
 		Handler: func() { app.EditorGroup.MoveWordRight(true) },
 	})
 	reg.Register(command.Command{
-		ID: "editor.deleteWordLeft", Title: "Delete Word Left",
+		ID: "editor.deleteWordLeft", Title: "Editor: Delete Word Left",
 		Handler: func() { app.EditorGroup.DeleteWordLeft() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.deleteWordRight", Title: "Delete Word Right",
+		ID: "editor.deleteWordRight", Title: "Editor: Delete Word Right",
 		Handler: func() { app.EditorGroup.DeleteWordRight() },
 	})
 
 	reg.Register(command.Command{
-		ID: "multicursor.selectNext", Title: "Add Next Occurrence",
+		ID: "multicursor.selectNext", Title: "Editor: Add Next Occurrence",
 		Handler: func() { app.EditorGroup.SelectNextOccurrence() },
 	})
 	reg.Register(command.Command{
-		ID: "multicursor.selectAll", Title: "Select All Occurrences",
+		ID: "multicursor.selectAll", Title: "Editor: Select All Occurrences",
 		Handler: func() { app.EditorGroup.SelectAllOccurrences() },
 	})
 	reg.Register(command.Command{
-		ID: "multicursor.undoCursor", Title: "Undo Last Cursor",
+		ID: "multicursor.undoCursor", Title: "Editor: Undo Last Cursor",
 		Handler: func() { app.EditorGroup.UndoLastCursor() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.splitSelectionToLines", Title: "Split Selection into Lines",
+		ID: "editor.splitSelectionToLines", Title: "Editor: Split Selection into Lines",
 		Handler: func() { app.EditorGroup.SplitSelectionToLines() },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.sortLinesAsc", Title: "Sort Lines Ascending",
+		ID: "editor.sortLinesAsc", Title: "Editor: Sort Lines Ascending",
 		Handler: func() { app.EditorGroup.SortLinesAsc() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.sortLinesDesc", Title: "Sort Lines Descending",
+		ID: "editor.sortLinesDesc", Title: "Editor: Sort Lines Descending",
 		Handler: func() { app.EditorGroup.SortLinesDesc() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.reverseLines", Title: "Reverse Lines",
+		ID: "editor.reverseLines", Title: "Editor: Reverse Lines",
 		Handler: func() { app.EditorGroup.ReverseLines() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.uniqueLines", Title: "Unique Lines",
+		ID: "editor.uniqueLines", Title: "Editor: Unique Lines",
 		Handler: func() { app.EditorGroup.UniqueLines() },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.upperCase", Title: "Transform to Uppercase",
+		ID: "editor.upperCase", Title: "Editor: Transform to Uppercase",
 		Handler: func() { app.EditorGroup.UpperCase() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.lowerCase", Title: "Transform to Lowercase",
+		ID: "editor.lowerCase", Title: "Editor: Transform to Lowercase",
 		Handler: func() { app.EditorGroup.LowerCase() },
 	})
 	reg.Register(command.Command{
-		ID: "editor.titleCase", Title: "Transform to Titlecase",
+		ID: "editor.titleCase", Title: "Editor: Transform to Titlecase",
 		Handler: func() { app.EditorGroup.TitleCase() },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.quit", Title: "Quit",
+		ID: "editor.quit", Title: "File: Quit",
 		Handler: app.Quit,
 	})
 }

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -92,32 +92,32 @@ func registerExplorerCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "explorer.refresh", Title: "Refresh Explorer",
+		ID: "explorer.refresh", Title: "Explorer: Refresh Explorer",
 		Handler: func() { app.Explorer.Reload() },
 	})
 
 	reg.Register(command.Command{
-		ID: "explorer.open", Title: "Open",
+		ID: "explorer.open", Title: "Explorer: Open",
 		Handler: func() { app.Explorer.ActivateSelected() },
 	})
 
 	reg.Register(command.Command{
-		ID: "explorer.newFile", Title: "New File",
+		ID: "explorer.newFile", Title: "Explorer: New File",
 		Handler: app.ExplorerNewFile,
 	})
 
 	reg.Register(command.Command{
-		ID: "explorer.newFolder", Title: "New Folder",
+		ID: "explorer.newFolder", Title: "Explorer: New Folder",
 		Handler: app.ExplorerNewFolder,
 	})
 
 	reg.Register(command.Command{
-		ID: "explorer.rename", Title: "Rename",
+		ID: "explorer.rename", Title: "Explorer: Rename",
 		Handler: app.ExplorerRename,
 	})
 
 	reg.Register(command.Command{
-		ID: "explorer.delete", Title: "Delete",
+		ID: "explorer.delete", Title: "Explorer: Delete",
 		Handler: app.ExplorerDelete,
 	})
 }

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -264,27 +264,27 @@ func registerWorkspaceCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "workspace.openFolder", Title: "Open Folder",
+		ID: "workspace.openFolder", Title: "File: Open Folder",
 		Handler: app.OpenFolder,
 	})
 
 	reg.Register(command.Command{
-		ID: "workspace.addFolder", Title: "Add Folder",
+		ID: "workspace.addFolder", Title: "File: Add Folder",
 		Handler: app.AddWorkspaceFolder,
 	})
 
 	reg.Register(command.Command{
-		ID: "workspace.removeFolder", Title: "Remove Folder",
+		ID: "workspace.removeFolder", Title: "File: Remove Folder",
 		Handler: app.RemoveWorkspaceFolder,
 	})
 
 	reg.Register(command.Command{
-		ID: "workspace.open", Title: "Open Workspace",
+		ID: "workspace.open", Title: "File: Open Workspace",
 		Handler: app.OpenWorkspace,
 	})
 
 	reg.Register(command.Command{
-		ID: "workspace.save", Title: "Save Workspace",
+		ID: "workspace.save", Title: "File: Save Workspace",
 		Handler: app.SaveWorkspace,
 	})
 }

--- a/internal/app/commands_palette.go
+++ b/internal/app/commands_palette.go
@@ -130,22 +130,22 @@ func registerPaletteCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "command.palette", Title: "Command Palette",
+		ID: "command.palette", Title: "View: Command Palette",
 		Handler: func() { app.OpenCommandPalette(false) },
 	})
 
 	reg.Register(command.Command{
-		ID: "file.quickOpen", Title: "Go to File",
+		ID: "file.quickOpen", Title: "File: Go to File",
 		Handler: func() { app.OpenCommandPalette(true) },
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.goToLine", Title: "Go to Line",
+		ID: "editor.goToLine", Title: "Navigate: Go to Line",
 		Handler: func() { app.OpenCommandPalette(false, ":") },
 	})
 
 	reg.Register(command.Command{
-		ID: "theme.switch", Title: "Switch Theme",
+		ID: "theme.switch", Title: "Preferences: Switch Theme",
 		Handler: app.ShowThemePicker,
 	})
 
@@ -153,12 +153,12 @@ func registerPaletteCommands(app *App) {
 	app.StatusBar.OnEolClick = app.ShowEolPicker
 
 	reg.Register(command.Command{
-		ID: "editor.indentation", Title: "Change Indentation",
+		ID: "editor.indentation", Title: "Preferences: Change Indentation",
 		Handler: app.ShowIndentPicker,
 	})
 
 	reg.Register(command.Command{
-		ID: "editor.lineEnding", Title: "Change Line Ending",
+		ID: "editor.lineEnding", Title: "Preferences: Change Line Ending",
 		Handler: app.ShowEolPicker,
 	})
 

--- a/internal/app/commands_search.go
+++ b/internal/app/commands_search.go
@@ -82,42 +82,42 @@ func registerSearchCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "search.find", Title: "Find",
+		ID: "search.find", Title: "Search: Find",
 		Handler: app.OpenFind,
 	})
 
 	reg.Register(command.Command{
-		ID: "search.findNext", Title: "Find Next",
+		ID: "search.findNext", Title: "Search: Find Next",
 		Handler: func() { app.EditorGroup.FindNext() },
 	})
 
 	reg.Register(command.Command{
-		ID: "search.findPrev", Title: "Find Previous",
+		ID: "search.findPrev", Title: "Search: Find Previous",
 		Handler: func() { app.EditorGroup.FindPrev() },
 	})
 
 	reg.Register(command.Command{
-		ID: "search.clearFind", Title: "Clear Find Highlights",
+		ID: "search.clearFind", Title: "Search: Clear Find Highlights",
 		Handler: func() { app.EditorGroup.ClearSearch() },
 	})
 
 	reg.Register(command.Command{
-		ID: "search.replace", Title: "Find and Replace",
+		ID: "search.replace", Title: "Search: Find and Replace",
 		Handler: app.OpenFindReplace,
 	})
 
 	reg.Register(command.Command{
-		ID: "search.expandAll", Title: "Expand All Search Results",
+		ID: "search.expandAll", Title: "Search: Expand All Search Results",
 		Handler: func() { app.Search.ExpandAll() },
 	})
 
 	reg.Register(command.Command{
-		ID: "search.collapseAll", Title: "Collapse All Search Results",
+		ID: "search.collapseAll", Title: "Search: Collapse All Search Results",
 		Handler: func() { app.Search.CollapseAll() },
 	})
 
 	reg.Register(command.Command{
-		ID: "search.clear", Title: "Clear Search Results",
+		ID: "search.clear", Title: "Search: Clear Search Results",
 		Handler: app.ClearGlobalSearch,
 	})
 }

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -70,12 +70,12 @@ func registerViewCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "sidebar.toggle", Title: "Toggle Sidebar",
+		ID: "sidebar.toggle", Title: "View: Toggle Sidebar",
 		Handler: app.ToggleSidebar,
 	})
 
 	reg.Register(command.Command{
-		ID: "sidebar.explorer", Title: "Show Explorer",
+		ID: "sidebar.explorer", Title: "View: Show Explorer",
 		Handler: func() {
 			app.Explorer.Reload()
 			app.ShowPanel("explorer", app.Explorer)
@@ -83,19 +83,19 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "sidebar.search", Title: "Show Search",
+		ID: "sidebar.search", Title: "View: Show Search",
 		Handler: func() {
 			app.ShowPanel("search", app.Search)
 		},
 	})
 
 	reg.Register(command.Command{
-		ID: "sidebar.searchReplace", Title: "Search and Replace in Files",
+		ID: "sidebar.searchReplace", Title: "Search: Search and Replace in Files",
 		Handler: app.ToggleSearchReplace,
 	})
 
 	reg.Register(command.Command{
-		ID: "sidebar.changes", Title: "Show Changes",
+		ID: "sidebar.changes", Title: "View: Show Changes",
 		Handler: func() {
 			app.Changes.Refresh()
 			app.ShowPanel("changes", app.Changes)
@@ -103,7 +103,7 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "sidebar.wider", Title: "Increase Sidebar Width",
+		ID: "sidebar.wider", Title: "View: Increase Sidebar Width",
 		Handler: func() {
 			if app.Sidebar.Visible {
 				app.SetSidebarWidth(app.SplitPanel.DividerPos + 1)
@@ -112,7 +112,7 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "sidebar.narrower", Title: "Decrease Sidebar Width",
+		ID: "sidebar.narrower", Title: "View: Decrease Sidebar Width",
 		Handler: func() {
 			if app.Sidebar.Visible {
 				app.SetSidebarWidth(app.SplitPanel.DividerPos - 1)
@@ -121,47 +121,47 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "sidebar.focus", Title: "Focus Sidebar",
+		ID: "sidebar.focus", Title: "View: Focus Sidebar",
 		Handler: app.FocusSidebar,
 	})
 
 	reg.Register(command.Command{
-		ID: "panel.toggle", Title: "Toggle Panel",
+		ID: "panel.toggle", Title: "View: Toggle Panel",
 		Handler: app.ToggleBottomPanel,
 	})
 
 	reg.Register(command.Command{
-		ID: "panel.focus", Title: "Focus Panel",
+		ID: "panel.focus", Title: "View: Focus Panel",
 		Handler: app.FocusPanel,
 	})
 
 	reg.Register(command.Command{
-		ID: "terminal.new", Title: "New Terminal",
+		ID: "terminal.new", Title: "Terminal: New Terminal",
 		Handler: app.SpawnTerminal,
 	})
 
 	reg.Register(command.Command{
-		ID: "terminal.toggle", Title: "Toggle Terminal",
+		ID: "terminal.toggle", Title: "Terminal: Toggle Terminal",
 		Handler: app.ToggleTerminal,
 	})
 
 	reg.Register(command.Command{
-		ID: "terminal.fullscreen", Title: "Toggle Terminal Fullscreen",
+		ID: "terminal.fullscreen", Title: "Terminal: Toggle Terminal Fullscreen",
 		Handler: app.ToggleTerminalFullscreen,
 	})
 
 	reg.Register(command.Command{
-		ID: "terminal.closeAll", Title: "Close All Terminals",
+		ID: "terminal.closeAll", Title: "Terminal: Close All Terminals",
 		Handler: app.CloseAllTerminals,
 	})
 
 	reg.Register(command.Command{
-		ID: "view.keyboardTester", Title: "Keyboard Tester",
+		ID: "view.keyboardTester", Title: "View: Keyboard Tester",
 		Handler: app.ShowKeyboardTester,
 	})
 
 	reg.Register(command.Command{
-		ID: "about", Title: "About ttt",
+		ID: "about", Title: "Help: About ttt",
 		Handler: func() {
 			OpenURL("https://github.com/eugenioenko/ttt")
 		},

--- a/internal/ui/palette_widget.go
+++ b/internal/ui/palette_widget.go
@@ -170,7 +170,18 @@ func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
 		}
 
 		surface.ClearRect(boxX+1, y, contentRight-boxX-1, 1, style)
-		surface.DrawText(boxX+2, y, item.Label, contentRight-1, style)
+		if colonIdx := strings.Index(item.Label, ": "); colonIdx >= 0 {
+			prefix := item.Label[:colonIdx+2]
+			rest := item.Label[colonIdx+2:]
+			prefixStyle := term.StyleMuted
+			if idx == p.Selected {
+				prefixStyle = style
+			}
+			surface.DrawText(boxX+2, y, prefix, contentRight-1, prefixStyle)
+			surface.DrawText(boxX+2+len([]rune(prefix)), y, rest, contentRight-1, style)
+		} else {
+			surface.DrawText(boxX+2, y, item.Label, contentRight-1, style)
+		}
 
 		if item.Detail != "" {
 			detailStyle := term.StyleMuted

--- a/tests/functional/case-transform.test.js
+++ b/tests/functional/case-transform.test.js
@@ -20,7 +20,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Uppercase");
+    tui.exec("Editor: Transform to Uppercase");
     tui.waitStable();
 
     const snap = tui.snapshot();
@@ -37,7 +37,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Lowercase");
+    tui.exec("Editor: Transform to Lowercase");
     tui.waitStable();
 
     const snap = tui.snapshot();
@@ -54,7 +54,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Titlecase");
+    tui.exec("Editor: Transform to Titlecase");
     tui.waitStable();
 
     const snap = tui.snapshot();
@@ -71,7 +71,7 @@ describe("case transforms", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Transform to Uppercase");
+    tui.exec("Editor: Transform to Uppercase");
     tui.waitStable();
 
     let snap = tui.snapshot();

--- a/tests/functional/code-folding.test.js
+++ b/tests/functional/code-folding.test.js
@@ -35,14 +35,14 @@ describe("code folding", () => {
     tui.press("enter");
     tui.waitStable();
 
-    tui.exec("Toggle Fold");
+    tui.exec("Fold: Toggle Fold");
     tui.waitStable();
 
     let snap = tui.snapshot();
     expect(snap).not.toContain("hello");
     expect(snap).toContain("⋯");
 
-    tui.exec("Toggle Fold");
+    tui.exec("Fold: Toggle Fold");
     tui.waitStable();
 
     snap = tui.snapshot();
@@ -84,7 +84,7 @@ describe("code folding", () => {
     tui.press("enter");
     tui.waitStable();
 
-    tui.exec("Toggle Fold");
+    tui.exec("Fold: Toggle Fold");
     tui.waitStable();
 
     const snap = tui.snapshot();

--- a/tests/functional/code-folding.test.js
+++ b/tests/functional/code-folding.test.js
@@ -35,14 +35,14 @@ describe("code folding", () => {
     tui.press("enter");
     tui.waitStable();
 
-    tui.exec("Fold: Toggle Fold");
+    tui.exec("Editor: Toggle Fold");
     tui.waitStable();
 
     let snap = tui.snapshot();
     expect(snap).not.toContain("hello");
     expect(snap).toContain("⋯");
 
-    tui.exec("Fold: Toggle Fold");
+    tui.exec("Editor: Toggle Fold");
     tui.waitStable();
 
     snap = tui.snapshot();
@@ -84,7 +84,7 @@ describe("code folding", () => {
     tui.press("enter");
     tui.waitStable();
 
-    tui.exec("Fold: Toggle Fold");
+    tui.exec("Editor: Toggle Fold");
     tui.waitStable();
 
     const snap = tui.snapshot();

--- a/tests/functional/command-palette.test.js
+++ b/tests/functional/command-palette.test.js
@@ -31,11 +31,29 @@ describe("command palette", () => {
     tui.start(dir);
     tui.waitFor("Explore");
 
-    tui.exec("Toggle Sidebar");
+    tui.exec("View: Toggle Sidebar");
     tui.waitStable();
 
     const snap = tui.snapshot();
     expect(snap).not.toContain("Explore");
+  });
+
+  it("should filter commands by category prefix", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "prefix.txt", "Prefix test");
+
+    tui.start(file);
+    tui.waitFor("prefix.txt");
+
+    tui.press("ctrl+p");
+    tui.waitStable();
+
+    tui.type("Editor:");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("Editor:");
+    expect(snap).toContain("Undo");
   });
 
   it("should dismiss palette with escape", () => {

--- a/tests/functional/duplicate-line.test.js
+++ b/tests/functional/duplicate-line.test.js
@@ -20,7 +20,7 @@ describe("duplicate line", () => {
     tui.press("arrow_down");
     tui.waitStable();
 
-    tui.exec("Duplicate Line");
+    tui.exec("Editor: Duplicate Line");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -40,7 +40,7 @@ describe("duplicate line", () => {
     tui.press("arrow_down");
     tui.waitStable();
 
-    tui.exec("Duplicate Line");
+    tui.exec("Editor: Duplicate Line");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -57,7 +57,7 @@ describe("duplicate line", () => {
     tui.start(file);
     tui.waitFor("Only");
 
-    tui.exec("Duplicate Line");
+    tui.exec("Editor: Duplicate Line");
     tui.waitStable();
 
     tui.press("ctrl+z");

--- a/tests/functional/line-endings.test.js
+++ b/tests/functional/line-endings.test.js
@@ -71,7 +71,7 @@ describe("line ending detection and preservation", () => {
     let snap = tui.snapshot();
     expect(snap).not.toContain("CRLF");
 
-    tui.exec("Change Line Ending");
+    tui.exec("Preferences: Change Line Ending");
     tui.waitStable();
     tui.type("CRLF");
     tui.waitStable();
@@ -97,7 +97,7 @@ describe("line ending detection and preservation", () => {
     tui.waitFor("aaa");
     tui.waitFor("CRLF");
 
-    tui.exec("Change Line Ending");
+    tui.exec("Preferences: Change Line Ending");
     tui.waitStable();
     tui.type("LF");
     tui.waitStable();

--- a/tests/functional/move-line.test.js
+++ b/tests/functional/move-line.test.js
@@ -17,7 +17,7 @@ describe("move line", () => {
     tui.start(file);
     tui.waitFor("AAA");
 
-    tui.exec("Move Line Down");
+    tui.exec("Editor: Move Line Down");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -38,7 +38,7 @@ describe("move line", () => {
     tui.press("arrow_down");
     tui.waitStable();
 
-    tui.exec("Move Line Up");
+    tui.exec("Editor: Move Line Up");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -55,7 +55,7 @@ describe("move line", () => {
     tui.start(file);
     tui.waitFor("First");
 
-    tui.exec("Move Line Up");
+    tui.exec("Editor: Move Line Up");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -72,7 +72,7 @@ describe("move line", () => {
     tui.start(file);
     tui.waitFor("One");
 
-    tui.exec("Move Line Down");
+    tui.exec("Editor: Move Line Down");
     tui.waitStable();
 
     tui.press("ctrl+z");

--- a/tests/functional/multi-cursor.test.js
+++ b/tests/functional/multi-cursor.test.js
@@ -46,7 +46,7 @@ describe("multi-cursor", () => {
     tui.press("ctrl+d");
     tui.waitStable();
 
-    tui.exec("Select All Occurrences");
+    tui.exec("Editor: Select All Occurrences");
     tui.waitStable();
 
     tui.type("pet");

--- a/tests/functional/sort-lines.test.js
+++ b/tests/functional/sort-lines.test.js
@@ -20,7 +20,7 @@ describe("sort lines", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Sort Lines Ascending");
+    tui.exec("Editor: Sort Lines Ascending");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -41,7 +41,7 @@ describe("sort lines", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Sort Lines Descending");
+    tui.exec("Editor: Sort Lines Descending");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -62,7 +62,7 @@ describe("sort lines", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Reverse Lines");
+    tui.exec("Editor: Reverse Lines");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -87,7 +87,7 @@ describe("sort lines", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Unique Lines");
+    tui.exec("Editor: Unique Lines");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -129,7 +129,7 @@ describe("sort lines", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Sort Lines Ascending");
+    tui.exec("Editor: Sort Lines Ascending");
     tui.waitStable();
 
     // Undo

--- a/tests/functional/split-selection.test.js
+++ b/tests/functional/split-selection.test.js
@@ -21,7 +21,7 @@ describe("split selection into lines", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Split Selection into Lines");
+    tui.exec("Editor: Split Selection into Lines");
     tui.waitStable();
 
     // Type 'X' — should appear on each of the 3 lines with cursors
@@ -44,7 +44,7 @@ describe("split selection into lines", () => {
     tui.start(file);
     tui.waitFor("hello");
 
-    tui.exec("Split Selection into Lines");
+    tui.exec("Editor: Split Selection into Lines");
     tui.waitStable();
 
     // Type 'Z' — should only appear once (single cursor)

--- a/tests/functional/toggle-comment.test.js
+++ b/tests/functional/toggle-comment.test.js
@@ -20,7 +20,7 @@ describe("toggle line comment", () => {
     tui.start(file);
     tui.waitFor("package main");
 
-    tui.exec("Toggle Line Comment");
+    tui.exec("Editor: Toggle Line Comment");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -38,7 +38,7 @@ describe("toggle line comment", () => {
     tui.start(file);
     tui.waitFor("// package main");
 
-    tui.exec("Toggle Line Comment");
+    tui.exec("Editor: Toggle Line Comment");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -60,7 +60,7 @@ describe("toggle line comment", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Toggle Line Comment");
+    tui.exec("Editor: Toggle Line Comment");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -83,7 +83,7 @@ describe("toggle line comment", () => {
     tui.press("ctrl+a");
     tui.waitStable();
 
-    tui.exec("Toggle Line Comment");
+    tui.exec("Editor: Toggle Line Comment");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -104,7 +104,7 @@ describe("toggle line comment", () => {
     tui.start(file);
     tui.waitFor("print");
 
-    tui.exec("Toggle Line Comment");
+    tui.exec("Editor: Toggle Line Comment");
     tui.waitStable();
 
     tui.press("ctrl+s");

--- a/tests/functional/word-delete.test.js
+++ b/tests/functional/word-delete.test.js
@@ -20,7 +20,7 @@ describe("word delete", () => {
     tui.press("end");
     tui.waitStable();
 
-    tui.exec("Delete Word Left");
+    tui.exec("Editor: Delete Word Left");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -40,7 +40,7 @@ describe("word delete", () => {
     tui.press("home");
     tui.waitStable();
 
-    tui.exec("Delete Word Right");
+    tui.exec("Editor: Delete Word Right");
     tui.waitStable();
 
     tui.press("ctrl+s");
@@ -60,7 +60,7 @@ describe("word delete", () => {
     tui.press("end");
     tui.waitStable();
 
-    tui.exec("Delete Word Left");
+    tui.exec("Editor: Delete Word Left");
     tui.waitStable();
 
     tui.press("ctrl+z");


### PR DESCRIPTION
## Summary

- Add category prefixes to all command palette entries for better discoverability and organization
- Categories: `Editor:`, `File:`, `View:`, `Search:`, `Tab:`, `Git:`, `Source:`, `Navigate:`, `Fold:`, `Terminal:`, `Explorer:`, `Preferences:`, `Help:`
- Update all functional tests to match new prefixed titles
- Add functional test verifying prefix-based filtering (type "Editor:" to filter)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (unit + E2E)
- [ ] `cd tests/functional && pnpm test` passes (functional blackbox tests)
- [ ] Open command palette and verify entries show category prefixes
- [ ] Type a prefix like "Editor:" and verify filtering works

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)