### PR TITLE
feat: add PR review comments tab in bottom panel

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -65,6 +65,7 @@ type App struct {
 	LastHoverCol       int
 	Problems           *ui.ProblemsWidget
 	References         *ui.ReferencesWidget
+	PRComments         *ui.PRCommentsWidget
 	AllDiagnostics     map[string][]ui.Diagnostic
 	Keybindings        []config.KeyBinding
 	LspNotified        map[string]bool
@@ -396,6 +397,20 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		a.EditorGroup.OpenFile(file)
 		a.EditorGroup.GoToLine(line + 1)
 		a.Root.SetFocus(a.EditorGroup)
+	}
+	a.PRComments.OnOpenFile = func(path string, line int) {
+		a.EditorGroup.OpenFile(path)
+		if line > 0 {
+			a.EditorGroup.GoToLine(line)
+		}
+		a.Root.SetFocus(a.EditorGroup)
+	}
+	a.PRComments.OnSubmitComment = func(body string) {
+		if a.PRComments.Owner == "" || a.PRComments.Number == 0 {
+			a.StatusWarn("No PR loaded")
+			return
+		}
+		a.AddPRCommentAsync(a.PRComments.Owner, a.PRComments.Repo, a.PRComments.Number, body)
 	}
 	a.EditorGroup.Editor.OnChange = func() {
 		path := a.EditorGroup.ActiveFilePath()

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -296,6 +296,29 @@ func RunEventLoop(
 					app.Root.SetFocus(app.Changes)
 					app.Sidebar.SetPanelDirty("changes", app.Changes.TotalChanges() > 0)
 					app.StatusNotify(fmt.Sprintf("Opened PR #%d: %s (%d files)", v.Info.Number, v.Info.Title, len(v.Info.Files)))
+					// Also fetch PR comments
+					app.FetchPRComments(v.Info.Owner, v.Info.Repo, v.Info.Number)
+				}
+			case *PRCommentsResult:
+				if v.Err != nil {
+					app.StatusError("Failed to fetch PR comments: " + v.Err.Error())
+				} else {
+					app.PRComments.Owner = v.Owner
+					app.PRComments.Repo = v.Repo
+					app.PRComments.Number = v.Number
+					app.PRComments.SetComments(v.Comments)
+					count := len(v.Comments)
+					if count > 0 {
+						app.BottomPanel.SetPanelDirty("comments", true)
+					}
+					app.StatusNotify(fmt.Sprintf("Loaded %d PR comments", count))
+				}
+			case *PRCommentAddResult:
+				if v.Err != nil {
+					app.StatusError("Failed to add comment: " + v.Err.Error())
+				} else {
+					app.StatusNotify("Comment posted")
+					app.FetchPRComments(v.Owner, v.Repo, v.Number)
 				}
 			}
 			redraw()

--- a/internal/app/pr.go
+++ b/internal/app/pr.go
@@ -22,6 +22,51 @@ type DiffContentResult struct {
 	Err      error
 }
 
