### PR TITLE
ci: split LSP tests into separate non-blocking job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,42 @@ jobs:
       - name: Install tui-use
         run: npm install -g tui-use
 
+      - name: Install test dependencies
+        working-directory: tests/functional
+        run: pnpm install
+
+      - name: Run functional tests
+        working-directory: tests/functional
+        run: pnpm exec vitest run --reporter=verbose --exclude='**/lsp*.test.js'
+
+  lsp-tests:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Build binary
+        run: make build
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: tests/functional/pnpm-lock.yaml
+
+      - name: Install tui-use
+        run: npm install -g tui-use
+
       - name: Install LSP servers
         run: |
           go install golang.org/x/tools/gopls@latest
@@ -86,6 +122,6 @@ jobs:
         working-directory: tests/functional
         run: pnpm install
 
-      - name: Run functional tests
+      - name: Run LSP tests
         working-directory: tests/functional
-        run: pnpm exec vitest run --reporter=verbose
+        run: pnpm exec vitest run --reporter=verbose -- lsp


### PR DESCRIPTION
## Summary
- Split `functional-tests` CI job into two: `functional-tests` (required, excludes LSP) and `lsp-tests` (non-blocking, `continue-on-error: true`)
- LSP tests depend on external language servers and are inherently flaky — they shouldn't block merges
- LSP server installation only happens in the `lsp-tests` job, making `functional-tests` faster
- Functional tests use `--exclude='**/lsp*.test.js'`, LSP tests use `-- lsp` filter

## Test plan
- [x] Verified `--exclude='**/lsp*.test.js'` correctly skips all 3 LSP test files
- [x] Verified `-- lsp` correctly runs only LSP test files
- [ ] CI should show 3 jobs: `test`, `functional-tests`, `lsp-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)