### PR TITLE
feat: add Options menu for editor look & feel settings

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -18,6 +18,7 @@ func RegisterCommands(app *App) {
 	registerWorkspaceCommands(app)
 	registerPRCommands(app)
 	registerHelpCommands(app)
+	registerOptionsCommands(app)
 	registerWidgetCallbacks(app)
 	RegisterEscapeDismissers(app)
 }

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func (a *App) ToggleLineNumbers() {
+	a.Settings.Editor.LineNumbers = !a.Settings.Editor.LineNumbers
+	a.EditorGroup.LineNumbers = a.Settings.Editor.LineNumbers
+	if a.EditorGroup.Editor != nil {
+		a.EditorGroup.Editor.LineNumbers = a.Settings.Editor.LineNumbers
+	}
+	config.SaveSettings(*a.Settings)
+}
+
+func (a *App) ToggleWordWrap() {
+	a.Settings.Editor.WordWrap = !a.Settings.Editor.WordWrap
+	config.SaveSettings(*a.Settings)
+}
+
+func (a *App) SetGutterStyle(style string) {
+	a.Settings.Editor.GutterStyle = style
+	a.EditorGroup.GutterStyle = style
+	if a.EditorGroup.Editor != nil {
+		a.EditorGroup.Editor.GutterStyle = style
+	}
+	config.SaveSettings(*a.Settings)
+}
+
+func (a *App) ShowGutterStylePicker() {
+	styles := []string{"minimal", "compact", "extended"}
+	var cmds []command.Command
+	for _, s := range styles {
+		cmds = append(cmds, command.Command{ID: s, Title: s})
+	}
+	a.ShowPicker(cmds, func(id string) {
+		a.SetGutterStyle(id)
+	})
+}
+
+func (a *App) SetTabSizeOption(size int) {
+	a.Settings.Editor.TabSize = size
+	a.EditorGroup.TabSize = size
+	a.EditorGroup.SetTabSize(size)
+	config.SaveSettings(*a.Settings)
+}
+
+func (a *App) ShowTabSizePicker() {
+	sizes := []int{2, 4, 8}
+	var cmds []command.Command
+	for _, s := range sizes {
+		label := fmt.Sprintf("Tab Size: %d", s)
+		cmds = append(cmds, command.Command{ID: strconv.Itoa(s), Title: label})
+	}
+	a.ShowPicker(cmds, func(id string) {
+		if size, err := strconv.Atoi(id); err == nil {
+			a.SetTabSizeOption(size)
+		}
+	})
+}
+
+func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
+	lineNumbersChecked := ui.MenuUnchecked
+	if a.Settings.Editor.LineNumbers {
+		lineNumbersChecked = ui.MenuChecked
+	}
+
+	wordWrapChecked := ui.MenuUnchecked
+	if a.Settings.Editor.WordWrap {
+		wordWrapChecked = ui.MenuChecked
+	}
+
+	items := []ui.ContextMenuItem{
+		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
+		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
+		ui.MenuSep(),
+		{Label: "Gutter Style", Command: "options.gutterStyle"},
+		{Label: "Tab Size", Command: "options.tabSize"},
+		ui.MenuSep(),
+		{Label: "Switch Theme", Command: "theme.switch"},
+		ui.MenuSep(),
+		{Label: "Open Settings", Command: "settings.open"},
+	}
+	return items
+}
+
+func registerOptionsCommands(app *App) {
+	reg := app.Reg
+
+	reg.Register(command.Command{
+		ID: "options.toggleLineNumbers", Title: "Toggle Line Numbers",
+		Handler: app.ToggleLineNumbers,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.toggleWordWrap", Title: "Toggle Word Wrap",
+		Handler: app.ToggleWordWrap,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.gutterStyle", Title: "Change Gutter Style",
+		Handler: app.ShowGutterStylePicker,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.tabSize", Title: "Change Tab Size",
+		Handler: app.ShowTabSizePicker,
+	})
+}

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -8,7 +8,7 @@ import (
 )
 
 var menuBarLabels = []string{
-	"menu.file", "menu.edit", "menu.selection", "menu.view", "menu.help",
+	"menu.file", "menu.edit", "menu.selection", "menu.view", "menu.options", "menu.help",
 }
 
 var menuBarMenus = [][]ui.ContextMenuItem{
@@ -63,10 +63,10 @@ var menuBarMenus = [][]ui.ContextMenuItem{
 		{Label: "Toggle Terminal", Command: "terminal.toggle"},
 		{Label: "New Terminal", Command: "terminal.new"},
 		ui.MenuSep(),
-		{Label: "Switch Theme", Command: "theme.switch"},
-		ui.MenuSep(),
 		{Label: "Keyboard Tester", Command: "view.keyboardTester"},
 	},
+	// Options (placeholder — replaced dynamically by openMenuBarDropdown)
+	nil,
 	// Help
 	{
 		{Label: "About", Command: "about"},
@@ -148,6 +148,8 @@ func openContextMenu(app *App, items []ui.ContextMenuItem, x, y int) {
 	app.Root.SetFocus(menu)
 }
 
+const menuOptionsIndex = 4
+
 func openMenuBarDropdown(app *App, index int) {
 	if index < 0 || index >= len(menuBarMenus) {
 		return
@@ -155,7 +157,11 @@ func openMenuBarDropdown(app *App, index int) {
 	reg := app.Reg
 	app.MenuBar.Selected = index
 	anchorX := app.MenuBar.ItemAnchorX(index)
-	menu := ui.NewContextMenuWidget(resolveShortcuts(reg, menuBarMenus[index]), anchorX, 1)
+	items := menuBarMenus[index]
+	if index == menuOptionsIndex {
+		items = app.BuildOptionsMenu()
+	}
+	menu := ui.NewContextMenuWidget(resolveShortcuts(reg, items), anchorX, 1)
 	menu.Borders = app.Borders
 	menu.OnExec = func(cmd string) {
 		app.Root.PopOverlay()

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -111,6 +111,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		{Name: "Edit"},
 		{Name: "Selection"},
 		{Name: "View"},
+		{Name: "Options"},
 		{Name: "Help"},
 	})
 

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -202,6 +202,7 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "alt+e", Command: "menu.edit"},
 		{Key: "alt+s", Command: "menu.selection"},
 		{Key: "alt+v", Command: "menu.view"},
+		{Key: "alt+o", Command: "menu.options"},
 		{Key: "alt+h", Command: "menu.help"},
 	}
 }

--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -11,7 +11,13 @@ type ContextMenuItem struct {
 	Shortcut string
 	Command  string
 	IsSep    bool
+	Checked  int // 0 = no indicator, 1 = unchecked, 2 = checked
 }
+
+const (
+	MenuUnchecked = 1
+	MenuChecked   = 2
+)
 
 func MenuSep() ContextMenuItem {
 	return ContextMenuItem{IsSep: true}
@@ -118,6 +124,9 @@ func (c *ContextMenuWidget) Render(surface *RenderSurface) {
 		}
 
 		surface.ClearRect(x+1, row, menuW-2, 1, style)
+		if it.Checked == MenuChecked {
+			surface.SetCell(x+1, row, term.Cell{Ch: '●', Style: style})
+		}
 		surface.DrawText(x+2, row, it.Label, x+menuW-1, style)
 
 		if it.Shortcut != "" {

--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -55,6 +55,15 @@ func NewContextMenuWidget(items []ContextMenuItem, x, y int) *ContextMenuWidget 
 
 func (c *ContextMenuWidget) Focusable() bool { return true }
 
+func (c *ContextMenuWidget) hasCheckedItems() bool {
+	for _, it := range c.Items {
+		if it.Checked != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *ContextMenuWidget) menuWidth() int {
 	maxLabel := 0
 	maxShort := 0
@@ -71,7 +80,10 @@ func (c *ContextMenuWidget) menuWidth() int {
 			maxShort = sr
 		}
 	}
-	w := maxLabel + 4
+	w := maxLabel + 6
+	if c.hasCheckedItems() {
+		w += 2
+	}
 	if maxShort > 0 {
 		w += maxShort + 2
 	}
@@ -124,10 +136,14 @@ func (c *ContextMenuWidget) Render(surface *RenderSurface) {
 		}
 
 		surface.ClearRect(x+1, row, menuW-2, 1, style)
-		if it.Checked == MenuChecked {
-			surface.SetCell(x+1, row, term.Cell{Ch: '●', Style: style})
+		labelX := x + 2
+		if c.hasCheckedItems() {
+			if it.Checked == MenuChecked {
+				surface.SetCell(x+1, row, term.Cell{Ch: '✓', Style: style})
+			}
+			labelX = x + 3
 		}
-		surface.DrawText(x+2, row, it.Label, x+menuW-1, style)
+		surface.DrawText(labelX, row, it.Label, x+menuW-1, style)
 
 		if it.Shortcut != "" {
 			shortStyle := term.StyleMuted

--- a/tests/e2e/options_menu_test.go
+++ b/tests/e2e/options_menu_test.go
@@ -1,0 +1,154 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestOptionsMenuToggleLineNumbers(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	if !h.app.Settings.Editor.LineNumbers {
+		t.Fatal("line numbers should be enabled by default")
+	}
+
+	h.exec("options.toggleLineNumbers")
+
+	if h.app.Settings.Editor.LineNumbers {
+		t.Error("line numbers should be disabled after toggle")
+	}
+	if h.app.EditorGroup.LineNumbers {
+		t.Error("editor group line numbers should be disabled after toggle")
+	}
+	if h.app.EditorGroup.Editor.LineNumbers {
+		t.Error("editor pane line numbers should be disabled after toggle")
+	}
+
+	h.exec("options.toggleLineNumbers")
+
+	if !h.app.Settings.Editor.LineNumbers {
+		t.Error("line numbers should be re-enabled after second toggle")
+	}
+	if !h.app.EditorGroup.LineNumbers {
+		t.Error("editor group line numbers should be re-enabled after second toggle")
+	}
+	if !h.app.EditorGroup.Editor.LineNumbers {
+		t.Error("editor pane line numbers should be re-enabled after second toggle")
+	}
+}
+
+func TestOptionsMenuToggleWordWrap(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	if h.app.Settings.Editor.WordWrap {
+		t.Fatal("word wrap should be disabled by default")
+	}
+
+	h.exec("options.toggleWordWrap")
+
+	if !h.app.Settings.Editor.WordWrap {
+		t.Error("word wrap should be enabled after toggle")
+	}
+
+	h.exec("options.toggleWordWrap")
+
+	if h.app.Settings.Editor.WordWrap {
+		t.Error("word wrap should be disabled after second toggle")
+	}
+}
+
+func TestOptionsMenuSetGutterStyle(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	if h.app.Settings.Editor.GutterStyle != "compact" {
+		t.Fatalf("expected default gutter style 'compact', got %q", h.app.Settings.Editor.GutterStyle)
+	}
+
+	h.app.SetGutterStyle("minimal")
+	h.redraw()
+
+	if h.app.Settings.Editor.GutterStyle != "minimal" {
+		t.Errorf("expected gutter style 'minimal', got %q", h.app.Settings.Editor.GutterStyle)
+	}
+	if h.app.EditorGroup.GutterStyle != "minimal" {
+		t.Errorf("expected editor group gutter style 'minimal', got %q", h.app.EditorGroup.GutterStyle)
+	}
+	if h.app.EditorGroup.Editor.GutterStyle != "minimal" {
+		t.Errorf("expected editor pane gutter style 'minimal', got %q", h.app.EditorGroup.Editor.GutterStyle)
+	}
+
+	h.app.SetGutterStyle("extended")
+	h.redraw()
+
+	if h.app.Settings.Editor.GutterStyle != "extended" {
+		t.Errorf("expected gutter style 'extended', got %q", h.app.Settings.Editor.GutterStyle)
+	}
+}
+
+func TestOptionsMenuSetTabSize(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	if h.app.Settings.Editor.TabSize != 4 {
+		t.Fatalf("expected default tab size 4, got %d", h.app.Settings.Editor.TabSize)
+	}
+
+	h.app.SetTabSizeOption(2)
+	h.redraw()
+
+	if h.app.Settings.Editor.TabSize != 2 {
+		t.Errorf("expected tab size 2, got %d", h.app.Settings.Editor.TabSize)
+	}
+	if h.app.EditorGroup.TabSize != 2 {
+		t.Errorf("expected editor group tab size 2, got %d", h.app.EditorGroup.TabSize)
+	}
+
+	h.app.SetTabSizeOption(8)
+	h.redraw()
+
+	if h.app.Settings.Editor.TabSize != 8 {
+		t.Errorf("expected tab size 8, got %d", h.app.Settings.Editor.TabSize)
+	}
+}
+
+func TestOptionsMenuBarPresent(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.assertContains("Options")
+}
+
+func TestOptionsMenuDynamicChecked(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	// Build the options menu and verify line numbers is checked
+	items := h.app.BuildOptionsMenu()
+	found := false
+	for _, item := range items {
+		if item.Command == "options.toggleLineNumbers" {
+			found = true
+			if item.Checked != 2 { // MenuChecked
+				t.Errorf("expected line numbers checked (2), got %d", item.Checked)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected to find options.toggleLineNumbers in menu items")
+	}
+
+	// Toggle line numbers off
+	h.exec("options.toggleLineNumbers")
+
+	// Rebuild and verify unchecked
+	items = h.app.BuildOptionsMenu()
+	for _, item := range items {
+		if item.Command == "options.toggleLineNumbers" {
+			if item.Checked != 1 { // MenuUnchecked
+				t.Errorf("expected line numbers unchecked (1), got %d", item.Checked)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add an **Options** menu to the menu bar (between View and Help) that surfaces editor display settings previously only reachable via command palette or settings.json
- Menu items: **Line Numbers** (toggle), **Word Wrap** (toggle), **Gutter Style** (picker: minimal/compact/extended), **Tab Size** (picker: 2/4/8), **Switch Theme** (existing picker), **Open Settings**
- Toggle items display a bullet indicator (●) showing current state, built dynamically each time the menu opens
- Add `Checked` field to `ContextMenuItem` for checked/unchecked indicator rendering
- Add `alt+o` keybinding to open the Options menu
- Move "Switch Theme" from the View menu into Options for better organization

Closes #114

## Test plan
- [x] 6 E2E tests covering toggle line numbers, toggle word wrap, set gutter style, set tab size, menu bar presence, and dynamic checked state
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: open Options menu via click or Alt+O, verify toggle indicators reflect current state
- [ ] Manual: toggle Line Numbers, verify gutter updates immediately
- [ ] Manual: change Gutter Style and Tab Size via pickers, verify editor updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)