### PR TITLE
fix: pass theme border set to TerminalPanelWidget

### DIFF
--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -90,6 +90,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	}
 
 	terminalPanel := ui.NewTerminalPanelWidget()
+	terminalPanel.Borders = borders
 	problems := ui.NewProblemsWidget()
 	references := ui.NewReferencesWidget()
 	bottomPanel := ui.NewBottomPanelWidget(borders)

--- a/tests/e2e/borders_test.go
+++ b/tests/e2e/borders_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestTerminalPanelBordersSet(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	if h.app.TerminalPanel.Borders == nil {
+		t.Fatal("TerminalPanel.Borders should not be nil")
+	}
+	if h.app.TerminalPanel.Borders != h.app.Borders {
+		t.Fatal("TerminalPanel.Borders should point to the same BorderSet as app.Borders")
+	}
+}
+
+func TestWidgetBordersConsistency(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	a := h.app
+	borders := a.Borders
+
+	// Verify all structural widgets share the same Borders pointer
+	checks := []struct {
+		name string
+		got  interface{}
+	}{
+		{"EditorGroup", a.EditorGroup.Borders},
+		{"ContentSplit", a.ContentSplit.Borders},
+		{"Sidebar", a.Sidebar.Borders},
+		{"SplitPanel", a.SplitPanel.Borders},
+		{"TerminalPanel", a.TerminalPanel.Borders},
+	}
+
+	for _, c := range checks {
+		if c.got == nil {
+			t.Errorf("%s.Borders is nil, expected app.Borders", c.name)
+		} else if c.got != borders {
+			t.Errorf("%s.Borders does not point to app.Borders", c.name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- TerminalPanelWidget was the only widget missing the `Borders` assignment from the app-level theme config
- Added `terminalPanel.Borders = borders` in `widgets.go`
- All other widgets (19 audited) were already correctly wired

## Test plan
- [x] E2E test: TerminalPanel.Borders is set and matches app.Borders
- [x] E2E test: all structural widgets share the same Borders pointer
- [x] `make build` and `make test` pass

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)