### PR TITLE
feat: add fuzzy matching to command palette

### DIFF
--- a/internal/ui/fuzzy.go
+++ b/internal/ui/fuzzy.go
@@ -1,0 +1,87 @@
+package ui
+
+import "strings"
+
+// fuzzyMatch checks whether query matches candidate using fuzzy matching.
+// Characters must appear in order but not necessarily contiguously.
+// Returns whether it matched and a score (higher = better).
+// Matching is case-insensitive.
+func fuzzyMatch(query, candidate string) (bool, int) {
+	if query == "" {
+		return true, 0
+	}
+
+	lowerQuery := strings.ToLower(query)
+	lowerCandidate := strings.ToLower(candidate)
+
+	// Fast path: exact substring match gets highest priority.
+	if idx := strings.Index(lowerCandidate, lowerQuery); idx >= 0 {
+		score := 1000
+		// Bonus for matching at start of string.
+		if idx == 0 {
+			score += 100
+		}
+		// Bonus for matching at start of a word.
+		if idx > 0 && isWordBoundary(candidate[idx-1]) {
+			score += 50
+		}
+		return true, score
+	}
+
+	// Fuzzy match: each query character must appear in order.
+	candidateRunes := []rune(lowerCandidate)
+	queryRunes := []rune(lowerQuery)
+	origRunes := []rune(candidate)
+
+	qi := 0 // index into query
+	score := 0
+	lastMatchIdx := -1
+	consecutive := 0
+
+	for ci := 0; ci < len(candidateRunes) && qi < len(queryRunes); ci++ {
+		if candidateRunes[ci] == queryRunes[qi] {
+			// Consecutive match bonus.
+			if lastMatchIdx == ci-1 {
+				consecutive++
+				score += consecutive * 8
+			} else {
+				consecutive = 0
+			}
+
+			// Word boundary bonus: match at start of word.
+			if ci == 0 {
+				score += 20
+			} else if isWordBoundaryRune(origRunes[ci-1]) {
+				score += 15
+			}
+
+			// Bonus for matching uppercase letters (initials).
+			if ci < len(origRunes) && origRunes[ci] >= 'A' && origRunes[ci] <= 'Z' {
+				score += 5
+			}
+
+			lastMatchIdx = ci
+			qi++
+		}
+	}
+
+	if qi < len(queryRunes) {
+		return false, 0
+	}
+
+	// Base score for a fuzzy match.
+	score += 100
+
+	// Penalty for longer candidates (prefer shorter, more specific matches).
+	score -= len(candidateRunes) / 4
+
+	return true, score
+}
+
+func isWordBoundary(b byte) bool {
+	return b == ' ' || b == '/' || b == '\\' || b == '_' || b == '-' || b == '.' || b == ':'
+}
+
+func isWordBoundaryRune(r rune) bool {
+	return r == ' ' || r == '/' || r == '\\' || r == '_' || r == '-' || r == '.' || r == ':'
+}

