### PR TITLE
fix: disable code folding when word wrap is enabled

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -322,7 +322,7 @@ func registerEditorCommands(app *App) {
 				return
 			}
 			e := app.EditorGroup.Editor
-			if e.Folds != nil {
+			if e.Folds != nil && !e.WordWrap {
 				e.Folds.Toggle(e.Cursor.Line)
 			}
 		},
@@ -336,7 +336,7 @@ func registerEditorCommands(app *App) {
 				return
 			}
 			e := app.EditorGroup.Editor
-			if e.Folds != nil {
+			if e.Folds != nil && !e.WordWrap {
 				e.Folds.CollapseAll()
 				e.EnsureCursorVisible()
 			}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -141,7 +141,7 @@ func (e *EditorPaneWidget) buildDiagIndex() {
 }
 
 func (e *EditorPaneWidget) hasFolds() bool {
-	return e.Folds != nil && e.Folds.HasCollapsedFolds()
+	return !e.WordWrap && e.Folds != nil && e.Folds.HasCollapsedFolds()
 }
 
 func (e *EditorPaneWidget) ensureTopLineVisible() {
@@ -303,7 +303,7 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 			for i, ch := range padded {
 				surface.SetCell(i, y, term.Cell{Ch: ch, Style: gutterStyle})
 			}
-			if e.Folds != nil && lineIdx < totalLines && !isWrapContinuation {
+			if e.Folds != nil && !e.WordWrap && lineIdx < totalLines && !isWrapContinuation {
 				if fr := e.Folds.FoldAt(lineIdx); fr != nil {
 					chevronCol := gutterW - 2
 					collapsedCh := '▶'


### PR DESCRIPTION
## Summary
- Disable fold chevrons and fold toggle/collapse commands when word wrap is active
- The wrap map bypasses fold visibility, so collapsed folds had no visual effect — chevrons toggled but lines never collapsed
- Folding works normally when word wrap is off; `expandAll` still works so folds aren't stuck collapsed after toggling word wrap off

## Test plan
- [x] Word wrap on: no fold chevrons shown, `ctrl+k [` and `ctrl+k 0` are no-ops
- [x] Word wrap off: folding works as expected
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)