### PR TITLE
fix: widget UX polish — find bar, autocomplete, scrollbar

### DIFF
--- a/internal/ui/autocomplete_widget.go
+++ b/internal/ui/autocomplete_widget.go
@@ -23,7 +23,30 @@ const (
 	CompletionModule
 )
 
-func (k CompletionKind) Symbol() rune { return '■' }
+func (k CompletionKind) Symbol() rune {
+	switch k {
+	case CompletionFunction:
+		return 'f'
+	case CompletionMethod:
+		return 'm'
+	case CompletionVariable:
+		return 'v'
+	case CompletionConstant:
+		return 'c'
+	case CompletionType:
+		return 'C'
+	case CompletionField:
+		return 'p'
+	case CompletionKeyword:
+		return 'k'
+	case CompletionSnippet:
+		return 'S'
+	case CompletionModule:
+		return 'M'
+	default:
+		return '■'
+	}
+}
 
 func (k CompletionKind) Style() term.Style {
 	switch k {

--- a/internal/ui/findbar_widget.go
+++ b/internal/ui/findbar_widget.go
@@ -63,7 +63,13 @@ func (f *FindBarWidget) syncActions() {
 
 func (f *FindBarWidget) barLayout() (barX, barY, barW, barH int) {
 	r := f.GetRect()
-	barW = 40
+	barW = r.W / 2
+	if barW > 80 {
+		barW = 80
+	}
+	if barW < 30 {
+		barW = 30
+	}
 	if barW > r.W-4 {
 		barW = r.W - 4
 	}
@@ -92,7 +98,13 @@ func (f *FindBarWidget) CursorPosition() (int, int, bool) {
 func (f *FindBarWidget) Render(surface *RenderSurface) {
 	sw, _ := surface.Size()
 
-	barW := 40
+	barW := sw / 2
+	if barW > 80 {
+		barW = 80
+	}
+	if barW < 30 {
+		barW = 30
+	}
 	if barW > sw-4 {
 		barW = sw - 4
 	}
@@ -127,9 +139,13 @@ func (f *FindBarWidget) Render(surface *RenderSurface) {
 	f.Input.Render(surface, barX+1, row, inputW)
 
 	cx := barX + 1 + inputW
+	infoStyle := term.StyleMuted
+	if f.Input.Text != "" && len(f.Matches) == 0 {
+		infoStyle = term.StyleDanger
+	}
 	for _, ch := range info {
 		if cx < barX+barW-1 {
-			surface.SetCell(cx, row, term.Cell{Ch: ch, Style: term.StyleMuted})
+			surface.SetCell(cx, row, term.Cell{Ch: ch, Style: infoStyle})
 			cx++
 		}
 	}
@@ -144,8 +160,8 @@ func (f *FindBarWidget) Render(surface *RenderSurface) {
 	f.btnPrev = HitRegion{}
 	f.btnNext = HitRegion{}
 	if hasMatches {
-		f.btnPrev = HitRegion{X: navStart + 1, Y: row, W: 1}
-		f.btnNext = HitRegion{X: navStart + 3, Y: row, W: 1}
+		f.btnPrev = HitRegion{X: navStart, Y: row, W: 3}
+		f.btnNext = HitRegion{X: navStart + 2, Y: row, W: 3}
 	}
 	closeStart := cx
 	for _, ch := range closeBtn {
@@ -154,7 +170,7 @@ func (f *FindBarWidget) Render(surface *RenderSurface) {
 			cx++
 		}
 	}
-	f.btnClose = HitRegion{X: closeStart + 1, Y: row, W: 1}
+	f.btnClose = HitRegion{X: closeStart, Y: row, W: 3}
 }
 
 func (f *FindBarWidget) currentDisplay() int {

--- a/internal/ui/replacebar_widget.go
+++ b/internal/ui/replacebar_widget.go
@@ -78,7 +78,13 @@ func (r *ReplaceBarWidget) syncActions() {
 
 func (r *ReplaceBarWidget) barLayout() (barX, barY, barW, barH int) {
 	rect := r.GetRect()
-	barW = 40
+	barW = rect.W / 2
+	if barW > 80 {
+		barW = 80
+	}
+	if barW < 30 {
+		barW = 30
+	}
 	if barW > rect.W-4 {
 		barW = rect.W - 4
 	}
@@ -108,7 +114,13 @@ func (r *ReplaceBarWidget) CursorPosition() (int, int, bool) {
 func (r *ReplaceBarWidget) Render(surface *RenderSurface) {
 	sw, _ := surface.Size()
 
-	barW := 40
+	barW := sw / 2
+	if barW > 80 {
+		barW = 80
+	}
+	if barW < 30 {
+		barW = 30
+	}
 	if barW > sw-4 {
 		barW = sw - 4
 	}
@@ -139,9 +151,13 @@ func (r *ReplaceBarWidget) Render(surface *RenderSurface) {
 	r.SearchInput.Render(surface, barX+1, findRow, searchInputW)
 
 	cx := barX + 1 + searchInputW
+	infoStyle := term.StyleMuted
+	if r.SearchInput.Text != "" && len(r.Matches) == 0 {
+		infoStyle = term.StyleDanger
+	}
 	for _, ch := range info {
 		if cx < barX+barW-1 {
-			surface.SetCell(cx, findRow, term.Cell{Ch: ch, Style: term.StyleMuted})
+			surface.SetCell(cx, findRow, term.Cell{Ch: ch, Style: infoStyle})
 			cx++
 		}
 	}
@@ -153,9 +169,9 @@ func (r *ReplaceBarWidget) Render(surface *RenderSurface) {
 			cx++
 		}
 	}
-	r.btnPrev = HitRegion{X: navStart + 1, Y: findRow, W: 1}
-	r.btnNext = HitRegion{X: navStart + 3, Y: findRow, W: 1}
-	r.btnClose = HitRegion{X: navStart + 5, Y: findRow, W: 1}
+	r.btnPrev = HitRegion{X: navStart, Y: findRow, W: 3}
+	r.btnNext = HitRegion{X: navStart + 2, Y: findRow, W: 3}
+	r.btnClose = HitRegion{X: navStart + 4, Y: findRow, W: 3}
 
 	replInputW := barW - 2
 	r.ReplaceInput.Render(surface, barX+1, replRow, replInputW)

--- a/internal/ui/scrollbar.go
+++ b/internal/ui/scrollbar.go
@@ -45,7 +45,7 @@ func (s *Scrollbar) Render(surface *RenderSurface, rx, ry int) {
 		if y >= thumbTop && y < thumbTop+thumbH {
 			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbarThumb})
 		} else {
-			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbar})
+			surface.SetCell(rx, ry+y, term.Cell{Ch: '░', Style: term.StyleScrollbar})
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- **Find/replace bar width scales with terminal width** — proportional to editor width (50%, min 30, max 80) instead of hardcoded 40 columns
- **Wider hit targets for find bar navigation buttons** — expanded from 1 to 3 cells for prev/next/close buttons in both find bar and replace bar
- **Visual feedback for no search matches** — match counter renders in `StyleDanger` color when query is non-empty but has zero matches
- **Distinct autocomplete completion kind symbols** — each kind gets a unique character (f=function, m=method, v=variable, c=constant, C=type, p=field, k=keyword, S=snippet, M=module) instead of all using `■`
- **Scrollbar track uses light shade character** — track uses `░` while thumb keeps `█` for better visual contrast across themes

Closes #122

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages including e2e)
- [ ] Manual: resize terminal and verify find bar scales proportionally
- [ ] Manual: click near (not exactly on) nav buttons in find bar — should register
- [ ] Manual: search for a non-existent string — counter should appear in red/danger color
- [ ] Manual: trigger autocomplete with LSP — verify different kind symbols appear
- [ ] Manual: scroll a long file — verify scrollbar track is visually distinct from thumb

🤖 Generated with [Claude Code](https://claude.com/claude-code)