+// PRCommentsResult is posted back to the event loop after fetching comments.
+type PRCommentsResult struct {
+	Comments []github.PRComment
+	Owner    string
+	Repo     string
+	Number   int
+	Err      error
+}
+
+// PRCommentAddResult is posted after adding a comment.
+type PRCommentAddResult struct {
+	Owner  string
+	Repo   string
+	Number int
+	Err    error
+}
+
+// FetchPRComments fetches review comments asynchronously and posts the result.
+func (a *App) FetchPRComments(owner, repo string, number int) {
+	go func() {
+		comments, err := github.FetchPRComments(owner, repo, number)
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&PRCommentsResult{
+			Comments: comments,
+			Owner:    owner,
+			Repo:     repo,
+			Number:   number,
+			Err:      err,
+		}))
+	}()
+}
+
+// AddPRComment submits a general comment asynchronously and posts the result.
+func (a *App) AddPRCommentAsync(owner, repo string, number int, body string) {
+	a.StatusNotify("Posting comment...")
+	go func() {
+		err := github.AddPRComment(owner, repo, number, body)
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&PRCommentAddResult{
+			Owner:  owner,
+			Repo:   repo,
+			Number: number,
+			Err:    err,
+		}))
+	}()
+}
+
 func (a *App) FetchAndOpenPR(url string) {
 	owner, repo, number, err := github.ParsePRURL(url)
 	if err != nil {

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -1,15 +1,15 @@
 package app
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/view"
 	"github.com/eugenioenko/ttt/internal/workspace"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 func isPRURL(arg string) bool {
@@ -122,10 +122,12 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	terminalPanel.Borders = borders
 	problems := ui.NewProblemsWidget()
 	references := ui.NewReferencesWidget()
+	prComments := ui.NewPRCommentsWidget()
 	bottomPanel := ui.NewBottomPanelWidget(borders)
 	bottomPanel.AddPanel("terminal", "TERMINAL", terminalPanel)
 	bottomPanel.AddPanel("problems", "PROBLEMS", problems)
 	bottomPanel.AddPanel("references", "REFERENCES", references)
+	bottomPanel.AddPanel("comments", "COMMENTS", prComments)
 
 	contentSplit := ui.NewContentSplitWidget()
 	contentSplit.Top = editorGroup
@@ -177,27 +179,28 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	root.SetFocus(editorGroup)
 
 	return &App{
-		Root:              root,
-		EditorGroup:       editorGroup,
-		Sidebar:           sidebar,
-		SplitPanel:        splitPanel,
-		ContentSplit:      contentSplit,
-		BottomPanel:       bottomPanel,
-		Explorer:          explorer,
-		Search:            search,
-		Changes:           changes,
-		MenuBar:           menuBar,
-		StatusBar:         statusBar,
-		Status:            status,
-		Borders:           borders,
-		Settings:          &cfg.Settings,
-		Workspace:         ws,
-		Palette:           BuildTerminalPalettePtr(cfg.Theme),
-		TerminalPanel:     terminalPanel,
-		Problems:          problems,
-		References:        references,
-		DocVersions:       make(map[string]int),
-		AllDiagnostics:    make(map[string][]ui.Diagnostic),
-		LspNotified:       make(map[string]bool),
+		Root:           root,
+		EditorGroup:    editorGroup,
+		Sidebar:        sidebar,
+		SplitPanel:     splitPanel,
+		ContentSplit:   contentSplit,
+		BottomPanel:    bottomPanel,
+		Explorer:       explorer,
+		Search:         search,
+		Changes:        changes,
+		MenuBar:        menuBar,
+		StatusBar:      statusBar,
+		Status:         status,
+		Borders:        borders,
+		Settings:       &cfg.Settings,
+		Workspace:      ws,
+		Palette:        BuildTerminalPalettePtr(cfg.Theme),
+		TerminalPanel:  terminalPanel,
+		Problems:       problems,
+		References:     references,
+		PRComments:     prComments,
+		DocVersions:    make(map[string]int),
+		AllDiagnostics: make(map[string][]ui.Diagnostic),
+		LspNotified:    make(map[string]bool),
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -133,6 +133,127 @@ func FetchFileContent(owner, repo, path, ref string) (string, error) {
 	return string(out), nil
 }
 
+// PRComment represents a comment on a pull request.
+// IsInline distinguishes review comments attached to a file/line
+// from general issue-level comments.
+type PRComment struct {
+	ID        int
+	Body      string
+	User      string
+	CreatedAt string
+	Path      string
+	Line      int
+	IsInline  bool
+}
+
+// FetchPRComments fetches both inline review comments and general
+// issue comments for a pull request, returning them as a unified list.
+func FetchPRComments(owner, repo string, number int) ([]PRComment, error) {
+	var comments []PRComment
+
+	// Fetch inline/review comments
+	reviewCmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/comments", owner, repo, number),
+		"--paginate")
+	reviewOut, err := reviewCmd.Output()
+	if err == nil && len(reviewOut) > 0 {
+		var reviewComments []struct {
+			ID   int    `json:"id"`
+			Body string `json:"body"`
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			CreatedAt string `json:"created_at"`
+			Path      string `json:"path"`
+			Line      *int   `json:"line"`
+		}
+		if err := json.Unmarshal(reviewOut, &reviewComments); err == nil {
+			for _, rc := range reviewComments {
+				line := 0
+				if rc.Line != nil {
+					line = *rc.Line
+				}
+				comments = append(comments, PRComment{
+					ID:        rc.ID,
+					Body:      rc.Body,
+					User:      rc.User.Login,
+					CreatedAt: rc.CreatedAt,
+					Path:      rc.Path,
+					Line:      line,
+					IsInline:  true,
+				})
+			}
+		}
+	}
+
+	// Fetch general issue comments
+	issueCmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/%s/%s/issues/%d/comments", owner, repo, number),
+		"--paginate")
+	issueOut, err := issueCmd.Output()
+	if err == nil && len(issueOut) > 0 {
+		var issueComments []struct {
+			ID   int    `json:"id"`
+			Body string `json:"body"`
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			CreatedAt string `json:"created_at"`
+		}
+		if err := json.Unmarshal(issueOut, &issueComments); err == nil {
+			for _, ic := range issueComments {
+				comments = append(comments, PRComment{
+					ID:        ic.ID,
+					Body:      ic.Body,
+					User:      ic.User.Login,
+					CreatedAt: ic.CreatedAt,
+					IsInline:  false,
+				})
+			}
+		}
+	}
+
+	return comments, nil
+}
+
+// AddPRComment adds a general comment to a pull request.
+func AddPRComment(owner, repo string, number int, body string) error {
+	payload, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return fmt.Errorf("marshal comment: %w", err)
+	}
+	cmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/%s/%s/issues/%d/comments", owner, repo, number),
+		"-X", "POST",
+		"--input", "-")
+	cmd.Stdin = strings.NewReader(string(payload))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("add comment failed: %s", string(out))
+	}
+	return nil
+}
+
+// AddPRInlineComment adds an inline review comment to a specific file and line.
+func AddPRInlineComment(owner, repo string, number int, body, path string, line int) error {
+	payload, err := json.Marshal(map[string]interface{}{
+		"body": body,
+		"path": path,
+		"line": line,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal inline comment: %w", err)
+	}
+	cmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/comments", owner, repo, number),
+		"-X", "POST",
+		"--input", "-")
+	cmd.Stdin = strings.NewReader(string(payload))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("add inline comment failed: %s", string(out))
+	}
+	return nil
+}
+
 func SplitMultiFileDiff(unified string) map[string]string {
 	result := make(map[string]string)
 	lines := strings.Split(unified, "\n")

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -38,6 +38,42 @@ func TestParsePRURL(t *testing.T) {
 	}
 }
 