--- a/internal/ui/fuzzy_test.go
+++ b/internal/ui/fuzzy_test.go
@@ -1,0 +1,132 @@
+package ui
+
+import "testing"
+
+func TestFuzzyMatchExactSubstring(t *testing.T) {
+	ok, score := fuzzyMatch("open", "File: Open")
+	if !ok {
+		t.Fatal("expected 'open' to match 'File: Open'")
+	}
+	if score < 1000 {
+		t.Fatalf("exact substring should score >= 1000, got %d", score)
+	}
+}
+
+func TestFuzzyMatchInitials(t *testing.T) {
+	ok, _ := fuzzyMatch("oc", "Open Changes")
+	if !ok {
+		t.Fatal("expected 'oc' to match 'Open Changes'")
+	}
+}
+
+func TestFuzzyMatchPartialWords(t *testing.T) {
+	// "ttu" matches T-r-a-n-s-f-o-r-m (skip) t-o (skip) U-ppercase
+	ok, _ := fuzzyMatch("ttu", "Transform to Uppercase")
+	if !ok {
+		t.Fatal("expected 'ttu' to match 'Transform to Uppercase'")
+	}
+}
+
+func TestFuzzyMatchNoMatchMissingChar(t *testing.T) {
+	// "tul" should NOT match "Transform to Uppercase" -- no 'l' in the candidate
+	ok, _ := fuzzyMatch("tul", "Transform to Uppercase")
+	if ok {
+		t.Fatal("expected 'tul' to NOT match 'Transform to Uppercase' (no 'l' in candidate)")
+	}
+}
+
+func TestFuzzyMatchCaseInsensitive(t *testing.T) {
+	ok, _ := fuzzyMatch("FILE", "File: Save")
+	if !ok {
+		t.Fatal("expected case-insensitive match")
+	}
+}
+
+func TestFuzzyMatchEmptyQuery(t *testing.T) {
+	ok, score := fuzzyMatch("", "anything")
+	if !ok {
+		t.Fatal("empty query should match everything")
+	}
+	if score != 0 {
+		t.Fatalf("empty query should score 0, got %d", score)
+	}
+}
+
+func TestFuzzyMatchNoMatch(t *testing.T) {
+	ok, _ := fuzzyMatch("xyz", "File: Open")
+	if ok {
+		t.Fatal("expected 'xyz' to not match 'File: Open'")
+	}
+}
+
+func TestFuzzyMatchOutOfOrder(t *testing.T) {
+	ok, _ := fuzzyMatch("po", "Open")
+	if ok {
+		t.Fatal("expected 'po' to not match 'Open' (out of order)")
+	}
+}
+
+func TestFuzzyMatchSubstringScoresHigherThanFuzzy(t *testing.T) {
+	_, substringScore := fuzzyMatch("to", "Toggle Sidebar")
+	_, fuzzyScore := fuzzyMatch("to", "Transform to Uppercase")
+
+	// "to" is a substring of "Toggle..." (at position 0: "To") and also "Transform to..."
+	// Both are substrings, but "Toggle" starts with "to"
+	if substringScore <= fuzzyScore {
+		t.Fatalf("start-of-string substring (%d) should score higher than mid-string (%d)",
+			substringScore, fuzzyScore)
+	}
+}
+
+func TestFuzzyMatchConsecutiveBonus(t *testing.T) {
+	_, scoreConsec := fuzzyMatch("spl", "Split Editor Right")
+	_, scoreSpread := fuzzyMatch("spr", "Split Editor Right")
+
+	// "spl" is a substring match (higher score), "spr" is fuzzy
+	if scoreConsec <= scoreSpread {
+		t.Fatalf("consecutive match (%d) should score higher than spread match (%d)",
+			scoreConsec, scoreSpread)
+	}
+}
+
+func TestFuzzyMatchWordBoundaryBonus(t *testing.T) {
+	// "fs" matching "File: Save" (both at word boundaries) vs "File: Sufs" (if it existed)
+	ok, _ := fuzzyMatch("fs", "File: Save")
+	if !ok {
+		t.Fatal("expected 'fs' to match 'File: Save'")
+	}
+}
+
+func TestFuzzyMatchFilePath(t *testing.T) {
+	ok, _ := fuzzyMatch("pw", "internal/ui/palette_widget.go")
+	if !ok {
+		t.Fatal("expected 'pw' to match file path")
+	}
+}
+
+func TestFuzzyMatchSingleChar(t *testing.T) {
+	ok, _ := fuzzyMatch("s", "Split Editor Right")
+	if !ok {
+		t.Fatal("single char should match")
+	}
+}
+
+func TestFuzzyMatchExactMatch(t *testing.T) {
+	ok, score := fuzzyMatch("File: Save", "File: Save")
+	if !ok {
+		t.Fatal("exact match should work")
+	}
+	if score < 1000 {
+		t.Fatalf("exact match should have high score, got %d", score)
+	}
+}
+
+func TestFuzzyMatchStartOfString(t *testing.T) {
+	_, scoreStart := fuzzyMatch("file", "File: Save")
+	_, scoreMid := fuzzyMatch("save", "File: Save")
+
+	if scoreStart <= scoreMid {
+		t.Fatalf("start-of-string match (%d) should score higher than mid-string (%d)",
+			scoreStart, scoreMid)
+	}
+}

