### PR TITLE
fix: cap command palette max width to 60 columns

### DIFF
--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -115,8 +115,8 @@ func (p *SelectDialogWidget) Render(surface *RenderSurface) {
 	sw, sh := surface.Size()
 
 	boxW := sw * 6 / 10 // 60% of terminal width
-	if boxW > 80 {
-		boxW = 80
+	if boxW > 60 {
+		boxW = 60
 	}
 	if boxW < 40 {
 		boxW = 40


### PR DESCRIPTION
## Summary
- Reduce the command palette max width from 80 back to 60 columns — the wider cap from the fuzzy matching PR felt too wide.

## Test plan
- [x] All existing tests pass
- [ ] Open the command palette in a wide terminal and confirm it caps at 60 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)