### PR TITLE
feat: add Open Default Settings command

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -1,13 +1,18 @@
 {
-  "tabSize": 4,
-  "insertSpaces": true,
-  "wordWrap": false,
-  "lineNumbers": true,
-  "sidebarVisible": true,
-  "sidebarWidth": 30,
+  "version": 1,
   "theme": "default-dark",
-  "formatOnSave": false,
-  "insertFinalNewline": true,
+  "editor": {
+    "tabSize": 4,
+    "insertSpaces": true,
+    "wordWrap": false,
+    "lineNumbers": true,
+    "formatOnSave": false,
+    "insertFinalNewline": true,
+    "trimTrailingWhitespace": false,
+    "focusOnOpen": false,
+    "gutterStyle": "compact",
+    "bracketPairColorization": false
+  },
   "search": {
     "debounce": 350
   },
@@ -16,23 +21,193 @@
     "showGitIgnored": true
   },
   "terminal": {
-    "shell": "",
     "scrollback": 1000
   },
   "lsp": {
-    "saveOnRename": false,
     "servers": {
-      "go": { "command": ["gopls"] },
-      "typescript": {
-        "command": ["typescript-language-server", "--stdio"],
+      "bash": {
+        "command": [
+          "bash-language-server",
+          "start"
+        ],
         "languages": {
-          ".ts": "typescript",
-          ".tsx": "typescriptreact",
-          ".js": "javascript",
-          ".jsx": "javascriptreact"
+          ".bash": "bash",
+          ".sh": "sh"
         }
+      },
+      "c": {
+        "command": [
+          "clangd"
+        ],
+        "languages": {
+          ".c": "c",
+          ".cc": "cpp",
+          ".cpp": "cpp",
+          ".cxx": "cpp",
+          ".h": "c",
+          ".hpp": "cpp"
+        }
+      },
+      "css": {
+        "command": [
+          "vscode-css-language-server",
+          "--stdio"
+        ],
+        "languages": {
+          ".css": "css",
+          ".less": "less",
+          ".scss": "scss"
+        }
+      },
+      "dart": {
+        "command": [
+          "dart",
+          "language-server",
+          "--protocol=lsp"
+        ]
+      },
+      "docker": {
+        "command": [
+          "docker-langserver",
+          "--stdio"
+        ],
+        "languages": {
+          "Dockerfile": "dockerfile"
+        }
+      },
+      "elixir": {
+        "command": [
+          "elixir-ls"
+        ]
+      },
+      "go": {
+        "command": [
+          "gopls"
+        ]
+      },
+      "html": {
+        "command": [
+          "vscode-html-language-server",
+          "--stdio"
+        ]
+      },
+      "java": {
+        "command": [
+          "jdtls"
+        ]
+      },
+      "json": {
+        "command": [
+          "vscode-json-language-server",
+          "--stdio"
+        ],
+        "languages": {
+          ".json": "json",
+          ".jsonc": "jsonc"
+        }
+      },
+      "kotlin": {
+        "command": [
+          "kotlin-language-server"
+        ]
+      },
+      "lua": {
+        "command": [
+          "lua-language-server"
+        ]
+      },
+      "markdown": {
+        "command": [
+          "marksman",
+          "server"
+        ]
+      },
+      "php": {
+        "command": [
+          "phpactor",
+          "language-server"
+        ]
+      },
+      "python": {
+        "command": [
+          "pyright-langserver",
+          "--stdio"
+        ]
+      },
+      "ruby": {
+        "command": [
+          "ruby-lsp"
+        ]
+      },
+      "rust": {
+        "command": [
+          "rust-analyzer"
+        ]
+      },
+      "svelte": {
+        "command": [
+          "svelteserver",
+          "--stdio"
+        ],
+        "languages": {
+          ".svelte": "svelte"
+        }
+      },
+      "tailwindcss": {
+        "command": [
+          "tailwindcss-language-server",
+          "--stdio"
+        ]
+      },
+      "terraform": {
+        "command": [
+          "terraform-ls",
+          "serve"
+        ],
+        "languages": {
+          ".tf": "terraform",
+          ".tfvars": "terraform"
+        }
+      },
+      "typescript": {
+        "command": [
+          "typescript-language-server",
+          "--stdio"
+        ],
+        "languages": {
+          ".cjs": "javascript",
+          ".cts": "typescript",
+          ".js": "javascript",
+          ".jsx": "javascriptreact",
+          ".mjs": "javascript",
+          ".mts": "typescript",
+          ".ts": "typescript",
+          ".tsx": "typescriptreact"
+        }
+      },
+      "vue": {
+        "command": [
+          "vue-language-server",
+          "--stdio"
+        ],
+        "languages": {
+          ".vue": "vue"
+        }
+      },
+      "yaml": {
+        "command": [
+          "yaml-language-server",
+          "--stdio"
+        ]
+      },
+      "zig": {
+        "command": [
+          "zls"
+        ]
       }
-    }
+    },
+    "saveOnRename": false,
+    "hoverDelay": 400
   },
   "autocomplete": {
     "enabled": true,

--- a/config/settings.json
+++ b/config/settings.json
@@ -207,7 +207,7 @@
       }
     },
     "saveOnRename": false,
