### PR TITLE
feat: rename CommandPaletteWidget to SelectDialogWidget and add mouse support

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -541,7 +541,7 @@ func (a *App) showDiffFindBar(dv *ui.DiffViewWidget) {
 }
 
 func (a *App) ShowPicker(items []command.Command, onSelect func(id string)) {
-	picker := ui.NewCommandPaletteWidget(items)
+	picker := ui.NewSelectDialogWidget(items)
 	picker.Borders = a.Borders
 	picker.OnExecute = func(id string) {
 		a.DismissDialog()

--- a/internal/app/commands_palette.go
+++ b/internal/app/commands_palette.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (a *App) OpenCommandPalette(fileMode bool, initialText ...string) {
-	palette := ui.NewCommandPaletteWidget(a.Reg.List())
+	palette := ui.NewSelectDialogWidget(a.Reg.List())
 	palette.Borders = a.Borders
 	palette.SetFiles(a.Workspace.Paths())
 	if len(initialText) > 0 {
@@ -46,7 +46,7 @@ func (a *App) ShowThemePicker() {
 	for _, name := range names {
 		cmds = append(cmds, command.Command{ID: name, Title: name})
 	}
-	picker := ui.NewCommandPaletteWidget(cmds)
+	picker := ui.NewSelectDialogWidget(cmds)
 	picker.Borders = a.Borders
 	originalStyleMap := a.Screen.GetStyleMap()
 	originalPalette := *a.Palette

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -103,7 +103,7 @@ func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 		return r.handleMouse(ev)
 	}
 
-	if res := r.handleOverlay(ev); res == EventConsumed {
+	if res := r.handleOverlay(ev); res != EventIgnored {
 		return EventConsumed
 	}
 

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -186,11 +186,6 @@ func (p *SelectDialogWidget) Render(surface *RenderSurface) {
 		p.scrollbar.Y = boxY + 3
 	}
 
-	var thumbTop, thumbH int
-	if showScroll {
-		thumbTop, thumbH = p.scrollbar.ThumbPos()
-	}
-
 	for i := 0; i < visibleItems && p.scrollOffset+i < len(p.Items); i++ {
 		y := boxY + 3 + i
 		idx := p.scrollOffset + i
@@ -215,15 +210,10 @@ func (p *SelectDialogWidget) Render(surface *RenderSurface) {
 				surface.DrawText(sx, y, item.Detail, contentRight-1, detailStyle)
 			}
 		}
+	}
 
-		if showScroll {
-			sx := boxX + boxW - 2
-			if i >= thumbTop && i < thumbTop+thumbH {
-				surface.SetCell(sx, y, term.Cell{Ch: '█', Style: term.StyleScrollbarThumb})
-			} else {
-				surface.SetCell(sx, y, term.Cell{Ch: ' ', Style: term.StyleScrollbar})
-			}
-		}
+	if showScroll {
+		p.scrollbar.Render(surface, p.scrollbar.X, p.scrollbar.Y)
 	}
 }
 

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -32,7 +32,7 @@ type paletteFile struct {
 	Abs string
 }
 
-type CommandPaletteWidget struct {
+type SelectDialogWidget struct {
 	BaseWidget
 	Commands          []command.Command
 	Items             []PaletteItem
@@ -49,10 +49,18 @@ type CommandPaletteWidget struct {
 	OnDismiss         func()
 	OnSelectionChange func(id string)
 	Borders           *term.BorderSet
+
+	boxX         int
+	boxY         int
+	boxW         int
+	boxH         int
+	visibleItems int
+	showScroll   bool
+	scrollbar    Scrollbar
 }
 
-func NewCommandPaletteWidget(commands []command.Command) *CommandPaletteWidget {
-	p := &CommandPaletteWidget{
+func NewSelectDialogWidget(commands []command.Command) *SelectDialogWidget {
+	p := &SelectDialogWidget{
 		Commands: commands,
 	}
 	p.Input = NewInputWidget()
@@ -65,7 +73,7 @@ func NewCommandPaletteWidget(commands []command.Command) *CommandPaletteWidget {
 	return p
 }
 
-func (p *CommandPaletteWidget) SetFiles(workDirs []string) {
+func (p *SelectDialogWidget) SetFiles(workDirs []string) {
 	p.files = nil
 	multiRoot := len(workDirs) > 1
 	for _, workDir := range workDirs {
@@ -97,13 +105,13 @@ func (p *CommandPaletteWidget) SetFiles(workDirs []string) {
 	}
 }
 
-func (p *CommandPaletteWidget) Focusable() bool { return true }
+func (p *SelectDialogWidget) Focusable() bool { return true }
 
-func (p *CommandPaletteWidget) CursorPosition() (int, int, bool) {
+func (p *SelectDialogWidget) CursorPosition() (int, int, bool) {
 	return p.Input.CursorX(p.inputX), p.inputY, true
 }
 
-func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
+func (p *SelectDialogWidget) Render(surface *RenderSurface) {
 	sw, sh := surface.Size()
 
 	boxW := sw * 6 / 10 // 60% of terminal width
@@ -133,6 +141,11 @@ func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
 	boxX := (sw - boxW) / 2
 	boxY := 2
 
+	p.boxX = boxX
+	p.boxY = boxY
+	p.boxW = boxW
+	p.boxH = boxH
+
 	b := term.DoubleBorderSet()
 	if p.Borders != nil {
 		b = *p.Borders
@@ -146,6 +159,8 @@ func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
 	p.Input.Render(surface, p.inputX, p.inputY, boxW-2)
 
 	if p.mode == paletteGoToLineMode {
+		p.visibleItems = 0
+		p.showScroll = false
 		return
 	}
 
@@ -154,17 +169,26 @@ func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
 	}
 
 	visibleItems := boxH - 4
+	p.visibleItems = visibleItems
 	p.ensureVisible(visibleItems)
 	showScroll := len(p.Items) > visibleItems
+	p.showScroll = showScroll
 	contentRight := boxX + boxW - 1
 	if showScroll {
 		contentRight--
 	}
 
+	if showScroll {
+		p.scrollbar.Height = visibleItems
+		p.scrollbar.TotalItems = len(p.Items)
+		p.scrollbar.TopItem = p.scrollOffset
+		p.scrollbar.X = boxX + boxW - 2
+		p.scrollbar.Y = boxY + 3
+	}
+
 	var thumbTop, thumbH int
 	if showScroll {
-		sb := Scrollbar{Height: visibleItems, TotalItems: len(p.Items), TopItem: p.scrollOffset}
-		thumbTop, thumbH = sb.ThumbPos()
+		thumbTop, thumbH = p.scrollbar.ThumbPos()
 	}
 
 	for i := 0; i < visibleItems && p.scrollOffset+i < len(p.Items); i++ {
@@ -203,14 +227,74 @@ func (p *CommandPaletteWidget) Render(surface *RenderSurface) {
 	}
 }
 
-func (p *CommandPaletteWidget) HandleEvent(ev tcell.Event) EventResult {
+func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 	if mev, ok := ev.(*tcell.EventMouse); ok {
-		if mev.Buttons()&tcell.Button1 != 0 {
-			mx, my := mev.Position()
-			if my == p.inputY {
-				p.Input.HandleClick(mx, my)
+		btn := mev.Buttons()
+		mx, my := mev.Position()
+
+		if p.showScroll {
+			if newTop, consumed := p.scrollbar.HandleEvent(ev); consumed {
+				p.scrollOffset = newTop
+				if p.Selected < p.scrollOffset {
+					p.Selected = p.scrollOffset
+					p.notifySelectionChange()
+				} else if p.visibleItems > 0 && p.Selected >= p.scrollOffset+p.visibleItems {
+					p.Selected = p.scrollOffset + p.visibleItems - 1
+					if p.Selected >= len(p.Items) {
+						p.Selected = len(p.Items) - 1
+					}
+					p.notifySelectionChange()
+				}
+				if p.scrollbar.IsDragging() {
+					return EventCaptured
+				}
+				return EventConsumed
+			}
+			if p.scrollbar.IsDragging() {
+				return EventCaptured
 			}
 		}
+
+		if btn&tcell.WheelUp != 0 {
+			if p.Selected > 0 {
+				p.Selected--
+				p.notifySelectionChange()
+			}
+			return EventConsumed
+		}
+		if btn&tcell.WheelDown != 0 {
+			if p.Selected < len(p.Items)-1 {
+				p.Selected++
+				p.notifySelectionChange()
+			}
+			return EventConsumed
+		}
+
+		if btn&tcell.Button1 != 0 {
+			if my == p.inputY {
+				p.Input.HandleClick(mx, my)
+				return EventConsumed
+			}
+
+			itemsStartY := p.boxY + 3
+			if p.visibleItems > 0 && my >= itemsStartY && my < itemsStartY+p.visibleItems {
+				clickedIdx := p.scrollOffset + (my - itemsStartY)
+				if clickedIdx >= 0 && clickedIdx < len(p.Items) {
+					p.Selected = clickedIdx
+					item := p.Items[p.Selected]
+					if p.mode == paletteCommandMode {
+						if p.OnExecute != nil {
+							p.OnExecute(item.ID)
+						}
+					} else {
+						if p.OnOpenFile != nil {
+							p.OnOpenFile(item.ID)
+						}
+					}
+				}
+			}
+		}
+
 		return EventConsumed
 	}
 
@@ -265,7 +349,7 @@ func (p *CommandPaletteWidget) HandleEvent(ev tcell.Event) EventResult {
 	return EventConsumed
 }
 
-func (p *CommandPaletteWidget) ensureVisible(visibleItems int) {
+func (p *SelectDialogWidget) ensureVisible(visibleItems int) {
 	if visibleItems <= 0 {
 		return
 	}
@@ -277,13 +361,13 @@ func (p *CommandPaletteWidget) ensureVisible(visibleItems int) {
 	}
 }
 
-func (p *CommandPaletteWidget) notifySelectionChange() {
+func (p *SelectDialogWidget) notifySelectionChange() {
 	if p.OnSelectionChange != nil && p.Selected >= 0 && p.Selected < len(p.Items) {
 		p.OnSelectionChange(p.Items[p.Selected].ID)
 	}
 }
 
-func (p *CommandPaletteWidget) filter() {
+func (p *SelectDialogWidget) filter() {
 	text := p.Input.Text
 	if strings.HasPrefix(text, ">") {
 		p.mode = paletteCommandMode
@@ -301,7 +385,7 @@ func (p *CommandPaletteWidget) filter() {
 	p.notifySelectionChange()
 }
 
-func (p *CommandPaletteWidget) filterCommands(query string) {
+func (p *SelectDialogWidget) filterCommands(query string) {
 	p.Items = nil
 	if query == "" {
 		for _, cmd := range p.Commands {
@@ -355,7 +439,7 @@ func fileDetail(f string) string {
 	return dir
 }
 
-func (p *CommandPaletteWidget) filterFiles(query string) {
+func (p *SelectDialogWidget) filterFiles(query string) {
 	p.Items = nil
 	if query == "" {
 		for _, f := range p.files {

--- a/internal/ui/selectdialog_widget_test.go
+++ b/internal/ui/selectdialog_widget_test.go
@@ -17,7 +17,7 @@ func testCommands() []command.Command {
 }
 
 func TestPaletteFilter(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 
 	if len(p.Items) != 4 {
 		t.Fatalf("empty query: expected 4, got %d", len(p.Items))
@@ -35,7 +35,7 @@ func TestPaletteFilter(t *testing.T) {
 }
 
 func TestPaletteNavigation(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 
 	p.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, 0))
 	if p.Selected != 1 {
@@ -55,7 +55,7 @@ func TestPaletteNavigation(t *testing.T) {
 }
 
 func TestPaletteExecute(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 	executed := ""
 	p.OnExecute = func(id string) { executed = id }
 
@@ -68,7 +68,7 @@ func TestPaletteExecute(t *testing.T) {
 }
 
 func TestPaletteDismiss(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 	dismissed := false
 	p.OnDismiss = func() { dismissed = true }
 
@@ -80,7 +80,7 @@ func TestPaletteDismiss(t *testing.T) {
 }
 
 func TestPaletteAlwaysConsumes(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 	result := p.HandleEvent(tcell.NewEventKey(tcell.KeyF1, 0, 0))
 	if result != EventConsumed {
 		t.Fatal("palette should consume all events (modal)")
@@ -88,7 +88,7 @@ func TestPaletteAlwaysConsumes(t *testing.T) {
 }
 
 func TestPaletteBackspace(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 
 	// Initial text is ">", type "sp" → ">sp"
 	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 's', 0))
@@ -104,7 +104,7 @@ func TestPaletteBackspace(t *testing.T) {
 }
 
 func TestPaletteFuzzyFilter(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 
 	// Type "fs" which should fuzzy match "File: Save" (F + S at word boundaries)
 	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'f', 0))
@@ -123,7 +123,7 @@ func TestPaletteFuzzyFilter(t *testing.T) {
 }
 
 func TestPaletteFuzzyFilterInitials(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 
 	// Type "se" which should fuzzy match "Split Editor Right" (s...e in Editor)
 	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 's', 0))
@@ -147,7 +147,7 @@ func TestPaletteFuzzyScoreOrdering(t *testing.T) {
 		{ID: "b", Title: "To Do List"},
 		{ID: "c", Title: "Top Level"},
 	}
-	p := NewCommandPaletteWidget(cmds)
+	p := NewSelectDialogWidget(cmds)
 
 	// Type "to" - "Toggle Sidebar" and "Top Level" start with "to" (substring at position 0),
 	// "To Do List" starts with "To" too. All are substring matches.
@@ -160,7 +160,7 @@ func TestPaletteFuzzyScoreOrdering(t *testing.T) {
 }
 
 func TestPaletteModeSwitch(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommands())
+	p := NewSelectDialogWidget(testCommands())
 
 	if p.mode != paletteCommandMode {
 		t.Fatal("expected command mode initially")
@@ -197,7 +197,7 @@ func testCommandsWithKeywords() []command.Command {
 }
 
 func TestPaletteKeywordMatch(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+	p := NewSelectDialogWidget(testCommandsWithKeywords())
 
 	// Type "collapse" which should match fold commands via keywords
 	for _, r := range "collapse" {
@@ -217,7 +217,7 @@ func TestPaletteKeywordMatch(t *testing.T) {
 }
 
 func TestPaletteKeywordEditorCategory(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+	p := NewSelectDialogWidget(testCommandsWithKeywords())
 
 	// Type "editor" which should return editor-related commands via keywords
 	for _, r := range "editor" {
@@ -248,7 +248,7 @@ func TestPaletteKeywordEditorCategory(t *testing.T) {
 }
 
 func TestPaletteKeywordNotDisplayed(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+	p := NewSelectDialogWidget(testCommandsWithKeywords())
 
 	// Type "collapse" to trigger keyword match
 	for _, r := range "collapse" {
@@ -268,7 +268,7 @@ func TestPaletteKeywordNotDisplayed(t *testing.T) {
 }
 
 func TestPaletteKeywordCollapseMatchesFoldCommands(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+	p := NewSelectDialogWidget(testCommandsWithKeywords())
 
 	for _, r := range "collapse" {
 		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
@@ -288,7 +288,7 @@ func TestPaletteKeywordCollapseMatchesFoldCommands(t *testing.T) {
 }
 
 func TestPaletteKeywordSubstitute(t *testing.T) {
-	p := NewCommandPaletteWidget(testCommandsWithKeywords())
+	p := NewSelectDialogWidget(testCommandsWithKeywords())
 
 	// "substitute" should match Find and Replace via keywords
 	for _, r := range "substitute" {
@@ -312,7 +312,7 @@ func TestPaletteTitleMatchPreferredOverKeyword(t *testing.T) {
 		{ID: "a", Title: "Find", Keywords: []string{"search"}},
 		{ID: "b", Title: "Search Panel", Keywords: []string{"find"}},
 	}
-	p := NewCommandPaletteWidget(cmds)
+	p := NewSelectDialogWidget(cmds)
 
 	// "find" should match both, but "a" has it in the title (exact substring = higher score)
 	for _, r := range "find" {


### PR DESCRIPTION
## Summary
- Rename `CommandPaletteWidget` → `SelectDialogWidget` and `NewCommandPaletteWidget` → `NewSelectDialogWidget` to reflect its generic purpose as a filterable list picker
- Rename file `palette_widget.go` → `selectdialog_widget.go` (and test file)
- Add mouse click to select and execute items
- Add mouse wheel scroll (WheelUp/WheelDown)
- Add scrollbar thumb drag support via existing `Scrollbar.HandleEvent()`
- Store layout fields (`boxX`, `boxY`, `visibleItems`, etc.) during Render for mouse hit testing (single source of truth)

Resolves #145

## Test plan
- [x] All existing unit tests pass (renamed references)
- [x] All E2E tests pass
- [x] `go build ./...` clean
- [ ] Manual: open command palette, click an item — executes
- [ ] Manual: open command palette, scroll wheel — selection moves
- [ ] Manual: open file picker with many files, drag scrollbar thumb

🤖 Generated with [Claude Code](https://claude.com/claude-code)