### PR TITLE
feat: add Help action to sidebar panel dropdowns

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -23,6 +23,8 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			{Label: "New File", Command: "file.new"},
 			{Label: "Add Folder", Command: "workspace.addFolder"},
 			{Label: "Refresh", Command: "explorer.refresh"},
+			ui.MenuSep(),
+			{Label: "Help", Command: "explorer.help"},
 		}
 	case "search":
 		replaceLabel := "Replace"
@@ -36,6 +38,8 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			{Label: "Collapse All", Command: "search.collapseAll"},
 			ui.MenuSep(),
 			{Label: "Clear Results", Command: "search.clear"},
+			ui.MenuSep(),
+			{Label: "Help", Command: "search.help"},
 		}
 	case "changes":
 		items = []ui.ContextMenuItem{
@@ -44,6 +48,8 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			{Label: "Pull", Command: "git.pull"},
 			{Label: "Push", Command: "git.push"},
 			{Label: "Sync", Command: "git.sync"},
+			ui.MenuSep(),
+			{Label: "Help", Command: "changes.help"},
 		}
 	}
 	if len(items) > 0 {

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -17,6 +17,7 @@ func RegisterCommands(app *App) {
 	registerGitCommands(app)
 	registerWorkspaceCommands(app)
 	registerPRCommands(app)
+	registerHelpCommands(app)
 	registerWidgetCallbacks(app)
 	RegisterEscapeDismissers(app)
 }

--- a/internal/app/commands_help.go
+++ b/internal/app/commands_help.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+var explorerHelpEntries = []ui.HelpEntry{
+	{Key: "Enter", Desc: "Open file or toggle folder"},
+	{Key: "Space", Desc: "Open file or toggle folder"},
+	{Key: "Left", Desc: "Collapse folder"},
+	{Key: "Right", Desc: "Expand folder"},
+	{Key: "Up / Down", Desc: "Navigate items"},
+}
+
+var searchHelpEntries = []ui.HelpEntry{
+	{Key: "Enter", Desc: "Activate selected result"},
+	{Key: "Up / Down", Desc: "Navigate results"},
+	{Key: "Tab", Desc: "Next input field"},
+	{Key: "Shift+Tab", Desc: "Previous input field"},
+	{Key: "Alt+c", Desc: "Toggle case sensitivity"},
+	{Key: "Alt+r", Desc: "Toggle regex mode"},
+}
+
+var changesHelpEntries = []ui.HelpEntry{
+	{Key: "Space", Desc: "Toggle stage/unstage file"},
+	{Key: "a", Desc: "Stage all files"},
+	{Key: "u", Desc: "Unstage all files"},
+	{Key: "d", Desc: "Discard selected file"},
+	{Key: "D", Desc: "Discard all files in group"},
+	{Key: "r", Desc: "Refresh changes"},
+	{Key: "o / v", Desc: "Open file"},
+	{Key: "c", Desc: "Open compact diff"},
+	{Key: "e", Desc: "Open extended diff"},
+	{Key: "Enter", Desc: "Open compact diff"},
+	{Key: "Up / Down", Desc: "Navigate files"},
+}
+
+func (a *App) ShowPanelHelp(title string, entries []ui.HelpEntry) {
+	dialog := ui.NewHelpDialogWidget(title, entries)
+	dialog.Borders = a.Borders
+	dialog.OnDismiss = func() {
+		a.DismissDialog()
+	}
+	a.ShowDialog(dialog)
+}
+
+func registerHelpCommands(app *App) {
+	reg := app.Reg
+
+	reg.Register(command.Command{
+		ID:    "explorer.help",
+		Title: "Explorer: Keyboard Shortcuts",
+		Handler: func() {
+			app.ShowPanelHelp("Explorer Shortcuts", explorerHelpEntries)
+		},
+	})
+
+	reg.Register(command.Command{
+		ID:    "search.help",
+		Title: "Search: Keyboard Shortcuts",
+		Handler: func() {
+			app.ShowPanelHelp("Search Shortcuts", searchHelpEntries)
+		},
+	})
+
+	reg.Register(command.Command{
+		ID:    "changes.help",
+		Title: "Changes: Keyboard Shortcuts",
+		Handler: func() {
+			app.ShowPanelHelp("Changes Shortcuts", changesHelpEntries)
+		},
+	})
+}

--- a/internal/app/commands_help.go
+++ b/internal/app/commands_help.go
@@ -5,7 +5,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/ui"
 )
 
