### PR TITLE
feat: add copy file path commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Functional tests with `tui` are the highest-value tests. Use `tui.exec("Command 
 - **Selection operations**: check `Selection.Active` first. Use `Selection.Range(cursor.Line, cursor.Col)` for bounds. Convention: if no selection, operate on all lines (for line-based commands) or no-op (for text transforms).
 - **Keybindings**: `ctrl+shift` combos are unreliable in terminals — avoid them. Use `ctrl+k <key>` chords for new commands. Check `DefaultKeybindings()` in `internal/config/keybindings.go` before assigning to avoid collisions. If no obvious binding exists, leave the command as command palette only — not every command needs a keybinding.
 - **Overlay stacking**: commands that open overlays via keybindings must guard against being called twice with `if a.Root.HasOverlay() { return }`. `ShowDialog`/`ShowConfirmDialog` themselves have no guard so legitimate stacking (e.g. quit confirm) still works.
+- **Command handlers**: define handlers as named methods on `App` (e.g. `app.ExplorerRename`) and reference them in `reg.Register(...)`. Do not use inline closures for non-trivial handlers.
 
 ### Post-implementation review
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,6 +68,7 @@ type App struct {
 	AllDiagnostics     map[string][]ui.Diagnostic
 	Keybindings        []config.KeyBinding
 	LspNotified        map[string]bool
+	ExplorerContextNode *ui.TreeNode
 	Reg                *command.Registry
 	Running            *bool
 	quitPending        bool

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -443,6 +443,9 @@ func registerWidgetCallbacks(app *App) {
 			{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
 			{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
 			{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
+			ui.MenuSep(),
+			{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
+			{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
 		}
 		if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
 			cmd := "diff.extendedView"
@@ -477,11 +480,15 @@ func registerWidgetCallbacks(app *App) {
 	app.Search.OnReplaceAll = app.ApplySearchReplaceAll
 
 	app.Explorer.OnRightClick = func(node *ui.TreeNode, sx, sy int) {
+		app.ExplorerContextNode = node
 		items := []ui.ContextMenuItem{
 			{Label: "Open", Command: "explorer.open"},
 			ui.MenuSep(),
 			{Label: "New File", Command: "explorer.newFile"},
 			{Label: "New Folder", Command: "explorer.newFolder"},
+			ui.MenuSep(),
+			{Label: "Copy Absolute Path", Command: "explorer.copyAbsolutePath"},
+			{Label: "Copy Relative Path", Command: "explorer.copyRelativePath"},
 			ui.MenuSep(),
 			{Label: "Rename", Command: "explorer.rename"},
 			{Label: "Delete", Command: "explorer.delete"},

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 )
 
 func (a *App) ExplorerNewFile() {
@@ -90,6 +91,39 @@ func (a *App) ExplorerDelete() {
 	)
 }
 
+func (a *App) activeFilePath() string {
+	path := a.EditorGroup.ActiveFilePath()
+	if path == "untitled" {
+		return ""
+	}
+	return path
+}
+
+func (a *App) explorerNodePath() string {
+	if a.ExplorerContextNode != nil {
+		return a.ExplorerContextNode.Path
+	}
+	if node := a.Explorer.SelectedNode(); node != nil {
+		return node.Path
+	}
+	return ""
+}
+
+func (a *App) relativePath(absPath string) string {
+	if folder := a.Workspace.FolderForFile(absPath); folder != nil {
+		if rel, err := filepath.Rel(folder.Path, absPath); err == nil {
+			return rel
+		}
+	}
+	primary := a.Workspace.Primary()
+	if primary != "" {
+		if rel, err := filepath.Rel(primary, absPath); err == nil {
+			return rel
+		}
+	}
+	return absPath
+}
+
 func registerExplorerCommands(app *App) {
 	reg := app.Reg
 
@@ -127,5 +161,65 @@ func registerExplorerCommands(app *App) {
 		ID: "explorer.delete", Title: "Explorer: Delete",
 		Keywords: []string{"view", "file", "remove"},
 		Handler:  app.ExplorerDelete,
+	})
+
+	reg.Register(command.Command{
+		ID: "file.copyAbsolutePath", Title: "File: Copy Absolute Path",
+		Keywords: []string{"file", "path", "copy", "clipboard", "absolute"},
+		Handler: func() {
+			path := app.activeFilePath()
+			if path == "" {
+				app.StatusWarn("No file open")
+				return
+			}
+			clipboard.Set(path)
+			app.StatusNotify("Absolute path copied to clipboard")
+		},
+	})
+
+	reg.Register(command.Command{
+		ID: "file.copyRelativePath", Title: "File: Copy Relative Path",
+		Keywords: []string{"file", "path", "copy", "clipboard", "relative"},
+		Handler: func() {
+			path := app.activeFilePath()
+			if path == "" {
+				app.StatusWarn("No file open")
+				return
+			}
+			rel := app.relativePath(path)
+			clipboard.Set(rel)
+			app.StatusNotify("Relative path copied to clipboard")
+		},
+	})
+
+	reg.Register(command.Command{
+		ID: "explorer.copyAbsolutePath", Title: "Explorer: Copy Absolute Path",
+		Keywords: []string{"explorer", "file", "path", "copy", "clipboard", "absolute"},
+		Handler: func() {
+			path := app.explorerNodePath()
+			if path == "" {
+				app.StatusWarn("No file selected")
+				return
+			}
+			clipboard.Set(path)
+			app.ExplorerContextNode = nil
+			app.StatusNotify("Absolute path copied to clipboard")
+		},
+	})
+
+	reg.Register(command.Command{
+		ID: "explorer.copyRelativePath", Title: "Explorer: Copy Relative Path",
+		Keywords: []string{"explorer", "file", "path", "copy", "clipboard", "relative"},
+		Handler: func() {
+			path := app.explorerNodePath()
+			if path == "" {
+				app.StatusWarn("No file selected")
+				return
+			}
+			rel := app.relativePath(path)
+			clipboard.Set(rel)
+			app.ExplorerContextNode = nil
+			app.StatusNotify("Relative path copied to clipboard")
+		},
 	})
 }

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -91,6 +91,50 @@ func (a *App) ExplorerDelete() {
 	)
 }
 
+func (a *App) CopyAbsolutePath() {
+	path := a.activeFilePath()
+	if path == "" {
+		a.StatusWarn("No file open")
+		return
+	}
+	clipboard.Set(path)
+	a.StatusNotify("Absolute path copied to clipboard")
+}
+
+func (a *App) CopyRelativePath() {
+	path := a.activeFilePath()
+	if path == "" {
+		a.StatusWarn("No file open")
+		return
+	}
+	rel := a.relativePath(path)
+	clipboard.Set(rel)
+	a.StatusNotify("Relative path copied to clipboard")
+}
+
+func (a *App) ExplorerCopyAbsolutePath() {
+	path := a.explorerNodePath()
+	if path == "" {
+		a.StatusWarn("No file selected")
+		return
+	}
+	clipboard.Set(path)
+	a.ExplorerContextNode = nil
+	a.StatusNotify("Absolute path copied to clipboard")
+}
+
+func (a *App) ExplorerCopyRelativePath() {
+	path := a.explorerNodePath()
+	if path == "" {
+		a.StatusWarn("No file selected")
+		return
+	}
+	rel := a.relativePath(path)
+	clipboard.Set(rel)
+	a.ExplorerContextNode = nil
+	a.StatusNotify("Relative path copied to clipboard")
+}
+
 func (a *App) activeFilePath() string {
 	path := a.EditorGroup.ActiveFilePath()
 	if path == "untitled" {
@@ -166,60 +210,24 @@ func registerExplorerCommands(app *App) {
 	reg.Register(command.Command{
 		ID: "file.copyAbsolutePath", Title: "File: Copy Absolute Path",
 		Keywords: []string{"file", "path", "copy", "clipboard", "absolute"},
-		Handler: func() {
-			path := app.activeFilePath()
-			if path == "" {
-				app.StatusWarn("No file open")
-				return
-			}
-			clipboard.Set(path)
-			app.StatusNotify("Absolute path copied to clipboard")
-		},
+		Handler:  app.CopyAbsolutePath,
 	})
 
 	reg.Register(command.Command{
 		ID: "file.copyRelativePath", Title: "File: Copy Relative Path",
 		Keywords: []string{"file", "path", "copy", "clipboard", "relative"},
-		Handler: func() {
-			path := app.activeFilePath()
-			if path == "" {
-				app.StatusWarn("No file open")
-				return
-			}
-			rel := app.relativePath(path)
-			clipboard.Set(rel)
-			app.StatusNotify("Relative path copied to clipboard")
-		},
+		Handler:  app.CopyRelativePath,
 	})
 
 	reg.Register(command.Command{
 		ID: "explorer.copyAbsolutePath", Title: "Explorer: Copy Absolute Path",
 		Keywords: []string{"explorer", "file", "path", "copy", "clipboard", "absolute"},
-		Handler: func() {
-			path := app.explorerNodePath()
-			if path == "" {
-				app.StatusWarn("No file selected")
-				return
-			}
-			clipboard.Set(path)
-			app.ExplorerContextNode = nil
-			app.StatusNotify("Absolute path copied to clipboard")
-		},
+		Handler:  app.ExplorerCopyAbsolutePath,
 	})
 
 	reg.Register(command.Command{
 		ID: "explorer.copyRelativePath", Title: "Explorer: Copy Relative Path",
 		Keywords: []string{"explorer", "file", "path", "copy", "clipboard", "relative"},
-		Handler: func() {
-			path := app.explorerNodePath()
-			if path == "" {
-				app.StatusWarn("No file selected")
-				return
-			}
-			rel := app.relativePath(path)
-			clipboard.Set(rel)
-			app.ExplorerContextNode = nil
-			app.StatusNotify("Relative path copied to clipboard")
-		},
+		Handler:  app.ExplorerCopyRelativePath,
 	})
 }

--- a/internal/app/commands_help.go
+++ b/internal/app/commands_help.go
@@ -8,6 +8,8 @@ import (
 var explorerHelpEntries = []ui.InfoEntry{
 	{Key: "Enter", Desc: "Open file or toggle folder"},
 	{Key: "Space", Desc: "Open file or toggle folder"},
+	{Key: "Shift+Enter", Desc: "Open context menu"},
+	{Key: "Menu*", Desc: "Open context menu (terminal-dependent)"},
 	{Key: "Left", Desc: "Collapse folder"},
 	{Key: "Right", Desc: "Expand folder"},
 	{Key: "Up / Down", Desc: "Navigate items"},

--- a/internal/ui/explorer_widget.go
+++ b/internal/ui/explorer_widget.go
@@ -258,6 +258,14 @@ func (e *ExplorerWidget) HandleEvent(ev tcell.Event) EventResult {
 				e.ActivateSelected()
 				return EventConsumed
 			}
+		case tcell.KeyEnter:
+			if tev.Modifiers()&tcell.ModShift != 0 {
+				if e.OnRightClick != nil && e.Selected >= 0 && e.Selected < len(e.FlatList) {
+					r := e.GetRect()
+					e.OnRightClick(e.FlatList[e.Selected], r.X, r.Y+e.Selected-e.ScrollTop)
+				}
+				return EventConsumed
+			}
 		case tcell.KeyLeft:
 			e.collapseSelected()
 			return EventConsumed

--- a/internal/ui/selectable_list.go
+++ b/internal/ui/selectable_list.go
@@ -97,6 +97,12 @@ func (sl *SelectableList) HandleListEvent(ev tcell.Event, rect Rect, itemCount i
 			return ListEventResult{Result: EventConsumed}
 		case tcell.KeyEnter:
 			return ListEventResult{Result: EventConsumed, Action: ListActionActivate}
+		case tcell.KeyMenu:
+			return ListEventResult{Result: EventConsumed, Action: ListActionContext, ScreenX: rect.X, ScreenY: rect.Y + sl.Selected - sl.ScrollTop}
+		case tcell.KeyF10:
+			if tev.Modifiers()&tcell.ModShift != 0 {
+				return ListEventResult{Result: EventConsumed, Action: ListActionContext, ScreenX: rect.X, ScreenY: rect.Y + sl.Selected - sl.ScrollTop}
+			}
 		}
 	}
 

--- a/internal/ui/selectable_list.go
+++ b/internal/ui/selectable_list.go
@@ -96,7 +96,9 @@ func (sl *SelectableList) HandleListEvent(ev tcell.Event, rect Rect, itemCount i
 			}
 			return ListEventResult{Result: EventConsumed}
 		case tcell.KeyEnter:
-			return ListEventResult{Result: EventConsumed, Action: ListActionActivate}
+			if tev.Modifiers() == 0 {
+				return ListEventResult{Result: EventConsumed, Action: ListActionActivate}
+			}
 		case tcell.KeyMenu:
 			return ListEventResult{Result: EventConsumed, Action: ListActionContext, ScreenX: rect.X, ScreenY: rect.Y + sl.Selected - sl.ScrollTop}
 		case tcell.KeyF10:

--- a/tests/e2e/copy_path_test.go
+++ b/tests/e2e/copy_path_test.go
@@ -1,0 +1,88 @@
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
+)
+
+func TestCopyAbsolutePathFromEditor(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	clipboard.DisableSystem()
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.redraw()
+
+	h.exec("file.copyAbsolutePath")
+
+	got := clipboard.Get()
+	want := filepath.Join(h.dir, "alpha.txt")
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestCopyRelativePathFromEditor(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	clipboard.DisableSystem()
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "subdir", "nested.txt"))
+	h.redraw()
+
+	h.exec("file.copyRelativePath")
+
+	got := clipboard.Get()
+	want := filepath.Join("subdir", "nested.txt")
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestCopyAbsolutePathFromExplorer(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	clipboard.DisableSystem()
+
+	h.exec("sidebar.explorer")
+
+	// Find a non-directory node in the explorer
+	var fileIdx int
+	for i, node := range h.app.Explorer.FlatList {
+		if !node.IsDir {
+			fileIdx = i
+			break
+		}
+	}
+	h.app.Explorer.Selected = fileIdx
+	h.app.ExplorerContextNode = h.app.Explorer.FlatList[fileIdx]
+	h.redraw()
+
+	h.exec("explorer.copyAbsolutePath")
+
+	got := clipboard.Get()
+	want := h.app.Explorer.FlatList[fileIdx].Path
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestCopyPathNoFileOpen(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	clipboard.DisableSystem()
+	clipboard.Set("")
+
+	h.exec("file.copyAbsolutePath")
+
+	got := clipboard.Get()
+	if got != "" {
+		t.Errorf("expected empty clipboard when no file open, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `file.copyAbsolutePath` and `file.copyRelativePath` commands accessible from the command palette and tab right-click context menu
- Add `explorer.copyAbsolutePath` and `explorer.copyRelativePath` commands in the file explorer right-click context menu (correctly uses the right-clicked node, not the active editor file)
- Add keyboard context menu support (Menu key / Shift+F10) to `SelectableList`, enabling context menus via keyboard in the explorer and other list widgets

## Test plan
- [x] E2E tests for copy absolute path from editor tab
- [x] E2E tests for copy relative path from editor tab
- [x] E2E tests for copy absolute path from explorer context node
- [x] E2E tests for no-file-open edge case
- [ ] Manual: right-click file in explorer → Copy Absolute Path → verify clipboard
- [ ] Manual: right-click tab → Copy Relative Path → verify clipboard
- [ ] Manual: select file in explorer → press Menu key → verify context menu appears

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)