### PR TITLE
fix: rebrand to TTT Editor for search discoverability

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -4,7 +4,7 @@ ttt is a fully-featured code editor that lives in the terminal. Not a simplified
 
 With AI-driven development, developers spend less time in editors manually. When they do open one, they want something fast and capable that's already where they are — not a full GUI app booting up. ttt fills that gap: split panes, file explorer, tabs, command palette, menus, dialogs, syntax highlighting, mouse support, and a secure plugin system — all in a single Go binary.
 
-> **Note:** Project was renamed from pico/macro to **ttt** (Terminal Text Tool). Module name is `ttt`, binary is `ttt`, repo is `eugenioenko/ttt`.
+> **Note:** Project was renamed from pico/macro to **ttt** (TTT Editor — Terminal Text Tool). Module name is `ttt`, binary is `ttt`, repo is `eugenioenko/ttt`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TTT — Terminal Text Tool
+# TTT Editor — Terminal Text Tool
 
 The IDE that lives in your terminal. Not a simplified terminal editor — a real alternative to VS Code, Zed, and Sublime that happens to run in your terminal. Single Go binary, zero config.
 

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -66,7 +66,7 @@ func main() {
 	for _, arg := range os.Args[1:] {
 		switch arg {
 		case "--help", "-h":
-			fmt.Printf(`ttt %s - Terminal Text Tool, an IDE for your terminal
+			fmt.Printf(`ttt %s - TTT Editor, Terminal Text Tool, an IDE for your terminal
 
 Usage: ttt [options] [files/folders/URLs...]
 

--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -7,12 +7,12 @@ export default defineConfig({
   integrations: [
     starlight({
       customCss: ['./src/styles/custom.css'],
-      title: 'TTT',
+      title: 'TTT Editor',
       favicon: '/favicon.svg',
       logo: {
         src: './src/assets/logo.svg',
       },
-      description: 'A terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal. Single Go binary, zero config.',
+      description: 'TTT Editor — a terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal. Single Go binary, zero config.',
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/eugenioenko/ttt' },
       ],

--- a/docs-web/src/content/docs/getting-started/introduction.md
+++ b/docs-web/src/content/docs/getting-started/introduction.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-TTT (Terminal Text Tool) is a fully-featured code editor that runs in your terminal. It is not a simplified terminal editor. It is a real alternative to VS Code, Zed, and Sublime that happens to run in your terminal.
+TTT Editor (Terminal Text Tool) is a fully-featured code editor that runs in your terminal. It is not a simplified terminal editor. It is a real alternative to VS Code, Zed, and Sublime that happens to run in your terminal.
 
 ## Why TTT?
 

--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: TTT - Terminal Text Tool
-description: A terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal.
+title: TTT Editor - Terminal Text Tool
+description: TTT Editor — a terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal.
 template: splash
 hero:
   tagline: The IDE that lives in your terminal.


### PR DESCRIPTION
## Summary
- Updated all user-facing references from "TTT - Terminal Text Tool" to "TTT Editor - Terminal Text Tool"
- Site title, meta description, README heading, CLI help text, and introduction page all now include "editor" in the name
- Helps search engines associate "ttt editor" queries with the project

## Context
Users searching "ttt editor" weren't finding the site because "editor" didn't appear in the name anywhere — only "Terminal Text Tool".

🤖 Generated with [Claude Code](https://claude.com/claude-code)