### PR TITLE
fix: cache bracket color map to avoid per-frame recomputation

### DIFF
--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -25,6 +25,7 @@ func (a *App) ToggleBracketPairColorization() {
 	a.EditorGroup.BracketPairColorization = a.Settings.Editor.BracketPairColorization
 	if a.EditorGroup.Editor != nil {
 		a.EditorGroup.Editor.BracketPairColorization = a.Settings.Editor.BracketPairColorization
+		a.EditorGroup.Editor.InvalidateBracketColors()
 	}
 	config.SaveSettings(*a.Settings)
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -959,6 +959,7 @@ func (g *EditorGroupWidget) syncTabs() {
 		g.Editor.LineChanges = t.LineChanges
 		g.Editor.buildDiagIndex()
 		g.Editor.InvalidateMaxLineWidth()
+		g.Editor.InvalidateBracketColors()
 		if t.TabSize > 0 {
 			g.Editor.TabSize = t.TabSize
 		}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -498,7 +498,6 @@ func (e *EditorPaneWidget) exec(cmd undo.EditCommand) {
 	if e.Undo != nil {
 		e.Undo.Push(cmd)
 	}
-	e.maxLineWidthDirty = true
 	e.bufferDirty = true
 	if e.Folds != nil && len(e.Buf.Lines) != prevLines {
 		e.Folds.SetRanges(fold.ComputeIndentRanges(e.Buf.Lines))
@@ -510,6 +509,7 @@ func (e *EditorPaneWidget) ExecCommand(cmd undo.EditCommand) { e.exec(cmd) }
 func (e *EditorPaneWidget) FlushOnChange() {
 	if e.bufferDirty {
 		e.bufferDirty = false
+		e.maxLineWidthDirty = true
 		e.bracketColorDirty = true
 		if e.OnChange != nil {
 			e.OnChange()
@@ -1748,7 +1748,6 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 
 	if len(cmds) > 0 && e.Undo != nil {
 		e.Undo.Push(&undo.BatchCommand{Commands: cmds})
-		e.maxLineWidthDirty = true
 		e.bufferDirty = true
 	}
 
@@ -2028,7 +2027,6 @@ func (e *EditorPaneWidget) multiExecRune(r rune) {
 	if e.Undo != nil {
 		e.Undo.Push(&undo.BatchCommand{Commands: cmds})
 	}
-	e.maxLineWidthDirty = true
 	e.bufferDirty = true
 	e.syncFromMulti()
 }
@@ -2072,7 +2070,6 @@ func (e *EditorPaneWidget) multiExecBackspace() {
 		if e.Undo != nil {
 			e.Undo.Push(&undo.BatchCommand{Commands: cmds})
 		}
-		e.maxLineWidthDirty = true
 		e.bufferDirty = true
 	}
 	e.Multi.Deduplicate()
@@ -2115,7 +2112,6 @@ func (e *EditorPaneWidget) multiExecDelete() {
 		if e.Undo != nil {
 			e.Undo.Push(&undo.BatchCommand{Commands: cmds})
 		}
-		e.maxLineWidthDirty = true
 		e.bufferDirty = true
 	}
 	e.Multi.Deduplicate()
@@ -2157,7 +2153,6 @@ func (e *EditorPaneWidget) multiExecEnter() {
 	if e.Undo != nil {
 		e.Undo.Push(&undo.BatchCommand{Commands: cmds})
 	}
-	e.maxLineWidthDirty = true
 	e.bufferDirty = true
 	e.syncFromMulti()
 }

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -60,14 +60,21 @@ type EditorPaneWidget struct {
 	searchByLine       map[int][]int
 	diagByLine         map[int][]int
 	LineChanges        []diff.LineChangeKind
+	bracketColorCache  bracketColorMap
+	bracketColorDirty  bool
 }
 
 func NewEditorPaneWidget(buf *buffer.Buffer, cur *cursor.Cursor, vp *view.Viewport) *EditorPaneWidget {
 	return &EditorPaneWidget{
-		Buf:      buf,
-		Cursor:   cur,
-		Viewport: vp,
+		Buf:               buf,
+		Cursor:            cur,
+		Viewport:          vp,
+		bracketColorDirty: true,
 	}
+}
+
+func (e *EditorPaneWidget) InvalidateBracketColors() {
+	e.bracketColorDirty = true
 }
 
 func (e *EditorPaneWidget) Focusable() bool { return true }
@@ -219,12 +226,11 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 
 	var bracketColors bracketColorMap
 	if e.BracketPairColorization {
-		visEnd := e.screenToBufferLine(h - 1)
-		if visEnd >= totalLines {
-			visEnd = totalLines - 1
+		if e.bracketColorDirty {
+			e.bracketColorCache = e.computeBracketColors()
+			e.bracketColorDirty = false
 		}
-		visStart := e.screenToBufferLine(0)
-		bracketColors = e.computeBracketColors(visStart, visEnd)
+		bracketColors = e.bracketColorCache
 	}
 	for y := 0; y < h; y++ {
 		lineIdx := e.screenToBufferLine(y)
@@ -504,6 +510,7 @@ func (e *EditorPaneWidget) ExecCommand(cmd undo.EditCommand) { e.exec(cmd) }
 func (e *EditorPaneWidget) FlushOnChange() {
 	if e.bufferDirty {
 		e.bufferDirty = false
+		e.bracketColorDirty = true
 		if e.OnChange != nil {
 			e.OnChange()
 		}
@@ -1343,7 +1350,7 @@ func isInStringOrComment(spans []highlight.Span, col int) bool {
 	return false
 }
 
-func (e *EditorPaneWidget) computeBracketColors(visibleStart, visibleEnd int) bracketColorMap {
+func (e *EditorPaneWidget) computeBracketColors() bracketColorMap {
 	result := make(bracketColorMap)
 	depth := 0
 	totalLines := len(e.Buf.Lines)
@@ -1354,18 +1361,13 @@ func (e *EditorPaneWidget) computeBracketColors(visibleStart, visibleEnd int) br
 	bracketStyles := e.BracketColorStyles
 	numStyles := len(bracketStyles)
 
-	for lineIdx := 0; lineIdx < totalLines && lineIdx <= visibleEnd; lineIdx++ {
+	for lineIdx := 0; lineIdx < totalLines; lineIdx++ {
 		line := e.Buf.Lines[lineIdx]
 		runes := []rune(line)
 
 		var spans []highlight.Span
-		if e.Highlighter != nil && lineIdx >= visibleStart {
+		if e.Highlighter != nil {
 			spans = e.Highlighter.HighlightLine(line)
-		}
-
-		var preSpans []highlight.Span
-		if e.Highlighter != nil && lineIdx < visibleStart {
-			preSpans = e.Highlighter.HighlightLine(line)
 		}
 
 		for col, ch := range runes {
@@ -1374,37 +1376,27 @@ func (e *EditorPaneWidget) computeBracketColors(visibleStart, visibleEnd int) br
 				continue
 			}
 
-			if lineIdx < visibleStart {
-				if isInStringOrComment(preSpans, col) {
-					continue
-				}
-			} else {
-				if isInStringOrComment(spans, col) {
-					continue
-				}
+			if isInStringOrComment(spans, col) {
+				continue
 			}
 
 			if openBrackets[ch] {
 				style := bracketStyles[depth%numStyles]
 				depth++
-				if lineIdx >= visibleStart {
-					if result[lineIdx] == nil {
-						result[lineIdx] = make(map[int]term.Style)
-					}
-					result[lineIdx][col] = style
+				if result[lineIdx] == nil {
+					result[lineIdx] = make(map[int]term.Style)
 				}
+				result[lineIdx][col] = style
 			} else if closingBrackets[ch] {
 				depth--
 				if depth < 0 {
 					depth = 0
 				}
 				style := bracketStyles[depth%numStyles]
-				if lineIdx >= visibleStart {
-					if result[lineIdx] == nil {
-						result[lineIdx] = make(map[int]term.Style)
-					}
-					result[lineIdx][col] = style
+				if result[lineIdx] == nil {
+					result[lineIdx] = make(map[int]term.Style)
 				}
+				result[lineIdx][col] = style
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Cache the `bracketColorMap` result from `computeBracketColors()` and only recompute when the buffer changes, instead of on every render frame
- Previously, scrolling a 10,000-line file to the bottom caused 10,000 lines to be scanned on every render frame; now it only scans once per edit
- Simplified `computeBracketColors()` to scan the entire file (since it's cached) and removed the `visibleStart`/`visibleEnd` parameter complexity
- Centralized both `bracketColorDirty` and `maxLineWidthDirty` invalidation into `FlushOnChange()`, so `exec()` only sets `bufferDirty` and all derived cache invalidations happen in one place

## Changes
- Added `bracketColorCache` and `bracketColorDirty` fields to `EditorPaneWidget`
- `bracketColorDirty` and `maxLineWidthDirty` are set in `FlushOnChange()` when `bufferDirty` is true — no longer scattered across `exec()` and multi-cursor methods
- Explicit `InvalidateBracketColors()` / `InvalidateMaxLineWidth()` remain for non-edit cases (tab switch, feature toggle)
- `computeBracketColors()` now takes no parameters and computes colors for all lines in the file

Closes #179

## Test plan
- [x] `make build` succeeds
- [x] All existing bracket colorization E2E tests pass (`TestBracketPairColorization`, `TestBracketPairColorizationToggle`, `TestBracketColorizationSkipsStrings`)
- [x] All other E2E and unit tests pass
- [ ] Manual verification: open a large file, scroll to bottom, verify bracket colors are correct and scrolling is smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)