### PR TITLE
fix: increase default bottom panel height

### DIFF
--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -25,7 +25,7 @@ type ContentSplitWidget struct {
 func NewContentSplitWidget() *ContentSplitWidget {
 	return &ContentSplitWidget{
 		ShowBottom: false,
-		BottomH:    10,
+		BottomH:    15,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Increase default bottom panel height from 10 to 15 rows for better visibility of terminal output and search results

## Test plan
- [x] Height is clamped if terminal is too small (existing logic)
- [ ] Manual: open terminal/search panel — verify 15 rows of content visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4cDCDwf25dd233tz69GPM