### PR TITLE
feat: distinct autocomplete completion kind symbols

### DIFF
--- a/internal/app/lsp_convert.go
+++ b/internal/app/lsp_convert.go
@@ -111,11 +111,13 @@ func lspKindToUI(kind lsp.CompletionItemKind) ui.CompletionKind {
 		return ui.CompletionMethod
 	case lsp.CIKVariable:
 		return ui.CompletionVariable
-	case lsp.CIKConstant, lsp.CIKEnumMember:
+	case lsp.CIKConstant:
 		return ui.CompletionConstant
-	case lsp.CIKClass, lsp.CIKInterface, lsp.CIKStruct, lsp.CIKEnum, lsp.CIKTypeParameter:
+	case lsp.CIKClass, lsp.CIKStruct, lsp.CIKTypeParameter:
 		return ui.CompletionType
-	case lsp.CIKField, lsp.CIKProperty:
+	case lsp.CIKField:
+		return ui.CompletionField
+	case lsp.CIKProperty:
 		return ui.CompletionField
 	case lsp.CIKKeyword:
 		return ui.CompletionKeyword
@@ -123,6 +125,20 @@ func lspKindToUI(kind lsp.CompletionItemKind) ui.CompletionKind {
 		return ui.CompletionSnippet
 	case lsp.CIKModule:
 		return ui.CompletionModule
+	case lsp.CIKInterface:
+		return ui.CompletionInterface
+	case lsp.CIKEnum:
+		return ui.CompletionEnum
+	case lsp.CIKEnumMember:
+		return ui.CompletionEnumMember
+	case lsp.CIKText:
+		return ui.CompletionText
+	case lsp.CIKValue:
+		return ui.CompletionValue
+	case lsp.CIKFile:
+		return ui.CompletionFile
+	case lsp.CIKFolder:
+		return ui.CompletionFolder
 	default:
 		return ui.CompletionVariable
 	}

--- a/internal/ui/autocomplete_widget.go
+++ b/internal/ui/autocomplete_widget.go
@@ -12,7 +12,7 @@ import (
 type CompletionKind int
 
 const (
-	CompletionFunction CompletionKind = iota
+	CompletionFunction   CompletionKind = iota
 	CompletionMethod
 	CompletionVariable
 	CompletionConstant
@@ -21,9 +21,53 @@ const (
 	CompletionKeyword
 	CompletionSnippet
 	CompletionModule
+	CompletionInterface
+	CompletionEnum
+	CompletionEnumMember
+	CompletionText
+	CompletionValue
+	CompletionFile
+	CompletionFolder
 )
 
-func (k CompletionKind) Symbol() rune { return '■' }
+func (k CompletionKind) Symbol() rune {
+	switch k {
+	case CompletionFunction:
+		return 'f'
+	case CompletionMethod:
+		return 'm'
+	case CompletionVariable:
+		return 'v'
+	case CompletionConstant:
+		return 'c'
+	case CompletionType:
+		return 'C'
+	case CompletionField:
+		return 'p'
+	case CompletionKeyword:
+		return 'k'
+	case CompletionSnippet:
+		return 'S'
+	case CompletionModule:
+		return 'M'
+	case CompletionInterface:
+		return 'I'
+	case CompletionEnum:
+		return 'E'
+	case CompletionEnumMember:
+		return 'e'
+	case CompletionText:
+		return 't'
+	case CompletionValue:
+		return 'V'
+	case CompletionFile:
+		return 'F'
+	case CompletionFolder:
+		return 'D'
+	default:
+		return '■'
+	}
+}
 
 func (k CompletionKind) Style() term.Style {
 	switch k {
@@ -45,6 +89,20 @@ func (k CompletionKind) Style() term.Style {
 		return term.StyleSyntaxString
 	case CompletionModule:
 		return term.StyleSyntaxComment
+	case CompletionInterface:
+		return term.StyleSyntaxType
+	case CompletionEnum:
+		return term.StyleSyntaxType
+	case CompletionEnumMember:
+		return term.StyleSyntaxNumber
+	case CompletionText:
+		return term.StyleSyntaxVariable
+	case CompletionValue:
+		return term.StyleSyntaxNumber
+	case CompletionFile:
+		return term.StyleSyntaxString
+	case CompletionFolder:
+		return term.StyleSyntaxString
 	default:
 		return term.StyleSyntaxVariable
 	}


### PR DESCRIPTION
## Summary
- Each LSP completion kind now shows a unique character in the autocomplete popup instead of the generic `■` square
- Added 7 new `CompletionKind` constants: Interface, Enum, EnumMember, Text, Value, File, Folder
- Updated `lspKindToUI()` to map LSP kinds to the new finer-grained UI kinds (e.g., Interface and Enum are no longer collapsed into Type)

Character mapping: `f`=function, `m`=method, `v`=variable, `c`=constant, `C`=class/type, `p`=field/property, `k`=keyword, `S`=snippet, `M`=module, `I`=interface, `E`=enum, `e`=enum member, `t`=text, `V`=value, `F`=file, `D`=folder, `■`=unknown/other.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all unit + E2E tests)
- Visual-only change — no new tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)