### PR TITLE
fix: improve LSP hover behavior

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -296,7 +296,7 @@ func (a *App) refreshProblems() {
 }
 
 func (a *App) checkMouseHover(mx, my int) {
-	if a.EditorGroup.Editor == nil {
+	if a.EditorGroup.Editor == nil || !a.Settings.LSP.IsHoverEnabled() {
 		return
 	}
 	r := a.EditorGroup.Editor.GetRect()

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -164,7 +164,7 @@ func RunEventLoop(
 				if btn == 0 {
 					app.checkMouseHover(mx, my)
 				}
-			} else if !app.isMouseOverHover(mx, my) && btn != 0 && !app.EditorGroup.Hover.IsDragging() {
+			} else if !app.isMouseOverHover(mx, my) && !app.EditorGroup.Hover.IsDragging() {
 				app.DismissHover()
 			}
 			app.Root.HandleEvent(tev)

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -140,6 +140,7 @@ func RunEventLoop(
 		ev := screen.PollEvent()
 		switch tev := ev.(type) {
 		case *tcell.EventKey:
+			app.DismissHover()
 			if app.EditorGroup.SignatureHelp != nil {
 				switch tev.Key() {
 				case tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -43,6 +43,7 @@ type LSPServerConfig struct {
 
 type LSPSettings struct {
 	Enabled            *bool                      `json:"enabled,omitempty"`
+	Hover              *bool                      `json:"hover,omitempty"`
 	Servers            map[string]LSPServerConfig `json:"servers,omitempty"`
 	SaveOnRename       bool                       `json:"saveOnRename"`
 	CodeActionsOnSave  []string                   `json:"codeActionsOnSave,omitempty"`
@@ -58,11 +59,15 @@ func (l LSPSettings) IsEnabled() bool {
 	return l.Enabled == nil || *l.Enabled
 }
 
+func (l LSPSettings) IsHoverEnabled() bool {
+	return l.Hover == nil || *l.Hover
+}
+
 func DefaultLSPSettings() LSPSettings {
 	var servers map[string]LSPServerConfig
 	json.Unmarshal(lspServersJSON, &servers)
 	return LSPSettings{
-		HoverDelay: 400,
+		HoverDelay: 500,
 		Servers:    servers,
 	}
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -194,8 +194,8 @@ func TestDefaultExplorerSettings(t *testing.T) {
 
 func TestDefaultLSPSettings(t *testing.T) {
 	ls := DefaultLSPSettings()
-	if ls.HoverDelay != 400 {
-		t.Errorf("expected HoverDelay 400, got %d", ls.HoverDelay)
+	if ls.HoverDelay != 500 {
+		t.Errorf("expected HoverDelay 500, got %d", ls.HoverDelay)
 	}
 	if ls.Servers == nil {
 		t.Error("expected Servers to be loaded from embedded JSON")


### PR DESCRIPTION
## Summary
- Dismiss hover tooltip on any keystroke (previously only Esc dismissed it)
- Add `lsp.hover` setting (`*bool`, default `true`) to disable mouse-triggered hover entirely via `"lsp": {"hover": false}` in settings.json
- Increase default `hoverDelay` from 400ms to 500ms — without word-boundary detection, a longer delay prevents accidental triggers

The explicit "Show Hover" command (`editor.hover`) still works even when `lsp.hover` is `false`, since that's an intentional action.

## Test plan
- [x] Build passes
- [x] All existing tests pass (unit + E2E)
- [ ] Manual: hover appears after 500ms mouse rest, dismissed by any key press
- [ ] Manual: set `"lsp": {"hover": false}` in settings.json, verify hover no longer triggers on mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)