### PR TITLE
fix: ConfigFilePath fallback respects OverrideConfigDir

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,11 +138,16 @@ func themeNameFromFile(filename string) string {
 }
 
 func ConfigFilePath(filename string) string {
-	for _, dir := range configPaths() {
+	paths := configPaths()
+	for _, dir := range paths {
 		path := filepath.Join(dir, filename)
 		if _, err := os.Stat(path); err == nil {
 			return path
 		}
+	}
+	if OverrideConfigDir != "" {
+		os.MkdirAll(OverrideConfigDir, 0755)
+		return filepath.Join(OverrideConfigDir, filename)
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		dir := filepath.Join(home, ".config", "ttt")


### PR DESCRIPTION
## Summary
- `ConfigFilePath` was falling through to `~/.config/ttt` when the file didn't exist in the override dir
- Tests calling `SaveSettings` (e.g. ToggleWordWrap) still clobbered user settings despite the override
- Now the fallback path uses `OverrideConfigDir` when set

## Test plan
- [x] `go test ./...` passes
- [x] Verified settings file timestamp does not change after running full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)