### PR TITLE
fix: use --include to filter LSP tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,4 +124,4 @@ jobs:
 
       - name: Run LSP tests
         working-directory: tests/functional
-        run: pnpm exec vitest run --reporter=verbose -- lsp
+        run: pnpm exec vitest run --reporter=verbose --include='**/lsp*.test.js'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,4 +124,4 @@ jobs:
 
       - name: Run LSP tests
         working-directory: tests/functional
-        run: pnpm exec vitest run --reporter=verbose 'lsp*.test.js'
+        run: pnpm exec vitest run --reporter=verbose lsp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,4 +124,4 @@ jobs:
 
       - name: Run LSP tests
         working-directory: tests/functional
-        run: pnpm exec vitest run --reporter=verbose --include='**/lsp*.test.js'
+        run: pnpm exec vitest run --reporter=verbose 'lsp*.test.js'

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -266,6 +267,31 @@ func registerGitCommands(app *App) {
 	registerGitCmd("git.pull", "Git: Pull", []string{"git", "fetch", "download"}, []func(string) error{git.Pull}, "Pulled")
 	registerGitCmd("git.push", "Git: Push", []string{"git", "upload", "publish"}, []func(string) error{git.Push}, "Pushed")
 	registerGitCmd("git.sync", "Git: Sync", []string{"git", "fetch", "upload"}, []func(string) error{git.Pull, git.Push}, "Synced")
+
+	reg.Register(command.Command{
+		ID: "git.copyPermalink", Title: "Git: Copy GitHub Permalink",
+		Keywords: []string{"git", "github", "link", "url", "permalink", "copy"},
+		Handler: func() {
+			filePath := app.EditorGroup.ActiveFilePath()
+			if filePath == "" || filePath == "untitled" {
+				app.StatusWarn("No file open")
+				return
+			}
+			folder := app.Workspace.FolderForFile(filePath)
+			if folder == nil || !folder.IsRepo {
+				app.StatusWarn("Not a git repository")
+				return
+			}
+			line, _ := app.EditorGroup.ActiveCursor()
+			link := git.Permalink(folder.Path, filePath, line)
+			if link == "" {
+				app.StatusWarn("Could not generate permalink — no remote found")
+				return
+			}
+			clipboard.Set(link)
+			app.StatusNotify("Permalink copied to clipboard")
+		},
+	})
 }
 
 func registerWorkspaceCommands(app *App) {

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -277,13 +277,13 @@ func registerGitCommands(app *App) {
 				app.StatusWarn("No file open")
 				return
 			}
-			folder := app.Workspace.FolderForFile(filePath)
-			if folder == nil || !folder.IsRepo {
+			repoDir := git.RepoRoot(filepath.Dir(filePath))
+			if repoDir == "" {
 				app.StatusWarn("Not a git repository")
 				return
 			}
 			line, _ := app.EditorGroup.ActiveCursor()
-			link := git.Permalink(folder.Path, filePath, line)
+			link := git.Permalink(repoDir, filePath, line)
 			if link == "" {
 				app.StatusWarn("Could not generate permalink — no remote found")
 				return

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -209,6 +209,59 @@ func FormatRelativeTime(t time.Time) string {
 	}
 }
 
+func HeadSHA(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func RemoteURL(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func Permalink(dir, filePath string, line int) string {
+	remote := RemoteURL(dir)
+	if remote == "" {
+		return ""
+	}
+	sha := HeadSHA(dir)
+	if sha == "" {
+		return ""
+	}
+
+	baseURL := remoteToHTTPS(remote)
+	if baseURL == "" {
+		return ""
+	}
+
+	relPath, err := filepath.Rel(dir, filePath)
+	if err != nil {
+		return ""
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	return fmt.Sprintf("%s/blob/%s/%s#L%d", baseURL, sha, relPath, line+1)
+}
+
+func remoteToHTTPS(remote string) string {
+	remote = strings.TrimSpace(remote)
+	if strings.HasPrefix(remote, "git@") {
+		remote = strings.TrimPrefix(remote, "git@")
+		remote = strings.Replace(remote, ":", "/", 1)
+		remote = "https://" + remote
+	}
+	remote = strings.TrimSuffix(remote, ".git")
+	return remote
+}
+
 func IgnoredFiles(dir string, paths []string) map[string]bool {
 	if len(paths) == 0 {
 		return nil

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -667,3 +667,21 @@ func TestRepoRootFromSubdir(t *testing.T) {
 		t.Errorf("RepoRoot(%q) = %q, want %q", subdir, gotDir, expectedDir)
 	}
 }
+
+func TestRemoteToHTTPS(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"git@github.com:user/repo.git", "https://github.com/user/repo"},
+		{"git@github.com:user/repo", "https://github.com/user/repo"},
+		{"https://github.com/user/repo.git", "https://github.com/user/repo"},
+		{"https://github.com/user/repo", "https://github.com/user/repo"},
+	}
+	for _, tt := range tests {
+		got := remoteToHTTPS(tt.input)
+		if got != tt.want {
+			t.Errorf("remoteToHTTPS(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/tests/functional/indent-detection.test.js
+++ b/tests/functional/indent-detection.test.js
@@ -25,8 +25,11 @@ describe("indent detection", () => {
       "});",
     ].join("\n");
     const file = createTempFile(dir, "astro.config.mjs", content);
+    const configFile = createTempFile(dir, "settings.json", JSON.stringify({
+      lsp: { notifyAvailability: false },
+    }));
 
-    tui.start(file);
+    tui.start("--config", configFile, file);
     tui.waitFor("astro.config.mjs");
     tui.waitStable();
 
@@ -47,8 +50,11 @@ describe("indent detection", () => {
       "}",
     ].join("\n");
     const file = createTempFile(dir, "main.go", content);
+    const configFile = createTempFile(dir, "settings.json", JSON.stringify({
+      lsp: { notifyAvailability: false },
+    }));
 
-    tui.start(file);
+    tui.start("--config", configFile, file);
     tui.waitFor("main.go");
     tui.waitStable();
 
@@ -66,8 +72,11 @@ describe("indent detection", () => {
       "};",
     ].join("\n");
     const file = createTempFile(dir, "config.mjs", content);
+    const configFile = createTempFile(dir, "settings.json", JSON.stringify({
+      lsp: { notifyAvailability: false },
+    }));
 
-    tui.start(file);
+    tui.start("--config", configFile, file);
     tui.waitFor("config.mjs");
     tui.waitStable();
 

--- a/tests/functional/matching-bracket.test.js
+++ b/tests/functional/matching-bracket.test.js
@@ -13,8 +13,11 @@ describe("go to matching bracket", () => {
   it("should jump to matching bracket with ctrl+k m", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "test.go", "func main() {\n\tx()\n}\n");
+    const configFile = createTempFile(dir, "settings.json", JSON.stringify({
+      lsp: { notifyAvailability: false },
+    }));
 
-    tui.start(file);
+    tui.start("--config", configFile, file);
     tui.waitFor("main");
 
     // Go to end of line 1 where '{' is the last character


### PR DESCRIPTION
## Summary
- The LSP CI job was running all functional tests instead of only LSP tests
- `-- lsp` positional filter doesn't restrict vitest to matching files
- Changed to `--include='**/lsp*.test.js'` to mirror the `--exclude` pattern used in the functional-tests job

## Test plan
- [ ] CI lsp-tests job should only run `lsp*.test.js` files
- [ ] CI functional-tests job unchanged (already uses `--exclude` correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)