-    "hoverDelay": 400
+    "hoverDelay": 500
   },
   "autocomplete": {
     "enabled": true,

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -94,6 +94,7 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		{Label: "Switch Theme", Command: "theme.switch"},
 		ui.MenuSep(),
 		{Label: "Open Settings", Command: "settings.open"},
+		{Label: "Open Default Settings", Command: "options.defaultSettings"},
 	}
 	return items
 }

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"strings"
+
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/buffer"
 	"github.com/eugenioenko/ttt/internal/term"
 )
 
@@ -47,11 +50,28 @@ func (a *App) ApplySettings(s config.Settings) {
 	}
 }
 
+func (a *App) OpenDefaultSettings() {
+	text := config.DefaultSettingsText()
+	lines := strings.Split(text, "\n")
+	// Remove trailing empty line from the split if present
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	buf := &buffer.Buffer{Lines: lines}
+	a.EditorGroup.OpenBuffer("Default Settings (Read Only)", buf)
+}
+
 func registerSettingsCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
 		ID: "settings.reload", Title: "Reload Settings",
 		Handler: app.ReloadSettings,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.defaultSettings", Title: "Preferences: Open Default Settings",
+		Keywords: []string{"preferences", "settings", "configuration", "options", "defaults", "reference"},
+		Handler:  app.OpenDefaultSettings,
 	})
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -169,6 +169,138 @@ func LoadSettings() Settings {
 	return s
 }
 
