### PR TITLE
fix: false green gutter on last line of every file

### DIFF
--- a/internal/app/gitgutter.go
+++ b/internal/app/gitgutter.go
@@ -58,7 +58,7 @@ func (a *App) RequestGitGutter(filePath string, bufferLines []string) {
 				changes[i] = diff.LineAdded
 			}
 		} else {
-			oldLines := strings.Split(strings.TrimSuffix(headContent, "\n"), "\n")
+			oldLines := strings.Split(headContent, "\n")
 			changes = diff.ComputeGutterChanges(oldLines, linesCopy)
 		}
 		a.Screen.PostEvent(tcell.NewEventInterrupt(&GitGutterResult{

--- a/internal/core/diff/gutter_lastline_test.go
+++ b/internal/core/diff/gutter_lastline_test.go
@@ -1,0 +1,38 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGutterUnchangedFileNoFalseAdded(t *testing.T) {
+	headContent := "hello\nworld\n"
+	oldLines := strings.Split(headContent, "\n")
+	newLines := []string{"hello", "world", ""}
+
+	changes := ComputeGutterChanges(oldLines, newLines)
+
+	for i, c := range changes {
+		if c != LineUnchanged {
+			t.Errorf("line %d: expected unchanged, got %d", i, c)
+		}
+	}
+}
+
+func TestGutterNoTrailingNewlineInHead(t *testing.T) {
+	headContent := "hello\nworld"
+	oldLines := strings.Split(headContent, "\n")
+	newLines := []string{"hello", "world", ""}
+
+	changes := ComputeGutterChanges(oldLines, newLines)
+
+	if changes[0] != LineUnchanged {
+		t.Errorf("line 0: expected unchanged, got %d", changes[0])
+	}
+	if changes[1] != LineUnchanged {
+		t.Errorf("line 1: expected unchanged, got %d", changes[1])
+	}
+	if changes[2] != LineAdded {
+		t.Errorf("line 2: expected added (new trailing newline), got %d", changes[2])
+	}
+}


### PR DESCRIPTION
## Summary
- The git gutter showed a green (added) indicator on the last line of every file, even when unchanged
- Root cause: `TrimSuffix(headContent, "\n")` before splitting removed the trailing empty line from the git HEAD content, but the buffer includes it (via `insertFinalNewline`), so the diff saw it as a new line
- Fix: split without trimming so HEAD lines match the buffer's representation

## Test plan
- [x] Unit test: unchanged file with trailing newline — no false added indicator
- [x] Unit test: HEAD without trailing newline + buffer with `insertFinalNewline` — last line correctly shows as added
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)