### PR TITLE
fix: use LSP trigger characters for completion and signature help

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,6 +57,8 @@ type App struct {
 	DocVersions        map[string]int
 	CompletionItems    []ui.CompletionItem
 	LspCompletionItems []lsp.CompletionItem
+	CompletionTriggers []string
+	BufferChanged      bool
 	AutocompleteTimer  *time.Timer
 	HoverTimer         *time.Timer
 	HoverGen           uint64
@@ -404,7 +406,7 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		text := strings.Join(a.EditorGroup.Editor.Buf.Lines, "\n")
 		a.NotifyLSPChange(path, lang, text)
 		a.ScheduleAutocomplete()
-		a.CheckSignatureHelpTrigger()
+		a.BufferChanged = true
 		a.ScheduleGitGutter()
 	}
 

--- a/internal/app/app_lsp.go
+++ b/internal/app/app_lsp.go
@@ -42,7 +42,9 @@ func (a *App) RefreshAutocomplete() {
 	}
 	prefix := a.currentPrefix()
 	if prefix == "" {
-		a.DismissAutocomplete()
+		if !a.isCompletionTrigger(a.charBeforeCursor()) {
+			a.DismissAutocomplete()
+		}
 		return
 	}
 	filtered := ui.FilterCompletions(a.CompletionItems, prefix)
@@ -51,6 +53,15 @@ func (a *App) RefreshAutocomplete() {
 		return
 	}
 	a.EditorGroup.Autocomplete.SetItems(filtered)
+}
+
+func (a *App) isCompletionTrigger(ch string) bool {
+	for _, tc := range a.CompletionTriggers {
+		if ch == tc {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *App) identStart() (line, start, col int) {
@@ -199,10 +210,9 @@ func (a *App) ScheduleAutocomplete() {
 	if a.AutocompleteTimer != nil {
 		a.AutocompleteTimer.Stop()
 	}
-	lastChar := a.charBeforeCursor()
 	delay := time.Duration(a.Settings.Autocomplete.Debounce) * time.Millisecond
 	a.AutocompleteTimer = time.AfterFunc(delay, func() {
-		a.Screen.PostEvent(tcell.NewEventInterrupt(&AutocompleteTrigger{TriggerChar: lastChar}))
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&AutocompleteTrigger{}))
 	})
 }
 
@@ -672,7 +682,11 @@ func (a *App) RequestCompletions(path, lang string, line, col int, triggerChar s
 		slog.Debug("lsp completion response", "count", len(items))
 		uiItems := LspToUICompletions(items)
 		if len(uiItems) > 0 {
-			a.Screen.PostEvent(tcell.NewEventInterrupt(&CompletionResult{Items: uiItems, LspItems: items}))
+			a.Screen.PostEvent(tcell.NewEventInterrupt(&CompletionResult{
+				Items:        uiItems,
+				LspItems:     items,
+				TriggerChars: client.CompletionTriggerCharacters(),
+			}))
 		}
 	}()
 }

--- a/internal/app/app_lsp.go
+++ b/internal/app/app_lsp.go
@@ -199,10 +199,28 @@ func (a *App) ScheduleAutocomplete() {
 	if a.AutocompleteTimer != nil {
 		a.AutocompleteTimer.Stop()
 	}
+	lastChar := a.charBeforeCursor()
 	delay := time.Duration(a.Settings.Autocomplete.Debounce) * time.Millisecond
 	a.AutocompleteTimer = time.AfterFunc(delay, func() {
-		a.Screen.PostEvent(tcell.NewEventInterrupt(&AutocompleteTrigger{}))
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&AutocompleteTrigger{TriggerChar: lastChar}))
 	})