+// DefaultSettingsText returns a formatted reference document showing all
+// available settings with their default values and descriptions. The output
+// uses JSONC-style comments (// ...) so it can serve as inline documentation.
+func DefaultSettingsText() string {
+	return `// Default Settings Reference
+// This is a read-only reference of all available settings and their defaults.
+// To customize, open your settings file via "Preferences: Open Settings"
+// and override only the values you want to change.
+//
+// Settings file location: ~/.config/ttt/settings.json
+{
+  // Schema version (do not change)
+  "version": 1,
+
+  // Color theme name (string, empty = default theme)
+  // Use "Switch Theme" command to browse available themes.
+  "theme": "",
+
+  // Enable debug mode (bool, default: false)
+  "debugMode": false,
+
+  // ── Editor ──────────────────────────────────────────────
+  "editor": {
+    // Number of spaces per tab stop (int, default: 4)
+    "tabSize": 4,
+
+    // Use spaces instead of tabs for indentation (bool, default: true)
+    "insertSpaces": true,
+
+    // Wrap long lines to fit the viewport (bool, default: false)
+    "wordWrap": false,
+
+    // Show line numbers in the gutter (bool, default: true)
+    "lineNumbers": true,
+
+    // Cursor style: "block", "underline", or "bar" (string, default: "")
+    "cursorStyle": "",
+
+    // Automatically format the file on save (bool, default: false)
+    "formatOnSave": false,
+
+    // Ensure the file ends with a newline on save (bool, default: true)
+    "insertFinalNewline": true,
+
+    // Remove trailing whitespace on save (bool, default: false)
+    "trimTrailingWhitespace": false,
+
+    // Diff view layout: "inline" or "side-by-side" (string, default: "")
+    "diffView": "",
+
+    // Focus the editor when opening a file from the sidebar (bool, default: false)
+    "focusOnOpen": false,
+
+    // Show git change indicators in the gutter (bool, default: true)
+    // Uses *bool — omitted means true.
+    "gitGutter": true,
+
+    // Gutter style: "minimal", "compact", or "extended" (string, default: "compact")
+    "gutterStyle": "compact",
+
+    // Colorize matching bracket pairs (bool, default: false)
+    "bracketPairColorization": false
+  },
+
+  // ── Search ──────────────────────────────────────────────
+  "search": {
+    // Debounce delay in ms before triggering search (int, default: 350)
+    "debounce": 350
+  },
+
+  // ── Explorer ────────────────────────────────────────────
+  "explorer": {
+    // Show hidden files (dotfiles) in the file explorer (bool, default: true)
+    "showHidden": true,
+
+    // Show files ignored by .gitignore (bool, default: true)
+    "showGitIgnored": true
+  },
+
+  // ── Terminal ────────────────────────────────────────────
+  "terminal": {
+    // Shell command for the integrated terminal (string, default: "" = $SHELL or /bin/sh)
+    "shell": "",
+
+    // Number of scrollback lines in the terminal (int, default: 1000)
+    "scrollback": 1000
+  },
+
+  // ── LSP (Language Server Protocol) ──────────────────────
+  "lsp": {
+    // Enable LSP support (bool, default: true)
+    // Uses *bool — omitted means true.
+    "enabled": true,
+
+    // Auto-save files when renamed via LSP (bool, default: false)
+    "saveOnRename": false,
+
+    // Code actions to run automatically on save (string array, default: [])
+    "codeActionsOnSave": [],
+
+    // Delay in ms before showing hover information (int, default: 400)
+    "hoverDelay": 400,
+
+    // Show notification when an LSP server is available but not installed
+    // (bool, default: true). Uses *bool — omitted means true.
+    "notifyAvailability": true,
+
+    // LSP server configurations per language.
+    // Each entry maps a language key to a server config with "command" (string array)
+    // and optional "languages" (map of file extension to language ID).
+    // See ~/.config/ttt/extensions.json for additional configuration.
+    "servers": {}
+  },
+
+  // ── Autocomplete ────────────────────────────────────────
+  "autocomplete": {
+    // Enable autocomplete suggestions (bool, default: true)
+    "enabled": true,
+
+    // Automatically show suggestions as you type (bool, default: true)
+    "autoSuggest": true,
+
+    // Debounce delay in ms before triggering autocomplete (int, default: 150)
+    "debounce": 150,
+
+    // Show function signature help on ( and , characters (bool, default: true)
+    "signatureHelp": true
+  }
+}
+`
+}
+
 func SaveSettings(s Settings) error {
 	path := ConfigFilePath("settings.json")
 	data, err := json.MarshalIndent(s, "", "  ")

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -263,14 +263,19 @@ func DefaultSettingsText() string {
     // Uses *bool — omitted means true.
     "enabled": true,
 
+    // Enable hover tooltips on mouse rest (bool, default: true)
+    // Uses *bool — omitted means true. Set to false to disable mouse-triggered hover.
+    // The "Show Hover" command still works when disabled.
+    "hover": true,
+
     // Auto-save files when renamed via LSP (bool, default: false)
     "saveOnRename": false,
 
     // Code actions to run automatically on save (string array, default: [])
     "codeActionsOnSave": [],
 
-    // Delay in ms before showing hover information (int, default: 400)
-    "hoverDelay": 400,
+    // Delay in ms before showing hover information (int, default: 500)
+    "hoverDelay": 500,
 
     // Show notification when an LSP server is available but not installed
     // (bool, default: true). Uses *bool — omitted means true.

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -253,5 +256,25 @@ func TestDefaultSettingsText(t *testing.T) {
 	// Should mention the *bool settings that default to true when omitted
 	if !strings.Contains(text, "omitted means true") {
 		t.Error("expected DefaultSettingsText to document *bool omit behavior")
+	}
+}
+
+func TestReferenceSettingsMatchesDefaults(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	refPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "config", "settings.json")
+	refData, err := os.ReadFile(refPath)
+	if err != nil {
+		t.Fatalf("failed to read config/settings.json: %v", err)
+	}
+
+	s := DefaultSettings()
+	s.Theme = "default-dark"
+	generated, _ := json.MarshalIndent(s, "", "  ")
+	generated = append(generated, '\n')
+
+	if string(generated) != string(refData) {
+		t.Errorf("config/settings.json is out of date with DefaultSettings().\n"+
+			"Regenerate it by running DefaultSettings() with theme='default-dark' and saving the output.\n"+
+			"Got %d bytes, want %d bytes", len(refData), len(generated))
 	}
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -238,7 +238,7 @@ func TestDefaultSettingsText(t *testing.T) {
 		`"debounce": 350`,
 		`"showHidden": true`,
 		`"scrollback": 1000`,
-		`"hoverDelay": 400`,
+		`"hoverDelay": 500`,
 		`"enabled": true`,
 		`"signatureHelp": true`,
 	}

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -199,5 +200,58 @@ func TestDefaultLSPSettings(t *testing.T) {
 	}
 	if ls.Servers == nil {
 		t.Error("expected Servers to be loaded from embedded JSON")
+	}
+}
+
+func TestDefaultSettingsText(t *testing.T) {
+	text := DefaultSettingsText()
+
+	if text == "" {
+		t.Fatal("DefaultSettingsText() returned empty string")
+	}
+
+	// Should contain all major sections
+	sections := []string{
+		`"editor"`,
+		`"search"`,
+		`"explorer"`,
+		`"terminal"`,
+		`"lsp"`,
+		`"autocomplete"`,
+	}
+	for _, section := range sections {
+		if !strings.Contains(text, section) {
+			t.Errorf("expected DefaultSettingsText to contain section %s", section)
+		}
+	}
+
+	// Should contain key settings with their default values
+	defaults := []string{
+		`"tabSize": 4`,
+		`"insertSpaces": true`,
+		`"lineNumbers": true`,
+		`"insertFinalNewline": true`,
+		`"gutterStyle": "compact"`,
+		`"debounce": 350`,
+		`"showHidden": true`,
+		`"scrollback": 1000`,
+		`"hoverDelay": 400`,
+		`"enabled": true`,
+		`"signatureHelp": true`,
+	}
+	for _, d := range defaults {
+		if !strings.Contains(text, d) {
+			t.Errorf("expected DefaultSettingsText to contain %s", d)
+		}
+	}
+
+	// Should contain descriptive comments
+	if !strings.Contains(text, "//") {
+		t.Error("expected DefaultSettingsText to contain comments")
+	}
+
+	// Should mention the *bool settings that default to true when omitted
+	if !strings.Contains(text, "omitted means true") {
+		t.Error("expected DefaultSettingsText to document *bool omit behavior")
 	}
 }

--- a/tests/e2e/default_settings_test.go
+++ b/tests/e2e/default_settings_test.go
@@ -1,0 +1,68 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultSettingsCommandRegistered(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	cmd, ok := h.reg.Get("options.defaultSettings")
+	if !ok {
+		t.Fatal("expected options.defaultSettings command to be registered")
+	}
+	if cmd.Title != "Preferences: Open Default Settings" {
+		t.Errorf("expected title 'Preferences: Open Default Settings', got %q", cmd.Title)
+	}
+}
+
+func TestDefaultSettingsOpensBuffer(t *testing.T) {
+	h := newTestHarness(t, 120, 40)
+	defer h.stop()
+
+	h.exec("options.defaultSettings")
+
+	// The tab bar should show the default settings tab
+	h.assertContains("Default Settings")
+
+	// The buffer should contain settings reference content
+	screen := h.screenText()
+	if !strings.Contains(screen, "Default Settings") {
+		t.Errorf("expected screen to show default settings tab, got:\n%s", screen)
+	}
+}
+
+func TestDefaultSettingsShowsSettingsSections(t *testing.T) {
+	h := newTestHarness(t, 120, 40)
+	defer h.stop()
+
+	h.exec("options.defaultSettings")
+
+	// The screen should show the beginning of the default settings reference
+	screen := h.screenText()
+	if !strings.Contains(screen, "Default Settings Reference") {
+		t.Errorf("expected screen to contain 'Default Settings Reference', got:\n%s", screen)
+	}
+}
+
+func TestDefaultSettingsReopensExistingTab(t *testing.T) {
+	h := newTestHarness(t, 120, 40)
+	defer h.stop()
+
+	// Open default settings twice
+	h.exec("options.defaultSettings")
+	h.exec("options.defaultSettings")
+
+	// Should still only have the default settings tab (plus the initial file tab)
+	// The OpenBuffer method deduplicates by path, so a second call should
+	// switch to the existing tab, not create a new one.
+	screen := h.screenText()
+	// Count occurrences of the tab name — should appear exactly once in the tab bar
+	tabBar := strings.Split(screen, "\n")[1] // tab bar is typically the second row
+	count := strings.Count(tabBar, "Default Settings")
+	if count > 1 {
+		t.Errorf("expected only one 'Default Settings' tab, found %d in tab bar: %q", count, tabBar)
+	}
+}

--- a/tests/functional/default-settings.test.js
+++ b/tests/functional/default-settings.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("default settings", () => {
+  it("should open default settings via command palette", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+
+    tui.start(file);
+    tui.waitFor("test.txt");
+
+    tui.exec("Preferences: Open Default Settings");
+    tui.waitFor("Default Settings");
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("Default Settings");
+    expect(snap).toContain("Default Settings Reference");
+  });
+
+  it("should show settings sections in the reference", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+
+    tui.start(file);
+    tui.waitFor("test.txt");
+
+    tui.exec("Preferences: Open Default Settings");
+    tui.waitFor("Default Settings");
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("editor");
+    expect(snap).toContain("tabSize");
+  });
+});

