### PR TITLE
fix: dismiss context menu when mouse leaves area

### DIFF
--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -225,9 +225,7 @@ func (c *ContextMenuWidget) HandleEvent(ev tcell.Event) EventResult {
 
 		if btn == tcell.ButtonNone {
 			if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
-				if c.OnDismiss != nil {
-					c.OnDismiss()
-				}
+				c.Selected = -1
 				return EventConsumed
 			}
 			itemIdx := my - r.Y - 1

--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -224,6 +224,12 @@ func (c *ContextMenuWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 
 		if btn == tcell.ButtonNone {
+			if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
+				if c.OnDismiss != nil {
+					c.OnDismiss()
+				}
+				return EventConsumed
+			}
 			itemIdx := my - r.Y - 1
 			if itemIdx >= 0 && itemIdx < len(c.Items) && !c.Items[itemIdx].IsSep {
 				c.Selected = itemIdx


### PR DESCRIPTION
## Summary
- Dismiss the context menu dropdown when the mouse moves outside its bounds, instead of keeping a stale selection tracking the mouse y-position

## Test plan
- Open any menu (File, Edit, etc.)
- Move the mouse outside the dropdown area
- Verify the menu dismisses automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)