### PR TITLE
docs: add Arch Linux (AUR) installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | s
 ```
 
 ### Arch Linux (AUR)
+
+Graciously maintained by [@Dominiquini](https://github.com/Dominiquini).
+
 ```sh
 yay -S ttt
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | s
 
 ### [Arch Linux (AUR)](https://aur.archlinux.org/packages/ttt)
 
-Community-maintained by [@Dominiquini](https://github.com/Dominiquini).
+Thanks to [@Dominiquini](https://github.com/Dominiquini) for maintaining the AUR package.
 
 ```sh
 yay -S ttt

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ brew install ttt
 curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
 ```
 
-### Arch Linux (AUR)
+### [Arch Linux (AUR)](https://aur.archlinux.org/packages/ttt)
 
-Graciously maintained by [@Dominiquini](https://github.com/Dominiquini).
+Community-maintained by [@Dominiquini](https://github.com/Dominiquini).
 
 ```sh
 yay -S ttt

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ brew install ttt
 curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
 ```
 
+### Arch Linux (AUR)
+```sh
+yay -S ttt
+```
+
 
 ### Go Install
 

--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -29,6 +29,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     INSTALL_DIR=~/.local/bin curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
     ```
   </TabItem>
+  <TabItem label="Arch Linux (AUR)">
+    Available on the [AUR](https://aur.archlinux.org/packages/ttt):
+
+    ```sh
+    yay -S ttt
+    ```
+  </TabItem>
 </Tabs>
 
 ## Download Binary


### PR DESCRIPTION
## Summary
- Add AUR installation option (`yay -S ttt`) to README.md and docs-web installation page
- A community member @Dominiquini  ([aur arch](https://aur.archlinux.org/packages/ttt)) packaged ttt for the AUR

## Test plan
tested in endeavouros laptop, installed perfectly 

