### PR TITLE
fix: sort command palette items alphabetically

### DIFF
--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -1,5 +1,7 @@
 package command
 
+import "sort"
+
 type Command struct {
 	ID       string
 	Title    string
@@ -53,5 +55,8 @@ func (r *Registry) List() []Command {
 	for _, cmd := range r.commands {
 		cmds = append(cmds, cmd)
 	}
+	sort.Slice(cmds, func(i, j int) bool {
+		return cmds[i].Title < cmds[j].Title
+	})
 	return cmds
 }


### PR DESCRIPTION
## Summary
- `Registry.List()` iterated a Go map, producing random order each time the command palette opened
- Sort the output alphabetically by title for a consistent, deterministic list

## Test plan
- [x] `go test ./...` passes
- [ ] Open command palette multiple times — items should always appear in the same order

🤖 Generated with [Claude Code](https://claude.com/claude-code)