### PR TITLE
fix: preserve bottom panel height when toggling

### DIFF
--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -9,11 +9,10 @@ import (
 func (a *App) ToggleTerminal() {
 	if !a.ContentSplit.ShowBottom {
 		r := a.ContentSplit.GetRect()
-		half := r.H / 2
-		if half > r.H-4 {
-			half = r.H - 4
+		maxH := r.H - 4
+		if a.ContentSplit.BottomH <= 1 || a.ContentSplit.BottomH > maxH {
+			a.ContentSplit.BottomH = min(r.H/2, maxH)
 		}
-		a.ContentSplit.BottomH = half
 		a.showTerminalPanel()
 	} else {
 		a.HideBottomPanel()


### PR DESCRIPTION
## Summary
- `ToggleTerminal` was resetting `BottomH` to half the screen every time the panel opened, discarding the user's resized height
- Now preserves the existing height, only resetting when it's too small (`<= 1`) or exceeds available space after a window resize
- Matches sidebar behavior where `DividerPos` persists across toggles

## Test plan
- [x] `go test ./...` passes
- [ ] Toggle terminal, resize it, toggle off/on — height should be preserved
- [ ] Shrink window so panel would exceed height, toggle — should clamp to half

🤖 Generated with [Claude Code](https://claude.com/claude-code)