### PR TITLE
fix: normalize multi-cursor selection and word movement

### DIFF
--- a/internal/core/multicursor/multicursor.go
+++ b/internal/core/multicursor/multicursor.go
@@ -109,6 +109,17 @@ func (mc *MultiCursor) Sort() {
 	}
 }
 
+func (mc *MultiCursor) NormalizePrimary() {
+	c := &mc.Cursors[mc.Primary]
+	if !c.Sel.Active {
+		return
+	}
+	start, end := c.Sel.Range(c.Line, c.Col)
+	c.Sel.Anchor = start
+	c.Line = end.Line
+	c.Col = end.Col
+}
+
 func (mc *MultiCursor) Deduplicate() {
 	if len(mc.Cursors) <= 1 {
 		return

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -2040,6 +2040,21 @@ func wordBoundaryRight(runes []rune, col int) int {
 }
 
 func (e *EditorPaneWidget) MoveWordLeft(shift bool) {
+	if e.isMultiActive() && !shift {
+		e.multiMoveAll(func(cs *multicursor.CursorState) {
+			if cs.Col == 0 {
+				if cs.Line > 0 {
+					cs.Line--
+					cs.Col = len([]rune(e.Buf.Lines[cs.Line]))
+				}
+			} else {
+				runes := []rune(e.Buf.Lines[cs.Line])
+				cs.Col = wordBoundaryLeft(runes, cs.Col)
+			}
+		})
+		e.scrollViewport()
+		return
+	}
 	e.startOrExtendSelection(shift)
 	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	if e.Cursor.Col == 0 {
@@ -2056,6 +2071,21 @@ func (e *EditorPaneWidget) MoveWordLeft(shift bool) {
 }
 
 func (e *EditorPaneWidget) MoveWordRight(shift bool) {
+	if e.isMultiActive() && !shift {
+		e.multiMoveAll(func(cs *multicursor.CursorState) {
+			runes := []rune(e.Buf.Lines[cs.Line])
+			if cs.Col >= len(runes) {
+				if cs.Line < len(e.Buf.Lines)-1 {
+					cs.Line++
+					cs.Col = 0
+				}
+			} else {
+				cs.Col = wordBoundaryRight(runes, cs.Col)
+			}
+		})
+		e.scrollViewport()
+		return
+	}
 	e.startOrExtendSelection(shift)
 	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
@@ -2397,6 +2427,8 @@ func (e *EditorPaneWidget) SelectNextOccurrence() {
 	}
 	e.ensureMulti()
 	e.syncToMulti()
+	e.Multi.NormalizePrimary()
+	e.syncFromMulti()
 
 	searchWord := e.multiSearchWord
 	lastCursor := e.Multi.Cursors[len(e.Multi.Cursors)-1]

--- a/tests/functional/multi-cursor.test.js
+++ b/tests/functional/multi-cursor.test.js
@@ -164,4 +164,35 @@ describe("multi-cursor", () => {
     const content = readFile(file);
     expect(content).toBe("let x = 1;\nlet y = 2;\nlet z = 3;\n");
   });
+
+  it("should move all cursors with ctrl+right word movement", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "wordmove.txt", "test one\ntest two\ntest three");
+
+    tui.start(file);
+    tui.waitFor("test one");
+
+    tui.press("home");
+    tui.press("ctrl+d");
+    tui.waitStable();
+    tui.press("ctrl+d");
+    tui.waitStable();
+    tui.press("ctrl+d");
+    tui.waitStable();
+
+    // All cursors have "test" selected; word-right x2: skip space, then jump to end of number word
+    tui.exec("Move Word Right");
+    tui.waitStable();
+    tui.exec("Move Word Right");
+    tui.waitStable();
+
+    tui.type("!");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const content = readFile(file);
+    expect(content).toBe("test one!\ntest two!\ntest three!\n");
+  });
 });


### PR DESCRIPTION
## Summary
- Normalize primary cursor selection direction on Ctrl+D so all multi-cursor selections have consistent anchor=start, cursor=end orientation (fixes right-to-left selection having cursor on the wrong side)
- Add Ctrl+Left/Right word movement support for all multi-cursors (previously only moved the primary cursor)
- Add functional test for multi-cursor word movement

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Functional test: select "test" across 3 lines with Ctrl+D, word-right x2, type "!" → appears after each number word
- [ ] Manual: select text right-to-left, Ctrl+D — verify all cursors align on the same side
- [ ] Manual: Ctrl+D multiple selections, then Ctrl+Left/Right — verify all cursors move

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4cDCDwf25dd233tz69GPM