+func TestPRCommentType(t *testing.T) {
+	// Verify PRComment fields can be set for both inline and general comments
+	inline := PRComment{
+		ID:        1,
+		Body:      "Needs a nil check here",
+		User:      "reviewer",
+		CreatedAt: "2024-01-15T10:30:00Z",
+		Path:      "internal/app/app.go",
+		Line:      42,
+		IsInline:  true,
+	}
+	if !inline.IsInline {
+		t.Error("expected inline comment")
+	}
+	if inline.Path != "internal/app/app.go" {
+		t.Errorf("expected path internal/app/app.go, got %s", inline.Path)
+	}
+	if inline.Line != 42 {
+		t.Errorf("expected line 42, got %d", inline.Line)
+	}
+
+	general := PRComment{
+		ID:        2,
+		Body:      "LGTM",
+		User:      "approver",
+		CreatedAt: "2024-01-15T11:00:00Z",
+		IsInline:  false,
+	}
+	if general.IsInline {
+		t.Error("expected general comment")
+	}
+	if general.Path != "" {
+		t.Errorf("expected empty path for general comment, got %s", general.Path)
+	}
+}
+
 func TestSplitMultiFileDiff(t *testing.T) {
 	unified := `diff --git a/file1.go b/file1.go
 --- a/file1.go

--- a/internal/ui/pr_comments_widget.go
+++ b/internal/ui/pr_comments_widget.go
@@ -1,0 +1,407 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/github"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+// commentItemKind distinguishes the different row types in the rendered list.
+type commentItemKind int
+
+const (
+	commentItemSection  commentItemKind = iota // section header ("General" / file path)
+	commentItemComment                         // a comment body row
+	commentItemInputRow                        // the input row at the bottom
+)
+
+// commentItem is one logical row in the flattened list used for rendering and
+// scrolling. For commentItemComment rows, commentIndex points into the
+// widget's Comments slice.
+type commentItem struct {
+	kind         commentItemKind
+	commentIndex int    // valid for commentItemComment
+	label        string // section header text
+}
+
+// PRCommentsWidget shows PR review comments in a scrollable list with an
+// input area at the bottom for adding new general comments.
+type PRCommentsWidget struct {
+	BaseWidget
+	Comments []github.PRComment
+
+	items        []commentItem
+	selected     int
+	scrollTop    int
+	scrollbar    Scrollbar
+	inputFocused bool
+	Input        *InputWidget
+
+	// PR coordinates needed by the caller for refresh / submit.
+	Owner  string
+	Repo   string
+	Number int
+
+	OnOpenFile      func(path string, line int)
+	OnSubmitComment func(body string)
+}
+
+func NewPRCommentsWidget() *PRCommentsWidget {
+	inp := NewInputWidget()
+	inp.Placeholder = "Add a comment..."
+	return &PRCommentsWidget{
+		Input: inp,
+	}
+}
+
+func (w *PRCommentsWidget) Focusable() bool { return true }
+
+// SetComments replaces the comment list and rebuilds the internal item list.
+func (w *PRCommentsWidget) SetComments(comments []github.PRComment) {
+	w.Comments = comments
+	w.buildItems()
+	if w.selected >= len(w.items) {
+		w.selected = len(w.items) - 1
+	}
+	if w.selected < 0 {
+		w.selected = 0
+	}
+}
+
+// buildItems creates a flat list of rows for rendering. The layout is:
+//   - "General Comments" section header (if any general comments)
+//   - general comments
+//   - One section header per file (if any inline comments)
+//   - inline comments grouped under that file
+//   - Input row at the very bottom
+func (w *PRCommentsWidget) buildItems() {
+	w.items = nil
+
+	var general []int
+	byFile := make(map[string][]int)
+	var fileOrder []string
+	filesSeen := make(map[string]bool)
+
+	for i, c := range w.Comments {
+		if !c.IsInline {
+			general = append(general, i)
+		} else {
+			if !filesSeen[c.Path] {
+				filesSeen[c.Path] = true
+				fileOrder = append(fileOrder, c.Path)
+			}
+			byFile[c.Path] = append(byFile[c.Path], i)
+		}
+	}
+
+	if len(general) > 0 {
+		w.items = append(w.items, commentItem{kind: commentItemSection, label: "General Comments"})
+		for _, idx := range general {
+			w.items = append(w.items, commentItem{kind: commentItemComment, commentIndex: idx})
+		}
+	}
+
+	for _, file := range fileOrder {
+		w.items = append(w.items, commentItem{kind: commentItemSection, label: file})
+		for _, idx := range byFile[file] {
+			w.items = append(w.items, commentItem{kind: commentItemComment, commentIndex: idx})
+		}
+	}
+
+	// Input row always at the end
+	w.items = append(w.items, commentItem{kind: commentItemInputRow})
+}
+
+func (w *PRCommentsWidget) Render(surface *RenderSurface) {
+	sw, sh := surface.Size()
+	if sw == 0 || sh == 0 {
+		return
+	}
+
+	totalRows := len(w.items)
+	if totalRows == 0 {
+		msg := "No PR comments"
+		x := 1
+		for _, ch := range msg {
+			if x >= sw {
+				break
+			}
+			surface.SetCell(x, 0, term.Cell{Ch: ch, Style: term.StyleMuted})
+			x++
+		}
+		return
+	}
+
+	// Scroll management
+	if w.scrollTop > w.selected {
+		w.scrollTop = w.selected
+	}
+	if w.selected >= w.scrollTop+sh {
+		w.scrollTop = w.selected - sh + 1
+	}
+
+	r := w.GetRect()
+	w.scrollbar.X = r.X + sw - 1
+	w.scrollbar.Y = r.Y
+	w.scrollbar.Height = sh
+	w.scrollbar.TotalItems = totalRows
+	w.scrollbar.TopItem = w.scrollTop
+
+	contentW := sw
+	if w.scrollbar.Visible() {
+		contentW = sw - 1
+	}
+
+	for y := 0; y < sh; y++ {
+		idx := w.scrollTop + y
+		if idx >= totalRows {
+			break
+		}
+		item := w.items[idx]
+
+		isSelected := idx == w.selected && !w.inputFocused
+
+		switch item.kind {
+		case commentItemSection:
+			w.renderSection(surface, y, contentW, isSelected, item.label)
+		case commentItemComment:
+			c := w.Comments[item.commentIndex]
+			w.renderComment(surface, y, contentW, isSelected, c)
+		case commentItemInputRow:
+			w.Input.Render(surface, 0, y, contentW)
+		}
+	}
+
+	w.scrollbar.Render(surface, sw-1, 0)
+}
+
+func (w *PRCommentsWidget) renderSection(surface *RenderSurface, y, width int, selected bool, label string) {
+	style := term.StyleMuted
+	if selected {
+		style = term.StyleSidebarSelected
+	}
+	for x := 0; x < width; x++ {
+		surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+	}
+	x := 1
+	for _, ch := range label {
+		if x >= width {
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: style})
+		x++
+	}
+}
+
+func (w *PRCommentsWidget) renderComment(surface *RenderSurface, y, width int, selected bool, c github.PRComment) {
+	style := term.StyleDefault
+	if selected {
+		style = term.StyleSidebarSelected
+	}
+
+	// Clear row
+	for x := 0; x < width; x++ {
+		surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+	}
+
+	x := 1
+
+	// Author
+	authorStyle := term.StyleSuccess
+	if selected {
+		authorStyle = term.StyleSidebarSelected
+	}
+	for _, ch := range c.User {
+		if x >= width-1 {
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: authorStyle})
+		x++
+	}
+	// separator
+	surface.SetCell(x, y, term.Cell{Ch: ':', Style: style})
+	x++
+	surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+	x++
+
+	// Body (first line only, truncated)
+	bodyLine := firstLine(c.Body)
+	bodyStyle := style
+	if !selected {
+		bodyStyle = term.StyleMuted
+	}
+
+	// Reserve space for file:line on the right if inline
+	rightLabel := ""
+	if c.IsInline && c.Path != "" {
+		if c.Line > 0 {
+			rightLabel = fmt.Sprintf(" %s:%d", filepath.Base(c.Path), c.Line)
+		} else {
+			rightLabel = " " + filepath.Base(c.Path)
+		}
+	}
+	rightW := len([]rune(rightLabel))
+	bodyMaxW := width - x - rightW
+
+	for _, ch := range bodyLine {
+		if bodyMaxW <= 0 {
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: bodyStyle})
+		x++
+		bodyMaxW--
+	}
+
+	// Render right-aligned file:line
+	if rightLabel != "" {
+		rx := width - rightW
+		if rx < x {
+			rx = x
+		}
+		locStyle := term.StyleMuted
+		if selected {
+			locStyle = term.StyleSidebarSelected
+		}
+		for _, ch := range rightLabel {
+			if rx >= width {
+				break
+			}
+			surface.SetCell(rx, y, term.Cell{Ch: ch, Style: locStyle})
+			rx++
+		}
+	}
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return s[:idx]
+	}
+	return s
+}
+
+func (w *PRCommentsWidget) HandleEvent(ev tcell.Event) EventResult {
+	// When input is focused, route keys there
+	if w.inputFocused {
+		if tev, ok := ev.(*tcell.EventKey); ok {
+			switch tev.Key() {
+			case tcell.KeyEscape:
+				w.inputFocused = false
+				return EventConsumed
+			case tcell.KeyEnter:
+				text := strings.TrimSpace(w.Input.Text)
+				if text != "" && w.OnSubmitComment != nil {
+					w.OnSubmitComment(text)
+					w.Input.Clear()
+				}
+				return EventConsumed
+			case tcell.KeyUp:
+				w.inputFocused = false
+				if w.selected > 0 {
+					w.selected--
+				}
+				return EventConsumed
+			default:
+				w.Input.HandleEvent(ev)
+				return EventConsumed
+			}
+		}
+	}
+
+	// Scrollbar takes priority
+	if newTop, consumed := w.scrollbar.HandleEvent(ev); consumed {
+		w.scrollTop = newTop
+		if w.scrollbar.IsDragging() {
+			return EventCaptured
+		}
+		return EventConsumed
+	}
+
+	switch tev := ev.(type) {
+	case *tcell.EventKey:
+		switch tev.Key() {
+		case tcell.KeyUp:
+			if w.selected > 0 {
+				w.selected--
+			}
+			return EventConsumed
+		case tcell.KeyDown:
+			if w.selected < len(w.items)-1 {
+				w.selected++
+			}
+			return EventConsumed
+		case tcell.KeyEnter:
+			w.activateSelected()
+			return EventConsumed
+		}
+	case *tcell.EventMouse:
+		btn := tev.Buttons()
+		_, my := tev.Position()
+		r := w.GetRect()
+		row := my - r.Y
+		idx := w.scrollTop + row
+
+		if btn&tcell.Button1 != 0 && idx >= 0 && idx < len(w.items) {
+			w.selected = idx
+			w.activateSelected()
+			return EventConsumed
+		}
+		if btn&tcell.WheelUp != 0 {
+			if w.scrollTop > 0 {
+				w.scrollTop--
+			}
+			return EventConsumed
+		}
+		if btn&tcell.WheelDown != 0 {
+			if w.scrollTop < len(w.items)-1 {
+				w.scrollTop++
+			}
+			return EventConsumed
+		}
+	}
+	return EventIgnored
+}
+
+func (w *PRCommentsWidget) activateSelected() {
+	if w.selected < 0 || w.selected >= len(w.items) {
+		return
+	}
+	item := w.items[w.selected]
+	switch item.kind {
+	case commentItemComment:
+		c := w.Comments[item.commentIndex]
+		if c.IsInline && c.Path != "" && w.OnOpenFile != nil {
+			w.OnOpenFile(c.Path, c.Line)
+		}
+	case commentItemInputRow:
+		w.inputFocused = true
+	}
+}
+
+// CursorPosition implements CursorProvider so the blinking cursor appears
+// in the input when it is focused.
+func (w *PRCommentsWidget) CursorPosition() (int, int, bool) {
+	if !w.inputFocused {
+		return 0, 0, false
+	}
+	r := w.GetRect()
+	for i, item := range w.items {
+		if item.kind == commentItemInputRow {
+			y := r.Y + i - w.scrollTop
+			return w.Input.CursorX(r.X), y, true
+		}
+	}
+	return 0, 0, false
+}
+
+// FocusedInput implements InputHolder for clipboard routing.
+func (w *PRCommentsWidget) FocusedInput() *InputWidget {
+	if !w.inputFocused {
+		return nil
+	}
+	return w.Input
+}

--- a/internal/ui/pr_comments_widget_test.go
+++ b/internal/ui/pr_comments_widget_test.go
@@ -1,0 +1,246 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/github"
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestPRCommentsWidgetEmpty(t *testing.T) {
+	w := NewPRCommentsWidget()
+	if !w.Focusable() {
+		t.Error("PRCommentsWidget should be focusable")
+	}
+	// Empty widget should have one item (the input row)
+	w.SetComments(nil)
+	if len(w.items) != 1 {
+		t.Errorf("expected 1 item (input row) with no comments, got %d", len(w.items))
+	}
+}
+
+func TestPRCommentsWidgetSetComments(t *testing.T) {
+	w := NewPRCommentsWidget()
+	comments := []github.PRComment{
+		{ID: 1, Body: "LGTM", User: "alice", IsInline: false},
+		{ID: 2, Body: "Fix typo", User: "bob", Path: "main.go", Line: 10, IsInline: true},
+		{ID: 3, Body: "Needs test", User: "carol", Path: "main.go", Line: 20, IsInline: true},
+		{ID: 4, Body: "Good pattern", User: "dave", Path: "lib.go", Line: 5, IsInline: true},
+	}
+	w.SetComments(comments)
+
+	// Expected items:
+	// 1. "General Comments" section header
+	// 2. LGTM comment
+	// 3. "main.go" section header
+	// 4. Fix typo comment
+	// 5. Needs test comment
+	// 6. "lib.go" section header
+	// 7. Good pattern comment
+	// 8. Input row
+	if len(w.items) != 8 {
+		t.Fatalf("expected 8 items, got %d", len(w.items))
+	}
+
+	if w.items[0].kind != commentItemSection {
+		t.Error("first item should be a section header")
+	}
+	if w.items[0].label != "General Comments" {
+		t.Errorf("expected 'General Comments', got %q", w.items[0].label)
+	}
+	if w.items[1].kind != commentItemComment {
+		t.Error("second item should be a comment")
+	}
+	if w.items[2].kind != commentItemSection {
+		t.Error("third item should be a section header")
+	}
+	if w.items[2].label != "main.go" {
+		t.Errorf("expected 'main.go', got %q", w.items[2].label)
+	}
+	if w.items[7].kind != commentItemInputRow {
+		t.Error("last item should be input row")
+	}
+}
+
+func TestPRCommentsWidgetOnlyInline(t *testing.T) {
+	w := NewPRCommentsWidget()
+	comments := []github.PRComment{
+		{ID: 1, Body: "Review comment", User: "alice", Path: "foo.go", Line: 5, IsInline: true},
+	}
+	w.SetComments(comments)
+
+	// Expected: section "foo.go", comment, input
+	if len(w.items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(w.items))
+	}
+	if w.items[0].kind != commentItemSection || w.items[0].label != "foo.go" {
+		t.Error("expected foo.go section header")
+	}
+}
+
+func TestPRCommentsWidgetOnlyGeneral(t *testing.T) {
+	w := NewPRCommentsWidget()
+	comments := []github.PRComment{
+		{ID: 1, Body: "Looks good", User: "alice", IsInline: false},
+		{ID: 2, Body: "Ship it", User: "bob", IsInline: false},
+	}
+	w.SetComments(comments)
+
+	// Expected: section "General Comments", 2 comments, input
+	if len(w.items) != 4 {
+		t.Fatalf("expected 4 items, got %d", len(w.items))
+	}
+}
+
+func TestPRCommentsWidgetKeyNavigation(t *testing.T) {
+	w := NewPRCommentsWidget()
+	w.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+	comments := []github.PRComment{
+		{ID: 1, Body: "General", User: "alice", IsInline: false},
+		{ID: 2, Body: "Inline", User: "bob", Path: "a.go", Line: 1, IsInline: true},
+	}
+	w.SetComments(comments)
+
+	// Navigate down
+	res := w.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, 0))
+	if res != EventConsumed {
+		t.Error("Down should be consumed")
+	}
+	if w.selected != 1 {
+		t.Errorf("expected selected=1, got %d", w.selected)
+	}
+
+	// Navigate up
+	res = w.HandleEvent(tcell.NewEventKey(tcell.KeyUp, 0, 0))
+	if res != EventConsumed {
+		t.Error("Up should be consumed")
+	}
+	if w.selected != 0 {
+		t.Errorf("expected selected=0, got %d", w.selected)
+	}
+
+	// Up at top stays at 0
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyUp, 0, 0))
+	if w.selected != 0 {
+		t.Errorf("expected selected=0 at top, got %d", w.selected)
+	}
+}
+
+func TestPRCommentsWidgetActivateInlineComment(t *testing.T) {
+	w := NewPRCommentsWidget()
+	w.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+	comments := []github.PRComment{
+		{ID: 1, Body: "Fix this", User: "alice", Path: "app.go", Line: 42, IsInline: true},
+	}
+	w.SetComments(comments)
+
+	var openedPath string
+	var openedLine int
+	w.OnOpenFile = func(path string, line int) {
+		openedPath = path
+		openedLine = line
+	}
+
+	// Select the comment (index 1, after section header)
+	w.selected = 1
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	if openedPath != "app.go" {
+		t.Errorf("expected path 'app.go', got %q", openedPath)
+	}
+	if openedLine != 42 {
+		t.Errorf("expected line 42, got %d", openedLine)
+	}
+}
+
+func TestPRCommentsWidgetActivateInputRow(t *testing.T) {
+	w := NewPRCommentsWidget()
+	w.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+	comments := []github.PRComment{
+		{ID: 1, Body: "Comment", User: "alice", IsInline: false},
+	}
+	w.SetComments(comments)
+
+	// Select the input row (last item)
+	w.selected = len(w.items) - 1
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	if !w.inputFocused {
+		t.Error("input should be focused after activating input row")
+	}
+}
+
+func TestPRCommentsWidgetInputSubmit(t *testing.T) {
+	w := NewPRCommentsWidget()
+	w.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+	w.SetComments(nil) // just the input row
+
+	var submitted string
+	w.OnSubmitComment = func(body string) {
+		submitted = body
+	}
+
+	// Focus input
+	w.selected = 0 // input row
+	w.inputFocused = true
+
+	// Type some text
+	w.Input.Text = "Great PR!"
+	w.Input.CursorPos = 9
+
+	// Press Enter to submit
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	if submitted != "Great PR!" {
+		t.Errorf("expected submitted 'Great PR!', got %q", submitted)
+	}
+	if w.Input.Text != "" {
+		t.Error("input should be cleared after submit")
+	}
+}
+
+func TestPRCommentsWidgetInputEscape(t *testing.T) {
+	w := NewPRCommentsWidget()
+	w.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+	w.SetComments(nil)
+	w.inputFocused = true
+
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEscape, 0, 0))
+
+	if w.inputFocused {
+		t.Error("input should be unfocused after Escape")
+	}
+}
+
+func TestPRCommentsWidgetCursorPosition(t *testing.T) {
+	w := NewPRCommentsWidget()
+	w.SetRect(Rect{X: 5, Y: 10, W: 80, H: 24})
+	w.SetComments(nil) // just input row
+
+	// Not focused - no cursor
+	_, _, visible := w.CursorPosition()
+	if visible {
+		t.Error("cursor should not be visible when input not focused")
+	}
+
+	// Focus input
+	w.inputFocused = true
+	_, _, visible = w.CursorPosition()
+	if !visible {
+		t.Error("cursor should be visible when input is focused")
+	}
+}
+
+func TestPRCommentsWidgetFocusedInput(t *testing.T) {
+	w := NewPRCommentsWidget()
+	w.SetComments(nil)
+
+	if inp := w.FocusedInput(); inp != nil {
+		t.Error("FocusedInput should return nil when not focused")
+	}
+
+	w.inputFocused = true
+	if inp := w.FocusedInput(); inp == nil {
+		t.Error("FocusedInput should return input when focused")
+	}
+}

--- a/tests/e2e/panel_test.go
+++ b/tests/e2e/panel_test.go
@@ -20,12 +20,12 @@ func TestBottomPanelTabClick(t *testing.T) {
 	panelY := h.app.BottomPanel.GetRect().Y
 	panelX := h.app.BottomPanel.GetRect().X
 
-	h.click(panelX+39, panelY)
+	h.click(panelX+49, panelY)
 	if h.app.BottomPanel.ActivePanel != "test-b" {
 		t.Errorf("expected active panel 'test-b' after click, got %q", h.app.BottomPanel.ActivePanel)
 	}
 
-	h.click(panelX+32, panelY)
+	h.click(panelX+42, panelY)
 	if h.app.BottomPanel.ActivePanel != "test-a" {
 		t.Errorf("expected active panel 'test-a' after click, got %q", h.app.BottomPanel.ActivePanel)
 	}
@@ -40,13 +40,13 @@ func TestTabbedPanelRemovePanel(t *testing.T) {
 	h.app.BottomPanel.AddPanel("p3", "Three", newEmptyWidget())
 	h.app.BottomPanel.SetActivePanel("p2")
 
-	if h.app.BottomPanel.PanelCount() != 6 {
-		t.Fatalf("expected 6 panels, got %d", h.app.BottomPanel.PanelCount())
+	if h.app.BottomPanel.PanelCount() != 7 {
+		t.Fatalf("expected 7 panels, got %d", h.app.BottomPanel.PanelCount())
 	}
 
 	h.app.BottomPanel.RemovePanel("p2")
-	if h.app.BottomPanel.PanelCount() != 5 {
-		t.Fatalf("expected 5 panels, got %d", h.app.BottomPanel.PanelCount())
+	if h.app.BottomPanel.PanelCount() != 6 {
+		t.Fatalf("expected 6 panels, got %d", h.app.BottomPanel.PanelCount())
 	}
 	if h.app.BottomPanel.ActivePanel == "p2" {
 		t.Error("active panel should have changed after removing it")
@@ -54,8 +54,8 @@ func TestTabbedPanelRemovePanel(t *testing.T) {
 
 	h.app.BottomPanel.RemovePanel("p1")
 	h.app.BottomPanel.RemovePanel("p3")
-	if h.app.BottomPanel.PanelCount() != 3 {
-		t.Fatalf("expected 3 panels (terminal+problems+references), got %d", h.app.BottomPanel.PanelCount())
+	if h.app.BottomPanel.PanelCount() != 4 {
+		t.Fatalf("expected 4 panels (terminal+problems+references+comments), got %d", h.app.BottomPanel.PanelCount())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `FetchPRComments`, `AddPRComment`, and `AddPRInlineComment` functions to `internal/github/github.go` for fetching and posting PR comments via `gh api`
- Create `PRCommentsWidget` in `internal/ui/pr_comments_widget.go` -- a scrollable bottom-panel widget that groups general comments and inline comments by file, with an input area for submitting new comments
- Wire the widget into the bottom panel as a "COMMENTS" tab, auto-populated when a PR is loaded, with callbacks for opening inline comment file locations and submitting new comments asynchronously

## Test plan
- [x] Unit tests for `PRComment` type in `internal/github/github_test.go`
- [x] Widget unit tests covering empty state, comment grouping, keyboard navigation, input focus/submit/escape, cursor position, and focused input in `internal/ui/pr_comments_widget_test.go`
- [x] Updated e2e panel tests to account for the new "comments" tab (panel count and click coordinates)
- [x] `make build` succeeds
- [x] `make test` passes (pre-existing config test failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)