### PR TITLE
feat: add scrollbar to problems widget

### DIFF
--- a/internal/ui/problems_widget.go
+++ b/internal/ui/problems_widget.go
@@ -22,6 +22,7 @@ type ProblemsWidget struct {
 	Items      []ProblemItem
 	selected   int
 	scrollTop  int
+	scrollbar  Scrollbar
 	OnNavigate func(file string, line, col int)
 }
 
@@ -73,6 +74,18 @@ func (p *ProblemsWidget) Render(surface *RenderSurface) {
 		p.scrollTop = p.selected - h + 1
 	}
 
+	r := p.GetRect()
+	p.scrollbar.X = r.X + w - 1
+	p.scrollbar.Y = r.Y
+	p.scrollbar.Height = h
+	p.scrollbar.TotalItems = len(p.Items)
+	p.scrollbar.TopItem = p.scrollTop
+
+	contentW := w
+	if p.scrollbar.Visible() {
+		contentW = w - 1
+	}
+
 	for y := 0; y < h; y++ {
 		idx := p.scrollTop + y
 		if idx >= len(p.Items) {
@@ -85,7 +98,7 @@ func (p *ProblemsWidget) Render(surface *RenderSurface) {
 			style = term.StyleSidebarSelected
 		}
 
-		for x := 0; x < w; x++ {
+		for x := 0; x < contentW; x++ {
 			surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
 		}
 
@@ -110,7 +123,7 @@ func (p *ProblemsWidget) Render(surface *RenderSurface) {
 		// File:line
 		loc := fmt.Sprintf("%s:%d", filepath.Base(item.File), item.Line+1)
 		for _, ch := range loc {
-			if x >= w {
+			if x >= contentW {
 				break
 			}
 			surface.SetCell(x, y, term.Cell{Ch: ch, Style: style})
@@ -124,16 +137,25 @@ func (p *ProblemsWidget) Render(surface *RenderSurface) {
 			msgStyle = term.StyleMuted
 		}
 		for _, ch := range item.Message {
-			if x >= w-1 {
+			if x >= contentW {
 				break
 			}
 			surface.SetCell(x, y, term.Cell{Ch: ch, Style: msgStyle})
 			x++
 		}
 	}
+
+	p.scrollbar.Render(surface, w-1, 0)
 }
 
 func (p *ProblemsWidget) HandleEvent(ev tcell.Event) EventResult {
+	if newTop, consumed := p.scrollbar.HandleEvent(ev); consumed {
+		p.scrollTop = newTop
+		if p.scrollbar.IsDragging() {
+			return EventCaptured
+		}
+		return EventConsumed
+	}
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
 		switch tev.Key() {

--- a/tests/e2e/problems_scrollbar_test.go
+++ b/tests/e2e/problems_scrollbar_test.go
@@ -1,0 +1,61 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func TestProblemsScrollbar(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	// Show the bottom panel with "problems" active
+	h.app.ContentSplit.ShowBottom = true
+	h.app.ContentSplit.BottomH = 6
+	h.app.BottomPanel.SetActivePanel("problems")
+
+	// Create enough problems to exceed the visible area (panel content area
+	// is BottomH minus 1 for the tab bar = 5 rows)
+	var items []ui.ProblemItem
+	for i := 0; i < 20; i++ {
+		items = append(items, ui.ProblemItem{
+			File:     fmt.Sprintf("file%d.go", i),
+			Line:     i + 1,
+			Col:      0,
+			Severity: ui.DiagError,
+			Message:  fmt.Sprintf("error %d", i),
+		})
+	}
+	h.app.Problems.SetItems(items)
+	h.redraw()
+
+	// The scrollbar should render on the rightmost column of the problems area.
+	// The scrollbar uses '█' characters.
+	screen := h.screenText()
+	if !containsRune(screen, '█') {
+		t.Errorf("expected scrollbar character '█' on screen when items exceed visible height, got:\n%s", screen)
+	}
+
+	// Now test with fewer items that fit — scrollbar should NOT appear
+	shortItems := []ui.ProblemItem{
+		{File: "a.go", Line: 1, Col: 0, Severity: ui.DiagError, Message: "err"},
+	}
+	h.app.Problems.SetItems(shortItems)
+	h.redraw()
+
+	screen = h.screenText()
+	if containsRune(screen, '█') {
+		t.Errorf("expected no scrollbar when items fit in visible area, got:\n%s", screen)
+	}
+}
+
+func containsRune(s string, r rune) bool {
+	for _, c := range s {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add scrollbar to problems panel matching the pattern used in search widget
- Uses existing `Scrollbar` component with `StyleScrollbar`/`StyleScrollbarThumb`
- Content width reduced by 1 when scrollbar is visible to prevent text overlap
- Scrollbar drag support included

## Test plan
- [x] E2E test: scrollbar appears when items exceed visible height
- [x] E2E test: scrollbar hidden when items fit
- [x] `make build` and `make test` pass

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)