### PR TITLE
feat: push upstream when no upstream set

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -115,8 +115,20 @@ func Pull(dir string) error {
 	return nil
 }
 
+func hasUpstream(dir string) bool {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	return cmd.Run() == nil
+}
+
 func Push(dir string) error {
-	cmd := exec.Command("git", "-C", dir, "push")
+	args := []string{"-C", dir, "push"}
+	if !hasUpstream(dir) {
+		branch := BranchName(dir)
+		if branch != "" {
+			args = []string{"-C", dir, "push", "--set-upstream", "origin", branch}
+		}
+	}
+	cmd := exec.Command("git", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s: %s", err, strings.TrimSpace(string(out)))
 	}


### PR DESCRIPTION
## Summary
- Auto-set upstream on `git push` when the current branch has no tracking branch, matching VS Code behavior
- Detects missing upstream via `git rev-parse @{u}`, then pushes with `--set-upstream origin <branch>`
- Falls back to regular `git push` when upstream already exists

## Test plan
- [x] Push from a new branch with no upstream — sets upstream automatically
- [x] Push from a branch with existing upstream — works as before
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)