-var explorerHelpEntries = []ui.HelpEntry{
+var explorerHelpEntries = []ui.InfoEntry{
 	{Key: "Enter", Desc: "Open file or toggle folder"},
 	{Key: "Space", Desc: "Open file or toggle folder"},
 	{Key: "Left", Desc: "Collapse folder"},
@@ -13,7 +13,7 @@ var explorerHelpEntries = []ui.HelpEntry{
 	{Key: "Up / Down", Desc: "Navigate items"},
 }
 
-var searchHelpEntries = []ui.HelpEntry{
+var searchHelpEntries = []ui.InfoEntry{
 	{Key: "Enter", Desc: "Activate selected result"},
 	{Key: "Up / Down", Desc: "Navigate results"},
 	{Key: "Tab", Desc: "Next input field"},
@@ -22,7 +22,7 @@ var searchHelpEntries = []ui.HelpEntry{
 	{Key: "Alt+r", Desc: "Toggle regex mode"},
 }
 
-var changesHelpEntries = []ui.HelpEntry{
+var changesHelpEntries = []ui.InfoEntry{
 	{Key: "Space", Desc: "Toggle stage/unstage file"},
 	{Key: "a", Desc: "Stage all files"},
 	{Key: "u", Desc: "Unstage all files"},
@@ -36,8 +36,8 @@ var changesHelpEntries = []ui.HelpEntry{
 	{Key: "Up / Down", Desc: "Navigate files"},
 }
 
-func (a *App) ShowPanelHelp(title string, entries []ui.HelpEntry) {
-	dialog := ui.NewHelpDialogWidget(title, entries)
+func (a *App) ShowPanelHelp(title string, entries []ui.InfoEntry) {
+	dialog := ui.NewInfoDialogWidget(title, entries)
 	dialog.Borders = a.Borders
 	dialog.OnDismiss = func() {
 		a.DismissDialog()

--- a/internal/ui/helpdialog_widget.go
+++ b/internal/ui/helpdialog_widget.go
@@ -6,17 +6,17 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
-// HelpEntry represents a single key-description pair in the help dialog.
-type HelpEntry struct {
+type InfoEntry struct {
 	Key  string
 	Desc string
 }
 
-// HelpDialogWidget shows a scrollable list of keyboard shortcuts for a panel.
-type HelpDialogWidget struct {
+type InfoDialogWidget struct {
 	BaseWidget
 	Title   string
-	Entries []HelpEntry
+	Entries []InfoEntry
+	Width   int
+	Height  int
 	Borders *term.BorderSet
 
 	OnDismiss func()
@@ -25,26 +25,25 @@ type HelpDialogWidget struct {
 	btnHit    HitRegion
 }
 
-func NewHelpDialogWidget(title string, entries []HelpEntry) *HelpDialogWidget {
-	return &HelpDialogWidget{
+func NewInfoDialogWidget(title string, entries []InfoEntry) *InfoDialogWidget {
+	return &InfoDialogWidget{
 		Title:   title,
 		Entries: entries,
 	}
 }
 
-func (d *HelpDialogWidget) Focusable() bool { return true }
+func (d *InfoDialogWidget) Focusable() bool { return true }
 
-func (d *HelpDialogWidget) Render(surface *RenderSurface) {
+func (d *InfoDialogWidget) Render(surface *RenderSurface) {
 	sw, sh := surface.Size()
 
-	// Compute box dimensions
 	keyColW := 0
 	for _, e := range d.Entries {
 		if len([]rune(e.Key)) > keyColW {
 			keyColW = len([]rune(e.Key))
 		}
 	}
-	keyColW += 2 // padding
+	keyColW += 2
 
 	descColW := 0
 	for _, e := range d.Entries {
@@ -59,7 +58,10 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		contentW = titleW
 	}
 
-	boxW := contentW + 4 // 2 border + 2 padding
+	boxW := contentW + 14 // 2 border + 2 padding + 10 extra width
+	if d.Width > 0 {
+		boxW = d.Width
+	}
 	if boxW > sw-4 {
 		boxW = sw - 4
 	}
@@ -67,10 +69,13 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		boxW = 20
 	}
 
-	// Box height: title + separator + entries + bottom border + close hint
-	maxEntries := len(d.Entries)
-	visibleEntries := maxEntries
-	maxVisibleH := sh - 8 // leave room for border + title + close hint
+	visibleEntries := len(d.Entries)
+	if d.Height > 0 {
+		if visibleEntries > d.Height {
+			visibleEntries = d.Height
+		}
+	}
+	maxVisibleH := sh - 8
 	if visibleEntries > maxVisibleH {
 		visibleEntries = maxVisibleH
 	}
@@ -78,7 +83,8 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		visibleEntries = 1
 	}
 
-	boxH := visibleEntries + 5 // top border + title + separator + entries + button row + bottom border
+	// top border + title + separator + entries + gutter + button row + bottom border
+	boxH := visibleEntries + 6
 	boxX := (sw - boxW) / 2
 	boxY := (sh - boxH) / 2
 	if boxY < 1 {
@@ -93,18 +99,15 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 	surface.ClearRect(boxX, boxY, boxW, boxH, term.StylePaletteItem)
 	surface.DrawBorder(boxX, boxY, boxW, boxH, b, term.StyleBorder)
 
-	// Title
 	surface.ClearRect(boxX+1, boxY+1, boxW-2, 1, term.StylePaletteItem)
 	titleX := boxX + (boxW-len([]rune(d.Title)))/2
 	surface.DrawText(titleX, boxY+1, d.Title, boxX+boxW-2, term.StylePaletteItem)
 
-	// Separator line
 	sepY := boxY + 2
 	for x := boxX + 1; x < boxX+boxW-1; x++ {
 		surface.SetCell(x, sepY, term.Cell{Ch: b.Horizontal, Style: term.StyleBorder})
 	}
 
-	// Clamp scroll
 	if d.scrollTop > len(d.Entries)-visibleEntries {
 		d.scrollTop = len(d.Entries) - visibleEntries
 	}
@@ -112,13 +115,11 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		d.scrollTop = 0
 	}
 
-	// Entries
 	innerW := boxW - 4
 	for i := 0; i < visibleEntries && d.scrollTop+i < len(d.Entries); i++ {
 		entry := d.Entries[d.scrollTop+i]
 		y := boxY + 3 + i
 
-		// Key column (right-aligned in its space, using selected style for emphasis)
 		keyRunes := []rune(entry.Key)
 		kw := keyColW
 		if kw > innerW/2 {
@@ -130,12 +131,10 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		}
 		surface.DrawText(kx, y, entry.Key, boxX+2+kw, term.StylePaletteItem)
 
-		// Description column
 		descX := boxX + 2 + kw + 2
 		surface.DrawText(descX, y, entry.Desc, boxX+boxW-2, term.StyleMuted)
 	}
 
-	// Scroll indicators
 	if d.scrollTop > 0 {
 		surface.SetCell(boxX+boxW-2, boxY+3, term.Cell{Ch: '^', Style: term.StyleMuted})
 	}
@@ -143,19 +142,22 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		surface.SetCell(boxX+boxW-2, boxY+3+visibleEntries-1, term.Cell{Ch: 'v', Style: term.StyleMuted})
 	}
 
-	// Close button
+	// Close button with 1 row gutter above
 	btnY := boxY + boxH - 2
-	btnLabel := " Close "
+	btnLabel := "Close"
 	btnRunes := []rune(btnLabel)
 	btnX := boxX + (boxW-len(btnRunes))/2
+	surface.ClearRect(boxX+1, btnY-1, boxW-2, 1, term.StylePaletteItem)
 	surface.ClearRect(boxX+1, btnY, boxW-2, 1, term.StylePaletteItem)
 	for j, ch := range btnRunes {
-		cell := term.Cell{Ch: ch, Style: term.StylePaletteSelected}
+		cell := term.Cell{Ch: ch, Style: term.StylePaletteItem}
+		if j == 0 {
+			cell.Underline = true
+		}
 		surface.SetCell(btnX+j, btnY, cell)
 	}
 	d.btnHit = HitRegion{X: btnX, Y: btnY, W: len(btnRunes)}
 
-	// Scrollbar if needed
 	if len(d.Entries) > visibleEntries && visibleEntries > 1 {
 		sbX := boxX + boxW - 2
 		sbTop := boxY + 3
@@ -172,7 +174,7 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 	}
 }
 
-func (d *HelpDialogWidget) HandleEvent(ev tcell.Event) EventResult {
+func (d *InfoDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 	if mev, ok := ev.(*tcell.EventMouse); ok {
 		btn := mev.Buttons()
 		mx, my := mev.Position()
@@ -229,6 +231,12 @@ func (d *HelpDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		if d.scrollTop > max {
 			d.scrollTop = max
+		}
+	case tcell.KeyRune:
+		if kev.Rune() == 'c' || kev.Rune() == 'C' {
+			if d.OnDismiss != nil {
+				d.OnDismiss()
+			}
 		}
 	}
 

--- a/internal/ui/helpdialog_widget.go
+++ b/internal/ui/helpdialog_widget.go
@@ -1,0 +1,225 @@
+package ui
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// HelpEntry represents a single key-description pair in the help dialog.
+type HelpEntry struct {
+	Key  string
+	Desc string
+}
+
+// HelpDialogWidget shows a scrollable list of keyboard shortcuts for a panel.
+type HelpDialogWidget struct {
+	BaseWidget
+	Title   string
+	Entries []HelpEntry
+	Borders *term.BorderSet
+
+	OnDismiss func()
+
+	scrollTop int
+}
+
+func NewHelpDialogWidget(title string, entries []HelpEntry) *HelpDialogWidget {
+	return &HelpDialogWidget{
+		Title:   title,
+		Entries: entries,
+	}
+}
+
+func (d *HelpDialogWidget) Focusable() bool { return true }
+
+func (d *HelpDialogWidget) Render(surface *RenderSurface) {
+	sw, sh := surface.Size()
+
+	// Compute box dimensions
+	keyColW := 0
+	for _, e := range d.Entries {
+		if len([]rune(e.Key)) > keyColW {
+			keyColW = len([]rune(e.Key))
+		}
+	}
+	keyColW += 2 // padding
+
+	descColW := 0
+	for _, e := range d.Entries {
+		if len([]rune(e.Desc)) > descColW {
+			descColW = len([]rune(e.Desc))
+		}
+	}
+
+	contentW := keyColW + descColW + 2
+	titleW := len([]rune(d.Title)) + 4
+	if titleW > contentW {
+		contentW = titleW
+	}
+
+	boxW := contentW + 4 // 2 border + 2 padding
+	if boxW > sw-4 {
+		boxW = sw - 4
+	}
+	if boxW < 20 {
+		boxW = 20
+	}
+
+	// Box height: title + separator + entries + bottom border + close hint
+	maxEntries := len(d.Entries)
+	visibleEntries := maxEntries
+	maxVisibleH := sh - 8 // leave room for border + title + close hint
+	if visibleEntries > maxVisibleH {
+		visibleEntries = maxVisibleH
+	}
+	if visibleEntries < 1 {
+		visibleEntries = 1
+	}
+
+	boxH := visibleEntries + 5 // top border + title + separator + entries + close hint + bottom border
+	boxX := (sw - boxW) / 2
+	boxY := (sh - boxH) / 2
+	if boxY < 1 {
+		boxY = 1
+	}
+
+	b := term.DoubleBorderSet()
+	if d.Borders != nil {
+		b = *d.Borders
+	}
+
+	surface.ClearRect(boxX, boxY, boxW, boxH, term.StylePaletteItem)
+	surface.DrawBorder(boxX, boxY, boxW, boxH, b, term.StyleBorder)
+
+	// Title
+	titleX := boxX + (boxW-len([]rune(d.Title)))/2
+	surface.DrawText(titleX, boxY+1, d.Title, boxX+boxW-2, term.StylePaletteSelected)
+
+	// Separator line
+	sepY := boxY + 2
+	for x := boxX + 1; x < boxX+boxW-1; x++ {
+		surface.SetCell(x, sepY, term.Cell{Ch: b.Horizontal, Style: term.StyleBorder})
+	}
+
+	// Clamp scroll
+	if d.scrollTop > len(d.Entries)-visibleEntries {
+		d.scrollTop = len(d.Entries) - visibleEntries
+	}
+	if d.scrollTop < 0 {
+		d.scrollTop = 0
+	}
+
+	// Entries
+	innerW := boxW - 4
+	for i := 0; i < visibleEntries && d.scrollTop+i < len(d.Entries); i++ {
+		entry := d.Entries[d.scrollTop+i]
+		y := boxY + 3 + i
+
+		// Key column (right-aligned in its space, using selected style for emphasis)
+		keyRunes := []rune(entry.Key)
+		kw := keyColW
+		if kw > innerW/2 {
+			kw = innerW / 2
+		}
+		kx := boxX + 2 + kw - len(keyRunes)
+		if kx < boxX+2 {
+			kx = boxX + 2
+		}
+		surface.DrawText(kx, y, entry.Key, boxX+2+kw, term.StylePaletteSelected)
+
+		// Description column
+		descX := boxX + 2 + kw + 2
+		surface.DrawText(descX, y, entry.Desc, boxX+boxW-2, term.StylePaletteItem)
+	}
+
+	// Scroll indicators
+	if d.scrollTop > 0 {
+		surface.SetCell(boxX+boxW-2, boxY+3, term.Cell{Ch: '^', Style: term.StyleMuted})
+	}
+	if d.scrollTop+visibleEntries < len(d.Entries) {
+		surface.SetCell(boxX+boxW-2, boxY+3+visibleEntries-1, term.Cell{Ch: 'v', Style: term.StyleMuted})
+	}
+
+	// Close hint
+	closeY := boxY + boxH - 1
+	closeText := " Press Esc to close "
+	closeX := boxX + (boxW-len([]rune(closeText)))/2
+	surface.DrawText(closeX, closeY, closeText, boxX+boxW-1, term.StyleMuted)
+
+	// Scrollbar if needed
+	if len(d.Entries) > visibleEntries && visibleEntries > 1 {
+		sbX := boxX + boxW - 2
+		sbTop := boxY + 3
+		ratio := float64(d.scrollTop) / float64(len(d.Entries)-visibleEntries)
+		thumbY := sbTop + int(ratio*float64(visibleEntries-1))
+		for y := sbTop; y < sbTop+visibleEntries; y++ {
+			ch := ' '
+			style := term.StyleScrollbar
+			if y == thumbY {
+				style = term.StyleScrollbarThumb
+			}
+			surface.SetCell(sbX, y, term.Cell{Ch: rune(ch), Style: style})
+		}
+	}
+}
+
+func (d *HelpDialogWidget) HandleEvent(ev tcell.Event) EventResult {
+	if mev, ok := ev.(*tcell.EventMouse); ok {
+		btn := mev.Buttons()
+		if btn&tcell.Button1 != 0 {
+			// Click anywhere dismisses
+			if d.OnDismiss != nil {
+				d.OnDismiss()
+			}
+			return EventConsumed
+		}
+		if btn&tcell.WheelUp != 0 {
+			d.scrollTop -= 3
+			if d.scrollTop < 0 {
+				d.scrollTop = 0
+			}
+			return EventConsumed
+		}
+		if btn&tcell.WheelDown != 0 {
+			max := len(d.Entries) - 5
+			if max < 0 {
+				max = 0
+			}
+			d.scrollTop += 3
+			if d.scrollTop > max {
+				d.scrollTop = max
+			}
+			return EventConsumed
+		}
+		return EventConsumed
+	}
+
+	kev, ok := ev.(*tcell.EventKey)
+	if !ok {
+		return EventConsumed
+	}
+
+	switch kev.Key() {
+	case tcell.KeyEscape, tcell.KeyEnter:
+		if d.OnDismiss != nil {
+			d.OnDismiss()
+		}
+	case tcell.KeyUp:
+		d.scrollTop--
+		if d.scrollTop < 0 {
+			d.scrollTop = 0
+		}
+	case tcell.KeyDown:
+		d.scrollTop++
+		max := len(d.Entries) - 5
+		if max < 0 {
+			max = 0
+		}
+		if d.scrollTop > max {
+			d.scrollTop = max
+		}
+	}
+
+	return EventConsumed
+}

--- a/internal/ui/helpdialog_widget.go
+++ b/internal/ui/helpdialog_widget.go
@@ -58,7 +58,7 @@ func (d *InfoDialogWidget) Render(surface *RenderSurface) {
 		contentW = titleW
 	}
 
-	boxW := contentW + 14 // 2 border + 2 padding + 10 extra width
+	boxW := contentW + 9 // 2 border + 2 padding + 5 extra width
 	if d.Width > 0 {
 		boxW = d.Width
 	}
@@ -144,17 +144,13 @@ func (d *InfoDialogWidget) Render(surface *RenderSurface) {
 
 	// Close button with 1 row gutter above
 	btnY := boxY + boxH - 2
-	btnLabel := "Close"
+	btnLabel := " Close "
 	btnRunes := []rune(btnLabel)
 	btnX := boxX + (boxW-len(btnRunes))/2
 	surface.ClearRect(boxX+1, btnY-1, boxW-2, 1, term.StylePaletteItem)
 	surface.ClearRect(boxX+1, btnY, boxW-2, 1, term.StylePaletteItem)
 	for j, ch := range btnRunes {
-		cell := term.Cell{Ch: ch, Style: term.StylePaletteItem}
-		if j == 0 {
-			cell.Underline = true
-		}
-		surface.SetCell(btnX+j, btnY, cell)
+		surface.SetCell(btnX+j, btnY, term.Cell{Ch: ch, Style: term.StylePaletteSelected})
 	}
 	d.btnHit = HitRegion{X: btnX, Y: btnY, W: len(btnRunes)}
 
@@ -231,12 +227,6 @@ func (d *InfoDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		if d.scrollTop > max {
 			d.scrollTop = max
-		}
-	case tcell.KeyRune:
-		if kev.Rune() == 'c' || kev.Rune() == 'C' {
-			if d.OnDismiss != nil {
-				d.OnDismiss()
-			}
 		}
 	}
 

--- a/internal/ui/helpdialog_widget.go
+++ b/internal/ui/helpdialog_widget.go
@@ -22,6 +22,7 @@ type HelpDialogWidget struct {
 	OnDismiss func()
 
 	scrollTop int
+	btnHit    HitRegion
 }
 
 func NewHelpDialogWidget(title string, entries []HelpEntry) *HelpDialogWidget {
@@ -77,7 +78,7 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		visibleEntries = 1
 	}
 
-	boxH := visibleEntries + 5 // top border + title + separator + entries + close hint + bottom border
+	boxH := visibleEntries + 5 // top border + title + separator + entries + button row + bottom border
 	boxX := (sw - boxW) / 2
 	boxY := (sh - boxH) / 2
 	if boxY < 1 {
@@ -93,8 +94,9 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 	surface.DrawBorder(boxX, boxY, boxW, boxH, b, term.StyleBorder)
 
 	// Title
+	surface.ClearRect(boxX+1, boxY+1, boxW-2, 1, term.StylePaletteItem)
 	titleX := boxX + (boxW-len([]rune(d.Title)))/2
-	surface.DrawText(titleX, boxY+1, d.Title, boxX+boxW-2, term.StylePaletteSelected)
+	surface.DrawText(titleX, boxY+1, d.Title, boxX+boxW-2, term.StylePaletteItem)
 
 	// Separator line
 	sepY := boxY + 2
@@ -126,11 +128,11 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		if kx < boxX+2 {
 			kx = boxX + 2
 		}
-		surface.DrawText(kx, y, entry.Key, boxX+2+kw, term.StylePaletteSelected)
+		surface.DrawText(kx, y, entry.Key, boxX+2+kw, term.StylePaletteItem)
 
 		// Description column
 		descX := boxX + 2 + kw + 2
-		surface.DrawText(descX, y, entry.Desc, boxX+boxW-2, term.StylePaletteItem)
+		surface.DrawText(descX, y, entry.Desc, boxX+boxW-2, term.StyleMuted)
 	}
 
 	// Scroll indicators
@@ -141,11 +143,17 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 		surface.SetCell(boxX+boxW-2, boxY+3+visibleEntries-1, term.Cell{Ch: 'v', Style: term.StyleMuted})
 	}
 
-	// Close hint
-	closeY := boxY + boxH - 1
-	closeText := " Press Esc to close "
-	closeX := boxX + (boxW-len([]rune(closeText)))/2
-	surface.DrawText(closeX, closeY, closeText, boxX+boxW-1, term.StyleMuted)
+	// Close button
+	btnY := boxY + boxH - 2
+	btnLabel := " Close "
+	btnRunes := []rune(btnLabel)
+	btnX := boxX + (boxW-len(btnRunes))/2
+	surface.ClearRect(boxX+1, btnY, boxW-2, 1, term.StylePaletteItem)
+	for j, ch := range btnRunes {
+		cell := term.Cell{Ch: ch, Style: term.StylePaletteSelected}
+		surface.SetCell(btnX+j, btnY, cell)
+	}
+	d.btnHit = HitRegion{X: btnX, Y: btnY, W: len(btnRunes)}
 
 	// Scrollbar if needed
 	if len(d.Entries) > visibleEntries && visibleEntries > 1 {
@@ -167,10 +175,13 @@ func (d *HelpDialogWidget) Render(surface *RenderSurface) {
 func (d *HelpDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 	if mev, ok := ev.(*tcell.EventMouse); ok {
 		btn := mev.Buttons()
+		mx, my := mev.Position()
 		if btn&tcell.Button1 != 0 {
-			// Click anywhere dismisses
-			if d.OnDismiss != nil {
-				d.OnDismiss()
+			if d.btnHit.Contains(mx, my) {
+				if d.OnDismiss != nil {
+					d.OnDismiss()
+				}
+				return EventConsumed
 			}
 			return EventConsumed
 		}

--- a/tests/e2e/help_dialog_test.go
+++ b/tests/e2e/help_dialog_test.go
@@ -1,0 +1,59 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestExplorerHelpDialog(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("explorer.help")
+
+	h.assertContains("Explorer Shortcuts")
+	h.assertContains("Open file or toggle folder")
+	h.assertContains("Collapse folder")
+	h.assertContains("Expand folder")
+
+	// Dismiss with Escape
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	h.assertNotContains("Explorer Shortcuts")
+}
+
+func TestSearchHelpDialog(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("search.help")
+
+	h.assertContains("Search Shortcuts")
+	h.assertContains("Toggle case sensitivity")
+	h.assertContains("Toggle regex mode")
+	h.assertContains("Next input field")
+
+	// Dismiss with Enter
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+
+	h.assertNotContains("Search Shortcuts")
+}
+
+func TestChangesHelpDialog(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("changes.help")
+
+	h.assertContains("Changes Shortcuts")
+	h.assertContains("Toggle stage/unstage file")
+	h.assertContains("Stage all files")
+	h.assertContains("Discard selected file")
+	h.assertContains("Open compact diff")
+
+	// Dismiss with Escape
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	h.assertNotContains("Changes Shortcuts")
+}


### PR DESCRIPTION
## Summary
- Each sidebar panel tab dropdown (Explorer, Search, Changes) now includes a "Help" action at the bottom with a separator, opening a dialog listing keyboard shortcuts for that panel
- New `HelpDialogWidget` in `internal/ui/` renders a scrollable dialog with key-description pairs, dismissible via Escape/Enter/click
- Three new commands (`explorer.help`, `search.help`, `changes.help`) registered and wired into the sidebar more menu
- E2E tests verify each help dialog opens with correct content and dismisses properly

Closes #64

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] E2E tests for all three help dialogs (explorer, search, changes)
- [ ] Manual: open each sidebar panel, click the "..." more button, verify "Help" appears at bottom with separator
- [ ] Manual: click "Help" and verify dialog shows correct shortcuts for each panel
- [ ] Manual: verify Escape and Enter both dismiss the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)