### PR TITLE
feat: About dialog with version, website, and GitHub link

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -132,6 +132,7 @@ Docs: https://tttedit.dev
 	editor, prURLs := app.BuildApp(&cfg, &borders)
 	editor.Init(screen, renderer, lspManager)
 
+	editor.Version = version
 	editor.Keybindings = cfg.Keybindings
 	editor.Reg = cmdRegistry
 	running := true

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -74,6 +74,7 @@ type App struct {
 	Watcher            *watcher.Watcher
 	GitGutterGen       int
 	GitGutterTimer     *time.Timer
+	Version            string
 }
 
 func (a *App) KeyFor(cmd string) string {

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -268,10 +268,20 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "about", Title: "About ttt",
+		ID: "about", Title: "About TTT Editor",
 		Keywords: []string{"help", "version", "info"},
 		Handler: func() {
-			OpenURL("https://github.com/eugenioenko/ttt")
+			dialog := ui.NewInfoDialogWidget("About TTT Editor", []ui.InfoEntry{
+				{Key: "Version", Desc: app.Version},
+				{Key: "Website", Desc: "https://tttedit.dev"},
+				{Key: "GitHub", Desc: "https://github.com/eugenioenko/ttt"},
+			})
+			dialog.Borders = app.Borders
+			dialog.InvertStyles = true
+			dialog.OnDismiss = func() {
+				app.DismissDialog()
+			}
+			app.ShowDialog(dialog)
 		},
 	})
 }

--- a/internal/ui/helpdialog_widget.go
+++ b/internal/ui/helpdialog_widget.go
@@ -13,11 +13,12 @@ type InfoEntry struct {
 
 type InfoDialogWidget struct {
 	BaseWidget
-	Title   string
-	Entries []InfoEntry
-	Width   int
-	Height  int
-	Borders *term.BorderSet
+	Title        string
+	Entries      []InfoEntry
+	Width        int
+	Height       int
+	Borders      *term.BorderSet
+	InvertStyles bool
 
 	OnDismiss func()
 
@@ -129,10 +130,14 @@ func (d *InfoDialogWidget) Render(surface *RenderSurface) {
 		if kx < boxX+2 {
 			kx = boxX + 2
 		}
-		surface.DrawText(kx, y, entry.Key, boxX+2+kw, term.StylePaletteItem)
+		keyStyle, descStyle := term.StylePaletteItem, term.StyleMuted
+		if d.InvertStyles {
+			keyStyle, descStyle = descStyle, keyStyle
+		}
+		surface.DrawText(kx, y, entry.Key, boxX+2+kw, keyStyle)
 
 		descX := boxX + 2 + kw + 2
-		surface.DrawText(descX, y, entry.Desc, boxX+boxW-2, term.StyleMuted)
+		surface.DrawText(descX, y, entry.Desc, boxX+boxW-2, descStyle)
 	}
 
 	if d.scrollTop > 0 {


### PR DESCRIPTION
## Summary
- Replace the About command (which opened GitHub in a browser) with an info dialog
- Shows version, website (tttedit.dev), and GitHub repo URL
- Added `InvertStyles` flag to `InfoDialogWidget` so labels render muted and values in foreground

## Test plan
- [x] `go test ./...` passes
- [ ] Open command palette, run "About TTT Editor" — dialog shows version, website, GitHub
- [ ] Verify labels are muted and values are in foreground color
- [ ] Press Esc or Enter or click Close to dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)