### PR TITLE
test: chaos monkey fuzz testing + fix 20 panics, PTY leak, and OSC 52 escape leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs-web/dist/
 .DS_Store
 *.log
 docs-web/.astro/
+chaos-output/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ttt - terminal text editor
 
-.PHONY: all test build run clean fmt lint
+.PHONY: all test build run clean fmt lint chaos chaos-docker chaos-docker-build
 
 all: build
 
@@ -20,6 +20,16 @@ fmt:
 
 lint:
 	golint ./...
+
+chaos:
+	go test -v -count=1 ./tests/chaos/ -run TestChaosMonkey
+
+chaos-docker-build:
+	docker build -t ttt-chaos -f tests/chaos/Dockerfile .
+
+chaos-docker:
+	mkdir -p chaos-output
+	docker run --rm -v $(PWD)/chaos-output:/output ttt-chaos
 
 clean:
 	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -586,6 +586,28 @@ pnpm test:stress       # run 10 times to catch flaky tests
 
 Functional tests run in CI on every push and pull request.
 
+### Chaos Monkey (Fuzz Testing)
+
+A randomized fuzz tester that hammers the editor with thousands of random events — keypresses, mouse clicks, resizes, clipboard operations, and command palette commands — to find panics and crashes that normal testing misses. It runs against a `tcell.SimulationScreen` so no real terminal is needed.
+
+Runs in Docker to prevent random commands from opening browser tabs or interfering with your session.
+
+```sh
+# Quick local run (50 iterations x 500 events)
+make chaos
+
+# Build Docker image
+make chaos-docker-build
+
+# Run continuously in Docker (crash logs saved to chaos-output/)
+make chaos-docker
+
+# Reproduce a specific crash deterministically
+CHAOS_REPLAY=chaos-output/crash-<seed>-<iter>.json go test ./tests/chaos/ -run TestChaosReplay
+```
+
+Each crash is saved as a JSON report with the random seed and full event log, so any panic can be replayed and debugged deterministically.
+
 ## Architecture
 
 The codebase follows a strict layered architecture: **core -> view -> render -> term -> ui**.

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -117,6 +117,7 @@ Docs: https://tttedit.dev
 	screen.SetStyleMap(app.BuildStyleMap(cfg.Theme))
 	screen.SetCursorStyle(term.ParseCursorStyle(cfg.Settings.Editor.CursorStyle))
 
+	// Route OSC 52 clipboard writes through the tty, not raw stderr
 	if tty, ok := screen.Tty(); ok {
 		clipboard.SetOSCWriter(tty)
 	}

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/app"
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/lsp"
 	"github.com/eugenioenko/ttt/internal/render"
@@ -115,6 +116,10 @@ Docs: https://tttedit.dev
 
 	screen.SetStyleMap(app.BuildStyleMap(cfg.Theme))
 	screen.SetCursorStyle(term.ParseCursorStyle(cfg.Settings.Editor.CursorStyle))
+
+	if tty, ok := screen.Tty(); ok {
+		clipboard.SetOSCWriter(tty)
+	}
 
 	lspManager := lsp.NewManager(cfg.Settings.LSP)
 	defer lspManager.Shutdown()

--- a/internal/core/buffer/buffer.go
+++ b/internal/core/buffer/buffer.go
@@ -85,6 +85,16 @@ type Buffer struct {
 	diskInfoSet bool
 }
 