--- a/internal/ui/palette_widget.go
+++ b/internal/ui/palette_widget.go
@@ -3,8 +3,10 @@ package ui
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/term"
 
@@ -20,9 +22,9 @@ const (
 )
 
 type PaletteItem struct {
-	Label    string
-	Detail   string
-	ID       string
+	Label  string
+	Detail string
+	ID     string
 }
 
 type paletteFile struct {
@@ -32,21 +34,21 @@ type paletteFile struct {
 
 type CommandPaletteWidget struct {
 	BaseWidget
-	Commands     []command.Command
-	Items        []PaletteItem
-	Input        *InputWidget
-	Selected     int
-	scrollOffset int
-	inputX       int
-	inputY       int
-	mode         paletteMode
-	files        []paletteFile
-	OnExecute          func(id string)
-	OnOpenFile         func(path string)
-	OnGoToLine         func(line int)
-	OnDismiss          func()
-	OnSelectionChange  func(id string)
-	Borders            *term.BorderSet
+	Commands          []command.Command
+	Items             []PaletteItem
+	Input             *InputWidget
+	Selected          int
+	scrollOffset      int
+	inputX            int
+	inputY            int
+	mode              paletteMode
+	files             []paletteFile
+	OnExecute         func(id string)
+	OnOpenFile        func(path string)
+	OnGoToLine        func(line int)
+	OnDismiss         func()
+	OnSelectionChange func(id string)
+	Borders           *term.BorderSet
 }
 
 func NewCommandPaletteWidget(commands []command.Command) *CommandPaletteWidget {
@@ -104,7 +106,13 @@ func (p *CommandPaletteWidget) CursorPosition() (int, int, bool) {
 func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
 	sw, sh := surface.Size()
 
-	boxW := 60
+	boxW := sw * 6 / 10 // 60% of terminal width
+	if boxW > 80 {
+		boxW = 80
+	}
+	if boxW < 40 {
+		boxW = 40
+	}
 	if boxW > sw-4 {
 		boxW = sw - 4
 	}
@@ -304,15 +312,28 @@ func (p *CommandPaletteWidget) filterCommands(query string) {
 			})
 		}
 	} else {
-		lower := strings.ToLower(query)
+		type scored struct {
+			item  PaletteItem
+			score int
+		}
+		var matches []scored
 		for _, cmd := range p.Commands {
-			if strings.Contains(strings.ToLower(cmd.Title), lower) {
-				p.Items = append(p.Items, PaletteItem{
-					Label:  cmd.Title,
-					Detail: cmd.Shortcut,
-					ID:     cmd.ID,
+			if ok, score := fuzzyMatch(query, cmd.Title); ok {
+				matches = append(matches, scored{
+					item: PaletteItem{
+						Label:  cmd.Title,
+						Detail: cmd.Shortcut,
+						ID:     cmd.ID,
+					},
+					score: score,
 				})
 			}
+		}
+		sort.Slice(matches, func(i, j int) bool {
+			return matches[i].score > matches[j].score
+		})
+		for _, m := range matches {
+			p.Items = append(p.Items, m.item)
 		}
 	}
 	p.Selected = 0
@@ -341,17 +362,30 @@ func (p *CommandPaletteWidget) filterFiles(query string) {
 			}
 		}
 	} else {
-		lower := strings.ToLower(query)
+		type scored struct {
+			item  PaletteItem
+			score int
+		}
+		var matches []scored
 		for _, f := range p.files {
-			if strings.Contains(strings.ToLower(f.Rel), lower) {
-				p.Items = append(p.Items, PaletteItem{
-					Label:  filepath.Base(f.Rel),
-					Detail: fileDetail(f.Rel),
-					ID:     f.Abs,
+			if ok, score := fuzzyMatch(query, f.Rel); ok {
+				matches = append(matches, scored{
+					item: PaletteItem{
+						Label:  filepath.Base(f.Rel),
+						Detail: fileDetail(f.Rel),
+						ID:     f.Abs,
+					},
+					score: score,
 				})
-				if len(p.Items) >= 100 {
-					break
-				}
+			}
+		}
+		sort.Slice(matches, func(i, j int) bool {
+			return matches[i].score > matches[j].score
+		})
+		for _, m := range matches {
+			p.Items = append(p.Items, m.item)
+			if len(p.Items) >= 100 {
+				break
 			}
 		}
 	}

--- a/internal/ui/palette_widget_test.go
+++ b/internal/ui/palette_widget_test.go
@@ -103,6 +103,62 @@ func TestPaletteBackspace(t *testing.T) {
 	}
 }
 
+func TestPaletteFuzzyFilter(t *testing.T) {
+	p := NewCommandPaletteWidget(testCommands())
+
+	// Type "fs" which should fuzzy match "File: Save" (F + S at word boundaries)
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'f', 0))
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 's', 0))
+
+	found := false
+	for _, item := range p.Items {
+		if item.ID == "file.save" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected fuzzy query 'fs' to match 'File: Save', got %d results", len(p.Items))
+	}
+}
+
+func TestPaletteFuzzyFilterInitials(t *testing.T) {
+	p := NewCommandPaletteWidget(testCommands())
+
+	// Type "se" which should fuzzy match "Split Editor Right" (s...e in Editor)
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 's', 0))
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
+
+	found := false
+	for _, item := range p.Items {
+		if item.ID == "editor.split" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected fuzzy query 'se' to match 'Split Editor Right'")
+	}
+}
+
+func TestPaletteFuzzyScoreOrdering(t *testing.T) {
+	cmds := []command.Command{
+		{ID: "a", Title: "Toggle Sidebar"},
+		{ID: "b", Title: "To Do List"},
+		{ID: "c", Title: "Top Level"},
+	}
+	p := NewCommandPaletteWidget(cmds)
+
+	// Type "to" - "Toggle Sidebar" and "Top Level" start with "to" (substring at position 0),
+	// "To Do List" starts with "To" too. All are substring matches.
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 't', 0))
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'o', 0))
+
+	if len(p.Items) < 3 {
+		t.Fatalf("expected at least 3 results, got %d", len(p.Items))
+	}
+}
+
 func TestPaletteModeSwitch(t *testing.T) {
 	p := NewCommandPaletteWidget(testCommands())
 


### PR DESCRIPTION
## Summary

- Replace `strings.Contains` substring filtering in the command palette with fuzzy matching that matches characters in order (not necessarily contiguous), enabling searches like "oc" for "Open Changes" or "fs" for "File: Save"
- Score-based ranking: exact substring matches get highest priority, with bonuses for consecutive matches, word boundary matches, and start-of-string matches
- Make palette width proportional to terminal width (60%, clamped 40-80 columns) instead of hardcoded 60
- Both command filtering and file filtering use the same fuzzy matcher

Closes #122

## Test plan

- [x] Unit tests for `fuzzyMatch()` covering: exact substring, initials, case-insensitivity, no-match, out-of-order rejection, score ordering (substring > fuzzy, start > mid-string, consecutive > spread)
- [x] Integration tests for palette widget fuzzy filtering through the `HandleEvent` flow
- [x] All existing palette tests pass unchanged (backward compatible)
- [x] `go build ./...` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)