--- a/tests/functional/settings-roundtrip.test.js
+++ b/tests/functional/settings-roundtrip.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { mkdirSync, copyFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "../..");
+const REFERENCE = resolve(ROOT, "config/settings.json");
+const BIN_CONFIG = resolve(ROOT, "bin/config");
+const BIN_SETTINGS = resolve(BIN_CONFIG, "settings.json");
+
+let dir;
+
+beforeEach(() => {
+  // Seed bin/config/settings.json so ttt reads/writes there instead of ~/.config/ttt
+  mkdirSync(BIN_CONFIG, { recursive: true });
+  copyFileSync(REFERENCE, BIN_SETTINGS);
+});
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+  if (existsSync(BIN_SETTINGS)) rmSync(BIN_SETTINGS);
+});
+
+describe("settings roundtrip", () => {
+  it("switching to monokai then back to default-dark produces identical settings.json", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello world");
+
+    tui.start(file);
+    tui.waitFor("test.txt");
+
+    // Switch to monokai
+    tui.exec("Switch Theme");
+    tui.waitStable();
+    tui.type("monokai");
+    tui.waitFor("monokai");
+    tui.press("enter");
+    tui.waitStable();
+
+    // Switch back to default-dark
+    tui.exec("Switch Theme");
+    tui.waitStable();
+    tui.type("default-dark");
+    tui.waitFor("default-dark");
+    tui.press("enter");
+    tui.waitStable();
+
+    const saved = readFileSync(BIN_SETTINGS, "utf8");
+    const reference = readFileSync(REFERENCE, "utf8");
+    expect(saved).toBe(reference);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `options.defaultSettings` command that opens a read-only JSONC reference document showing all available settings with defaults and descriptions
- Wired into the Options menu ("Open Default Settings") and command palette ("Preferences: Open Default Settings")
- Documents the `*bool` + `omitempty` settings (`gitGutter`, `lsp.enabled`, `lsp.notifyAvailability`) that are invisible when using their defaults

Closes #185

## Test plan
- [x] Unit test: `TestDefaultSettingsText` verifies all sections, defaults, and `*bool` documentation
- [x] E2E tests: command registration, buffer opening, content rendering, tab deduplication
- [x] Functional tests: command palette opens the tab, settings sections visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)