### PR TITLE
feat: add hidden keywords for command palette fuzzy search

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -179,16 +179,19 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "editor.focus", Title: "Focus Editor",
-		Handler: app.FocusEditor,
+		Keywords: []string{"editor"},
+		Handler:  app.FocusEditor,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.autocomplete", Title: "Trigger Autocomplete",
-		Handler: app.TriggerAutocomplete,
+		Keywords: []string{"editor", "completion", "suggest", "intellisense"},
+		Handler:  app.TriggerAutocomplete,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.hover", Title: "Show Hover",
+		Keywords: []string{"editor", "tooltip", "info"},
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			line, col := app.EditorGroup.ActiveCursor()
@@ -199,31 +202,37 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "editor.goToDefinition", Title: "Go to Definition",
-		Handler: func() { app.withEditorLSP(app.RequestDefinition) },
+		Keywords: []string{"editor", "navigate", "jump"},
+		Handler:  func() { app.withEditorLSP(app.RequestDefinition) },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.goToImplementation", Title: "Go to Implementation",
-		Handler: func() { app.withEditorLSP(app.RequestImplementation) },
+		Keywords: []string{"editor", "navigate", "jump"},
+		Handler:  func() { app.withEditorLSP(app.RequestImplementation) },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.goToTypeDefinition", Title: "Go to Type Definition",
-		Handler: func() { app.withEditorLSP(app.RequestTypeDefinition) },
+		Keywords: []string{"editor", "navigate", "jump"},
+		Handler:  func() { app.withEditorLSP(app.RequestTypeDefinition) },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.findReferences", Title: "Find All References",
-		Handler: func() { app.withEditorLSP(app.RequestReferences) },
+		Keywords: []string{"editor", "navigate", "search", "usages"},
+		Handler:  func() { app.withEditorLSP(app.RequestReferences) },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.rename", Title: "Rename Symbol",
-		Handler: app.RenameSymbol,
+		Keywords: []string{"editor", "refactor"},
+		Handler:  app.RenameSymbol,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.organizeImports", Title: "Source Action: Organize Imports",
+		Keywords: []string{"editor", "source", "cleanup"},
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			app.RequestCodeAction(path, lang, "source.organizeImports")
@@ -232,6 +241,7 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "editor.fixAll", Title: "Source Action: Fix All",
+		Keywords: []string{"editor", "source", "lint", "autofix"},
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			app.RequestCodeAction(path, lang, "source.fixAll")
@@ -240,6 +250,7 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "editor.formatDocument", Title: "Source Action: Format Document",
+		Keywords: []string{"editor", "source", "prettier", "beautify"},
 		Handler: func() {
 			path, lang := app.editorPathLang()
 			app.RequestFormatting(path, lang)
@@ -248,36 +259,43 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "editor.formatSelection", Title: "Source Action: Format Selection",
-		Handler: app.FormatSelection,
+		Keywords: []string{"editor", "source", "prettier", "beautify"},
+		Handler:  app.FormatSelection,
 	})
 
 	reg.Register(command.Command{
 		ID: "tab.next", Title: "Next Tab",
-		Handler: func() { app.EditorGroup.NextTab() },
+		Keywords: []string{"tab", "switch"},
+		Handler:  func() { app.EditorGroup.NextTab() },
 	})
 
 	reg.Register(command.Command{
 		ID: "tab.prev", Title: "Previous Tab",
-		Handler: func() { app.EditorGroup.PrevTab() },
+		Keywords: []string{"tab", "switch"},
+		Handler:  func() { app.EditorGroup.PrevTab() },
 	})
 
 	reg.Register(command.Command{
 		ID: "tab.close", Title: "Close Tab",
-		Handler: app.CloseTab,
+		Keywords: []string{"tab"},
+		Handler:  app.CloseTab,
 	})
 
 	reg.Register(command.Command{
 		ID: "tab.closeOthers", Title: "Close Other Tabs",
-		Handler: func() { app.EditorGroup.CloseOtherTabs() },
+		Keywords: []string{"tab"},
+		Handler:  func() { app.EditorGroup.CloseOtherTabs() },
 	})
 
 	reg.Register(command.Command{
 		ID: "tab.closeAll", Title: "Close All Tabs",
-		Handler: func() { app.EditorGroup.CloseAllTabs() },
+		Keywords: []string{"tab"},
+		Handler:  func() { app.EditorGroup.CloseAllTabs() },
 	})
 
 	reg.Register(command.Command{
 		ID: "diff.extendedView", Title: "Git: Extended Diff",
+		Keywords: []string{"git", "changes", "compare"},
 		Handler: func() {
 			if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
 				dv.SetExtended(true)
@@ -287,6 +305,7 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "diff.compactView", Title: "Git: Compact Diff",
+		Keywords: []string{"git", "changes", "compare"},
 		Handler: func() {
 			if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
 				dv.SetExtended(false)
@@ -296,6 +315,7 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "fold.toggle", Title: "Toggle Fold",
+		Keywords: []string{"editor", "collapse", "expand", "hide", "lines"},
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -309,6 +329,7 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "fold.collapseAll", Title: "Fold All",
+		Keywords: []string{"editor", "collapse", "expand", "hide", "lines"},
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -323,6 +344,7 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "fold.expandAll", Title: "Unfold All",
+		Keywords: []string{"editor", "collapse", "expand", "hide", "lines"},
 		Handler: func() {
 			if !app.EditorGroup.IsEditorActive() {
 				return
@@ -336,160 +358,196 @@ func registerEditorCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "file.new", Title: "New File",
-		Handler: app.NewFile,
+		Keywords: []string{"file", "create"},
+		Handler:  app.NewFile,
 	})
 
 	reg.Register(command.Command{
 		ID: "file.save", Title: "Save File",
-		Handler: app.SaveFile,
+		Keywords: []string{"file", "write"},
+		Handler:  app.SaveFile,
 	})
 
 	reg.Register(command.Command{
 		ID: "file.saveAs", Title: "Save As...",
-		Handler: app.SaveFileAs,
+		Keywords: []string{"file", "write", "export"},
+		Handler:  app.SaveFileAs,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.undo", Title: "Undo",
-		Handler: func() { app.EditorGroup.Undo() },
+		Keywords: []string{"editor", "revert"},
+		Handler:  func() { app.EditorGroup.Undo() },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.redo", Title: "Redo",
-		Handler: func() { app.EditorGroup.Redo() },
+		Keywords: []string{"editor"},
+		Handler:  func() { app.EditorGroup.Redo() },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.selectAll", Title: "Select All",
-		Handler: func() { app.EditorGroup.SelectAll() },
+		Keywords: []string{"editor", "selection"},
+		Handler:  func() { app.EditorGroup.SelectAll() },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.copy", Title: "Copy",
-		Handler: app.Copy,
+		Keywords: []string{"editor", "clipboard"},
+		Handler:  app.Copy,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.cut", Title: "Cut",
-		Handler: app.Cut,
+		Keywords: []string{"editor", "clipboard"},
+		Handler:  app.Cut,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.paste", Title: "Paste",
-		Handler: app.Paste,
+		Keywords: []string{"editor", "clipboard"},
+		Handler:  app.Paste,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.moveLineUp", Title: "Move Line Up",
-		Handler: func() { app.EditorGroup.MoveLineUp() },
+		Keywords: []string{"editor", "lines"},
+		Handler:  func() { app.EditorGroup.MoveLineUp() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.moveLineDown", Title: "Move Line Down",
-		Handler: func() { app.EditorGroup.MoveLineDown() },
+		Keywords: []string{"editor", "lines"},
+		Handler:  func() { app.EditorGroup.MoveLineDown() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.duplicateLine", Title: "Duplicate Line",
-		Handler: func() { app.EditorGroup.DuplicateLine() },
+		Keywords: []string{"editor", "lines", "clone"},
+		Handler:  func() { app.EditorGroup.DuplicateLine() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.deleteLine", Title: "Delete Line",
-		Handler: func() { app.EditorGroup.DeleteLine() },
+		Keywords: []string{"editor", "lines", "remove"},
+		Handler:  func() { app.EditorGroup.DeleteLine() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.joinLines", Title: "Join Lines",
-		Handler: func() { app.EditorGroup.JoinLines() },
+		Keywords: []string{"editor", "lines", "merge", "combine"},
+		Handler:  func() { app.EditorGroup.JoinLines() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.insertLineBelow", Title: "Insert Line Below",
-		Handler: func() { app.EditorGroup.InsertLineBelow() },
+		Keywords: []string{"editor", "lines"},
+		Handler:  func() { app.EditorGroup.InsertLineBelow() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.insertLineAbove", Title: "Insert Line Above",
-		Handler: func() { app.EditorGroup.InsertLineAbove() },
+		Keywords: []string{"editor", "lines"},
+		Handler:  func() { app.EditorGroup.InsertLineAbove() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.toggleComment", Title: "Toggle Line Comment",
-		Handler: func() { app.EditorGroup.ToggleLineComment() },
+		Keywords: []string{"editor", "comment", "uncomment"},
+		Handler:  func() { app.EditorGroup.ToggleLineComment() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.moveWordLeft", Title: "Move Word Left",
-		Handler: func() { app.EditorGroup.MoveWordLeft(false) },
+		Keywords: []string{"editor", "navigate"},
+		Handler:  func() { app.EditorGroup.MoveWordLeft(false) },
 	})
 	reg.Register(command.Command{
 		ID: "editor.moveWordRight", Title: "Move Word Right",
-		Handler: func() { app.EditorGroup.MoveWordRight(false) },
+		Keywords: []string{"editor", "navigate"},
+		Handler:  func() { app.EditorGroup.MoveWordRight(false) },
 	})
 	reg.Register(command.Command{
 		ID: "editor.selectWordLeft", Title: "Select Word Left",
-		Handler: func() { app.EditorGroup.MoveWordLeft(true) },
+		Keywords: []string{"editor", "selection"},
+		Handler:  func() { app.EditorGroup.MoveWordLeft(true) },
 	})
 	reg.Register(command.Command{
 		ID: "editor.selectWordRight", Title: "Select Word Right",
-		Handler: func() { app.EditorGroup.MoveWordRight(true) },
+		Keywords: []string{"editor", "selection"},
+		Handler:  func() { app.EditorGroup.MoveWordRight(true) },
 	})
 	reg.Register(command.Command{
 		ID: "editor.deleteWordLeft", Title: "Delete Word Left",
-		Handler: func() { app.EditorGroup.DeleteWordLeft() },
+		Keywords: []string{"editor"},
+		Handler:  func() { app.EditorGroup.DeleteWordLeft() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.deleteWordRight", Title: "Delete Word Right",
-		Handler: func() { app.EditorGroup.DeleteWordRight() },
+		Keywords: []string{"editor"},
+		Handler:  func() { app.EditorGroup.DeleteWordRight() },
 	})
 
 	reg.Register(command.Command{
 		ID: "multicursor.selectNext", Title: "Add Next Occurrence",
-		Handler: func() { app.EditorGroup.SelectNextOccurrence() },
+		Keywords: []string{"editor", "multicursor", "selection"},
+		Handler:  func() { app.EditorGroup.SelectNextOccurrence() },
 	})
 	reg.Register(command.Command{
 		ID: "multicursor.selectAll", Title: "Select All Occurrences",
-		Handler: func() { app.EditorGroup.SelectAllOccurrences() },
+		Keywords: []string{"editor", "multicursor", "selection"},
+		Handler:  func() { app.EditorGroup.SelectAllOccurrences() },
 	})
 	reg.Register(command.Command{
 		ID: "multicursor.undoCursor", Title: "Undo Last Cursor",
-		Handler: func() { app.EditorGroup.UndoLastCursor() },
+		Keywords: []string{"editor", "multicursor"},
+		Handler:  func() { app.EditorGroup.UndoLastCursor() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.splitSelectionToLines", Title: "Split Selection into Lines",
-		Handler: func() { app.EditorGroup.SplitSelectionToLines() },
+		Keywords: []string{"editor", "multicursor", "selection"},
+		Handler:  func() { app.EditorGroup.SplitSelectionToLines() },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.sortLinesAsc", Title: "Sort Lines Ascending",
-		Handler: func() { app.EditorGroup.SortLinesAsc() },
+		Keywords: []string{"editor", "lines", "order"},
+		Handler:  func() { app.EditorGroup.SortLinesAsc() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.sortLinesDesc", Title: "Sort Lines Descending",
-		Handler: func() { app.EditorGroup.SortLinesDesc() },
+		Keywords: []string{"editor", "lines", "order"},
+		Handler:  func() { app.EditorGroup.SortLinesDesc() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.reverseLines", Title: "Reverse Lines",
-		Handler: func() { app.EditorGroup.ReverseLines() },
+		Keywords: []string{"editor", "lines", "flip"},
+		Handler:  func() { app.EditorGroup.ReverseLines() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.uniqueLines", Title: "Unique Lines",
-		Handler: func() { app.EditorGroup.UniqueLines() },
+		Keywords: []string{"editor", "lines", "deduplicate", "distinct"},
+		Handler:  func() { app.EditorGroup.UniqueLines() },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.upperCase", Title: "Transform to Uppercase",
-		Handler: func() { app.EditorGroup.UpperCase() },
+		Keywords: []string{"editor", "case", "capitalize"},
+		Handler:  func() { app.EditorGroup.UpperCase() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.lowerCase", Title: "Transform to Lowercase",
-		Handler: func() { app.EditorGroup.LowerCase() },
+		Keywords: []string{"editor", "case"},
+		Handler:  func() { app.EditorGroup.LowerCase() },
 	})
 	reg.Register(command.Command{
 		ID: "editor.titleCase", Title: "Transform to Titlecase",
-		Handler: func() { app.EditorGroup.TitleCase() },
+		Keywords: []string{"editor", "case", "capitalize"},
+		Handler:  func() { app.EditorGroup.TitleCase() },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.goToMatchingBracket", Title: "Go to Matching Bracket",
-		Handler: func() { app.EditorGroup.GoToMatchingBracket() },
+		Keywords: []string{"editor", "navigate", "parenthesis", "brace"},
+		Handler:  func() { app.EditorGroup.GoToMatchingBracket() },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.quit", Title: "Quit",
-		Handler: app.Quit,
+		Keywords: []string{"exit", "close"},
+		Handler:  app.Quit,
 	})
 }

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -93,31 +93,37 @@ func registerExplorerCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "explorer.refresh", Title: "Refresh Explorer",
-		Handler: func() { app.Explorer.Reload() },
+		Keywords: []string{"view", "file", "reload"},
+		Handler:  func() { app.Explorer.Reload() },
 	})
 
 	reg.Register(command.Command{
 		ID: "explorer.open", Title: "Open",
-		Handler: func() { app.Explorer.ActivateSelected() },
+		Keywords: []string{"view", "file"},
+		Handler:  func() { app.Explorer.ActivateSelected() },
 	})
 
 	reg.Register(command.Command{
 		ID: "explorer.newFile", Title: "New File",
-		Handler: app.ExplorerNewFile,
+		Keywords: []string{"view", "file", "create"},
+		Handler:  app.ExplorerNewFile,
 	})
 
 	reg.Register(command.Command{
 		ID: "explorer.newFolder", Title: "New Folder",
-		Handler: app.ExplorerNewFolder,
+		Keywords: []string{"view", "file", "create", "directory"},
+		Handler:  app.ExplorerNewFolder,
 	})
 
 	reg.Register(command.Command{
 		ID: "explorer.rename", Title: "Rename",
-		Handler: app.ExplorerRename,
+		Keywords: []string{"view", "file"},
+		Handler:  app.ExplorerRename,
 	})
 
 	reg.Register(command.Command{
 		ID: "explorer.delete", Title: "Delete",
-		Handler: app.ExplorerDelete,
+		Keywords: []string{"view", "file", "remove"},
+		Handler:  app.ExplorerDelete,
 	})
 }

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -183,6 +183,7 @@ func registerGitCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "changes.openDiff", Title: "Git: Open Compact Diff",
+		Keywords: []string{"git", "changes", "diff", "compare"},
 		Handler: func() {
 			app.openSelectedDiff(false)
 		},
@@ -190,6 +191,7 @@ func registerGitCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "changes.openExtendedDiff", Title: "Git: Open Extended Diff",
+		Keywords: []string{"git", "changes", "diff", "compare"},
 		Handler: func() {
 			app.openSelectedDiff(true)
 		},
@@ -197,6 +199,7 @@ func registerGitCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "changes.openFile", Title: "Git: Open File",
+		Keywords: []string{"git", "changes"},
 		Handler: func() {
 			fullPath := app.Changes.SelectedFullPath()
 			if fullPath != "" {
@@ -208,11 +211,13 @@ func registerGitCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "changes.refresh", Title: "Git: Refresh Changes",
-		Handler: func() { app.Changes.Refresh() },
+		Keywords: []string{"git", "changes", "reload"},
+		Handler:  func() { app.Changes.Refresh() },
 	})
 
 	reg.Register(command.Command{
 		ID: "changes.stage", Title: "Git: Stage File",
+		Keywords: []string{"git", "changes", "add"},
 		Handler: func() {
 			dir, status, ok := app.Changes.SelectedFile()
 			if ok && !status.Staged {
@@ -224,6 +229,7 @@ func registerGitCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "changes.unstage", Title: "Git: Unstage File",
+		Keywords: []string{"git", "changes", "remove"},
 		Handler: func() {
 			dir, status, ok := app.Changes.SelectedFile()
 			if ok && status.Staged {
@@ -235,12 +241,14 @@ func registerGitCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "changes.discard", Title: "Git: Discard Changes",
-		Handler: app.DiscardSelected,
+		Keywords: []string{"git", "changes", "revert", "undo"},
+		Handler:  app.DiscardSelected,
 	})
 
-	registerGitCmd := func(id, title string, ops []func(string) error, verb string) {
+	registerGitCmd := func(id, title string, keywords []string, ops []func(string) error, verb string) {
 		reg.Register(command.Command{
 			ID: id, Title: title,
+			Keywords: keywords,
 			Handler: func() {
 				for _, dir := range app.Changes.Dirs {
 					for _, op := range ops {
@@ -255,9 +263,9 @@ func registerGitCommands(app *App) {
 			},
 		})
 	}
-	registerGitCmd("git.pull", "Git: Pull", []func(string) error{git.Pull}, "Pulled")
-	registerGitCmd("git.push", "Git: Push", []func(string) error{git.Push}, "Pushed")
-	registerGitCmd("git.sync", "Git: Sync", []func(string) error{git.Pull, git.Push}, "Synced")
+	registerGitCmd("git.pull", "Git: Pull", []string{"git", "fetch", "download"}, []func(string) error{git.Pull}, "Pulled")
+	registerGitCmd("git.push", "Git: Push", []string{"git", "upload", "publish"}, []func(string) error{git.Push}, "Pushed")
+	registerGitCmd("git.sync", "Git: Sync", []string{"git", "fetch", "upload"}, []func(string) error{git.Pull, git.Push}, "Synced")
 }
 
 func registerWorkspaceCommands(app *App) {
@@ -265,27 +273,32 @@ func registerWorkspaceCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "workspace.openFolder", Title: "Open Folder",
-		Handler: app.OpenFolder,
+		Keywords: []string{"file", "directory", "project"},
+		Handler:  app.OpenFolder,
 	})
 
 	reg.Register(command.Command{
 		ID: "workspace.addFolder", Title: "Add Folder",
-		Handler: app.AddWorkspaceFolder,
+		Keywords: []string{"file", "directory", "project"},
+		Handler:  app.AddWorkspaceFolder,
 	})
 
 	reg.Register(command.Command{
 		ID: "workspace.removeFolder", Title: "Remove Folder",
-		Handler: app.RemoveWorkspaceFolder,
+		Keywords: []string{"file", "directory", "project"},
+		Handler:  app.RemoveWorkspaceFolder,
 	})
 
 	reg.Register(command.Command{
 		ID: "workspace.open", Title: "Open Workspace",
-		Handler: app.OpenWorkspace,
+		Keywords: []string{"file", "project"},
+		Handler:  app.OpenWorkspace,
 	})
 
 	reg.Register(command.Command{
 		ID: "workspace.save", Title: "Save Workspace",
-		Handler: app.SaveWorkspace,
+		Keywords: []string{"file", "project"},
+		Handler:  app.SaveWorkspace,
 	})
 }
 
@@ -294,10 +307,12 @@ func registerPRCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "pr.review", Title: "Git: Review PR",
-		Handler: app.OpenPullRequestDialog,
+		Keywords: []string{"git", "pull request", "github"},
+		Handler:  app.OpenPullRequestDialog,
 	})
 	reg.Register(command.Command{
 		ID: "pr.close", Title: "Git: Close PR",
-		Handler: func() { app.Changes.RemovePRGroups() },
+		Keywords: []string{"git", "pull request", "github"},
+		Handler:  func() { app.Changes.RemovePRGroups() },
 	})
 }

--- a/internal/app/commands_help.go
+++ b/internal/app/commands_help.go
@@ -49,24 +49,27 @@ func registerHelpCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID:    "explorer.help",
-		Title: "Explorer: Keyboard Shortcuts",
+		ID:       "explorer.help",
+		Title:    "Explorer: Keyboard Shortcuts",
+		Keywords: []string{"view", "help", "keybindings"},
 		Handler: func() {
 			app.ShowPanelHelp("Explorer Shortcuts", explorerHelpEntries)
 		},
 	})
 
 	reg.Register(command.Command{
-		ID:    "search.help",
-		Title: "Search: Keyboard Shortcuts",
+		ID:       "search.help",
+		Title:    "Search: Keyboard Shortcuts",
+		Keywords: []string{"search", "help", "keybindings"},
 		Handler: func() {
 			app.ShowPanelHelp("Search Shortcuts", searchHelpEntries)
 		},
 	})
 
 	reg.Register(command.Command{
-		ID:    "changes.help",
-		Title: "Changes: Keyboard Shortcuts",
+		ID:       "changes.help",
+		Title:    "Changes: Keyboard Shortcuts",
+		Keywords: []string{"git", "help", "keybindings"},
 		Handler: func() {
 			app.ShowPanelHelp("Changes Shortcuts", changesHelpEntries)
 		},

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -94,21 +94,25 @@ func registerOptionsCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "options.toggleLineNumbers", Title: "Toggle Line Numbers",
-		Handler: app.ToggleLineNumbers,
+		Keywords: []string{"preferences", "settings", "editor", "view"},
+		Handler:  app.ToggleLineNumbers,
 	})
 
 	reg.Register(command.Command{
 		ID: "options.toggleWordWrap", Title: "Toggle Word Wrap",
-		Handler: app.ToggleWordWrap,
+		Keywords: []string{"preferences", "settings", "editor", "view"},
+		Handler:  app.ToggleWordWrap,
 	})
 
 	reg.Register(command.Command{
 		ID: "options.gutterStyle", Title: "Change Gutter Style",
-		Handler: app.ShowGutterStylePicker,
+		Keywords: []string{"preferences", "settings", "editor", "view"},
+		Handler:  app.ShowGutterStylePicker,
 	})
 
 	reg.Register(command.Command{
 		ID: "options.tabSize", Title: "Change Tab Size",
-		Handler: app.ShowTabSizePicker,
+		Keywords: []string{"preferences", "settings", "editor", "indentation"},
+		Handler:  app.ShowTabSizePicker,
 	})
 }

--- a/internal/app/commands_palette.go
+++ b/internal/app/commands_palette.go
@@ -136,17 +136,20 @@ func registerPaletteCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "file.quickOpen", Title: "Go to File",
-		Handler: func() { app.OpenCommandPalette(true) },
+		Keywords: []string{"file", "navigate", "open"},
+		Handler:  func() { app.OpenCommandPalette(true) },
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.goToLine", Title: "Go to Line",
-		Handler: func() { app.OpenCommandPalette(false, ":") },
+		Keywords: []string{"editor", "navigate", "jump"},
+		Handler:  func() { app.OpenCommandPalette(false, ":") },
 	})
 
 	reg.Register(command.Command{
 		ID: "theme.switch", Title: "Switch Theme",
-		Handler: app.ShowThemePicker,
+		Keywords: []string{"preferences", "settings", "colors", "appearance"},
+		Handler:  app.ShowThemePicker,
 	})
 
 	app.StatusBar.OnIndentClick = app.ShowIndentPicker
@@ -154,16 +157,19 @@ func registerPaletteCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "editor.indentation", Title: "Change Indentation",
-		Handler: app.ShowIndentPicker,
+		Keywords: []string{"editor", "preferences", "settings", "spaces", "tabs"},
+		Handler:  app.ShowIndentPicker,
 	})
 
 	reg.Register(command.Command{
 		ID: "editor.lineEnding", Title: "Change Line Ending",
-		Handler: app.ShowEolPicker,
+		Keywords: []string{"editor", "preferences", "settings", "eol", "crlf", "lf"},
+		Handler:  app.ShowEolPicker,
 	})
 
 	reg.Register(command.Command{
 		ID: "settings.open", Title: "Preferences: Open Settings",
+		Keywords: []string{"preferences", "settings", "configuration", "options"},
 		Handler: func() {
 			path := config.ConfigFilePath("settings.json")
 			config.EnsureConfigFile(path, "{}\n")
@@ -173,6 +179,7 @@ func registerPaletteCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "keybindings.open", Title: "Preferences: Open Keyboard Shortcuts",
+		Keywords: []string{"preferences", "settings", "hotkeys", "keymap"},
 		Handler: func() {
 			path := config.ConfigFilePath("keybindings.json")
 			config.EnsureConfigFile(path, "{}\n")

--- a/internal/app/commands_search.go
+++ b/internal/app/commands_search.go
@@ -83,41 +83,49 @@ func registerSearchCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "search.find", Title: "Find",
-		Handler: app.OpenFind,
+		Keywords: []string{"search", "find", "locate"},
+		Handler:  app.OpenFind,
 	})
 
 	reg.Register(command.Command{
 		ID: "search.findNext", Title: "Find Next",
-		Handler: func() { app.EditorGroup.FindNext() },
+		Keywords: []string{"search", "find"},
+		Handler:  func() { app.EditorGroup.FindNext() },
 	})
 
 	reg.Register(command.Command{
 		ID: "search.findPrev", Title: "Find Previous",
-		Handler: func() { app.EditorGroup.FindPrev() },
+		Keywords: []string{"search", "find"},
+		Handler:  func() { app.EditorGroup.FindPrev() },
 	})
 
 	reg.Register(command.Command{
 		ID: "search.clearFind", Title: "Clear Find Highlights",
-		Handler: func() { app.EditorGroup.ClearSearch() },
+		Keywords: []string{"search", "find"},
+		Handler:  func() { app.EditorGroup.ClearSearch() },
 	})
 
 	reg.Register(command.Command{
 		ID: "search.replace", Title: "Find and Replace",
-		Handler: app.OpenFindReplace,
+		Keywords: []string{"search", "find", "replace", "substitute"},
+		Handler:  app.OpenFindReplace,
 	})
 
 	reg.Register(command.Command{
 		ID: "search.expandAll", Title: "Expand All Search Results",
-		Handler: func() { app.Search.ExpandAll() },
+		Keywords: []string{"search"},
+		Handler:  func() { app.Search.ExpandAll() },
 	})
 
 	reg.Register(command.Command{
 		ID: "search.collapseAll", Title: "Collapse All Search Results",
-		Handler: func() { app.Search.CollapseAll() },
+		Keywords: []string{"search"},
+		Handler:  func() { app.Search.CollapseAll() },
 	})
 
 	reg.Register(command.Command{
 		ID: "search.clear", Title: "Clear Search Results",
-		Handler: app.ClearGlobalSearch,
+		Keywords: []string{"search"},
+		Handler:  app.ClearGlobalSearch,
 	})
 }

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -71,11 +71,13 @@ func registerViewCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "sidebar.toggle", Title: "Toggle Sidebar",
-		Handler: app.ToggleSidebar,
+		Keywords: []string{"view", "panel", "show", "hide"},
+		Handler:  app.ToggleSidebar,
 	})
 
 	reg.Register(command.Command{
 		ID: "sidebar.explorer", Title: "Show Explorer",
+		Keywords: []string{"view", "file", "tree", "browser"},
 		Handler: func() {
 			app.Explorer.Reload()
 			app.ShowPanel("explorer", app.Explorer)
@@ -84,6 +86,7 @@ func registerViewCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "sidebar.search", Title: "Show Search",
+		Keywords: []string{"view", "search", "find", "grep"},
 		Handler: func() {
 			app.ShowPanel("search", app.Search)
 		},
@@ -91,11 +94,13 @@ func registerViewCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "sidebar.searchReplace", Title: "Search and Replace in Files",
-		Handler: app.ToggleSearchReplace,
+		Keywords: []string{"view", "search", "find", "replace", "substitute"},
+		Handler:  app.ToggleSearchReplace,
 	})
 
 	reg.Register(command.Command{
 		ID: "sidebar.changes", Title: "Show Changes",
+		Keywords: []string{"view", "git", "diff", "source control"},
 		Handler: func() {
 			app.Changes.Refresh()
 			app.ShowPanel("changes", app.Changes)
@@ -104,6 +109,7 @@ func registerViewCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "sidebar.wider", Title: "Increase Sidebar Width",
+		Keywords: []string{"view", "resize"},
 		Handler: func() {
 			if app.Sidebar.Visible {
 				app.SetSidebarWidth(app.SplitPanel.DividerPos + 1)
@@ -113,6 +119,7 @@ func registerViewCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "sidebar.narrower", Title: "Decrease Sidebar Width",
+		Keywords: []string{"view", "resize"},
 		Handler: func() {
 			if app.Sidebar.Visible {
 				app.SetSidebarWidth(app.SplitPanel.DividerPos - 1)
@@ -122,46 +129,55 @@ func registerViewCommands(app *App) {
 
 	reg.Register(command.Command{
 		ID: "sidebar.focus", Title: "Focus Sidebar",
-		Handler: app.FocusSidebar,
+		Keywords: []string{"view"},
+		Handler:  app.FocusSidebar,
 	})
 
 	reg.Register(command.Command{
 		ID: "panel.toggle", Title: "Toggle Panel",
-		Handler: app.ToggleBottomPanel,
+		Keywords: []string{"view", "bottom", "show", "hide"},
+		Handler:  app.ToggleBottomPanel,
 	})
 
 	reg.Register(command.Command{
 		ID: "panel.focus", Title: "Focus Panel",
-		Handler: app.FocusPanel,
+		Keywords: []string{"view", "bottom"},
+		Handler:  app.FocusPanel,
 	})
 
 	reg.Register(command.Command{
 		ID: "terminal.new", Title: "New Terminal",
-		Handler: app.SpawnTerminal,
+		Keywords: []string{"terminal", "shell", "console", "bash"},
+		Handler:  app.SpawnTerminal,
 	})
 
 	reg.Register(command.Command{
 		ID: "terminal.toggle", Title: "Toggle Terminal",
-		Handler: app.ToggleTerminal,
+		Keywords: []string{"terminal", "shell", "console", "bash"},
+		Handler:  app.ToggleTerminal,
 	})
 
 	reg.Register(command.Command{
 		ID: "terminal.fullscreen", Title: "Toggle Terminal Fullscreen",
-		Handler: app.ToggleTerminalFullscreen,
+		Keywords: []string{"terminal", "shell", "maximize"},
+		Handler:  app.ToggleTerminalFullscreen,
 	})
 
 	reg.Register(command.Command{
 		ID: "terminal.closeAll", Title: "Close All Terminals",
-		Handler: app.CloseAllTerminals,
+		Keywords: []string{"terminal", "shell"},
+		Handler:  app.CloseAllTerminals,
 	})
 
 	reg.Register(command.Command{
 		ID: "view.keyboardTester", Title: "Keyboard Tester",
-		Handler: app.ShowKeyboardTester,
+		Keywords: []string{"view", "debug", "input"},
+		Handler:  app.ShowKeyboardTester,
 	})
 
 	reg.Register(command.Command{
 		ID: "about", Title: "About ttt",
+		Keywords: []string{"help", "version", "info"},
 		Handler: func() {
 			OpenURL("https://github.com/eugenioenko/ttt")
 		},

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -4,6 +4,7 @@ type Command struct {
 	ID       string
 	Title    string
 	Shortcut string
+	Keywords []string
 	Handler  func()
 }
 

--- a/internal/ui/palette_widget.go
+++ b/internal/ui/palette_widget.go
@@ -318,14 +318,21 @@ func (p *CommandPaletteWidget) filterCommands(query string) {
 		}
 		var matches []scored
 		for _, cmd := range p.Commands {
-			if ok, score := fuzzyMatch(query, cmd.Title); ok {
+			bestOk, bestScore := fuzzyMatch(query, cmd.Title)
+			for _, kw := range cmd.Keywords {
+				if ok, score := fuzzyMatch(query, kw); ok && (!bestOk || score > bestScore) {
+					bestOk = true
+					bestScore = score
+				}
+			}
+			if bestOk {
 				matches = append(matches, scored{
 					item: PaletteItem{
 						Label:  cmd.Title,
 						Detail: cmd.Shortcut,
 						ID:     cmd.ID,
 					},
-					score: score,
+					score: bestScore,
 				})
 			}
 		}

--- a/internal/ui/palette_widget_test.go
+++ b/internal/ui/palette_widget_test.go
@@ -181,3 +181,148 @@ func TestPaletteModeSwitch(t *testing.T) {
 		t.Fatalf("expected 4 commands, got %d", len(p.Items))
 	}
 }
+
+func testCommandsWithKeywords() []command.Command {
+	return []command.Command{
+		{ID: "fold.toggle", Title: "Toggle Fold", Keywords: []string{"editor", "collapse", "expand", "hide", "lines"}},
+		{ID: "fold.collapseAll", Title: "Fold All", Keywords: []string{"editor", "collapse", "expand", "hide", "lines"}},
+		{ID: "fold.expandAll", Title: "Unfold All", Keywords: []string{"editor", "collapse", "expand", "hide", "lines"}},
+		{ID: "editor.undo", Title: "Undo", Keywords: []string{"editor", "revert"}},
+		{ID: "editor.redo", Title: "Redo", Keywords: []string{"editor"}},
+		{ID: "search.find", Title: "Find", Keywords: []string{"search", "find", "locate"}},
+		{ID: "search.replace", Title: "Find and Replace", Keywords: []string{"search", "find", "replace", "substitute"}},
+		{ID: "terminal.toggle", Title: "Toggle Terminal", Keywords: []string{"terminal", "shell", "console", "bash"}},
+		{ID: "settings.open", Title: "Preferences: Open Settings", Keywords: []string{"preferences", "settings", "configuration", "options"}},
+	}
+}
+
+func TestPaletteKeywordMatch(t *testing.T) {
+	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+
+	// Type "collapse" which should match fold commands via keywords
+	for _, r := range "collapse" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	found := false
+	for _, item := range p.Items {
+		if item.ID == "fold.toggle" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected keyword 'collapse' to match 'Toggle Fold'")
+	}
+}
+
+func TestPaletteKeywordEditorCategory(t *testing.T) {
+	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+
+	// Type "editor" which should return editor-related commands via keywords
+	for _, r := range "editor" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	if len(p.Items) == 0 {
+		t.Fatal("expected 'editor' to return results via keyword matching")
+	}
+
+	// All fold commands and editor commands should be in results
+	foundFold := false
+	foundUndo := false
+	for _, item := range p.Items {
+		if item.ID == "fold.toggle" {
+			foundFold = true
+		}
+		if item.ID == "editor.undo" {
+			foundUndo = true
+		}
+	}
+	if !foundFold {
+		t.Fatal("expected 'editor' keyword to match fold.toggle")
+	}
+	if !foundUndo {
+		t.Fatal("expected 'editor' keyword to match editor.undo")
+	}
+}
+
+func TestPaletteKeywordNotDisplayed(t *testing.T) {
+	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+
+	// Type "collapse" to trigger keyword match
+	for _, r := range "collapse" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	// Verify the label shows the Title, not the keyword
+	for _, item := range p.Items {
+		if item.ID == "fold.toggle" {
+			if item.Label != "Toggle Fold" {
+				t.Fatalf("expected label 'Toggle Fold', got '%s'", item.Label)
+			}
+			return
+		}
+	}
+	t.Fatal("fold.toggle not found in results")
+}
+
+func TestPaletteKeywordCollapseMatchesFoldCommands(t *testing.T) {
+	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+
+	for _, r := range "collapse" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	foldIDs := map[string]bool{"fold.toggle": false, "fold.collapseAll": false, "fold.expandAll": false}
+	for _, item := range p.Items {
+		if _, ok := foldIDs[item.ID]; ok {
+			foldIDs[item.ID] = true
+		}
+	}
+	for id, found := range foldIDs {
+		if !found {
+			t.Fatalf("expected 'collapse' keyword to match %s", id)
+		}
+	}
+}
+
+func TestPaletteKeywordSubstitute(t *testing.T) {
+	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+
+	// "substitute" should match Find and Replace via keywords
+	for _, r := range "substitute" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	found := false
+	for _, item := range p.Items {
+		if item.ID == "search.replace" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected keyword 'substitute' to match 'Find and Replace'")
+	}
+}
+
+func TestPaletteTitleMatchPreferredOverKeyword(t *testing.T) {
+	cmds := []command.Command{
+		{ID: "a", Title: "Find", Keywords: []string{"search"}},
+		{ID: "b", Title: "Search Panel", Keywords: []string{"find"}},
+	}
+	p := NewCommandPaletteWidget(cmds)
+
+	// "find" should match both, but "a" has it in the title (exact substring = higher score)
+	for _, r := range "find" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	if len(p.Items) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(p.Items))
+	}
+	if p.Items[0].ID != "a" {
+		t.Fatalf("expected title match 'Find' (id=a) to rank first, got id=%s", p.Items[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Keywords []string` field to `command.Command` struct
- Fuzzy matcher now searches keywords in addition to title, using the best score
- Category keywords on all commands: editor, file, view, search, git, terminal, tab, navigate, source, preferences
- Synonym keywords: collapse/expand/hide for fold, find/replace for search, shell/console for terminal, clipboard for copy/cut/paste, etc.
- Keywords are never displayed — only used for matching

## Test plan
- [x] "collapse" finds fold commands
- [x] "editor" returns editor-related commands
- [x] Labels show titles, not keywords
- [x] All 3 fold commands found via "collapse"
- [x] "substitute" finds Find and Replace
- [x] Title matches rank higher than keyword matches
- [x] `make build` and `make test` pass

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)