### PR TITLE
feat: experimental Cmd as Ctrl for macOS

### DIFF
--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -120,6 +120,12 @@ func (a *App) ShowBorderStylePicker() {
 	})
 }
 
+func (a *App) ToggleCmdAsCtrl() {
+	a.Settings.Experimental.CmdAsCtrl = !a.Settings.Experimental.CmdAsCtrl
+	a.Root.CmdAsCtrl = a.Settings.Experimental.CmdAsCtrl
+	config.SaveSettings(*a.Settings)
+}
+
 func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	lineNumbersChecked := ui.MenuUnchecked
 	if a.Settings.Editor.LineNumbers {
@@ -146,6 +152,11 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		gitGutterChecked = ui.MenuChecked
 	}
 
+	cmdAsCtrlChecked := ui.MenuUnchecked
+	if a.Settings.Experimental.CmdAsCtrl {
+		cmdAsCtrlChecked = ui.MenuChecked
+	}
+
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
@@ -156,6 +167,8 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		{Label: "Gutter Style", Command: "options.gutterStyle"},
 		{Label: "Border Style", Command: "options.borderStyle"},
 		{Label: "Indentation", Command: "options.indentation"},
+		ui.MenuSep(),
+		{Label: "Cmd as Ctrl", Command: "options.toggleCmdAsCtrl", Checked: cmdAsCtrlChecked},
 		ui.MenuSep(),
 		{Label: "Switch Theme", Command: "theme.switch"},
 		ui.MenuSep(),
@@ -218,5 +231,11 @@ func registerOptionsCommands(app *App) {
 		ID: "options.indentation", Title: "Editor Indentation",
 		Keywords: []string{"preferences", "settings", "editor", "indentation", "tabs", "spaces"},
 		Handler:  app.ShowIndentSettings,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.toggleCmdAsCtrl", Title: "Experimental: Toggle Cmd as Ctrl",
+		Keywords: []string{"preferences", "settings", "experimental", "macos", "cmd", "super", "meta"},
+		Handler:  app.ToggleCmdAsCtrl,
 	})
 }

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -175,6 +175,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	rootBox.AddChild(statusBar, ui.LayoutConstraint{Type: ui.Fixed, Value: 1})
 
 	root := ui.NewRoot(rootBox)
+	root.CmdAsCtrl = cfg.Settings.Experimental.CmdAsCtrl
 	root.SetFocus(editorGroup)
 
 	return &App{

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -131,6 +131,10 @@ func DefaultExplorerSettings() ExplorerSettings {
 	}
 }
 
+type ExperimentalSettings struct {
+	CmdAsCtrl bool `json:"cmdAsCtrl"`
+}
+
 type Settings struct {
 	Version      int                  `json:"version"`
 	Theme        string               `json:"theme,omitempty"`
@@ -141,6 +145,7 @@ type Settings struct {
 	Terminal     TerminalSettings     `json:"terminal,omitzero"`
 	LSP          LSPSettings          `json:"lsp,omitzero"`
 	Autocomplete AutocompleteSettings `json:"autocomplete,omitzero"`
+	Experimental ExperimentalSettings `json:"experimental,omitzero"`
 }
 
 func DefaultSettings() Settings {

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -45,6 +45,7 @@ type Root struct {
 	EscapeDismissers []func() bool
 	EscapeFallback   func()
 	capturedWidget   Widget
+	CmdAsCtrl        bool
 }
 
 func NewRoot(main Widget) *Root {
@@ -97,6 +98,14 @@ func matchKeyChord(kev *tcell.EventKey, gk GlobalKeyBinding) bool {
 
 func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 	kev, isKey := ev.(*tcell.EventKey)
+	if isKey && r.CmdAsCtrl {
+		mod := kev.Modifiers()
+		if mod&tcell.ModMeta != 0 {
+			mod = (mod &^ tcell.ModMeta) | tcell.ModCtrl
+			ev = tcell.NewEventKey(kev.Key(), kev.Rune(), mod)
+			kev = ev.(*tcell.EventKey)
+		}
+	}
 	if isKey {
 		for _, gk := range r.ForceKeys {
 			if matchKey(kev, gk) {

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -102,7 +102,13 @@ func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 		mod := kev.Modifiers()
 		if mod&tcell.ModMeta != 0 {
 			mod = (mod &^ tcell.ModMeta) | tcell.ModCtrl
-			ev = tcell.NewEventKey(kev.Key(), kev.Rune(), mod)
+			key, ch := kev.Key(), kev.Rune()
+			if key == tcell.KeyRune && ch >= 'a' && ch <= 'z' {
+				key = tcell.KeyCtrlA + tcell.Key(ch-'a')
+			} else if key == tcell.KeyRune && ch >= 'A' && ch <= 'Z' {
+				key = tcell.KeyCtrlA + tcell.Key(ch-'A')
+			}
+			ev = tcell.NewEventKey(key, ch, mod)
 			kev = ev.(*tcell.EventKey)
 		}
 	}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -102,13 +102,7 @@ func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 		mod := kev.Modifiers()
 		if mod&tcell.ModMeta != 0 {
 			mod = (mod &^ tcell.ModMeta) | tcell.ModCtrl
-			key, ch := kev.Key(), kev.Rune()
-			if key == tcell.KeyRune && ch >= 'a' && ch <= 'z' {
-				key = tcell.KeyCtrlA + tcell.Key(ch-'a')
-			} else if key == tcell.KeyRune && ch >= 'A' && ch <= 'Z' {
-				key = tcell.KeyCtrlA + tcell.Key(ch-'A')
-			}
-			ev = tcell.NewEventKey(key, ch, mod)
+			ev = tcell.NewEventKey(kev.Key(), kev.Rune(), mod)
 			kev = ev.(*tcell.EventKey)
 		}
 	}


### PR DESCRIPTION
Addresses #246

## Summary
- Add `experimental.cmdAsCtrl` setting that remaps Cmd/Super (ModMeta) to Ctrl in key event handling
- On terminals supporting the Kitty keyboard protocol (Ghostty, Kitty, WezTerm, iTerm2 nightly), macOS users can use Cmd+C/V/Z/S etc. instead of Ctrl equivalents
- Toggleable from Options menu ("Cmd as Ctrl") and command palette ("Experimental: Toggle Cmd as Ctrl")
- Off by default, persisted to settings.json when enabled

## How it works
At the top of `Root.HandleEvent`, if the setting is on and a key event has `ModMeta` set, the modifier is replaced with `ModCtrl`. This means all existing keybindings (force keys, chords, global keys, widget keys) work with Cmd automatically — no per-command wiring needed.

## Limitations
- Only works on terminals that implement the Kitty keyboard protocol and forward Cmd/Super as a distinct modifier
- Older terminals (stock iTerm2, Terminal.app) swallow Cmd+key before it reaches the app — no change there

## Test plan
- [x] All existing tests pass
- [ ] Verify toggle from Options menu persists and takes effect immediately
- [ ] On a supported terminal (Ghostty/Kitty), enable setting and verify Cmd+C/V/Z/S work

🤖 Generated with [Claude Code](https://claude.com/claude-code)