### PR TITLE
fix: resolve copy path for diff tabs

### DIFF
--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -3,6 +3,7 @@ package app
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
@@ -139,6 +140,12 @@ func (a *App) activeFilePath() string {
 	path := a.EditorGroup.ActiveFilePath()
 	if path == "untitled" {
 		return ""
+	}
+	path = strings.TrimSuffix(path, " (diff)")
+	if !filepath.IsAbs(path) {
+		if len(a.Workspace.Folders) > 0 {
+			path = filepath.Join(a.Workspace.Folders[0].Path, path)
+		}
 	}
 	return path
 }


### PR DESCRIPTION
## Summary
- Strip " (diff)" suffix from tab file path before copying
- Resolve relative paths (from git diff) to absolute using workspace root
- Extract inline command handlers into named App methods per project conventions

## Test plan
- [x] Open a diff tab, right-click tab → Copy Absolute Path → get the real file path
- [x] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)