### PR TITLE
feat: add Git: Copy GitHub Permalink command

### DIFF
--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -266,6 +267,31 @@ func registerGitCommands(app *App) {
 	registerGitCmd("git.pull", "Git: Pull", []string{"git", "fetch", "download"}, []func(string) error{git.Pull}, "Pulled")
 	registerGitCmd("git.push", "Git: Push", []string{"git", "upload", "publish"}, []func(string) error{git.Push}, "Pushed")
 	registerGitCmd("git.sync", "Git: Sync", []string{"git", "fetch", "upload"}, []func(string) error{git.Pull, git.Push}, "Synced")
+
+	reg.Register(command.Command{
+		ID: "git.copyPermalink", Title: "Git: Copy GitHub Permalink",
+		Keywords: []string{"git", "github", "link", "url", "permalink", "copy"},
+		Handler: func() {
+			filePath := app.EditorGroup.ActiveFilePath()
+			if filePath == "" || filePath == "untitled" {
+				app.StatusWarn("No file open")
+				return
+			}
+			folder := app.Workspace.FolderForFile(filePath)
+			if folder == nil || !folder.IsRepo {
+				app.StatusWarn("Not a git repository")
+				return
+			}
+			line, _ := app.EditorGroup.ActiveCursor()
+			link := git.Permalink(folder.Path, filePath, line)
+			if link == "" {
+				app.StatusWarn("Could not generate permalink — no remote found")
+				return
+			}
+			clipboard.Set(link)
+			app.StatusNotify("Permalink copied to clipboard")
+		},
+	})
 }
 
 func registerWorkspaceCommands(app *App) {

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -277,13 +277,13 @@ func registerGitCommands(app *App) {
 				app.StatusWarn("No file open")
 				return
 			}
-			folder := app.Workspace.FolderForFile(filePath)
-			if folder == nil || !folder.IsRepo {
+			repoDir := git.RepoRoot(filepath.Dir(filePath))
+			if repoDir == "" {
 				app.StatusWarn("Not a git repository")
 				return
 			}
 			line, _ := app.EditorGroup.ActiveCursor()
-			link := git.Permalink(folder.Path, filePath, line)
+			link := git.Permalink(repoDir, filePath, line)
 			if link == "" {
 				app.StatusWarn("Could not generate permalink — no remote found")
 				return

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -209,6 +209,59 @@ func FormatRelativeTime(t time.Time) string {
 	}
 }
 
+func HeadSHA(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func RemoteURL(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func Permalink(dir, filePath string, line int) string {
+	remote := RemoteURL(dir)
+	if remote == "" {
+		return ""
+	}
+	sha := HeadSHA(dir)
+	if sha == "" {
+		return ""
+	}
+
+	baseURL := remoteToHTTPS(remote)
+	if baseURL == "" {
+		return ""
+	}
+
+	relPath, err := filepath.Rel(dir, filePath)
+	if err != nil {
+		return ""
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	return fmt.Sprintf("%s/blob/%s/%s#L%d", baseURL, sha, relPath, line+1)
+}
+
+func remoteToHTTPS(remote string) string {
+	remote = strings.TrimSpace(remote)
+	if strings.HasPrefix(remote, "git@") {
+		remote = strings.TrimPrefix(remote, "git@")
+		remote = strings.Replace(remote, ":", "/", 1)
+		remote = "https://" + remote
+	}
+	remote = strings.TrimSuffix(remote, ".git")
+	return remote
+}
+
 func IgnoredFiles(dir string, paths []string) map[string]bool {
 	if len(paths) == 0 {
 		return nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -667,3 +667,21 @@ func TestRepoRootFromSubdir(t *testing.T) {
 		t.Errorf("RepoRoot(%q) = %q, want %q", subdir, gotDir, expectedDir)
 	}
 }
+
+func TestRemoteToHTTPS(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"git@github.com:user/repo.git", "https://github.com/user/repo"},
+		{"git@github.com:user/repo", "https://github.com/user/repo"},
+		{"https://github.com/user/repo.git", "https://github.com/user/repo"},
+		{"https://github.com/user/repo", "https://github.com/user/repo"},
+	}
+	for _, tt := range tests {
+		got := remoteToHTTPS(tt.input)
+		if got != tt.want {
+			t.Errorf("remoteToHTTPS(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a "Git: Copy GitHub Permalink" command to the command palette
- Constructs a permalink using the current HEAD SHA, remote URL, file path, and cursor line
- Shows status bar notifications: success message on copy, warning if not a git repo or no remote found
- Handles both SSH (`git@github.com:...`) and HTTPS remote URL formats

## Test plan
- [x] Unit test for `remoteToHTTPS` covering SSH and HTTPS formats
- [ ] Open a file in a git repo, run command from palette → permalink copied
- [ ] Open a file outside a git repo → "Not a git repository" warning
- [ ] Repo with no remote → "Could not generate permalink" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)