### PR TITLE
fix: homepage title line break

### DIFF
--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -1,8 +1,9 @@
 ---
-title: "TTT Editor <br> Terminal Text Tool"
+title: TTT Editor - Terminal Text Tool
 description: TTT Editor — a terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal.
 template: splash
 hero:
+  title: "TTT Editor <br> Terminal Text Tool"
   tagline: The IDE that lives in your terminal.
   actions:
     - text: Get Started

--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: TTT Editor - Terminal Text Tool
+title: "TTT Editor <br> Terminal Text Tool"
 description: TTT Editor — a terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal.
 template: splash
 hero:

--- a/docs-web/src/styles/custom.css
+++ b/docs-web/src/styles/custom.css
@@ -27,9 +27,11 @@
 .hero h1 {
   text-align: center;
   width: 100%;
+  position: relative;
 }
 
 .hero h1::after {
+  position: absolute;
   content: '_';
   animation: blink 1s step-end infinite;
   color: var(--sl-color-text);

--- a/docs-web/src/styles/custom.css
+++ b/docs-web/src/styles/custom.css
@@ -24,6 +24,11 @@
   text-align: center;
 }
 
+.hero h1 {
+  text-align: center;
+  width: 100%;
+}
+
 .hero h1::after {
   content: '_';
   animation: blink 1s step-end infinite;


### PR DESCRIPTION
Splits the homepage title into two lines: **TTT Editor** on top, **Terminal Text Tool** below.