+}
+
+func (a *App) charBeforeCursor() string {
+	if !a.EditorGroup.IsEditorActive() {
+		return ""
+	}
+	editor := a.EditorGroup.Editor
+	line := editor.Cursor.Line
+	col := editor.Cursor.Col
+	if col <= 0 || line >= len(editor.Buf.Lines) {
+		return ""
+	}
+	runes := []rune(editor.Buf.Lines[line])
+	if col > len(runes) {
+		return ""
+	}
+	return string(runes[col-1])
 }
 
 func (a *App) CheckSignatureHelpTrigger() {
@@ -222,16 +240,26 @@ func (a *App) CheckSignatureHelpTrigger() {
 	if col > len(runes) {
 		return
 	}
-	ch := runes[col-1]
-	if ch == '(' || ch == ',' {
-		path := a.EditorGroup.ActiveFilePath()
-		lang := ""
-		if editor.Highlighter != nil {
-			lang = editor.Highlighter.Language()
-		}
-		a.RequestSignatureHelp(path, lang, line, col)
-	} else if ch == ')' {
+	ch := string(runes[col-1])
+	if ch == ")" {
 		a.DismissSignatureHelp()
+		return
+	}
+	path := a.EditorGroup.ActiveFilePath()
+	lang := ""
+	if editor.Highlighter != nil {
+		lang = editor.Highlighter.Language()
+	}
+	serverKey, _, ok := a.lspResolve(path, lang)
+	if !ok {
+		return
+	}
+	triggers := a.LspManager.SignatureHelpTriggerCharacters(serverKey)
+	for _, tc := range triggers {
+		if ch == tc {
+			a.RequestSignatureHelp(path, lang, line, col)
+			return
+		}
 	}
 }
 
@@ -608,7 +636,7 @@ func (a *App) lspResolve(path, lang string) (serverKey, languageID string, ok bo
 	return a.LspManager.ResolveLanguage(path, lang)
 }
 
-func (a *App) RequestCompletions(path, lang string, line, col int) {
+func (a *App) RequestCompletions(path, lang string, line, col int, triggerChar string) {
 	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
@@ -620,8 +648,23 @@ func (a *App) RequestCompletions(path, lang string, line, col int) {
 			slog.Error("lsp client", "err", err)
 			return
 		}
-		slog.Debug("lsp completion request", "path", path, "line", line, "col", col)
-		items, err := client.Completion(FileURI(path), line, col)
+		var ctx *lsp.CompletionContext
+		if triggerChar != "" {
+			for _, tc := range client.CompletionTriggerCharacters() {
+				if triggerChar == tc {
+					ctx = &lsp.CompletionContext{
+						TriggerKind:      lsp.CompletionTriggerTriggerCharacter,
+						TriggerCharacter: triggerChar,
+					}
+					break
+				}
+			}
+		}
+		if ctx == nil {
+			ctx = &lsp.CompletionContext{TriggerKind: lsp.CompletionTriggerInvoked}
+		}
+		slog.Debug("lsp completion request", "path", path, "line", line, "col", col, "triggerChar", triggerChar)
+		items, err := client.Completion(FileURI(path), line, col, ctx)
 		if err != nil {
 			slog.Error("lsp completion", "err", err)
 			return

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -40,7 +40,7 @@ func (a *App) TriggerAutocomplete() {
 		a.StatusWarn(lang + " language server is not configured. Add it to settings.json under lsp.servers")
 	} else {
 		line, col := a.EditorGroup.ActiveCursor()
-		a.RequestCompletions(path, lang, line, col)
+		a.RequestCompletions(path, lang, line, col, "")
 	}
 }
 

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -196,14 +196,14 @@ func RunEventLoop(
 			case *AutocompleteTrigger:
 				if !app.IsAutocompleteActive() {
 					prefix := app.currentPrefix()
-					if len(prefix) >= 1 {
+					if len(prefix) >= 1 || v.TriggerChar != "" {
 						path := app.EditorGroup.ActiveFilePath()
 						lang := ""
 						if app.EditorGroup.Editor != nil && app.EditorGroup.Editor.Highlighter != nil {
 							lang = app.EditorGroup.Editor.Highlighter.Language()
 						}
 						line, col := app.EditorGroup.ActiveCursor()
-						app.RequestCompletions(path, lang, line, col)
+						app.RequestCompletions(path, lang, line, col, v.TriggerChar)
 					}
 				}
 			case *SignatureHelpResult:

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -150,6 +150,10 @@ func RunEventLoop(
 			slog.Debug("key", "key", tev.Key(), "rune", string(tev.Rune()), "mod", tev.Modifiers())
 			app.Root.HandleEvent(tev)
 			app.RefreshAutocomplete()
+			if app.BufferChanged {
+				app.BufferChanged = false
+				app.CheckSignatureHelpTrigger()
+			}
 			syncStatus()
 			redraw()
 
@@ -194,16 +198,21 @@ func RunEventLoop(
 			case *GitGutterTrigger:
 				app.RequestGitGutterForActiveFile()
 			case *AutocompleteTrigger:
+				triggerChar := app.charBeforeCursor()
+				isTrigger := triggerChar != "" && (len(app.CompletionTriggers) == 0 || app.isCompletionTrigger(triggerChar))
+				if isTrigger && app.IsAutocompleteActive() {
+					app.DismissAutocomplete()
+				}
 				if !app.IsAutocompleteActive() {
 					prefix := app.currentPrefix()
-					if len(prefix) >= 1 || v.TriggerChar != "" {
+					if len(prefix) >= 1 || isTrigger {
 						path := app.EditorGroup.ActiveFilePath()
 						lang := ""
 						if app.EditorGroup.Editor != nil && app.EditorGroup.Editor.Highlighter != nil {
 							lang = app.EditorGroup.Editor.Highlighter.Language()
 						}
 						line, col := app.EditorGroup.ActiveCursor()
-						app.RequestCompletions(path, lang, line, col, v.TriggerChar)
+						app.RequestCompletions(path, lang, line, col, triggerChar)
 					}
 				}
 			case *SignatureHelpResult:
@@ -212,6 +221,7 @@ func RunEventLoop(
 				}
 			case *CompletionResult:
 				if len(v.Items) > 0 {
+					app.CompletionTriggers = v.TriggerChars
 					app.ShowAutocomplete(v.Items, v.LspItems)
 				}
 			case *HoverResult:

--- a/internal/app/lsp_convert.go
+++ b/internal/app/lsp_convert.go
@@ -11,8 +11,9 @@ import (
 )
 
 type CompletionResult struct {
-	Items    []ui.CompletionItem
-	LspItems []lsp.CompletionItem
+	Items        []ui.CompletionItem
+	LspItems     []lsp.CompletionItem
+	TriggerChars []string
 }
 
 type LocationResult struct {

--- a/internal/app/lsp_convert.go
+++ b/internal/app/lsp_convert.go
@@ -26,7 +26,9 @@ type HoverResult struct {
 	Gen     uint64
 }
 
-type AutocompleteTrigger struct{}
+type AutocompleteTrigger struct {
+	TriggerChar string
+}
 
 type DiagnosticsResult struct {
 	Path        string

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -17,6 +17,10 @@ type Client struct {
 	mu      sync.Mutex
 	done    chan struct{}
 
+	completionTriggers   []string
+	signatureTriggers    []string
+	signatureRetriggers  []string
+
 	OnDiagnostics func(params PublishDiagnosticsParams)
 }
 
@@ -155,6 +159,15 @@ func (c *Client) Initialize(rootURI string) error {
 	}
 	slog.Debug("lsp initialized", "capabilities", initResult.Capabilities)
 
+	caps := initResult.Capabilities
+	if caps.CompletionProvider != nil {
+		c.completionTriggers = caps.CompletionProvider.TriggerCharacters
+	}
+	if caps.SignatureHelpProvider != nil {
+		c.signatureTriggers = caps.SignatureHelpProvider.TriggerCharacters
+		c.signatureRetriggers = caps.SignatureHelpProvider.RetriggerCharacters
+	}
+
 	return c.notify("initialized", struct{}{})
 }
 
@@ -192,10 +205,23 @@ func (c *Client) DidClose(uri string) error {
 	})
 }
 
-func (c *Client) Completion(uri string, line, col int) ([]CompletionItem, error) {
+func (c *Client) CompletionTriggerCharacters() []string {
+	return c.completionTriggers
+}
+
+func (c *Client) SignatureHelpTriggerCharacters() []string {
+	return c.signatureTriggers
+}
+
+func (c *Client) SignatureHelpRetriggerCharacters() []string {
+	return c.signatureRetriggers
+}
+
+func (c *Client) Completion(uri string, line, col int, ctx *CompletionContext) ([]CompletionItem, error) {
 	result, err := c.call("textDocument/completion", CompletionParams{
 		TextDocument: TextDocumentIdentifier{URI: uri},
 		Position:     Position{Line: line, Character: col},
+		Context:      ctx,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -68,6 +68,18 @@ func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 }
 
 
+func (m *Manager) SignatureHelpTriggerCharacters(serverKey string) []string {
+	m.mu.Lock()
+	client, ok := m.servers[serverKey]
+	m.mu.Unlock()
+	if ok {
+		if chars := client.SignatureHelpTriggerCharacters(); len(chars) > 0 {
+			return chars
+		}
+	}
+	return []string{"(", ","}
+}
+
 func (m *Manager) ResolveLanguage(filePath, chromaLang string) (serverKey, languageID string, ok bool) {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	for name, cfg := range m.config.Servers {

--- a/internal/lsp/protocol.go
+++ b/internal/lsp/protocol.go
@@ -66,9 +66,15 @@ type InitializeResult struct {
 
 type ServerCapabilities struct {
 	CompletionProvider              *CompletionOptions       `json:"completionProvider,omitempty"`
+	SignatureHelpProvider           *SignatureHelpOptions    `json:"signatureHelpProvider,omitempty"`
 	TextDocumentSync                *TextDocumentSyncOptions `json:"textDocumentSync,omitempty"`
 	DocumentFormattingProvider      BoolOrObject `json:"documentFormattingProvider,omitempty"`
 	DocumentRangeFormattingProvider BoolOrObject `json:"documentRangeFormattingProvider,omitempty"`
+}
+
+type SignatureHelpOptions struct {
+	TriggerCharacters   []string `json:"triggerCharacters,omitempty"`
+	RetriggerCharacters []string `json:"retriggerCharacters,omitempty"`
 }
 
 type CompletionOptions struct {
@@ -189,9 +195,23 @@ type CodeAction struct {
 	Diagnostics []Diagnostic   `json:"diagnostics,omitempty"`
 }
 
+type CompletionTriggerKind int
+
+const (
+	CompletionTriggerInvoked                         CompletionTriggerKind = 1
+	CompletionTriggerTriggerCharacter                CompletionTriggerKind = 2
+	CompletionTriggerTriggerForIncompleteCompletions CompletionTriggerKind = 3
+)
+
+type CompletionContext struct {
+	TriggerKind      CompletionTriggerKind `json:"triggerKind"`
+	TriggerCharacter string                `json:"triggerCharacter,omitempty"`
+}
+
 type CompletionParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Position     Position               `json:"position"`
+	Context      *CompletionContext     `json:"context,omitempty"`
 }
 
 type CompletionItemKind int

--- a/tests/functional/lsp-autocomplete-trigger.test.js
+++ b/tests/functional/lsp-autocomplete-trigger.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { cpSync, unlinkSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as tui from "./tui.js";
+import { createTempDir, cleanupDir } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LSP_DIR = resolve(__dirname, "lsp", "typescript");
+const LOG_FILE = resolve(
+  process.env.HOME || process.env.USERPROFILE,
+  ".config",
+  "ttt",
+  "ttt.log"
+);
+
+function sleep(ms) {
+  execSync(`sleep ${ms / 1000}`);
+}
+
+function logSize() {
+  if (!existsSync(LOG_FILE)) return 0;
+  return statSync(LOG_FILE).size;
+}
+
+function waitForLogAfter(pattern, afterBytes, timeoutMs = 15000) {
+  const re = new RegExp(pattern);
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (existsSync(LOG_FILE)) {
+      const full = readFileSync(LOG_FILE, "utf8");
+      const tail = full.substring(afterBytes);
+      if (re.test(tail)) return tail;
+    }
+    sleep(200);
+  }
+  if (existsSync(LOG_FILE)) {
+    return readFileSync(LOG_FILE, "utf8").substring(afterBytes);
+  }
+  return "";
+}
+
+function lspServerAvailable() {
+  try {
+    execSync("which typescript-language-server", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const available = lspServerAvailable();
+
+describe("lsp autocomplete trigger characters", () => {
+  let dir;
+
+  beforeEach(() => {
+    if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
+  });
+
+  afterEach(() => {
+    tui.kill();
+    if (dir) cleanupDir(dir);
+    dir = null;
+  });
+
+  const testFn = available ? it : it.skip;
+
+  testFn("console. triggers completions, typing ( shows signature help", () => {
+    dir = createTempDir();
+    cpSync(LSP_DIR, dir, { recursive: true });
+
+    const testFile = resolve(dir, "trigger.js");
+    writeFileSync(testFile, "// test\n\n", "utf8");
+    const configFile = resolve(LSP_DIR, "settings.json");
+
+    tui.start("--config", configFile, testFile);
+    tui.waitFor("// test");
+    waitForLogAfter("lsp initialized", 0);
+
+    // Move to line 2 and type 'consol' — should trigger completion
+    tui.press("ctrl+g");
+    tui.waitStable();
+    tui.type("2");
+    tui.press("enter");
+    tui.waitStable();
+
+    tui.type("consol");
+    let log = waitForLogAfter("lsp completion response.*count=[1-9]", 0);
+    expect(log).toMatch(/lsp completion response.*count=[1-9]/);
+
+    // Mark position so we only look at new log entries
+    let mark = logSize();
+
+    // Type '.' — should trigger new completions for console properties
+    tui.type(".");
+    log = waitForLogAfter("lsp completion response.*count=[1-9]", mark);
+    expect(log).toMatch(/lsp completion response.*count=[1-9]/);
+
+    // Mark again for signature help detection
+    mark = logSize();
+
+    // Type 'log(' — should trigger signature help
+    tui.type("log(");
+    log = waitForLogAfter("lsp signature help response.*label=", mark);
+    expect(log).toMatch(/lsp signature help response.*label=/);
+
+    tui.press("escape");
+    tui.press("ctrl+q");
+    sleep(200);
+    tui.press("arrow_right");
+    tui.press("enter");
+  });
+
+  testFn("string literal dot triggers completions for string methods", () => {
+    dir = createTempDir();
+    cpSync(LSP_DIR, dir, { recursive: true });
+
+    const testFile = resolve(dir, "trigger2.js");
+    writeFileSync(testFile, "// test\n\n", "utf8");
+    const configFile = resolve(LSP_DIR, "settings.json");
+
+    tui.start("--config", configFile, testFile);
+    tui.waitFor("// test");
+    waitForLogAfter("lsp initialized", 0);
+
+    tui.press("ctrl+g");
+    tui.waitStable();
+    tui.type("2");
+    tui.press("enter");
+    tui.waitStable();
+
+    // Type '"hello world!".' — dot after string literal triggers completions
+    tui.type('"hello world!".');
+    let log = waitForLogAfter("lsp completion response.*count=[1-9]", 0);
+    expect(log).toMatch(/lsp completion response.*count=[1-9]/);
+
+    tui.press("escape");
+    tui.press("ctrl+q");
+    sleep(200);
+    tui.press("arrow_right");
+    tui.press("enter");
+  });
+});


### PR DESCRIPTION
## Summary

- **Completion after trigger characters (e.g. `.`)** — typing `console.` now triggers a completion request. Previously, the prefix length check required at least one identifier character after the trigger, so `console.` produced no request while `console.l` did.
- **CompletionContext in LSP requests** — completion requests now include `triggerKind` and `triggerCharacter` per the LSP spec, so servers can return appropriate results for trigger-character vs invoked completions.
- **Server-declared signature help triggers** — signature help triggers (`(`, `,`) were hardcoded. Now reads `signatureHelpProvider.triggerCharacters` from the server's initialize response, falling back to `(` and `,` if the server doesn't declare any.
- **Stores server capabilities** — the LSP client now stores `completionProvider.triggerCharacters`, `signatureHelpProvider.triggerCharacters`, and `signatureHelpProvider.retriggerCharacters` from the initialize handshake.

## Test plan

- [ ] Open a JS/TS file with an LSP server configured
- [ ] Type `console.` — verify completions appear (log, error, warn, etc.)
- [ ] Type `console.l` — verify completions still work as before (log)
- [ ] Type a function call with `(` — verify signature help appears
- [ ] Manual trigger via command palette still works
- [ ] Run `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)