### PR TITLE
fix: rank title matches above keyword matches in command palette

### DIFF
--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -394,9 +394,12 @@ func (p *SelectDialogWidget) filterCommands(query string) {
 		for _, cmd := range p.Commands {
 			bestOk, bestScore := fuzzyMatch(query, cmd.Title)
 			for _, kw := range cmd.Keywords {
-				if ok, score := fuzzyMatch(query, kw); ok && (!bestOk || score > bestScore) {
-					bestOk = true
-					bestScore = score
+				if ok, score := fuzzyMatch(query, kw); ok {
+					penalized := score / 2
+					if !bestOk || penalized > bestScore {
+						bestOk = true
+						bestScore = penalized
+					}
 				}
 			}
 			if bestOk {

--- a/internal/ui/selectdialog_widget_test.go
+++ b/internal/ui/selectdialog_widget_test.go
@@ -326,3 +326,24 @@ func TestPaletteTitleMatchPreferredOverKeyword(t *testing.T) {
 		t.Fatalf("expected title match 'Find' (id=a) to rank first, got id=%s", p.Items[0].ID)
 	}
 }
+
+func TestPaletteTitleMatchRanksAboveKeywordOnly(t *testing.T) {
+	cmds := []command.Command{
+		{ID: "linenumbers", Title: "Toggle Line Numbers", Keywords: []string{"settings", "preferences"}},
+		{ID: "settings", Title: "Preferences: Open Settings", Keywords: []string{"preferences", "configuration"}},
+	}
+	p := NewSelectDialogWidget(cmds)
+
+	// "settings" is in the title of the second command, but only a keyword of the first.
+	// The title match should rank higher.
+	for _, r := range "settings" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, 0))
+	}
+
+	if len(p.Items) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(p.Items))
+	}
+	if p.Items[0].ID != "settings" {
+		t.Fatalf("expected title match 'Preferences: Open Settings' (id=settings) to rank first, got id=%s (%s)", p.Items[0].ID, p.Items[0].Label)
+	}
+}


### PR DESCRIPTION
## Summary
- Penalize keyword-only matches in the command palette fuzzy search by halving their score, so commands where the query appears in the title consistently rank above commands where it only appears as a keyword.
- For example, searching "settings" now ranks "Preferences: Open Settings" above "Toggle Line Numbers" (which only has "settings" as a keyword).
- Added a test case (`TestPaletteTitleMatchRanksAboveKeywordOnly`) verifying this ranking behavior.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/ui/ -run TestFuzzy -v` -- all 15 fuzzy tests pass
- [x] `go test ./internal/ui/ -run TestPalette -v` -- all 17 palette tests pass (including existing keyword tests and new ranking test)
- [x] `go test ./internal/ui/ -v` -- full UI package test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)