+func (b *Buffer) ClampLine(line int) int {
+	if line < 0 {
+		return 0
+	}
+	if line >= len(b.Lines) {
+		return len(b.Lines) - 1
+	}
+	return line
+}
+
 // InsertRune inserts a rune at the given line and column.
 func (b *Buffer) InsertRune(line, col int, r rune) {
 	if line < 0 || line >= len(b.Lines) {

--- a/internal/core/clipboard/clipboard.go
+++ b/internal/core/clipboard/clipboard.go
@@ -3,6 +3,7 @@ package clipboard
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -10,12 +11,17 @@ import (
 )
 
 var (
-	content      string
-	useSystem    = true
+	content   string
+	useSystem = true
+	oscWriter io.Writer
 )
 
 func DisableSystem() {
 	useSystem = false
+}
+
+func SetOSCWriter(w io.Writer) {
+	oscWriter = w
 }
 
 func Set(s string) {
@@ -35,8 +41,10 @@ func Get() string {
 }
 
 func writeSystemClipboard(s string) {
-	encoded := base64.StdEncoding.EncodeToString([]byte(s))
-	fmt.Fprintf(os.Stderr, "\033]52;c;%s\a", encoded)
+	if oscWriter != nil {
+		encoded := base64.StdEncoding.EncodeToString([]byte(s))
+		fmt.Fprintf(oscWriter, "\033]52;c;%s\a", encoded)
+	}
 
 	if name, args := findCopyCmd(); name != "" {
 		c := exec.Command(name, args...)

--- a/internal/core/clipboard/clipboard.go
+++ b/internal/core/clipboard/clipboard.go
@@ -20,6 +20,9 @@ func DisableSystem() {
 	useSystem = false
 }
 
+// SetOSCWriter sets the destination for OSC 52 clipboard escape sequences.
+// Without this, OSC 52 writes to raw stderr which leaks escape sequences in
+// headless, piped, and unsupported terminal contexts. Set to the tcell tty.
 func SetOSCWriter(w io.Writer) {
 	oscWriter = w
 }
@@ -41,6 +44,7 @@ func Get() string {
 }
 
 func writeSystemClipboard(s string) {
+	// Only emit OSC 52 when a writer is configured — avoids leaking escape sequences
 	if oscWriter != nil {
 		encoded := base64.StdEncoding.EncodeToString([]byte(s))
 		fmt.Fprintf(oscWriter, "\033]52;c;%s\a", encoded)

--- a/internal/core/selection/selection.go
+++ b/internal/core/selection/selection.go
@@ -50,6 +50,9 @@ func (s *Selection) Text(lines []string, curLine, curCol int) string {
 		return ""
 	}
 	start, end := s.Range(curLine, curCol)
+	if start.Line >= len(lines) || end.Line >= len(lines) || start.Line < 0 || end.Line < 0 {
+		return ""
+	}
 	if start.Line == end.Line {
 		runes := []rune(lines[start.Line])
 		sc, ec := start.Col, end.Col

--- a/internal/core/undo/undo.go
+++ b/internal/core/undo/undo.go
@@ -395,6 +395,10 @@ func (c *DeleteSelectionCommand) Apply(b *buffer.Buffer) {
 	if c.StartLine >= len(b.Lines) {
 		return
 	}
+	if c.EndLine >= len(b.Lines) {
+		c.EndLine = len(b.Lines) - 1
+		c.EndCol = len([]rune(b.Lines[c.EndLine]))
+	}
 
 	startRunes := []rune(b.Lines[c.StartLine])
 	sc := c.StartCol
@@ -407,6 +411,9 @@ func (c *DeleteSelectionCommand) Apply(b *buffer.Buffer) {
 		ec := c.EndCol
 		if ec > len(endRunes) {
 			ec = len(endRunes)
+		}
+		if sc > ec {
+			sc = ec
 		}
 		c.Deleted = string(endRunes[sc:ec])
 		b.Lines[c.StartLine] = string(startRunes[:sc]) + string(endRunes[ec:])

--- a/internal/term/tcell_screen.go
+++ b/internal/term/tcell_screen.go
@@ -136,3 +136,7 @@ func (t *TcellScreen) SetCursorStyle(style CursorStyle) {
 func (t *TcellScreen) PostEvent(ev tcell.Event) error {
 	return t.scr.PostEvent(ev)
 }
+
+func (t *TcellScreen) Tty() (tcell.Tty, bool) {
+	return t.scr.Tty()
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -51,6 +51,8 @@ func New(shell string, cols, rows, scrollbackMax int, env []string, dir string) 
 	t.vt = vt10x.New(vt10x.WithSize(cols, rows), vt10x.WithScrollback(scrollbackMax))
 
 	cmd := exec.Command(shell)
+	// Verify dir exists before setting it — chaos monkey and random commands can
+	// delete the workspace dir, causing pty.Start to fail with "no such file or directory"
 	if dir != "" {
 		if _, err := os.Stat(dir); err == nil {
 			cmd.Dir = dir

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -51,7 +51,11 @@ func New(shell string, cols, rows, scrollbackMax int, env []string, dir string) 
 	t.vt = vt10x.New(vt10x.WithSize(cols, rows), vt10x.WithScrollback(scrollbackMax))
 
 	cmd := exec.Command(shell)
-	cmd.Dir = dir
+	if dir != "" {
+		if _, err := os.Stat(dir); err == nil {
+			cmd.Dir = dir
+		}
+	}
 	cmd.Env = append(os.Environ(), env...)
 	cmd.Env = append(cmd.Env, "TERM=xterm-256color")
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -694,6 +694,9 @@ func (g *EditorGroupWidget) ReplaceMatch(match FindMatch, replacement string) {
 	if !g.IsEditorActive() {
 		return
 	}
+	if match.Line < 0 || match.Line >= len(g.Editor.Buf.Lines) {
+		return
+	}
 	runes := []rune(g.Editor.Buf.Lines[match.Line])
 	endCol := match.Col + match.Len
 	if endCol > len(runes) {

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -493,9 +493,7 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 		e.CursorX = curScreenCol + gutterW + r.X
 		e.CursorY = curVisRow - topVisRow + r.Y
 	} else {
-		if e.Cursor.Line >= len(e.Buf.Lines) {
-			e.Cursor.Line = len(e.Buf.Lines) - 1
-		}
+		e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 		cursorVisCol := bufColToVisualCol(e.Buf.Lines[e.Cursor.Line], e.Cursor.Col, tabW)
 		e.CursorX = cursorVisCol - e.Viewport.LeftCol + gutterW + r.X
 		if foldsActive {
@@ -856,10 +854,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 					cs.Line++
 					if e.Folds != nil {
 						if r := e.Folds.ContainingFold(cs.Line); r != nil {
-							cs.Line = r.EndLine + 1
-							if cs.Line >= len(e.Buf.Lines) {
-								cs.Line = len(e.Buf.Lines) - 1
-							}
+							cs.Line = e.Buf.ClampLine(r.EndLine + 1)
 						}
 					}
 					lineLen := len([]rune(e.Buf.Lines[cs.Line]))
@@ -948,10 +943,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 	case tcell.KeyPgUp:
 		e.startOrExtendSelection(shift)
-		e.Cursor.Line -= e.Viewport.Height
-		if e.Cursor.Line < 0 {
-			e.Cursor.Line = 0
-		}
+		e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line - e.Viewport.Height)
 		e.skipHiddenLineUp()
 		lineLen := len([]rune(e.Buf.Lines[e.Cursor.Line]))
 		if e.Cursor.Col > lineLen {
@@ -959,10 +951,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 	case tcell.KeyPgDn:
 		e.startOrExtendSelection(shift)
-		e.Cursor.Line += e.Viewport.Height
-		if e.Cursor.Line >= len(e.Buf.Lines) {
-			e.Cursor.Line = len(e.Buf.Lines) - 1
-		}
+		e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line + e.Viewport.Height)
 		e.skipHiddenLineDown()
 		lineLen := len([]rune(e.Buf.Lines[e.Cursor.Line]))
 		if e.Cursor.Col > lineLen {
@@ -1095,9 +1084,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		tabSize := e.resolveTabSize()
 		if hasSel {
 			start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
-			if end.Line >= len(e.Buf.Lines) {
-				end.Line = len(e.Buf.Lines) - 1
-			}
+			end.Line = e.Buf.ClampLine(end.Line)
 			for line := start.Line; line <= end.Line; line++ {
 				remove := leadingIndentWidth(e.Buf.Lines[line], tabSize)
 				if remove > 0 {
@@ -1785,9 +1772,7 @@ func (e *EditorPaneWidget) DeleteLine() {
 		e.Cursor.Col = 0
 	} else {
 		e.exec(&undo.DeleteLineCommand{Idx: e.Cursor.Line})
-		if e.Cursor.Line >= len(e.Buf.Lines) {
-			e.Cursor.Line = len(e.Buf.Lines) - 1
-		}
+		e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	}
 	lineLen := len([]rune(e.Buf.Lines[e.Cursor.Line]))
 	if e.Cursor.Col > lineLen {
@@ -1875,15 +1860,8 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 			endLine--
 		}
 	}
-	if startLine >= len(e.Buf.Lines) {
-		startLine = len(e.Buf.Lines) - 1
-	}
-	if endLine >= len(e.Buf.Lines) {
-		endLine = len(e.Buf.Lines) - 1
-	}
-	if startLine < 0 || endLine < 0 {
-		return
-	}
+	startLine = e.Buf.ClampLine(startLine)
+	endLine = e.Buf.ClampLine(endLine)
 
 	allCommented := true
 	for l := startLine; l <= endLine; l++ {
@@ -2012,9 +1990,6 @@ func (e *EditorPaneWidget) UniqueLines() {
 		}
 	}
 	e.exec(&undo.ReplaceLinesCommand{Start: start, OldLines: old, NewLines: unique})
-	if e.Cursor.Line >= len(e.Buf.Lines) {
-		e.Cursor.Line = len(e.Buf.Lines) - 1
-	}
 	e.clampCursor()
 	e.scrollViewport()
 }

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -618,12 +618,7 @@ func (e *EditorPaneWidget) pasteText(text string) {
 	if e.Selection != nil && e.Selection.Active {
 		e.deleteSelection()
 	}
-	if e.Cursor.Line >= len(e.Buf.Lines) {
-		e.Cursor.Line = len(e.Buf.Lines) - 1
-	}
-	if e.Cursor.Line < 0 {
-		e.Cursor.Line = 0
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	lines := strings.Split(text, "\n")
 	if len(lines) == 1 {
 		e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Text: lines[0]})
@@ -811,12 +806,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventIgnored
 	}
 
-	if e.Cursor.Line >= len(e.Buf.Lines) {
-		e.Cursor.Line = len(e.Buf.Lines) - 1
-	}
-	if e.Cursor.Line < 0 {
-		e.Cursor.Line = 0
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 
 	switch kev.Key() {
 	case tcell.KeyRune, tcell.KeyBackspace, tcell.KeyBackspace2, tcell.KeyDelete:
@@ -1198,10 +1188,7 @@ func (e *EditorPaneWidget) mouseToPos(r Rect, mx, my int) (line, col int) {
 }
 
 func (e *EditorPaneWidget) selectWord(line, col int) {
-	if e.Selection == nil {
-		return
-	}
-	if line < 0 || line >= len(e.Buf.Lines) {
+	if e.Selection == nil || line < 0 || line >= len(e.Buf.Lines) {
 		return
 	}
 	runes := []rune(e.Buf.Lines[line])
@@ -1540,12 +1527,7 @@ func (e *EditorPaneWidget) computeBracketColors() bracketColorMap {
 }
 
 func (e *EditorPaneWidget) clampCursor() {
-	if e.Cursor.Line < 0 {
-		e.Cursor.Line = 0
-	}
-	if e.Cursor.Line >= len(e.Buf.Lines) {
-		e.Cursor.Line = len(e.Buf.Lines) - 1
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	if e.Cursor.Col < 0 {
 		e.Cursor.Col = 0
 	}
@@ -1556,10 +1538,7 @@ func (e *EditorPaneWidget) skipHiddenLineDown() {
 		return
 	}
 	if r := e.Folds.ContainingFold(e.Cursor.Line); r != nil {
-		e.Cursor.Line = r.EndLine + 1
-		if e.Cursor.Line >= len(e.Buf.Lines) {
-			e.Cursor.Line = len(e.Buf.Lines) - 1
-		}
+		e.Cursor.Line = e.Buf.ClampLine(r.EndLine + 1)
 		lineLen := len([]rune(e.Buf.Lines[e.Cursor.Line]))
 		if e.Cursor.Col > lineLen {
 			e.Cursor.Col = lineLen
@@ -1631,12 +1610,7 @@ func (e *EditorPaneWidget) scrollViewport() {
 			e.Viewport.TopLine = e.Cursor.Line - e.Viewport.Height + 1
 		}
 	}
-	if e.Cursor.Line >= len(e.Buf.Lines) {
-		e.Cursor.Line = len(e.Buf.Lines) - 1
-	}
-	if e.Cursor.Line < 0 {
-		e.Cursor.Line = 0
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	visCol := bufColToVisualCol(e.Buf.Lines[e.Cursor.Line], e.Cursor.Col, e.resolveTabSize())
 	if visCol < e.Viewport.LeftCol {
 		e.Viewport.LeftCol = visCol
@@ -1793,9 +1767,7 @@ func (e *EditorPaneWidget) MoveLineDown() {
 }
 
 func (e *EditorPaneWidget) DuplicateLine() {
-	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
-		return
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	text := e.Buf.Lines[e.Cursor.Line]
 	e.exec(&undo.InsertLineCommand{Idx: e.Cursor.Line + 1, Text: text})
 	e.Cursor.Line++
@@ -1804,12 +1776,7 @@ func (e *EditorPaneWidget) DuplicateLine() {
 }
 
 func (e *EditorPaneWidget) DeleteLine() {
-	if e.Cursor.Line >= len(e.Buf.Lines) {
-		e.Cursor.Line = len(e.Buf.Lines) - 1
-	}
-	if e.Cursor.Line < 0 {
-		e.Cursor.Line = 0
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	if len(e.Buf.Lines) <= 1 {
 		e.exec(&undo.DeleteSelectionCommand{
 			StartLine: 0, StartCol: 0,
@@ -1981,25 +1948,15 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 // lineRange returns the start and end line indices for the current selection,
 // or the full buffer range if no selection is active.
 func (e *EditorPaneWidget) lineRange() (int, int) {
-	maxLine := len(e.Buf.Lines) - 1
-	if maxLine < 0 {
-		return 0, 0
-	}
 	if e.Selection != nil && e.Selection.Active {
 		start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
 		endLine := end.Line
 		if end.Col == 0 && endLine > start.Line {
 			endLine--
 		}
-		if start.Line > maxLine {
-			start.Line = maxLine
-		}
-		if endLine > maxLine {
-			endLine = maxLine
-		}
-		return start.Line, endLine
+		return e.Buf.ClampLine(start.Line), e.Buf.ClampLine(endLine)
 	}
-	return 0, maxLine
+	return 0, len(e.Buf.Lines) - 1
 }
 
 // copyLines returns a copy of the buffer lines in the given range (inclusive).
@@ -2109,9 +2066,7 @@ func wordBoundaryRight(runes []rune, col int) int {
 
 func (e *EditorPaneWidget) MoveWordLeft(shift bool) {
 	e.startOrExtendSelection(shift)
-	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
-		return
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	if e.Cursor.Col == 0 {
 		if e.Cursor.Line > 0 {
 			e.Cursor.Line--
@@ -2127,9 +2082,7 @@ func (e *EditorPaneWidget) MoveWordLeft(shift bool) {
 
 func (e *EditorPaneWidget) MoveWordRight(shift bool) {
 	e.startOrExtendSelection(shift)
-	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
-		return
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
 	if e.Cursor.Col >= len(runes) {
 		if e.Cursor.Line < len(e.Buf.Lines)-1 {
@@ -2147,9 +2100,7 @@ func (e *EditorPaneWidget) DeleteWordLeft() {
 	if e.Cursor.Col == 0 {
 		return
 	}
-	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
-		return
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
 	start := wordBoundaryLeft(runes, e.Cursor.Col)
 	e.exec(&undo.DeleteSelectionCommand{
@@ -2162,9 +2113,7 @@ func (e *EditorPaneWidget) DeleteWordLeft() {
 }
 
 func (e *EditorPaneWidget) DeleteWordRight() {
-	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
-		return
-	}
+	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
 	if e.Cursor.Col >= len(runes) {
 		return
@@ -2291,12 +2240,7 @@ func (e *EditorPaneWidget) multiExecBackspace() {
 			e.adjustLaterCursors(i, start, end)
 			continue
 		}
-		if cs.Line >= len(e.Buf.Lines) {
-			cs.Line = len(e.Buf.Lines) - 1
-		}
-		if cs.Line < 0 {
-			continue
-		}
+		cs.Line = e.Buf.ClampLine(cs.Line)
 		if cs.Col > 0 {
 			cmd := &undo.DeleteRuneCommand{Line: cs.Line, Col: cs.Col - 1}
 			cmd.Apply(e.Buf)
@@ -2342,12 +2286,7 @@ func (e *EditorPaneWidget) multiExecDelete() {
 			e.adjustLaterCursors(i, start, end)
 			continue
 		}
-		if cs.Line >= len(e.Buf.Lines) {
-			cs.Line = len(e.Buf.Lines) - 1
-		}
-		if cs.Line < 0 {
-			continue
-		}
+		cs.Line = e.Buf.ClampLine(cs.Line)
 		lineLen := len([]rune(e.Buf.Lines[cs.Line]))
 		if cs.Col < lineLen {
 			cmd := &undo.DeleteRuneCommand{Line: cs.Line, Col: cs.Col}
@@ -2389,12 +2328,7 @@ func (e *EditorPaneWidget) multiExecEnter() {
 			cs.Sel.Clear()
 			e.adjustLaterCursors(i, start, end)
 		}
-		if cs.Line >= len(e.Buf.Lines) {
-			cs.Line = len(e.Buf.Lines) - 1
-		}
-		if cs.Line < 0 {
-			continue
-		}
+		cs.Line = e.Buf.ClampLine(cs.Line)
 		indent := leadingWhitespace(e.Buf.Lines[cs.Line])
 		cmd := &undo.SplitLineCommand{Line: cs.Line, Col: cs.Col}
 		cmd.Apply(e.Buf)
@@ -2456,19 +2390,11 @@ func (e *EditorPaneWidget) shiftLaterLines(editedIdx, fromLine, delta int) {
 
 func (e *EditorPaneWidget) multiMoveAll(moveFn func(cs *multicursor.CursorState)) {
 	e.syncToMulti()
-	maxLine := len(e.Buf.Lines) - 1
-	if maxLine < 0 {
-		maxLine = 0
-	}
 	for i := range e.Multi.Cursors {
 		e.Multi.Cursors[i].Sel.Clear()
-		if e.Multi.Cursors[i].Line > maxLine {
-			e.Multi.Cursors[i].Line = maxLine
-		}
+		e.Multi.Cursors[i].Line = e.Buf.ClampLine(e.Multi.Cursors[i].Line)
 		moveFn(&e.Multi.Cursors[i])
-		if e.Multi.Cursors[i].Line > maxLine {
-			e.Multi.Cursors[i].Line = maxLine
-		}
+		e.Multi.Cursors[i].Line = e.Buf.ClampLine(e.Multi.Cursors[i].Line)
 	}
 	e.Multi.Deduplicate()
 	e.syncFromMulti()
@@ -2590,8 +2516,7 @@ func (e *EditorPaneWidget) SplitSelectionToLines() {
 	if start.Line == end.Line {
 		return
 	}
-	maxLine := len(e.Buf.Lines) - 1
-	if start.Line > maxLine || end.Line > maxLine || maxLine < 0 {
+	if start.Line >= len(e.Buf.Lines) || end.Line >= len(e.Buf.Lines) {
 		e.Selection.Clear()
 		return
 	}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -493,6 +493,9 @@ func (e *EditorPaneWidget) Render(surface *RenderSurface) {
 		e.CursorX = curScreenCol + gutterW + r.X
 		e.CursorY = curVisRow - topVisRow + r.Y
 	} else {
+		if e.Cursor.Line >= len(e.Buf.Lines) {
+			e.Cursor.Line = len(e.Buf.Lines) - 1
+		}
 		cursorVisCol := bufColToVisualCol(e.Buf.Lines[e.Cursor.Line], e.Cursor.Col, tabW)
 		e.CursorX = cursorVisCol - e.Viewport.LeftCol + gutterW + r.X
 		if foldsActive {
@@ -1089,6 +1092,9 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		tabSize := e.resolveTabSize()
 		if hasSel {
 			start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
+			if end.Line >= len(e.Buf.Lines) {
+				end.Line = len(e.Buf.Lines) - 1
+			}
 			for line := start.Line; line <= end.Line; line++ {
 				remove := leadingIndentWidth(e.Buf.Lines[line], tabSize)
 				if remove > 0 {

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -618,6 +618,12 @@ func (e *EditorPaneWidget) pasteText(text string) {
 	if e.Selection != nil && e.Selection.Active {
 		e.deleteSelection()
 	}
+	if e.Cursor.Line >= len(e.Buf.Lines) {
+		e.Cursor.Line = len(e.Buf.Lines) - 1
+	}
+	if e.Cursor.Line < 0 {
+		e.Cursor.Line = 0
+	}
 	lines := strings.Split(text, "\n")
 	if len(lines) == 1 {
 		e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Text: lines[0]})
@@ -803,6 +809,13 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 	kev, ok := ev.(*tcell.EventKey)
 	if !ok {
 		return EventIgnored
+	}
+
+	if e.Cursor.Line >= len(e.Buf.Lines) {
+		e.Cursor.Line = len(e.Buf.Lines) - 1
+	}
+	if e.Cursor.Line < 0 {
+		e.Cursor.Line = 0
 	}
 
 	switch kev.Key() {
@@ -1186,6 +1199,9 @@ func (e *EditorPaneWidget) mouseToPos(r Rect, mx, my int) (line, col int) {
 
 func (e *EditorPaneWidget) selectWord(line, col int) {
 	if e.Selection == nil {
+		return
+	}
+	if line < 0 || line >= len(e.Buf.Lines) {
 		return
 	}
 	runes := []rune(e.Buf.Lines[line])
@@ -1615,6 +1631,12 @@ func (e *EditorPaneWidget) scrollViewport() {
 			e.Viewport.TopLine = e.Cursor.Line - e.Viewport.Height + 1
 		}
 	}
+	if e.Cursor.Line >= len(e.Buf.Lines) {
+		e.Cursor.Line = len(e.Buf.Lines) - 1
+	}
+	if e.Cursor.Line < 0 {
+		e.Cursor.Line = 0
+	}
 	visCol := bufColToVisualCol(e.Buf.Lines[e.Cursor.Line], e.Cursor.Col, e.resolveTabSize())
 	if visCol < e.Viewport.LeftCol {
 		e.Viewport.LeftCol = visCol
@@ -1771,6 +1793,9 @@ func (e *EditorPaneWidget) MoveLineDown() {
 }
 
 func (e *EditorPaneWidget) DuplicateLine() {
+	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
+		return
+	}
 	text := e.Buf.Lines[e.Cursor.Line]
 	e.exec(&undo.InsertLineCommand{Idx: e.Cursor.Line + 1, Text: text})
 	e.Cursor.Line++
@@ -1779,6 +1804,12 @@ func (e *EditorPaneWidget) DuplicateLine() {
 }
 
 func (e *EditorPaneWidget) DeleteLine() {
+	if e.Cursor.Line >= len(e.Buf.Lines) {
+		e.Cursor.Line = len(e.Buf.Lines) - 1
+	}
+	if e.Cursor.Line < 0 {
+		e.Cursor.Line = 0
+	}
 	if len(e.Buf.Lines) <= 1 {
 		e.exec(&undo.DeleteSelectionCommand{
 			StartLine: 0, StartCol: 0,
@@ -1877,6 +1908,15 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 			endLine--
 		}
 	}
+	if startLine >= len(e.Buf.Lines) {
+		startLine = len(e.Buf.Lines) - 1
+	}
+	if endLine >= len(e.Buf.Lines) {
+		endLine = len(e.Buf.Lines) - 1
+	}
+	if startLine < 0 || endLine < 0 {
+		return
+	}
 
 	allCommented := true
 	for l := startLine; l <= endLine; l++ {
@@ -1941,15 +1981,25 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 // lineRange returns the start and end line indices for the current selection,
 // or the full buffer range if no selection is active.
 func (e *EditorPaneWidget) lineRange() (int, int) {
+	maxLine := len(e.Buf.Lines) - 1
+	if maxLine < 0 {
+		return 0, 0
+	}
 	if e.Selection != nil && e.Selection.Active {
 		start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
 		endLine := end.Line
 		if end.Col == 0 && endLine > start.Line {
 			endLine--
 		}
+		if start.Line > maxLine {
+			start.Line = maxLine
+		}
+		if endLine > maxLine {
+			endLine = maxLine
+		}
 		return start.Line, endLine
 	}
-	return 0, len(e.Buf.Lines) - 1
+	return 0, maxLine
 }
 
 // copyLines returns a copy of the buffer lines in the given range (inclusive).
@@ -2059,6 +2109,9 @@ func wordBoundaryRight(runes []rune, col int) int {
 
 func (e *EditorPaneWidget) MoveWordLeft(shift bool) {
 	e.startOrExtendSelection(shift)
+	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
+		return
+	}
 	if e.Cursor.Col == 0 {
 		if e.Cursor.Line > 0 {
 			e.Cursor.Line--
@@ -2074,6 +2127,9 @@ func (e *EditorPaneWidget) MoveWordLeft(shift bool) {
 
 func (e *EditorPaneWidget) MoveWordRight(shift bool) {
 	e.startOrExtendSelection(shift)
+	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
+		return
+	}
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
 	if e.Cursor.Col >= len(runes) {
 		if e.Cursor.Line < len(e.Buf.Lines)-1 {
@@ -2091,6 +2147,9 @@ func (e *EditorPaneWidget) DeleteWordLeft() {
 	if e.Cursor.Col == 0 {
 		return
 	}
+	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
+		return
+	}
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
 	start := wordBoundaryLeft(runes, e.Cursor.Col)
 	e.exec(&undo.DeleteSelectionCommand{
@@ -2103,6 +2162,9 @@ func (e *EditorPaneWidget) DeleteWordLeft() {
 }
 
 func (e *EditorPaneWidget) DeleteWordRight() {
+	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
+		return
+	}
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
 	if e.Cursor.Col >= len(runes) {
 		return
@@ -2229,6 +2291,12 @@ func (e *EditorPaneWidget) multiExecBackspace() {
 			e.adjustLaterCursors(i, start, end)
 			continue
 		}
+		if cs.Line >= len(e.Buf.Lines) {
+			cs.Line = len(e.Buf.Lines) - 1
+		}
+		if cs.Line < 0 {
+			continue
+		}
 		if cs.Col > 0 {
 			cmd := &undo.DeleteRuneCommand{Line: cs.Line, Col: cs.Col - 1}
 			cmd.Apply(e.Buf)
@@ -2274,6 +2342,12 @@ func (e *EditorPaneWidget) multiExecDelete() {
 			e.adjustLaterCursors(i, start, end)
 			continue
 		}
+		if cs.Line >= len(e.Buf.Lines) {
+			cs.Line = len(e.Buf.Lines) - 1
+		}
+		if cs.Line < 0 {
+			continue
+		}
 		lineLen := len([]rune(e.Buf.Lines[cs.Line]))
 		if cs.Col < lineLen {
 			cmd := &undo.DeleteRuneCommand{Line: cs.Line, Col: cs.Col}
@@ -2314,6 +2388,12 @@ func (e *EditorPaneWidget) multiExecEnter() {
 			cs.Col = start.Col
 			cs.Sel.Clear()
 			e.adjustLaterCursors(i, start, end)
+		}
+		if cs.Line >= len(e.Buf.Lines) {
+			cs.Line = len(e.Buf.Lines) - 1
+		}
+		if cs.Line < 0 {
+			continue
 		}
 		indent := leadingWhitespace(e.Buf.Lines[cs.Line])
 		cmd := &undo.SplitLineCommand{Line: cs.Line, Col: cs.Col}
@@ -2376,9 +2456,19 @@ func (e *EditorPaneWidget) shiftLaterLines(editedIdx, fromLine, delta int) {
 
 func (e *EditorPaneWidget) multiMoveAll(moveFn func(cs *multicursor.CursorState)) {
 	e.syncToMulti()
+	maxLine := len(e.Buf.Lines) - 1
+	if maxLine < 0 {
+		maxLine = 0
+	}
 	for i := range e.Multi.Cursors {
 		e.Multi.Cursors[i].Sel.Clear()
+		if e.Multi.Cursors[i].Line > maxLine {
+			e.Multi.Cursors[i].Line = maxLine
+		}
 		moveFn(&e.Multi.Cursors[i])
+		if e.Multi.Cursors[i].Line > maxLine {
+			e.Multi.Cursors[i].Line = maxLine
+		}
 	}
 	e.Multi.Deduplicate()
 	e.syncFromMulti()
@@ -2498,6 +2588,11 @@ func (e *EditorPaneWidget) SplitSelectionToLines() {
 	}
 	start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
 	if start.Line == end.Line {
+		return
+	}
+	maxLine := len(e.Buf.Lines) - 1
+	if start.Line > maxLine || end.Line > maxLine || maxLine < 0 {
+		e.Selection.Clear()
 		return
 	}
 	// If the selection ends at column 0 of the last line,

--- a/internal/ui/input_widget.go
+++ b/internal/ui/input_widget.go
@@ -63,6 +63,15 @@ func (inp *InputWidget) clearSel() {
 func (inp *InputWidget) deleteSelection() {
 	lo, hi := inp.selRange()
 	runes := []rune(inp.Text)
+	if lo > len(runes) {
+		lo = len(runes)
+	}
+	if hi > len(runes) {
+		hi = len(runes)
+	}
+	if lo > hi {
+		lo = hi
+	}
 	inp.Text = string(append(runes[:lo], runes[hi:]...))
 	inp.CursorPos = lo
 	inp.clearSel()

--- a/tests/chaos/Dockerfile
+++ b/tests/chaos/Dockerfile
@@ -11,6 +11,8 @@ RUN go test -c -o /chaos-test ./tests/chaos/
 
 FROM alpine:3.21
 
+RUN apk add --no-cache bash
+
 COPY --from=builder /chaos-test /chaos-test
 
 ENV CHAOS_LOOP=1

--- a/tests/chaos/Dockerfile
+++ b/tests/chaos/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN go test -c -o /chaos-test ./tests/chaos/
+
+FROM alpine:3.21
+
+COPY --from=builder /chaos-test /chaos-test
+
+ENV CHAOS_LOOP=1
+ENV CHAOS_EVENTS=500
+ENV CHAOS_OUTPUT_DIR=/output
+
+VOLUME /output
+
+ENTRYPOINT ["/chaos-test", "-test.run", "TestChaosLoop", "-test.v", "-test.timeout", "0"]

--- a/tests/chaos/chaos_test.go
+++ b/tests/chaos/chaos_test.go
@@ -47,6 +47,7 @@ type chaosHarness struct {
 }
 
 func newChaosHarness(seed int64) *chaosHarness {
+	// Prevent OSC 52 escape sequences from leaking into test output
 	clipboard.DisableSystem()
 	dir, _ := os.MkdirTemp("", "chaos-*")
 
@@ -106,6 +107,7 @@ func newChaosHarness(seed int64) *chaosHarness {
 }
 
 func (h *chaosHarness) cleanup() {
+	// Close terminals before removing the temp dir to avoid PTY fd leaks across iterations
 	h.app.CloseAllTerminals()
 	h.screen.Fini()
 	os.RemoveAll(h.dir)

--- a/tests/chaos/chaos_test.go
+++ b/tests/chaos/chaos_test.go
@@ -1,0 +1,385 @@
+package chaos
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/app"
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/render"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/workspace"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+type EventRecord struct {
+	Type string `json:"type"`
+	Desc string `json:"desc"`
+}
+
+type CrashReport struct {
+	Seed       int64         `json:"seed"`
+	Iteration  int           `json:"iteration"`
+	EventCount int           `json:"event_count"`
+	Events     []EventRecord `json:"events"`
+	Panic      string        `json:"panic"`
+	Stack      string        `json:"stack"`
+}
+
+type chaosHarness struct {
+	app      *app.App
+	screen   tcell.SimulationScreen
+	reg      *command.Registry
+	renderer *render.Renderer
+	dir      string
+	events   []EventRecord
+	rng      *rand.Rand
+}
+
+func newChaosHarness(seed int64) *chaosHarness {
+	dir, _ := os.MkdirTemp("", "chaos-*")
+
+	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "readme.md"), []byte("# Test\n\nSome content here.\n\n- item 1\n- item 2\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "data.txt"), []byte(strings.Repeat("The quick brown fox jumps over the lazy dog.\n", 20)), 0644)
+	os.MkdirAll(filepath.Join(dir, "src"), 0755)
+	os.WriteFile(filepath.Join(dir, "src", "lib.go"), []byte("package src\n\nfunc Add(a, b int) int { return a + b }\n"), 0644)
+
+	w, h := 80, 24
+	sim := tcell.NewSimulationScreen("")
+	sim.Init()
+	sim.SetSize(w, h)
+
+	cfg := config.AppConfig{
+		Keybindings: config.DefaultKeybindings(),
+		Settings:    config.DefaultSettings(),
+		Theme:       config.DefaultTheme(),
+	}
+	config.ParseKeyBindings(cfg.Keybindings)
+
+	screen := term.NewTcellScreenFrom(sim)
+	screen.SetStyleMap(app.BuildStyleMap(cfg.Theme))
+
+	borders := app.BuildBorderSet(cfg.Theme.Borders)
+
+	ws := workspace.New([]string{dir})
+	editor := app.BuildAppFromConfig(&cfg, &borders, ws, nil)
+	editor.Screen = screen
+	editor.Renderer = &render.Renderer{}
+
+	reg := command.NewRegistry()
+	editor.Reg = reg
+	running := true
+	editor.Running = &running
+	app.RegisterCommands(editor)
+	app.BindKeys(editor.Root, reg, cfg.Keybindings)
+	editor.Root.SetSize(w, h)
+
+	cells := make([][]term.Cell, h)
+	for y := range cells {
+		cells[y] = make([]term.Cell, w)
+	}
+	editor.Root.Render(cells)
+	editor.Renderer.SetCurrent(cells)
+	editor.Renderer.Render(screen)
+
+	return &chaosHarness{
+		app:      editor,
+		screen:   sim,
+		reg:      reg,
+		renderer: editor.Renderer,
+		dir:      dir,
+		events:   nil,
+		rng:      rand.New(rand.NewSource(seed)),
+	}
+}
+
+func (h *chaosHarness) cleanup() {
+	h.screen.Fini()
+	os.RemoveAll(h.dir)
+}
+
+func (h *chaosHarness) redraw() {
+	cells := make([][]term.Cell, h.app.Root.Height)
+	for y := range cells {
+		cells[y] = make([]term.Cell, h.app.Root.Width)
+	}
+	h.app.Root.Render(cells)
+	h.renderer.SetCurrent(cells)
+	h.renderer.Render(h.app.Screen)
+}
+
+func (h *chaosHarness) flushOnChange() {
+	if h.app.EditorGroup.Editor != nil {
+		h.app.EditorGroup.Editor.FlushOnChange()
+	}
+}
+
+func (h *chaosHarness) dispatch(ev tcell.Event) {
+	h.app.Root.HandleEvent(ev)
+	h.flushOnChange()
+	h.redraw()
+}
+
+func (h *chaosHarness) record(typ, desc string) {
+	h.events = append(h.events, EventRecord{Type: typ, Desc: desc})
+}
+
+var printableRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 \t!@#$%^&*()_+-=[]{}|;':\",./<>?`~")
+
+var specialKeys = []tcell.Key{
+	tcell.KeyEscape, tcell.KeyEnter, tcell.KeyTab, tcell.KeyBacktab,
+	tcell.KeyBackspace, tcell.KeyBackspace2, tcell.KeyDelete,
+	tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,
+	tcell.KeyHome, tcell.KeyEnd, tcell.KeyPgUp, tcell.KeyPgDn,
+	tcell.KeyF1, tcell.KeyF2, tcell.KeyF3, tcell.KeyF5,
+}
+
+var ctrlKeys = []tcell.Key{
+	tcell.KeyCtrlA, tcell.KeyCtrlB, tcell.KeyCtrlC, tcell.KeyCtrlD,
+	tcell.KeyCtrlE, tcell.KeyCtrlF, tcell.KeyCtrlG, tcell.KeyCtrlH,
+	tcell.KeyCtrlK, tcell.KeyCtrlL, tcell.KeyCtrlN, tcell.KeyCtrlO,
+	tcell.KeyCtrlP, tcell.KeyCtrlQ, tcell.KeyCtrlR, tcell.KeyCtrlS,
+	tcell.KeyCtrlT, tcell.KeyCtrlU, tcell.KeyCtrlV, tcell.KeyCtrlW,
+	tcell.KeyCtrlX, tcell.KeyCtrlY, tcell.KeyCtrlZ,
+	tcell.KeyCtrlSpace,
+}
+
+var chordFollowRunes = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+func (h *chaosHarness) randomEvent() {
+	w, hh := h.app.Root.Width, h.app.Root.Height
+
+	switch h.rng.Intn(100) {
+	case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+		20, 21, 22, 23, 24, 25, 26, 27, 28, 29:
+		// 30%: printable rune
+		r := printableRunes[h.rng.Intn(len(printableRunes))]
+		h.record("rune", string(r))
+		h.dispatch(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone))
+
+	case 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44:
+		// 15%: special key
+		k := specialKeys[h.rng.Intn(len(specialKeys))]
+		h.record("special", fmt.Sprintf("key=%d", k))
+		h.dispatch(tcell.NewEventKey(k, 0, tcell.ModNone))
+
+	case 45, 46, 47, 48, 49, 50, 51, 52, 53, 54:
+		// 10%: ctrl+key
+		k := ctrlKeys[h.rng.Intn(len(ctrlKeys))]
+		h.record("ctrl", fmt.Sprintf("key=%d", k))
+		h.dispatch(tcell.NewEventKey(k, 0, tcell.ModCtrl))
+
+	case 55, 56, 57, 58, 59, 60, 61, 62, 63, 64:
+		// 10%: chord (ctrl+k followed by a rune)
+		h.record("chord", "ctrl+k")
+		h.dispatch(tcell.NewEventKey(tcell.KeyCtrlK, 0, tcell.ModCtrl))
+		r := chordFollowRunes[h.rng.Intn(len(chordFollowRunes))]
+		h.record("chord-follow", string(r))
+		h.dispatch(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone))
+
+	case 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79:
+		// 15%: mouse click
+		mx := h.rng.Intn(w)
+		my := h.rng.Intn(hh)
+		h.record("click", fmt.Sprintf("x=%d,y=%d", mx, my))
+		h.dispatch(tcell.NewEventMouse(mx, my, tcell.Button1, tcell.ModNone))
+		h.dispatch(tcell.NewEventMouse(mx, my, tcell.ButtonNone, tcell.ModNone))
+
+	case 80, 81, 82, 83, 84:
+		// 5%: mouse scroll
+		mx := h.rng.Intn(w)
+		my := h.rng.Intn(hh)
+		btn := tcell.WheelUp
+		dir := "up"
+		if h.rng.Intn(2) == 0 {
+			btn = tcell.WheelDown
+			dir = "down"
+		}
+		h.record("scroll", fmt.Sprintf("x=%d,y=%d,dir=%s", mx, my, dir))
+		h.dispatch(tcell.NewEventMouse(mx, my, btn, tcell.ModNone))
+
+	case 85, 86, 87, 88, 89:
+		// 5%: resize
+		nw := 40 + h.rng.Intn(120)
+		nh := 10 + h.rng.Intn(50)
+		h.record("resize", fmt.Sprintf("w=%d,h=%d", nw, nh))
+		h.screen.SetSize(nw, nh)
+		h.app.Root.SetSize(nw, nh)
+		h.redraw()
+
+	case 90, 91, 92, 93, 94:
+		// 5%: execute random command
+		cmds := h.reg.List()
+		if len(cmds) > 0 {
+			cmd := cmds[h.rng.Intn(len(cmds))]
+			h.record("command", cmd.ID)
+			h.reg.Execute(cmd.ID)
+			h.flushOnChange()
+			h.redraw()
+		}
+
+	default:
+		// 10%: shift+special key
+		k := specialKeys[h.rng.Intn(len(specialKeys))]
+		h.record("shift-special", fmt.Sprintf("key=%d", k))
+		h.dispatch(tcell.NewEventKey(k, 0, tcell.ModShift))
+	}
+}
+
+func writeCrashReport(report CrashReport) string {
+	outputDir := os.Getenv("CHAOS_OUTPUT_DIR")
+	if outputDir == "" {
+		outputDir = "."
+	}
+	os.MkdirAll(outputDir, 0755)
+	filename := filepath.Join(outputDir, fmt.Sprintf("crash-%d-%d.json", report.Seed, report.Iteration))
+	data, _ := json.MarshalIndent(report, "", "  ")
+	os.WriteFile(filename, data, 0644)
+	return filename
+}
+
+func runIteration(seed int64, eventsPerRun int) *CrashReport {
+	h := newChaosHarness(seed)
+	defer h.cleanup()
+
+	var report *CrashReport
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				report = &CrashReport{
+					Seed:       seed,
+					Iteration:  0,
+					EventCount: len(h.events),
+					Events:     h.events,
+					Panic:      fmt.Sprintf("%v", r),
+					Stack:      string(debug.Stack()),
+				}
+			}
+		}()
+
+		for i := 0; i < eventsPerRun; i++ {
+			h.randomEvent()
+		}
+	}()
+
+	return report
+}
+
+func TestChaosMonkey(t *testing.T) {
+	iterations := 50
+	eventsPerRun := 500
+
+	if v := os.Getenv("CHAOS_ITERATIONS"); v != "" {
+		fmt.Sscanf(v, "%d", &iterations)
+	}
+	if v := os.Getenv("CHAOS_EVENTS"); v != "" {
+		fmt.Sscanf(v, "%d", &eventsPerRun)
+	}
+
+	baseSeed := time.Now().UnixNano()
+	if v := os.Getenv("CHAOS_SEED"); v != "" {
+		fmt.Sscanf(v, "%d", &baseSeed)
+	}
+
+	var crashes []CrashReport
+
+	for i := 0; i < iterations; i++ {
+		seed := baseSeed + int64(i)
+		report := runIteration(seed, eventsPerRun)
+		if report != nil {
+			report.Iteration = i
+			file := writeCrashReport(*report)
+			t.Errorf("CRASH at iteration %d (seed=%d): %s\n  saved to %s", i, seed, report.Panic, file)
+			crashes = append(crashes, *report)
+		}
+	}
+
+	if len(crashes) == 0 {
+		t.Logf("OK: %d iterations x %d events = %d total events, no panics (base seed: %d)",
+			iterations, eventsPerRun, iterations*eventsPerRun, baseSeed)
+	} else {
+		t.Errorf("FAILED: %d/%d iterations crashed", len(crashes), iterations)
+	}
+}
+
+func TestChaosReplay(t *testing.T) {
+	replayFile := os.Getenv("CHAOS_REPLAY")
+	if replayFile == "" {
+		t.Skip("set CHAOS_REPLAY=<crash-file.json> to replay")
+	}
+
+	data, err := os.ReadFile(replayFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var report CrashReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newChaosHarness(report.Seed)
+	defer h.cleanup()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Logf("REPRODUCED panic: %v", r)
+			t.Logf("Stack:\n%s", debug.Stack())
+			t.FailNow()
+		}
+	}()
+
+	for i := 0; i < report.EventCount; i++ {
+		h.randomEvent()
+	}
+
+	t.Log("Replay completed without panic — may be non-deterministic or already fixed")
+}
+
+// TestChaosLoop runs continuously until stopped — designed for Docker.
+func TestChaosLoop(t *testing.T) {
+	if os.Getenv("CHAOS_LOOP") == "" {
+		t.Skip("set CHAOS_LOOP=1 to run continuous chaos loop")
+	}
+
+	eventsPerRun := 500
+	if v := os.Getenv("CHAOS_EVENTS"); v != "" {
+		fmt.Sscanf(v, "%d", &eventsPerRun)
+	}
+
+	outputDir := os.Getenv("CHAOS_OUTPUT_DIR")
+	if outputDir == "" {
+		outputDir = "/output"
+	}
+	os.Setenv("CHAOS_OUTPUT_DIR", outputDir)
+
+	iteration := 0
+	totalCrashes := 0
+
+	for {
+		seed := time.Now().UnixNano()
+		report := runIteration(seed, eventsPerRun)
+		if report != nil {
+			report.Iteration = iteration
+			file := writeCrashReport(*report)
+			totalCrashes++
+			fmt.Fprintf(os.Stderr, "CRASH #%d at iteration %d (seed=%d): %s\n  → %s\n",
+				totalCrashes, iteration, seed, report.Panic, file)
+		}
+
+		iteration++
+		if iteration%100 == 0 {
+			fmt.Fprintf(os.Stderr, "chaos: %d iterations, %d crashes\n", iteration, totalCrashes)
+		}
+	}
+}

--- a/tests/chaos/chaos_test.go
+++ b/tests/chaos/chaos_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/app"
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/workspace"
@@ -46,6 +47,7 @@ type chaosHarness struct {
 }
 
 func newChaosHarness(seed int64) *chaosHarness {
+	clipboard.DisableSystem()
 	dir, _ := os.MkdirTemp("", "chaos-*")
 
 	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n"), 0644)
@@ -104,6 +106,7 @@ func newChaosHarness(seed int64) *chaosHarness {
 }
 
 func (h *chaosHarness) cleanup() {
+	h.app.CloseAllTerminals()
 	h.screen.Fini()
 	os.RemoveAll(h.dir)
 }


### PR DESCRIPTION
## Summary

Chaos monkey fuzz testing harness that generates random events (keys, clicks, resizes, commands) against the editor via SimulationScreen and catches panics. Runs in Docker to avoid random commands opening browser tabs or crashing the session.

### What it found and fixed

- **20 panics** from bounds check failures across buffer, cursor, selection, undo, editor widgets, and input handling — all fixed with guards and a new `Buffer.ClampLine` helper to DRY up repeated bounds checks
- **PTY file descriptor leak** — chaos harness wasn't closing terminals between iterations, eventually exhausting `/dev/ptmx` in Docker
- **OSC 52 escape sequence leak** — clipboard writes went directly to `os.Stderr`, bypassing tcell. Now routed through the tcell tty via `clipboard.SetOSCWriter()`, so escape sequences only emit when a real terminal is attached
- **Terminal spawn crash on deleted directory** — `terminal.New` now validates `cmd.Dir` exists before passing it to `pty.Start`

### Results

25,000+ iterations with 0 crashes, 0 PTY errors, 0 escape sequence leaks on the latest image.

## Usage
```sh
# Quick local run (50 iterations x 500 events)
make chaos

# Build Docker image
make chaos-docker-build

# Run continuously in Docker (crash logs in chaos-output/)
make chaos-docker

# Reproduce a specific crash
CHAOS_REPLAY=chaos-output/crash-<seed>-<iter>.json go test ./tests/chaos/ -run TestChaosReplay
```

## Test plan
- [x] `make test` - all unit and e2e tests pass
- [x] Local chaos: 25,000 events, no panics
- [x] Docker chaos: 25,000+ iterations, 0 crashes, no PTY exhaustion, no escape sequence leaks
- [x] Replay: deterministically reproduced crashes from saved reports before fixing
