### PR TITLE
fix: explorer file indent and scrollbar

### DIFF
--- a/internal/ui/explorer_widget.go
+++ b/internal/ui/explorer_widget.go
@@ -26,13 +26,14 @@ type TreeNode struct {
 type ExplorerWidget struct {
 	BaseWidget
 	SelectableList
-	Roots      []*TreeNode
-	FlatList   []*TreeNode
-	ActiveFile string
-	Settings   config.ExplorerSettings
+	Roots        []*TreeNode
+	FlatList     []*TreeNode
+	ActiveFile   string
+	Settings     config.ExplorerSettings
 	OnOpenFile   func(path string)
 	OnRightClick func(node *TreeNode, screenX, screenY int)
 	OnRootMenu   func(node *TreeNode, screenX, screenY int)
+	scrollbar Scrollbar
 }
 
 func NewExplorerWidget(settings config.ExplorerSettings, rootPaths ...string) *ExplorerWidget {
@@ -189,6 +190,13 @@ func (e *ExplorerWidget) Render(surface *RenderSurface) {
 	}
 	e.EnsureVisible(visibleHeight)
 
+	r := e.GetRect()
+	e.scrollbar.X = r.X + w - 1
+	e.scrollbar.Y = r.Y
+	e.scrollbar.Height = visibleHeight
+	e.scrollbar.TotalItems = len(e.FlatList)
+	e.scrollbar.TopItem = e.ScrollTop
+
 	for i := 0; i < visibleHeight; i++ {
 		idx := e.ScrollTop + i
 		if idx >= len(e.FlatList) {
@@ -246,9 +254,19 @@ func (e *ExplorerWidget) Render(surface *RenderSurface) {
 			surface.SetCell(w-2, y, term.Cell{Ch: '⋮', Style: style})
 		}
 	}
+
+	e.scrollbar.Render(surface, w-1, 0)
 }
 
 func (e *ExplorerWidget) HandleEvent(ev tcell.Event) EventResult {
+	if newTop, consumed := e.scrollbar.HandleEvent(ev); consumed {
+		e.ScrollTop = newTop
+		if e.scrollbar.IsDragging() {
+			return EventCaptured
+		}
+		return EventConsumed
+	}
+
 	r := e.GetRect()
 
 	if tev, ok := ev.(*tcell.EventMouse); ok {

--- a/internal/ui/explorer_widget.go
+++ b/internal/ui/explorer_widget.go
@@ -227,8 +227,6 @@ func (e *ExplorerWidget) Render(surface *RenderSurface) {
 				surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
 			}
 			x++
-		} else {
-			x += 2
 		}
 
 		// Name

--- a/internal/ui/selectable_list.go
+++ b/internal/ui/selectable_list.go
@@ -18,16 +18,20 @@ type ListEventResult struct {
 }
 
 type SelectableList struct {
-	Selected  int
-	ScrollTop int
+	Selected     int
+	ScrollTop    int
+	lastSelected int
 }
 
 func (sl *SelectableList) EnsureVisible(visibleHeight int) {
-	if sl.Selected < sl.ScrollTop {
-		sl.ScrollTop = sl.Selected
-	}
-	if sl.Selected >= sl.ScrollTop+visibleHeight {
-		sl.ScrollTop = sl.Selected - visibleHeight + 1
+	if sl.Selected != sl.lastSelected {
+		sl.lastSelected = sl.Selected
+		if sl.Selected < sl.ScrollTop {
+			sl.ScrollTop = sl.Selected
+		}
+		if sl.Selected >= sl.ScrollTop+visibleHeight {
+			sl.ScrollTop = sl.Selected - visibleHeight + 1
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove extra 2-char chevron placeholder on file nodes in the explorer tree, so files align with directory chevrons instead of being indented further right
- Add scrollbar to the explorer file tree (same pattern as the search widget)
- Fix scroll clamping bug: move `lastSelected` tracking into `SelectableList.EnsureVisible` so mouse wheel and scrollbar drag can freely move `ScrollTop` without it being reset every render frame — also fixes the same latent issue in the changes widget

## Test plan
- [x] Unit tests pass (`go test ./internal/ui/`)
- [x] E2E tests pass (`go test ./tests/e2e/`)
- [ ] Verify explorer file indent visually — files should align with directory chevrons
- [ ] Expand directories until items overflow, verify scrollbar appears
- [ ] Mouse wheel and scrollbar drag should scroll through all items, not just one page

🤖 Generated with [Claude Code](https://claude.com/claude-code)