### PR TITLE
feat: implement word wrap rendering

### DIFF
--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -17,6 +17,10 @@ func (a *App) ToggleLineNumbers() {
 
 func (a *App) ToggleWordWrap() {
 	a.Settings.Editor.WordWrap = !a.Settings.Editor.WordWrap
+	a.EditorGroup.WordWrap = a.Settings.Editor.WordWrap
+	if a.EditorGroup.Editor != nil {
+		a.EditorGroup.Editor.WordWrap = a.Settings.Editor.WordWrap
+	}
 	config.SaveSettings(*a.Settings)
 }
 

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -107,6 +107,8 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.InsertSpaces = cfg.Settings.Editor.InsertSpaces
 	editorGroup.InsertFinalNewline = cfg.Settings.Editor.InsertFinalNewline
 	editorGroup.TrimTrailingWhitespace = cfg.Settings.Editor.TrimTrailingWhitespace
+	editorGroup.WordWrap = cfg.Settings.Editor.WordWrap
+	editorGroup.Editor.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.Editor.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.BracketColorStyles = bracketStyles

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -71,6 +71,7 @@ type EditorGroupWidget struct {
 	InsertSpaces           bool
 	LineNumbers            bool
 	GutterStyle             string
+	WordWrap                bool
 	BracketPairColorization bool
 	BracketColorStyles      []term.Style
 	InsertFinalNewline      bool

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -22,46 +22,49 @@ import (
 
 type EditorPaneWidget struct {
 	BaseWidget
-	Buf                *buffer.Buffer
-	Cursor             *cursor.Cursor
-	Viewport           *view.Viewport
-	Undo               *undo.UndoStack
-	Selection          *selection.Selection
-	CursorX            int
-	CursorY            int
-	TabSize            int
-	UseTabs            bool
-	LineNumbers        bool
+	Buf                     *buffer.Buffer
+	Cursor                  *cursor.Cursor
+	Viewport                *view.Viewport
+	Undo                    *undo.UndoStack
+	Selection               *selection.Selection
+	CursorX                 int
+	CursorY                 int
+	TabSize                 int
+	UseTabs                 bool
+	LineNumbers             bool
 	GutterStyle             string
+	WordWrap                bool
 	BracketPairColorization bool
 	BracketColorStyles      []term.Style
 	Highlighter             *highlight.Highlighter
-	SearchQuery        string
-	SearchMatches      []FindMatch
-	SearchActive       int
-	lastClickTime      int64
-	lastClickLine      int
-	lastClickCol       int
-	clickCount         int
-	mouseDown          bool
-	scrollbar          Scrollbar
-	hscrollbar         HScrollbar
-	Diagnostics        []Diagnostic
-	Folds              *fold.State
-	OnChange           func()
-	bufferDirty        bool
-	Multi              *multicursor.MultiCursor
-	multiSearchWord    string
-	maxLineWidth       int
-	maxLineWidthDirty  bool
-	gutterHover        bool
-	gutterHoverLine    int
-	cachedVisibleLines []int
-	searchByLine       map[int][]int
-	diagByLine         map[int][]int
-	LineChanges        []diff.LineChangeKind
-	bracketColorCache  bracketColorMap
-	bracketColorDirty  bool
+	SearchQuery             string
+	SearchMatches           []FindMatch
+	SearchActive            int
+	lastClickTime           int64
+	lastClickLine           int
+	lastClickCol            int
+	clickCount              int
+	mouseDown               bool
+	scrollbar               Scrollbar
+	hscrollbar              HScrollbar
+	Diagnostics             []Diagnostic
+	Folds                   *fold.State
+	OnChange                func()
+	bufferDirty             bool
+	Multi                   *multicursor.MultiCursor
+	multiSearchWord         string
+	maxLineWidth            int
+	maxLineWidthDirty       bool
+	gutterHover             bool
+	gutterHoverLine         int
+	cachedVisibleLines      []int
+	searchByLine            map[int][]int
+	diagByLine              map[int][]int
+	LineChanges             []diff.LineChangeKind
+	bracketColorCache       bracketColorMap
+	bracketColorDirty       bool
+	wrapMap                 []wrapEntry
+	wrapTopOffset           int
 }
 
 func NewEditorPaneWidget(buf *buffer.Buffer, cur *cursor.Cursor, vp *view.Viewport) *EditorPaneWidget {
@@ -175,9 +178,10 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 	gutterW := e.GutterWidth()
 
 	maxLineW := e.computeMaxLineWidth()
+	tabW := e.resolveTabSize()
 
 	editorW := w - gutterW
-	showHScrollbar := maxLineW > editorW
+	showHScrollbar := !e.WordWrap && maxLineW > editorW
 	if showHScrollbar {
 		h--
 	}
@@ -195,6 +199,10 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 		visibleCount = len(e.cachedVisibleLines)
 	}
 
+	if e.WordWrap {
+		visibleCount = totalVisualLines(e.Buf.Lines, editorW, tabW)
+	}
+
 	showScrollbar := visibleCount > h
 	if showScrollbar {
 		editorW--
@@ -205,6 +213,12 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 
 	e.Viewport.Width = editorW
 	e.Viewport.Height = h
+
+	if e.WordWrap {
+		e.Viewport.LeftCol = 0
+		visibleCount = totalVisualLines(e.Buf.Lines, editorW, tabW)
+		showScrollbar = visibleCount > h
+	}
 
 	sel := e.Selection
 	hasSel := sel != nil && sel.Active
@@ -232,8 +246,27 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 		}
 		bracketColors = e.bracketColorCache
 	}
+
+	if e.WordWrap {
+		e.wrapMap = buildWrapMap(e.Buf.Lines, e.Viewport.TopLine, e.wrapTopOffset, h, editorW, tabW)
+	} else {
+		e.wrapMap = nil
+	}
+
 	for y := 0; y < h; y++ {
-		lineIdx := e.screenToBufferLine(y)
+		var lineIdx int
+		var segStartCol int
+		var isWrapContinuation bool
+
+		if e.WordWrap && e.wrapMap != nil {
+			entry := e.wrapMap[y]
+			lineIdx = entry.bufLine
+			segStartCol = entry.startCol
+			isWrapContinuation = segStartCol > 0
+		} else {
+			lineIdx = e.screenToBufferLine(y)
+			segStartCol = 0
+		}
 
 		if gutterW > 0 {
 			gutterStyle := term.StyleLineNumber
@@ -241,7 +274,7 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 				gutterStyle = term.StyleActiveLine
 			}
 			var padded string
-			if !e.LineNumbers {
+			if !e.LineNumbers || (e.WordWrap && isWrapContinuation) {
 				padded = strings.Repeat(" ", gutterW)
 			} else {
 				numStr := ""
@@ -260,7 +293,7 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 			for i, ch := range padded {
 				surface.SetCell(i, y, term.Cell{Ch: ch, Style: gutterStyle})
 			}
-			if e.Folds != nil && lineIdx < totalLines {
+			if e.Folds != nil && lineIdx < totalLines && !isWrapContinuation {
 				if fr := e.Folds.FoldAt(lineIdx); fr != nil {
 					chevronCol := gutterW - 2
 					collapsedCh := '▶'
@@ -277,8 +310,7 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 					}
 				}
 			}
-			// Git gutter indicators
-			if lineIdx < totalLines && lineIdx < len(e.LineChanges) {
+			if lineIdx < totalLines && lineIdx < len(e.LineChanges) && !isWrapContinuation {
 				change := e.LineChanges[lineIdx]
 				if change != diff.LineUnchanged {
 					var ch rune
@@ -308,12 +340,17 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 
 			isCollapsedLine := e.Folds != nil && e.Folds.IsCollapsed(lineIdx)
 			var annRunes []rune
-			if isCollapsedLine {
+			if isCollapsedLine && !isWrapContinuation {
 				annRunes = []rune(" ⋯")
 			}
 
-			tabW := e.resolveTabSize()
-			screenCells := e.renderLineToScreen(line, syntaxSpans, isCollapsedLine, annRunes, tabW, e.Viewport.LeftCol, editorW)
+			var leftCol int
+			if e.WordWrap {
+				leftCol = bufColToVisualCol(e.Buf.Lines[lineIdx], segStartCol, tabW)
+			} else {
+				leftCol = e.Viewport.LeftCol
+			}
+			screenCells := e.renderLineToScreen(line, syntaxSpans, isCollapsedLine, annRunes, tabW, leftCol, editorW)
 			var lineBrackets []bracketColorEntry
 			if bracketColors != nil && lineIdx < len(bracketColors) {
 				lineBrackets = bracketColors[lineIdx]
@@ -408,7 +445,12 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 		e.scrollbar.X = r.X + scrollbarCol
 		e.scrollbar.Y = r.Y
 		e.scrollbar.Height = h
-		if foldsActive {
+		if e.WordWrap {
+			e.scrollbar.TotalItems = visibleCount + h - 1
+			curTopVisRow, _ := bufferPosToWrapScreenPos(e.Buf.Lines, e.Viewport.TopLine, 0, editorW, tabW)
+			curTopVisRow += e.wrapTopOffset
+			e.scrollbar.TopItem = curTopVisRow
+		} else if foldsActive {
 			e.scrollbar.TotalItems = visibleCount + h - 1
 			topVis := e.Folds.BufferToVisible(e.Viewport.TopLine)
 			if topVis < 0 {
@@ -434,18 +476,26 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 	}
 
 	r := e.GetRect()
-	cursorVisCol := bufColToVisualCol(e.Buf.Lines[e.Cursor.Line], e.Cursor.Col, e.resolveTabSize())
-	e.CursorX = cursorVisCol - e.Viewport.LeftCol + gutterW + r.X
-	if foldsActive {
-		curVis := e.Folds.BufferToVisible(e.Cursor.Line)
-		topVis := e.Folds.BufferToVisible(e.Viewport.TopLine)
-		if curVis >= 0 && topVis >= 0 {
-			e.CursorY = curVis - topVis + r.Y
+	if e.WordWrap {
+		curVisRow, curScreenCol := bufferPosToWrapScreenPos(e.Buf.Lines, e.Cursor.Line, e.Cursor.Col, editorW, tabW)
+		topVisRow, _ := bufferPosToWrapScreenPos(e.Buf.Lines, e.Viewport.TopLine, 0, editorW, tabW)
+		topVisRow += e.wrapTopOffset
+		e.CursorX = curScreenCol + gutterW + r.X
+		e.CursorY = curVisRow - topVisRow + r.Y
+	} else {
+		cursorVisCol := bufColToVisualCol(e.Buf.Lines[e.Cursor.Line], e.Cursor.Col, tabW)
+		e.CursorX = cursorVisCol - e.Viewport.LeftCol + gutterW + r.X
+		if foldsActive {
+			curVis := e.Folds.BufferToVisible(e.Cursor.Line)
+			topVis := e.Folds.BufferToVisible(e.Viewport.TopLine)
+			if curVis >= 0 && topVis >= 0 {
+				e.CursorY = curVis - topVis + r.Y
+			} else {
+				e.CursorY = e.Cursor.Line - e.Viewport.TopLine + r.Y
+			}
 		} else {
 			e.CursorY = e.Cursor.Line - e.Viewport.TopLine + r.Y
 		}
-	} else {
-		e.CursorY = e.Cursor.Line - e.Viewport.TopLine + r.Y
 	}
 }
 
@@ -1077,18 +1127,37 @@ func (e *EditorPaneWidget) mouseToPos(r Rect, mx, my int) (line, col int) {
 	}
 	gutterW := e.GutterWidth()
 	screenY := my - r.Y
-	line = e.screenToBufferLine(screenY)
-	visCol := mx - r.X - gutterW + e.Viewport.LeftCol
-	if visCol < 0 {
-		visCol = 0
+
+	if e.WordWrap && e.wrapMap != nil && screenY >= 0 && screenY < len(e.wrapMap) {
+		entry := e.wrapMap[screenY]
+		line = entry.bufLine
+		segVisCol := mx - r.X - gutterW
+		if segVisCol < 0 {
+			segVisCol = 0
+		}
+		segLeftCol := bufColToVisualCol(e.Buf.Lines[line], entry.startCol, e.resolveTabSize())
+		col = visualColToBufCol(e.Buf.Lines[line], segLeftCol+segVisCol, e.resolveTabSize())
+	} else {
+		line = e.screenToBufferLine(screenY)
+		visCol := mx - r.X - gutterW + e.Viewport.LeftCol
+		if visCol < 0 {
+			visCol = 0
+		}
+		if line < 0 {
+			line = 0
+		}
+		if line >= len(e.Buf.Lines) {
+			line = len(e.Buf.Lines) - 1
+		}
+		col = visualColToBufCol(e.Buf.Lines[line], visCol, e.resolveTabSize())
 	}
+
 	if line < 0 {
 		line = 0
 	}
 	if line >= len(e.Buf.Lines) {
 		line = len(e.Buf.Lines) - 1
 	}
-	col = visualColToBufCol(e.Buf.Lines[line], visCol, e.resolveTabSize())
 	lineLen := len([]rune(e.Buf.Lines[line]))
 	if col > lineLen {
 		col = lineLen
@@ -1499,6 +1568,10 @@ func (e *EditorPaneWidget) expandFoldAtCursor() {
 }
 
 func (e *EditorPaneWidget) scrollViewport() {
+	if e.WordWrap {
+		e.scrollViewportWrap()
+		return
+	}
 	if e.Folds != nil && e.Folds.HasCollapsedFolds() {
 		curVis := e.Folds.BufferToVisible(e.Cursor.Line)
 		topVis := e.Folds.BufferToVisible(e.Viewport.TopLine)
@@ -1532,11 +1605,47 @@ func (e *EditorPaneWidget) scrollViewport() {
 	}
 }
 
+func (e *EditorPaneWidget) scrollViewportWrap() {
+	e.Viewport.LeftCol = 0
+	tabW := e.resolveTabSize()
+	width := e.Viewport.Width
+	if width < 1 {
+		width = 1
+	}
+
+	curVisRow, _ := bufferPosToWrapScreenPos(e.Buf.Lines, e.Cursor.Line, e.Cursor.Col, width, tabW)
+	topVisRow, _ := bufferPosToWrapScreenPos(e.Buf.Lines, e.Viewport.TopLine, 0, width, tabW)
+	topVisRow += e.wrapTopOffset
+
+	if curVisRow < topVisRow {
+		e.Viewport.TopLine, e.wrapTopOffset = wrapVisualRowToTopLine(e.Buf.Lines, curVisRow, width, tabW)
+	}
+	if curVisRow >= topVisRow+e.Viewport.Height {
+		newTop := curVisRow - e.Viewport.Height + 1
+		e.Viewport.TopLine, e.wrapTopOffset = wrapVisualRowToTopLine(e.Buf.Lines, newTop, width, tabW)
+	}
+}
+
 func isEditorIdentRune(r rune) bool {
 	return r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
 }
 
 func (e *EditorPaneWidget) scrollUp(n int) {
+	if e.WordWrap {
+		tabW := e.resolveTabSize()
+		width := e.Viewport.Width
+		if width < 1 {
+			width = 1
+		}
+		topVisRow, _ := bufferPosToWrapScreenPos(e.Buf.Lines, e.Viewport.TopLine, 0, width, tabW)
+		topVisRow += e.wrapTopOffset
+		newTop := topVisRow - n
+		if newTop < 0 {
+			newTop = 0
+		}
+		e.Viewport.TopLine, e.wrapTopOffset = wrapVisualRowToTopLine(e.Buf.Lines, newTop, width, tabW)
+		return
+	}
 	if e.Folds != nil && e.Folds.HasCollapsedFolds() {
 		topVis := e.Folds.BufferToVisible(e.Viewport.TopLine)
 		newVis := topVis - n
@@ -1553,6 +1662,25 @@ func (e *EditorPaneWidget) scrollUp(n int) {
 }
 
 func (e *EditorPaneWidget) scrollDown(n int) {
+	if e.WordWrap {
+		tabW := e.resolveTabSize()
+		width := e.Viewport.Width
+		if width < 1 {
+			width = 1
+		}
+		topVisRow, _ := bufferPosToWrapScreenPos(e.Buf.Lines, e.Viewport.TopLine, 0, width, tabW)
+		topVisRow += e.wrapTopOffset
+		totalVis := totalVisualLines(e.Buf.Lines, width, tabW)
+		newTop := topVisRow + n
+		if newTop >= totalVis {
+			newTop = totalVis - 1
+		}
+		if newTop < 0 {
+			newTop = 0
+		}
+		e.Viewport.TopLine, e.wrapTopOffset = wrapVisualRowToTopLine(e.Buf.Lines, newTop, width, tabW)
+		return
+	}
 	if e.Folds != nil && e.Folds.HasCollapsedFolds() {
 		totalLines := len(e.Buf.Lines)
 		visCount := e.Folds.VisibleLineCount(totalLines)

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -210,6 +210,16 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 	if editorW < 1 {
 		editorW = 1
 	}
+	if e.WordWrap && editorW > 4 {
+		switch e.GutterStyle {
+		case "minimal":
+			editorW--
+		case "extended":
+			editorW -= 3
+		default:
+			editorW -= 2
+		}
+	}
 
 	e.Viewport.Width = editorW
 	e.Viewport.Height = h

--- a/internal/ui/word_wrap.go
+++ b/internal/ui/word_wrap.go
@@ -1,0 +1,145 @@
+package ui
+
+type wrapEntry struct {
+	bufLine  int
+	startCol int
+}
+
+// buildWrapMap computes a screen-row to (bufferLine, startCol) mapping for word wrap.
+// topLine is the first buffer line; wrapOffset is the visual row offset within that line
+// (0 means start from the beginning of the line). Returns exactly screenHeight entries.
+func buildWrapMap(lines []string, topLine, wrapOffset, screenHeight, width, tabW int) []wrapEntry {
+	if width < 1 {
+		width = 1
+	}
+	result := make([]wrapEntry, 0, screenHeight)
+	bufLine := topLine
+
+	for len(result) < screenHeight {
+		if bufLine >= len(lines) {
+			result = append(result, wrapEntry{bufLine: bufLine, startCol: 0})
+			bufLine++
+			continue
+		}
+
+		runes := []rune(lines[bufLine])
+		segments := wrapLineSegments(runes, width, tabW)
+
+		startSeg := 0
+		if bufLine == topLine {
+			startSeg = wrapOffset
+			if startSeg >= len(segments) {
+				startSeg = 0
+			}
+		}
+
+		for i := startSeg; i < len(segments) && len(result) < screenHeight; i++ {
+			result = append(result, wrapEntry{bufLine: bufLine, startCol: segments[i]})
+		}
+
+		bufLine++
+	}
+
+	return result
+}
+
+// wrapLineSegments returns the starting rune offsets for each visual row of a wrapped line.
+// For a line "abcdefgh" with width 3, returns [0, 3, 6].
+func wrapLineSegments(runes []rune, width, tabW int) []int {
+	if len(runes) == 0 {
+		return []int{0}
+	}
+	segments := []int{0}
+	visCol := 0
+	for i, ch := range runes {
+		var advance int
+		if ch == '\t' {
+			advance = ((visCol/tabW)+1)*tabW - visCol
+		} else {
+			advance = 1
+		}
+		if visCol+advance > width && visCol > 0 {
+			segments = append(segments, i)
+			visCol = advance
+		} else {
+			visCol += advance
+		}
+	}
+	return segments
+}
+
+// wrapLineVisualRows returns the number of visual rows a line occupies when wrapped.
+func wrapLineVisualRows(line string, width, tabW int) int {
+	runes := []rune(line)
+	return len(wrapLineSegments(runes, width, tabW))
+}
+
+// totalVisualLines returns the total number of visual rows for all buffer lines when wrapped.
+func totalVisualLines(lines []string, width, tabW int) int {
+	total := 0
+	for _, line := range lines {
+		total += wrapLineVisualRows(line, width, tabW)
+	}
+	return total
+}
+
+// bufferPosToWrapScreenPos converts a buffer (line, col) to a screen position
+// relative to the wrap layout. Returns (visualRow, screenCol) where visualRow
+// is the absolute visual row from the top of the document.
+func bufferPosToWrapScreenPos(lines []string, line, col, width, tabW int) (visualRow, screenCol int) {
+	if width < 1 {
+		width = 1
+	}
+	for i := 0; i < line && i < len(lines); i++ {
+		visualRow += wrapLineVisualRows(lines[i], width, tabW)
+	}
+
+	if line >= len(lines) {
+		return visualRow, 0
+	}
+
+	runes := []rune(lines[line])
+	segments := wrapLineSegments(runes, width, tabW)
+
+	segIdx := 0
+	for i := len(segments) - 1; i >= 0; i-- {
+		if col >= segments[i] {
+			segIdx = i
+			break
+		}
+	}
+
+	visualRow += segIdx
+	segStart := segments[segIdx]
+
+	screenCol = 0
+	for i := segStart; i < col && i < len(runes); i++ {
+		if runes[i] == '\t' {
+			screenCol = ((screenCol / tabW) + 1) * tabW
+		} else {
+			screenCol++
+		}
+	}
+
+	return visualRow, screenCol
+}
+
+// wrapVisualRowToTopLine finds the buffer line and wrap offset for a given
+// absolute visual row.
+func wrapVisualRowToTopLine(lines []string, targetVisRow, width, tabW int) (bufLine, wrapOffset int) {
+	if targetVisRow <= 0 {
+		return 0, 0
+	}
+	visRow := 0
+	for i, line := range lines {
+		rows := wrapLineVisualRows(line, width, tabW)
+		if visRow+rows > targetVisRow {
+			return i, targetVisRow - visRow
+		}
+		visRow += rows
+	}
+	if len(lines) == 0 {
+		return 0, 0
+	}
+	return len(lines) - 1, 0
+}

--- a/internal/ui/word_wrap_test.go
+++ b/internal/ui/word_wrap_test.go
@@ -1,0 +1,181 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWrapLineSegments(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		width    int
+		tabW     int
+		expected []int
+	}{
+		{"empty line", "", 10, 4, []int{0}},
+		{"short line fits", "hello", 10, 4, []int{0}},
+		{"exact fit", "12345", 5, 4, []int{0}},
+		{"one wrap", "1234567890", 5, 4, []int{0, 5}},
+		{"two wraps", "123456789012345", 5, 4, []int{0, 5, 10}},
+		{"single char width", "abc", 1, 4, []int{0, 1, 2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runes := []rune(tt.line)
+			got := wrapLineSegments(runes, tt.width, tt.tabW)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %d segments, got %d: %v", len(tt.expected), len(got), got)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("segment[%d] = %d, expected %d", i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestWrapLineVisualRows(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		width    int
+		expected int
+	}{
+		{"empty line", "", 10, 1},
+		{"short line", "hello", 10, 1},
+		{"exact width", "12345", 5, 1},
+		{"one extra char", "123456", 5, 2},
+		{"two rows", "1234567890", 5, 2},
+		{"three rows", "123456789012345", 5, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapLineVisualRows(tt.line, tt.width, 4)
+			if got != tt.expected {
+				t.Errorf("expected %d visual rows, got %d", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestTotalVisualLines(t *testing.T) {
+	lines := []string{
+		"short",
+		"this is a longer line that wraps",
+		"",
+		"another short",
+	}
+	total := totalVisualLines(lines, 10, 4)
+	expected := 1 + 4 + 1 + 2
+	if total != expected {
+		t.Errorf("expected %d total visual lines, got %d", expected, total)
+	}
+}
+
+func TestBufferPosToWrapScreenPos(t *testing.T) {
+	lines := []string{
+		"1234567890ABCDE",
+		"short",
+	}
+	width := 5
+
+	visRow, screenCol := bufferPosToWrapScreenPos(lines, 0, 0, width, 4)
+	if visRow != 0 || screenCol != 0 {
+		t.Errorf("(0,0): expected visRow=0, screenCol=0, got %d, %d", visRow, screenCol)
+	}
+
+	visRow, screenCol = bufferPosToWrapScreenPos(lines, 0, 3, width, 4)
+	if visRow != 0 || screenCol != 3 {
+		t.Errorf("(0,3): expected visRow=0, screenCol=3, got %d, %d", visRow, screenCol)
+	}
+
+	visRow, screenCol = bufferPosToWrapScreenPos(lines, 0, 7, width, 4)
+	if visRow != 1 || screenCol != 2 {
+		t.Errorf("(0,7): expected visRow=1, screenCol=2, got %d, %d", visRow, screenCol)
+	}
+
+	visRow, screenCol = bufferPosToWrapScreenPos(lines, 1, 0, width, 4)
+	if visRow != 3 || screenCol != 0 {
+		t.Errorf("(1,0): expected visRow=3, screenCol=0, got %d, %d", visRow, screenCol)
+	}
+
+	visRow, screenCol = bufferPosToWrapScreenPos(lines, 1, 3, width, 4)
+	if visRow != 3 || screenCol != 3 {
+		t.Errorf("(1,3): expected visRow=3, screenCol=3, got %d, %d", visRow, screenCol)
+	}
+}
+
+func TestWrapVisualRowToTopLine(t *testing.T) {
+	lines := []string{
+		"1234567890",
+		"short",
+	}
+	width := 5
+
+	bufLine, offset := wrapVisualRowToTopLine(lines, 0, width, 4)
+	if bufLine != 0 || offset != 0 {
+		t.Errorf("visRow=0: expected (0,0), got (%d,%d)", bufLine, offset)
+	}
+
+	bufLine, offset = wrapVisualRowToTopLine(lines, 1, width, 4)
+	if bufLine != 0 || offset != 1 {
+		t.Errorf("visRow=1: expected (0,1), got (%d,%d)", bufLine, offset)
+	}
+
+	bufLine, offset = wrapVisualRowToTopLine(lines, 2, width, 4)
+	if bufLine != 1 || offset != 0 {
+		t.Errorf("visRow=2: expected (1,0), got (%d,%d)", bufLine, offset)
+	}
+}
+
+func TestBuildWrapMap(t *testing.T) {
+	lines := []string{
+		"1234567890",
+		"short",
+	}
+	width := 5
+
+	wm := buildWrapMap(lines, 0, 0, 4, width, 4)
+	if len(wm) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(wm))
+	}
+
+	if wm[0].bufLine != 0 || wm[0].startCol != 0 {
+		t.Errorf("entry[0]: expected (0,0), got (%d,%d)", wm[0].bufLine, wm[0].startCol)
+	}
+	if wm[1].bufLine != 0 || wm[1].startCol != 5 {
+		t.Errorf("entry[1]: expected (0,5), got (%d,%d)", wm[1].bufLine, wm[1].startCol)
+	}
+	if wm[2].bufLine != 1 || wm[2].startCol != 0 {
+		t.Errorf("entry[2]: expected (1,0), got (%d,%d)", wm[2].bufLine, wm[2].startCol)
+	}
+
+	wm2 := buildWrapMap(lines, 0, 1, 3, width, 4)
+	if wm2[0].bufLine != 0 || wm2[0].startCol != 5 {
+		t.Errorf("offset entry[0]: expected (0,5), got (%d,%d)", wm2[0].bufLine, wm2[0].startCol)
+	}
+	if wm2[1].bufLine != 1 || wm2[1].startCol != 0 {
+		t.Errorf("offset entry[1]: expected (1,0), got (%d,%d)", wm2[1].bufLine, wm2[1].startCol)
+	}
+}
+
+func TestBuildWrapMapLongLine(t *testing.T) {
+	longLine := strings.Repeat("x", 100)
+	lines := []string{longLine}
+	width := 10
+
+	wm := buildWrapMap(lines, 0, 0, 5, width, 4)
+	for i, entry := range wm {
+		if entry.bufLine != 0 {
+			t.Errorf("entry[%d]: expected bufLine=0, got %d", i, entry.bufLine)
+		}
+		expectedStart := i * 10
+		if entry.startCol != expectedStart {
+			t.Errorf("entry[%d]: expected startCol=%d, got %d", i, expectedStart, entry.startCol)
+		}
+	}
+}

--- a/tests/e2e/word_wrap_test.go
+++ b/tests/e2e/word_wrap_test.go
@@ -1,0 +1,170 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestWordWrapToggle(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	if h.app.Settings.Editor.WordWrap {
+		t.Fatal("word wrap should be disabled by default")
+	}
+
+	h.exec("options.toggleWordWrap")
+
+	if !h.app.Settings.Editor.WordWrap {
+		t.Error("word wrap should be enabled after toggle")
+	}
+	if !h.app.EditorGroup.WordWrap {
+		t.Error("editor group word wrap should be enabled after toggle")
+	}
+	if !h.app.EditorGroup.Editor.WordWrap {
+		t.Error("editor pane word wrap should be enabled after toggle")
+	}
+
+	h.exec("options.toggleWordWrap")
+
+	if h.app.Settings.Editor.WordWrap {
+		t.Error("word wrap should be disabled after second toggle")
+	}
+	if h.app.EditorGroup.WordWrap {
+		t.Error("editor group word wrap should be disabled after second toggle")
+	}
+	if h.app.EditorGroup.Editor.WordWrap {
+		t.Error("editor pane word wrap should be disabled after second toggle")
+	}
+}
+
+func TestWordWrapRendersLongLine(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	longLine := strings.Repeat("abcde", 20)
+	path := filepath.Join(h.dir, "wrap.txt")
+	os.WriteFile(path, []byte(longLine), 0644)
+
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	screenBefore := h.screenText()
+
+	h.exec("options.toggleWordWrap")
+	h.redraw()
+
+	screenAfter := h.screenText()
+
+	countBefore := strings.Count(screenBefore, "abcdeabcde")
+	countAfter := strings.Count(screenAfter, "abcdeabcde")
+
+	if countAfter <= countBefore {
+		t.Errorf("wrapped screen should show more content: unwrapped has %d occurrences, wrapped has %d",
+			countBefore, countAfter)
+	}
+}
+
+func TestWordWrapLineNumbersOnlyOnFirstRow(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	longLine := strings.Repeat("x", 200)
+	path := filepath.Join(h.dir, "wrapnum.txt")
+	os.WriteFile(path, []byte(longLine+"\nsecondline"), 0644)
+
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	h.exec("options.toggleWordWrap")
+	h.redraw()
+
+	editor := h.app.EditorGroup.Editor
+	r := editor.GetRect()
+	gutterW := editor.GutterWidth()
+
+	lineNumCount := 0
+	for y := 0; y < r.H; y++ {
+		screenY := r.Y + y
+		row := h.screenRow(screenY)
+		if r.X+gutterW > len([]rune(row)) {
+			continue
+		}
+		runes := []rune(row)
+		gutter := string(runes[r.X : r.X+gutterW])
+		trimmed := strings.TrimSpace(gutter)
+		if trimmed != "" && len(trimmed) > 0 && trimmed[0] >= '1' && trimmed[0] <= '9' {
+			lineNumCount++
+		}
+	}
+
+	bufLines := len(editor.Buf.Lines)
+	if lineNumCount != bufLines {
+		t.Errorf("expected %d line numbers (one per buffer line), got %d", bufLines, lineNumCount)
+	}
+
+	totalEditorRows := r.H
+	if lineNumCount >= totalEditorRows {
+		t.Error("line numbers should appear on fewer rows than total editor rows (proving some rows are continuation)")
+	}
+}
+
+func TestWordWrapCursorPosition(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	longLine := strings.Repeat("abcde", 20)
+	path := filepath.Join(h.dir, "wrapcur.txt")
+	os.WriteFile(path, []byte(longLine), 0644)
+
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	h.exec("options.toggleWordWrap")
+	h.redraw()
+
+	editor := h.app.EditorGroup.Editor
+	editor.Cursor.Col = 0
+	h.redraw()
+
+	startY := editor.CursorY
+
+	editorW := editor.Viewport.Width
+	moveCount := editorW + 5
+	for i := 0; i < moveCount; i++ {
+		h.pressKey(tcell.KeyRight, 0)
+	}
+	h.redraw()
+
+	if editor.Cursor.Col != moveCount {
+		t.Errorf("expected cursor col %d, got %d", moveCount, editor.Cursor.Col)
+	}
+
+	if editor.CursorY <= startY {
+		t.Errorf("cursor should have moved to a wrapped row, startY=%d, curY=%d", startY, editor.CursorY)
+	}
+}
+
+func TestWordWrapDisablesHorizontalScroll(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	longLine := strings.Repeat("x", 200)
+	path := filepath.Join(h.dir, "nohscroll.txt")
+	os.WriteFile(path, []byte(longLine), 0644)
+
+	h.app.EditorGroup.OpenFile(path)
+	h.redraw()
+
+	h.exec("options.toggleWordWrap")
+	h.redraw()
+
+	editor := h.app.EditorGroup.Editor
+	if editor.Viewport.LeftCol != 0 {
+		t.Errorf("expected LeftCol=0 with word wrap, got %d", editor.Viewport.LeftCol)
+	}
+}

--- a/tests/functional/word-wrap.test.js
+++ b/tests/functional/word-wrap.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function ensureWordWrapOff() {
+  const snap = tui.snapshot();
+  const statusLine = snap.split("\n").find((l) => l.includes("Ln "));
+  if (!statusLine) return;
+  // Toggle word wrap to make sure it's off, then check if the line got longer or shorter
+  // Since we can't directly read the setting, we just toggle it off explicitly
+  // by checking the options menu
+}
+
+describe("word wrap", () => {
+  it("should wrap long lines making off-screen content visible", () => {
+    dir = createTempDir();
+    // Make line long enough that it definitely exceeds any terminal width
+    const longText = "VISIBLE_" + "x".repeat(500) + "_ENDMARK";
+    const file = createTempFile(dir, "wrap.txt", longText);
+
+    tui.start(file);
+    tui.waitFor("VISIBLE_");
+    tui.waitStable();
+
+    // First ensure word wrap is off: toggle twice if needed
+    let snap = tui.snapshot();
+    if (snap.includes("ENDMARK")) {
+      // Word wrap might be on from a previous test, toggle it off
+      tui.exec("Toggle Word Wrap");
+      tui.waitStable();
+      snap = tui.snapshot();
+    }
+
+    // Now ENDMARK should not be visible (line is too long)
+    expect(snap).not.toContain("ENDMARK");
+
+    // Toggle word wrap on
+    tui.exec("Toggle Word Wrap");
+    tui.waitStable();
+
+    const after = tui.snapshot();
+    expect(after).toContain("ENDMARK");
+  });
+
+  it("should show wrapped content on multiple screen rows", () => {
+    dir = createTempDir();
+    const longText = "HELLO".repeat(200);
+    const file = createTempFile(dir, "wrap2.txt", longText);
+
+    tui.start(file);
+    tui.waitFor("HELLO");
+    tui.waitStable();
+
+    // Ensure word wrap is on
+    let snap = tui.snapshot();
+    let helloLines = snap.split("\n").filter((l) => l.includes("HELLO")).length;
+    if (helloLines <= 1) {
+      tui.exec("Toggle Word Wrap");
+      tui.waitStable();
+    }
+
+    snap = tui.snapshot();
+    helloLines = snap.split("\n").filter((l) => l.includes("HELLO")).length;
+    expect(helloLines).toBeGreaterThan(1);
+  });
+
+  it("should toggle word wrap off and hide off-screen content again", () => {
+    dir = createTempDir();
+    const longText = "VISIBLE_" + "x".repeat(500) + "_ENDMARK";
+    const file = createTempFile(dir, "wrap3.txt", longText);
+
+    tui.start(file);
+    tui.waitFor("VISIBLE_");
+    tui.waitStable();
+
+    // Ensure word wrap is on first
+    let snap = tui.snapshot();
+    if (!snap.includes("ENDMARK")) {
+      tui.exec("Toggle Word Wrap");
+      tui.waitStable();
+    }
+
+    snap = tui.snapshot();
+    expect(snap).toContain("ENDMARK");
+
+    // Toggle word wrap off
+    tui.exec("Toggle Word Wrap");
+    tui.waitStable();
+
+    snap = tui.snapshot();
+    expect(snap).not.toContain("ENDMARK");
+  });
+});


### PR DESCRIPTION
## Summary
- Implement the `wordWrap` setting which was previously a no-op
- Long lines visually wrap at the editor viewport width instead of extending off-screen with horizontal scrolling
- Character-level wrapping (matches VS Code's default "on" mode)
- Line numbers only appear on the first visual row of each buffer line
- Cursor, mouse clicks, and scrollbar all work correctly with wrapped lines

Closes #88

## Test plan
- [x] Unit tests for wrap calculation (segments, visual rows, buffer-to-screen mapping)
- [x] E2E tests for toggle propagation, rendering, line numbers, cursor position, h-scroll disabled
- [x] Functional tests: off-screen content visible when wrapped, multi-row display, toggle off restores normal view
- [ ] Manual: open a markdown file, toggle Word Wrap from Options menu, verify long paragraphs wrap cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)