### PR TITLE
fix: expand tilde in user-provided paths

### DIFF
--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -50,7 +50,7 @@ func (a *App) OpenFolder() {
 		if path == "" {
 			return
 		}
-		abs, err := filepath.Abs(path)
+		abs, err := filepath.Abs(workspace.ExpandPath(path))
 		if err != nil {
 			a.StatusError("Error: " + err.Error())
 			return
@@ -76,7 +76,7 @@ func (a *App) AddWorkspaceFolder() {
 		if path == "" {
 			return
 		}
-		abs, err := filepath.Abs(path)
+		abs, err := filepath.Abs(workspace.ExpandPath(path))
 		if err != nil {
 			a.StatusError("Error: " + err.Error())
 			return
@@ -116,7 +116,7 @@ func (a *App) OpenWorkspace() {
 		if path == "" {
 			return
 		}
-		abs, err := filepath.Abs(path)
+		abs, err := filepath.Abs(workspace.ExpandPath(path))
 		if err != nil {
 			a.StatusError("Error: " + err.Error())
 			return
@@ -145,7 +145,7 @@ func (a *App) SaveWorkspace() {
 		if path == "" {
 			return
 		}
-		abs, err := filepath.Abs(path)
+		abs, err := filepath.Abs(workspace.ExpandPath(path))
 		if err != nil {
 			a.StatusError("Error: " + err.Error())
 			return

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -38,7 +38,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 			}
 			continue
 		}
-		absPath, err := filepath.Abs(args[i])
+		absPath, err := filepath.Abs(workspace.ExpandPath(args[i]))
 		if err != nil {
 			openFiles = append(openFiles, args[i])
 			continue

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -25,6 +25,20 @@ type workspaceFolder struct {
 	Path string `json:"path"`
 }
 
+func ExpandPath(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
 func New(paths []string) *Workspace {
 	w := &Workspace{}
 	for _, p := range paths {
@@ -34,7 +48,7 @@ func New(paths []string) *Workspace {
 }
 
 func (w *Workspace) AddFolder(path string) {
-	abs, err := filepath.Abs(path)
+	abs, err := filepath.Abs(ExpandPath(path))
 	if err != nil {
 		abs = path
 	}
@@ -50,7 +64,7 @@ func (w *Workspace) AddFolder(path string) {
 }
 
 func (w *Workspace) RemoveFolder(path string) {
-	abs, err := filepath.Abs(path)
+	abs, err := filepath.Abs(ExpandPath(path))
 	if err != nil {
 		abs = path
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -6,6 +6,50 @@ import (
 	"testing"
 )
 
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"~", home},
+		{"~/Documents", filepath.Join(home, "Documents")},
+		{"~/a/b/c", filepath.Join(home, "a", "b", "c")},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+		{"~user/path", "~user/path"},
+		{"", ""},
+		{"~/", filepath.Join(home, "")},
+	}
+
+	for _, tt := range tests {
+		got := ExpandPath(tt.input)
+		if got != tt.want {
+			t.Errorf("ExpandPath(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestAddFolderTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+
+	ws := &Workspace{}
+	ws.AddFolder("~")
+	if len(ws.Folders) != 1 {
+		t.Fatalf("expected 1 folder, got %d", len(ws.Folders))
+	}
+	if ws.Folders[0].Path != home {
+		t.Errorf("expected %s, got %s", home, ws.Folders[0].Path)
+	}
+}
+
 func TestNew(t *testing.T) {
 	tmp := t.TempDir()
 	dir1 := filepath.Join(tmp, "repo1")


### PR DESCRIPTION
Fixes #245

## Summary
- Add `workspace.ExpandPath` to resolve `~` and `~/...` to the home directory before `filepath.Abs` (which treats `~` as a literal directory name)
- Apply at all user-input path sites: OpenFolder, AddWorkspaceFolder, OpenWorkspace, SaveWorkspace, CLI args, and `workspace.AddFolder`/`RemoveFolder`

## Test plan
- [x] Unit tests for `ExpandPath` covering `~`, `~/path`, absolute, relative, `~user/path`, empty string
- [x] Unit test for `AddFolder("~")` resolving to home dir
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)