### PR TITLE
fix: prevent tests from overwriting user settings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,7 +55,13 @@ func Load(settingsFile string) AppConfig {
 	return cfg
 }
 
+var OverrideConfigDir string
+
 func configPaths() []string {
+	if OverrideConfigDir != "" {
+		return []string{OverrideConfigDir}
+	}
+
 	var paths []string
 
 	if exe, err := os.Executable(); err == nil {

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -41,6 +41,11 @@ func newTestHarness(t *testing.T, w, h int) *testHarness {
 	os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
 	os.WriteFile(filepath.Join(dir, "subdir", "nested.txt"), []byte("nested"), 0644)
 
+	configDir := filepath.Join(dir, "config")
+	os.MkdirAll(configDir, 0755)
+	config.OverrideConfigDir = configDir
+	t.Cleanup(func() { config.OverrideConfigDir = "" })
+
 	sim := tcell.NewSimulationScreen("")
 	if err := sim.Init(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- Add `config.OverrideConfigDir` variable to redirect config path resolution in tests
- E2E and chaos test harnesses now write to a temp dir instead of `~/.config/ttt/`
- Fixes a bug where running `go test` would overwrite the user's real `settings.json` with test defaults

## Test plan
- [x] `go test ./tests/e2e/` passes
- [x] Verified `~/.config/ttt/settings.json` is not modified after running tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)