### PR TITLE
fix: word wrap mouse crash on stale wrapMap

### DIFF
--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -1141,6 +1141,9 @@ func (e *EditorPaneWidget) mouseToPos(r Rect, mx, my int) (line, col int) {
 	if e.WordWrap && e.wrapMap != nil && screenY >= 0 && screenY < len(e.wrapMap) {
 		entry := e.wrapMap[screenY]
 		line = entry.bufLine
+		if line >= len(e.Buf.Lines) {
+			line = len(e.Buf.Lines) - 1
+		}
 		segVisCol := mx - r.X - gutterW
 		if segVisCol < 0 {
 			segVisCol = 0


### PR DESCRIPTION
## Summary
- Fixes index-out-of-range panic in `mouseToPos` when clicking in a word-wrapped editor after buffer edits
- The `wrapMap` can hold stale `bufLine` indices after lines are deleted; this adds a bounds check before indexing `Buf.Lines`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Reproduced crash by clicking in word-wrapped editor after edits; no longer panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)