### PR TITLE
feat: add LSP Code Assist toggle to Options menu

### DIFF
--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -34,6 +34,12 @@ func (a *App) ToggleBracketPairColorization() {
 	config.SaveSettings(*a.Settings)
 }
 
+func (a *App) ToggleLSP() {
+	enabled := !a.Settings.LSP.IsEnabled()
+	a.Settings.LSP.Enabled = &enabled
+	config.SaveSettings(*a.Settings)
+}
+
 func (a *App) ToggleGitGutter() {
 	enabled := !a.Settings.Editor.IsGitGutterEnabled()
 	a.Settings.Editor.GitGutter = &enabled
@@ -81,6 +87,11 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		bracketColorChecked = ui.MenuChecked
 	}
 
+	lspChecked := ui.MenuUnchecked
+	if a.Settings.LSP.IsEnabled() {
+		lspChecked = ui.MenuChecked
+	}
+
 	gitGutterChecked := ui.MenuUnchecked
 	if a.Settings.Editor.IsGitGutterEnabled() {
 		gitGutterChecked = ui.MenuChecked
@@ -90,6 +101,7 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
 		{Label: "Bracket Colors", Command: "options.toggleBracketColors", Checked: bracketColorChecked},
+		{Label: "LSP Code Assist", Command: "options.toggleLSP", Checked: lspChecked},
 		{Label: "Git Gutter", Command: "options.toggleGitGutter", Checked: gitGutterChecked},
 		ui.MenuSep(),
 		{Label: "Gutter Style", Command: "options.gutterStyle"},
@@ -120,6 +132,12 @@ func registerOptionsCommands(app *App) {
 	reg.Register(command.Command{
 		ID: "options.toggleBracketColors", Title: "Toggle Bracket Pair Colorization",
 		Handler: app.ToggleBracketPairColorization,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.toggleLSP", Title: "Toggle LSP",
+		Keywords: []string{"preferences", "settings", "language", "server", "autocomplete"},
+		Handler:  app.ToggleLSP,
 	})
 
 	reg.Register(command.Command{


### PR DESCRIPTION
## Summary
- Add "LSP Code Assist" toggle to the Options menu with checkbox
- Disables all LSP features instantly (autocomplete, hover, diagnostics, signature help, go-to-definition, etc.)
- Also available via command palette as "Toggle LSP"
- Useful for low-powered devices or when editing plain text

## Test plan
- [x] All tests pass
- [x] Toggle appears in Options menu with correct check state
- [x] Disabling stops LSP requests immediately
- [x] Re-enabling restores LSP functionality
- [x] Setting persists across restarts via `lsp.enabled` in settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)