### PR TITLE
feat: add context menu to explorer root folder nodes

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -479,6 +479,17 @@ func registerWidgetCallbacks(app *App) {
 	app.Search.OnReplace = app.ApplySearchReplace
 	app.Search.OnReplaceAll = app.ApplySearchReplaceAll
 
+	app.Explorer.OnRootMenu = func(node *ui.TreeNode, sx, sy int) {
+		app.ExplorerContextNode = node
+		items := []ui.ContextMenuItem{
+			{Label: "Refresh", Command: "explorer.refresh"},
+			{Label: "Copy Path", Command: "explorer.copyAbsolutePath"},
+			ui.MenuSep(),
+			{Label: "Remove from Workspace", Command: "explorer.removeRoot"},
+		}
+		openContextMenu(app, items, sx, sy)
+	}
+
 	app.Explorer.OnRightClick = func(node *ui.TreeNode, sx, sy int) {
 		app.ExplorerContextNode = node
 		items := []ui.ContextMenuItem{

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -135,6 +135,20 @@ func (a *App) ExplorerCopyRelativePath() {
 	a.StatusNotify("Relative path copied to clipboard")
 }
 
+func (a *App) ExplorerRemoveRoot() {
+	path := a.explorerNodePath()
+	if path == "" {
+		return
+	}
+	a.ExplorerContextNode = nil
+	if len(a.Workspace.Paths()) <= 1 {
+		a.StatusWarn("Cannot remove the last folder")
+		return
+	}
+	a.Workspace.RemoveFolder(path)
+	a.refreshWorkspaceWidgets()
+}
+
 func (a *App) activeFilePath() string {
 	path := a.EditorGroup.ActiveFilePath()
 	if path == "untitled" {
@@ -229,5 +243,11 @@ func registerExplorerCommands(app *App) {
 		ID: "explorer.copyRelativePath", Title: "Explorer: Copy Relative Path",
 		Keywords: []string{"explorer", "file", "path", "copy", "clipboard", "relative"},
 		Handler:  app.ExplorerCopyRelativePath,
+	})
+
+	reg.Register(command.Command{
+		ID: "explorer.removeRoot", Title: "Explorer: Remove Folder from Workspace",
+		Keywords: []string{"explorer", "workspace", "folder", "remove"},
+		Handler:  app.ExplorerRemoveRoot,
 	})
 }

--- a/internal/ui/explorer_widget.go
+++ b/internal/ui/explorer_widget.go
@@ -32,6 +32,7 @@ type ExplorerWidget struct {
 	Settings   config.ExplorerSettings
 	OnOpenFile   func(path string)
 	OnRightClick func(node *TreeNode, screenX, screenY int)
+	OnRootMenu   func(node *TreeNode, screenX, screenY int)
 }
 
 func NewExplorerWidget(settings config.ExplorerSettings, rootPaths ...string) *ExplorerWidget {
@@ -59,6 +60,15 @@ func (e *ExplorerWidget) SelectedNode() *TreeNode {
 		return e.FlatList[e.Selected]
 	}
 	return nil
+}
+
+func (e *ExplorerWidget) IsRoot(node *TreeNode) bool {
+	for _, root := range e.Roots {
+		if root == node {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *ExplorerWidget) Reload() {
@@ -233,11 +243,31 @@ func (e *ExplorerWidget) Render(surface *RenderSurface) {
 			surface.SetCell(x, y, term.Cell{Ch: ch, Style: nameStyle})
 			x++
 		}
+
+		if e.IsRoot(node) && w >= 3 {
+			surface.SetCell(w-2, y, term.Cell{Ch: '⋮', Style: style})
+		}
 	}
 }
 
 func (e *ExplorerWidget) HandleEvent(ev tcell.Event) EventResult {
 	r := e.GetRect()
+
+	if tev, ok := ev.(*tcell.EventMouse); ok {
+		if tev.Buttons()&tcell.Button1 != 0 {
+			mx, my := tev.Position()
+			idx := e.ScrollTop + (my - r.Y)
+			if idx >= 0 && idx < len(e.FlatList) && mx >= r.X+r.W-3 {
+				node := e.FlatList[idx]
+				if e.IsRoot(node) && e.OnRootMenu != nil {
+					e.Selected = idx
+					e.OnRootMenu(node, mx, my)
+					return EventConsumed
+				}
+			}
+		}
+	}
+
 	res := e.SelectableList.HandleListEvent(ev, r, len(e.FlatList))
 	if res.Result == EventConsumed {
 		switch res.Action {


### PR DESCRIPTION
## Summary
- Render a `⋮` icon on the right edge of root folder nodes in the explorer
- Clicking it opens a context menu with: Refresh, Copy Path, Remove from Workspace
- Add `explorer.removeRoot` command that removes the selected root from the workspace

Closes #223

## Test plan
- [x] Build passes
- [x] E2E tests pass
- [ ] Open multi-folder workspace, click `⋮` on a root → menu appears
- [ ] "Remove from Workspace" removes the folder (guards against removing the last one)
- [ ] "Copy Path" copies the absolute path
- [ ] "Refresh" reloads the explorer tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)