### PR TITLE
docs: revamp docs-web landing page and all documentation

### DIFF
--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -44,7 +44,7 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [Releases]
 
 ## Go Install
 
-Requires [Go](https://go.dev/) 1.18 or newer:
+Requires [Go](https://go.dev/) 1.24 or newer:
 
 ```sh
 go install github.com/eugenioenko/ttt/cmd/ttt@latest

--- a/docs-web/src/content/docs/getting-started/introduction.md
+++ b/docs-web/src/content/docs/getting-started/introduction.md
@@ -7,17 +7,22 @@ sidebar:
 
 TTT Editor (Terminal Text Tool) is a fully-featured code editor that runs in your terminal. It is not a simplified terminal editor. It is a real alternative to VS Code, Zed, and Sublime that happens to run in your terminal.
 
+TTT is designed to feel like a GUI desktop app. You get menus, dialogs, right-click context menus, a file explorer, and full mouse support, all inside your terminal.
+
 ## Why TTT?
 
 - **Single binary** built with Go, no runtime dependencies
 - **Zero config** out of the box, but fully customizable
-- **Multi-cursor editing** with Ctrl+D, Ctrl+K L, and Alt+Click
-- **LSP support** for language-aware editing (completions, diagnostics, formatting, rename, references)
-- **Integrated terminal** with full VT escape sequence support
-- **Git integration** with staging, committing, and diff view
-- **Multi-folder workspaces** for working across multiple projects
-- **10 built-in themes** with full JSON customization
 - **Familiar keybindings** inspired by VS Code
+- **Multi-cursor editing** with Ctrl+D, Ctrl+K L, and Alt+Click
+- **LSP support** with 23+ built-in language servers for completions, diagnostics with inline squiggles, hover, rename, references, and formatting
+- **Integrated terminal** with true color support and multiple tabs
+- **Git integration** with staging, committing, pushing, diff view (partial and full-file diffs), blame, and GitHub PR review
+- **Multi-folder workspaces** for working across multiple projects
+- **Built-in themes** with full JSON customization
+- **Code folding** and **bracket pair colorization**
+- **Ripgrep-powered search** across your workspace
+- **.editorconfig support** for consistent formatting
 
 ## Prerequisites
 

--- a/docs-web/src/content/docs/getting-started/quick-start.md
+++ b/docs-web/src/content/docs/getting-started/quick-start.md
@@ -20,8 +20,9 @@ ttt https://github.com/owner/repo/pull/123  # review a PR
 ## Basic Navigation
 
 - **Ctrl+P** opens the command palette
-- **Alt+P** opens quick file open
+- **Ctrl+K P** opens quick file open
 - **Ctrl+B** toggles the sidebar
+- **Ctrl+O** opens a folder
 - **Ctrl+T** toggles the terminal (half screen)
 - **Alt+T** toggles the terminal fullscreen
 - **Ctrl+G** opens Go to Line
@@ -30,7 +31,7 @@ ttt https://github.com/owner/repo/pull/123  # review a PR
 
 - **Ctrl+Z / Ctrl+Y** for undo/redo
 - **Ctrl+C / Ctrl+X / Ctrl+V** for copy/cut/paste
-- **Ctrl+F** to find, **Ctrl+H** to find and replace
+- **Ctrl+F** to find, **Ctrl+R** to find and replace
 - **Ctrl+A** to select all
 - **Ctrl+D** to select the next occurrence (multi-cursor)
 - **Alt+Click** to add cursors at multiple positions
@@ -44,7 +45,7 @@ ttt https://github.com/owner/repo/pull/123  # review a PR
 
 ## Command Palette
 
-Press **Ctrl+P** to open the command palette. All available commands are listed there. Type `>` to switch between file search and command mode.
+Press **Ctrl+P** to open the command palette. By default it searches files. Type a `>` prefix to switch to command mode, which lists all available editor commands.
 
 ## Configuration
 

--- a/docs-web/src/content/docs/guides/editor.md
+++ b/docs-web/src/content/docs/guides/editor.md
@@ -9,12 +9,14 @@ TTT uses [chroma](https://github.com/alecthomas/chroma) for syntax highlighting,
 
 ## Bracket Matching
 
-Matching brackets are highlighted automatically when the cursor is on a bracket character.
+Matching brackets are highlighted automatically when the cursor is on a bracket character. Press **Ctrl+K M** to jump to the matching bracket.
+
+Bracket pair colorization is also available, rendering each nesting level in a distinct color. It is off by default and can be enabled with the `editor.bracketPairColorization` setting.
 
 ## Find and Replace
 
 - **Ctrl+F** opens the find bar with match navigation
-- **Ctrl+H** opens find and replace with replace-one and replace-all
+- **Ctrl+R** opens find and replace with replace-one and replace-all
 - **F3 / Shift+F3** to jump between matches
 
 ## Go to Line
@@ -33,25 +35,60 @@ Press **Ctrl+G** to open the Go to Line dialog.
 
 ## Multi-Cursor Editing
 
-TTT supports editing with multiple cursors simultaneously. Place cursors at multiple locations and type, delete, or insert lines — all cursors act in parallel.
+TTT supports editing with multiple cursors simultaneously. Place cursors at multiple locations and type, delete, or insert lines. All cursors act in parallel.
 
 ### Adding Cursors
 
-- **Ctrl+D** — select the current word (or extend the current selection) and add a cursor at the next occurrence
-- **Ctrl+K L** — select all occurrences of the current word/selection at once
-- **Alt+Click** — add a cursor at the clicked position
+- **Ctrl+D** selects the current word (or extends the current selection) and adds a cursor at the next occurrence
+- **Ctrl+K L** selects all occurrences of the current word/selection at once
+- **Alt+Click** adds a cursor at the clicked position
 
 ### Removing Cursors
 
-- **Ctrl+K U** — undo the last cursor addition
-- **Escape** — collapse back to a single cursor (when multiple cursors are active)
+- **Ctrl+K U** undoes the last cursor addition
+- **Escape** collapses back to a single cursor (when multiple cursors are active)
 
 ### Behavior
 
 - Typing, backspace, delete, and enter work at all cursor positions simultaneously
 - Undo/redo groups multi-cursor edits into a single action
 - The status bar shows the cursor count (e.g., "3 cursors") when multiple cursors are active
-- All cursors render as solid blocks
+
+## Line Operations
+
+- **Alt+Up / Alt+Down** moves the current line (or selected lines) up or down
+- **Ctrl+K K** deletes the current line
+- **Ctrl+Enter** inserts a new line below the cursor
+- **Ctrl+K J** joins the current line with the next line
+
+## Toggle Comment
+
+Press **Ctrl+/** to toggle line comments on the current line or selection.
+
+## Code Folding
+
+TTT supports indent-based code folding:
+
+- **Ctrl+K [** toggles the fold at the current line
+- **Ctrl+K 0** collapses all foldable regions
+- **Ctrl+K 9** expands all foldable regions
+
+## Text Transforms
+
+These commands are available from the command palette:
+
+- **Transform to Uppercase** / **Transform to Lowercase** / **Transform to Titlecase**
+- **Sort Lines Ascending** (**Ctrl+K O**) / **Sort Lines Descending**
+- **Reverse Lines**
+- **Unique Lines** (remove duplicates)
+- **Split Selection into Lines**
+
+## Word Operations
+
+- **Ctrl+Left / Ctrl+Right** moves the cursor one word left or right
+- **Ctrl+Shift+Left / Ctrl+Shift+Right** selects one word left or right
+- **Alt+Backspace** deletes the word to the left
+- **Alt+Delete** or **Ctrl+Delete** deletes the word to the right
 
 ## Indentation
 
@@ -66,8 +103,12 @@ TTT supports `.editorconfig` files and picks up indent size automatically per fi
 
 ## Line Numbers
 
-Line numbers are shown in the gutter with current-line highlighting. Toggle with `lineNumbers` in settings.
+Line numbers are shown in the gutter with current-line highlighting. The gutter style can be set to `minimal`, `compact` (default), or `extended` via the `editor.gutterStyle` setting. Toggle line numbers on or off with the `lineNumbers` setting.
 
 ## Git Blame
 
 Inline blame info for the current line is shown in the status bar, including the author, relative time, and commit summary.
+
+## Git Gutter
+
+When enabled, diff indicators appear in the line number gutter showing added, modified, and removed lines compared to the last committed version. Toggle with the "Toggle Git Gutter" command in the command palette.

--- a/docs-web/src/content/docs/guides/git.md
+++ b/docs-web/src/content/docs/guides/git.md
@@ -34,8 +34,16 @@ The changes panel in the sidebar (**Ctrl+K C**) provides a full staging workflow
 
 ## Diff View
 
-- Select a changed file to open a diff with syntax highlighting layered on diff backgrounds
-- Untracked files open directly in the editor
+Select a changed file in the changes panel to open a side-by-side diff. Syntax highlighting is layered on top of diff background colors so you can read the code naturally while seeing what changed.
+
+TTT offers two diff modes:
+
+- **Partial diff view** shows only the changed hunks with surrounding context lines, letting you focus on what actually changed.
+- **Full-file diff view** shows the complete file with changes highlighted inline.
+
+You can toggle between partial and full-file diff views to get the level of detail you need.
+
+Untracked files open directly in the editor instead of showing a diff.
 
 ## Multi-Root Support
 
@@ -47,16 +55,25 @@ When working with multiple folders:
 
 ## Pull Request Review
 
-Open a GitHub pull request directly from the command line:
+You can review GitHub pull requests directly in TTT without cloning the branch or switching contexts. Pass a PR URL on the command line:
 
 ```sh
 ttt https://github.com/owner/repo/pull/123
+```
 
-# Review a PR with the repo tree open
+This opens the PR's changed files in the changes panel. Select any file to see its diff with full syntax highlighting.
+
+To review a PR alongside your local repository, pass both:
+
+```sh
 ttt . https://github.com/owner/repo/pull/123
 ```
 
-Changed files appear in the changes panel with diff view.
+This gives you the local file tree in the explorer and the PR's changed files in the changes panel, so you can cross-reference the PR against the existing codebase.
+
+## Git Gutter
+
+The line number area displays diff indicators that show which lines have been added, modified, or deleted compared to the last commit. This gives you at-a-glance visibility into your uncommitted changes as you edit.
 
 ## Git Blame
 

--- a/docs-web/src/content/docs/guides/keybindings.md
+++ b/docs-web/src/content/docs/guides/keybindings.md
@@ -5,7 +5,7 @@ description: Keyboard shortcuts and customization.
 
 All keybindings are customizable via `keybindings.json`. A complete example is available at [`config/keybindings.json`](https://github.com/eugenioenko/ttt/blob/main/config/keybindings.json) in the repository. TTT supports chord sequences (e.g. `ctrl+k ctrl+t`) for two-step shortcuts.
 
-You can open your keybindings file directly from the command palette (**Ctrl+P**) with **Preferences: Open Keyboard Shortcuts**.
+You can open your keybindings file directly from the command palette (**Ctrl+P**) with **Preferences: Open Keyboard Shortcuts**, or press **Ctrl+K Y**.
 
 ## Default Keybindings
 
@@ -15,7 +15,8 @@ You can open your keybindings file directly from the command palette (**Ctrl+P**
 |----------|--------|
 | Ctrl+Q | Quit |
 | Ctrl+P | Command palette |
-| Alt+P | Quick open file |
+| Ctrl+K P | Quick open file |
+| Ctrl+O | Open folder / workspace |
 | Escape | Focus editor |
 
 ### File
@@ -37,6 +38,34 @@ You can open your keybindings file directly from the command palette (**Ctrl+P**
 | Ctrl+X | Cut |
 | Ctrl+V | Paste |
 | Ctrl+G | Go to line |
+| Ctrl+/ | Toggle comment |
+| Ctrl+K J | Join lines |
+| Ctrl+K K | Delete line |
+| Ctrl+K O | Sort lines ascending |
+| Ctrl+K M | Go to matching bracket |
+| Ctrl+Enter | Insert line below |
+| Alt+Up | Move line up |
+| Alt+Down | Move line down |
+
+### Word Navigation
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+Left | Move word left |
+| Ctrl+Right | Move word right |
+| Ctrl+Shift+Left | Select word left |
+| Ctrl+Shift+Right | Select word right |
+| Alt+Backspace | Delete word left |
+| Alt+Delete | Delete word right |
+| Ctrl+Delete | Delete word right |
+
+### Code Folding
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+K [ | Toggle fold |
+| Ctrl+K 0 | Collapse all folds |
+| Ctrl+K 9 | Expand all folds |
 
 ### Multi-Cursor
 
@@ -53,7 +82,7 @@ You can open your keybindings file directly from the command palette (**Ctrl+P**
 | Shortcut | Action |
 |----------|--------|
 | Ctrl+F | Find |
-| Ctrl+H | Find and replace |
+| Ctrl+R | Find and replace |
 | F3 / Shift+F3 | Find next / previous |
 
 ### View
@@ -61,12 +90,17 @@ You can open your keybindings file directly from the command palette (**Ctrl+P**
 | Shortcut | Action |
 |----------|--------|
 | Ctrl+B | Toggle sidebar |
-| Ctrl+J | Toggle bottom panel |
+| Ctrl+K B | Toggle bottom panel |
 | Ctrl+K E | Show file explorer |
 | Ctrl+K F | Search across files |
+| Ctrl+K R | Search and replace across files |
 | Ctrl+K C | Show changes |
 | Ctrl+0 | Focus sidebar |
-| Ctrl+K Ctrl+T | Switch theme |
+| Ctrl+K Y | Open keyboard shortcuts |
+| Alt+Shift+Up | Panel taller |
+| Alt+Shift+Down | Panel shorter |
+| Alt+Shift+Left | Sidebar narrower |
+| Alt+Shift+Right | Sidebar wider |
 
 ### Tabs
 
@@ -96,7 +130,8 @@ You can open your keybindings file directly from the command palette (**Ctrl+P**
 
 | Shortcut | Action |
 |----------|--------|
-| Ctrl+` | Toggle terminal |
+| Ctrl+T | Toggle terminal |
+| Alt+T | Terminal fullscreen |
 | Ctrl+K T | New terminal tab |
 
 ### Changes Panel
@@ -114,7 +149,11 @@ You can open your keybindings file directly from the command palette (**Ctrl+P**
 | Shortcut | Action |
 |----------|--------|
 | F10 / Alt+F | File menu |
-| Alt+E / S / V / H | Edit / Selection / View / Help |
+| Alt+E | Edit menu |
+| Alt+S | Selection menu |
+| Alt+V | View menu |
+| Alt+O | Options menu |
+| Alt+H | Help menu |
 
 ## Customizing Keybindings
 
@@ -138,8 +177,8 @@ TTT supports two-step chord sequences. Press the first key combination, then the
 
 Use **View > Keyboard Shortcuts** from the menu bar (or the command palette) to browse and edit keybindings. The editor shows a searchable list of all commands with their current shortcuts. Select a command to see action buttons:
 
-- **Edit** — record a new key combination for the command
-- **Reset** — restore the default keybinding
-- **Clear** — remove the keybinding
+- **Edit** - record a new key combination for the command
+- **Reset** - restore the default keybinding
+- **Clear** - remove the keybinding
 
 Changes are saved to `keybindings.json` and take effect immediately.

--- a/docs-web/src/content/docs/guides/lsp.md
+++ b/docs-web/src/content/docs/guides/lsp.md
@@ -7,7 +7,7 @@ TTT has built-in LSP support for language-aware editing features. Language serve
 
 ## Built-in Language Support
 
-TTT ships with built-in configurations for popular language servers. You just need to install the server binary — TTT will detect and use it automatically. If a server isn't installed, TTT shows a brief notification when you open a file of that language.
+TTT ships with 24 built-in language server configurations. You just need to install the server binary and TTT will detect and use it automatically. If a server isn't installed, TTT shows a brief notification when you open a file of that language (disable this with `lsp.notifyAvailability: false`).
 
 To disable LSP entirely, set `lsp.enabled` to `false` in your settings:
 
@@ -31,7 +31,7 @@ go install golang.org/x/tools/gopls@latest
 npm install -g typescript typescript-language-server
 ```
 
-Handles `.ts`, `.tsx`, `.js`, and `.jsx` files.
+Handles `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.mts`, `.cjs`, and `.cts` files.
 
 ### Python {#python}
 
@@ -108,6 +108,8 @@ npm install -g vscode-langservers-extracted
 npm install -g vscode-langservers-extracted
 ```
 
+Handles `.json` and `.jsonc` files.
+
 ### YAML {#yaml}
 
 ```sh
@@ -119,6 +121,8 @@ npm install -g yaml-language-server
 ```sh
 npm install -g bash-language-server
 ```
+
+Handles `.sh` and `.bash` files.
 
 ### Docker {#docker}
 
@@ -169,6 +173,8 @@ composer global require phpactor/phpactor
 ```sh
 # See https://github.com/hashicorp/terraform-ls
 ```
+
+Handles `.tf` and `.tfvars` files.
 
 ### Markdown {#markdown}
 
@@ -302,7 +308,9 @@ The LSP server publishes diagnostics (errors, warnings, hints) which are display
 
 ```json
 {
-  "formatOnSave": true
+  "editor": {
+    "formatOnSave": true
+  }
 }
 ```
 
@@ -335,3 +343,17 @@ Configure automatic code actions that run before each save:
   }
 }
 ```
+
+## LSP Settings Reference
+
+All LSP settings are nested under `lsp.*` in `settings.json`. Autocomplete settings are separate, under `autocomplete.*`.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `lsp.enabled` | boolean | `true` | Enable or disable LSP support entirely |
+| `lsp.hover` | boolean | `true` | Enable or disable hover information |
+| `lsp.hoverDelay` | number | `500` | Delay in milliseconds before showing hover info |
+| `lsp.saveOnRename` | boolean | `false` | Auto-save files affected by a rename |
+| `lsp.codeActionsOnSave` | string[] | `[]` | Code actions to run before each save |
+| `lsp.notifyAvailability` | boolean | `true` | Show a notification when a language server is not installed |
+| `lsp.servers` | object | *(24 built-in)* | Custom or overridden language server configurations |

--- a/docs-web/src/content/docs/guides/search.md
+++ b/docs-web/src/content/docs/guides/search.md
@@ -12,10 +12,17 @@ The sidebar search panel (**Ctrl+K F**) is powered by [ripgrep](https://github.c
 - Tab between search, include, and exclude inputs
 - Searches across all workspace folders simultaneously
 - Click a result to jump to the file and line
+- Search debounce is configurable (default 350ms, setting: `search.debounce`)
+
+### Search and Replace Across Files
+
+Use **Ctrl+K R** to open the sidebar search and replace panel. This lets you find and replace text across all files in the workspace.
 
 ## Find in File
 
 - **Ctrl+F** opens the inline find bar
-- **Ctrl+H** opens find and replace
+- **Ctrl+R** opens find and replace
 - **F3 / Shift+F3** to jump to next/previous match
+- **Alt+C** toggles case sensitivity
+- **Alt+R** / **Alt+X** toggles regex matching
 - Replace-one and replace-all support

--- a/docs-web/src/content/docs/guides/terminal.md
+++ b/docs-web/src/content/docs/guides/terminal.md
@@ -16,14 +16,14 @@ TTT includes a built-in terminal emulator. Press **Ctrl+T** to toggle the termin
 ## Features
 
 - Full VT escape sequence support via `hinshun/vt10x` and PTY management via `creack/pty`
-- 256-color rendering with direct RGB color support
-- When the terminal is focused, all keys go to the PTY except force keys (Ctrl+T, Alt+T, Ctrl+Q, Ctrl+P, etc.)
+- True color (24-bit) and 256-color rendering with direct RGB color support
+- When the terminal is focused, all keys go to the PTY except force keys: Ctrl+T, Alt+T, Ctrl+Q, Ctrl+P, Ctrl+K P, Ctrl+B
 - Scrollback buffer with mouse wheel scrolling (3 lines), Shift+PgUp/PgDn (half page), and a draggable scrollbar
 - Click the terminal content area to focus it; any keypress snaps back to the live view when scrolled up
 
 ## Bottom Panel
 
-The bottom panel contains three tabs:
+Toggle the bottom panel with **Ctrl+K B**. It contains three tabs:
 
 - **Terminal** for the integrated terminal
 - **Problems** listing all LSP diagnostics grouped by file; click to jump to location

--- a/docs-web/src/content/docs/guides/themes.md
+++ b/docs-web/src/content/docs/guides/themes.md
@@ -7,22 +7,30 @@ TTT supports fully customizable themes via JSON files. You can change every colo
 
 ## Built-in Themes
 
-10 themes are included:
+TTT ships with a collection of built-in themes:
 
 - Aurora
 - Bubblegum
 - Default Dark
 - Default Light
+- Dracula
+- High Contrast Dark
+- High Contrast Light
 - Hotline
 - Monokai
+- Nord
 - One Dark
+- Rainy Day
+- Rainy Day Dark
 - Solarized Dark
 - Solarized Light
+- Turbo Vision
 - Virtru Dark
+- Zenith
 
 ## Switching Themes
 
-Press **Ctrl+K Ctrl+T** (or use **View > Switch Theme** from the menu bar) to open the theme picker with a live preview.
+Use **View > Switch Theme** from the menu bar, or search for **Switch Theme** in the command palette (**Ctrl+P**), to open the theme picker. The picker shows a live preview of each theme as you navigate the list, so you can try them out before committing to one.
 
 ## Customizing
 

--- a/docs-web/src/content/docs/guides/workspaces.md
+++ b/docs-web/src/content/docs/guides/workspaces.md
@@ -14,6 +14,11 @@ The file explorer lives in the sidebar (**Ctrl+B** to toggle, **Ctrl+K E** to fo
 
 When multiple folders are open, each root is shown as a collapsible group.
 
+## Quick Navigation
+
+- **Ctrl+O** to open a folder (`workspace.openFolder`)
+- **Ctrl+K P** for quick file open with fuzzy search (`file.quickOpen`)
+
 ## Opening Files and Folders
 
 ```sh

--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: TTT Editor - Terminal Text Tool
-description: TTT Editor — a terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal.
+description: TTT Editor, a terminal text editor. A real alternative to VS Code, Zed, and Sublime that runs in your terminal.
 template: splash
 hero:
   title: "TTT Editor <br> Terminal Text Tool"
@@ -22,25 +22,28 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 ## Features
 
 <CardGrid stagger>
-  <Card title="LSP Support" icon="setting">
-    Built-in Language Server Protocol support: completions, diagnostics, formatting, rename, references, signature help, and more.
+  <Card title="GUI in Your Terminal" icon="laptop">
+    Menus, dialogs, mouse support, right-click context menus, and a file explorer. TTT is designed to feel like a desktop app, not a terminal one.
   </Card>
-  <Card title="Integrated Terminal" icon="laptop">
-    Full terminal emulator with VT escape sequence support, 256-color rendering, and multiple tabs.
+  <Card title="Built-in Themes" icon="star">
+    Ships with themes out of the box. Customize everything via JSON or the built-in theme picker with live preview.
   </Card>
-  <Card title="Git Integration" icon="github">
-    Stage, unstage, commit, pull, push, and sync from within the editor. Inline diff view with syntax highlighting.
+  <Card title="LSP Intelligence" icon="setting">
+    Completions, diagnostics with inline squiggles, hover info, rename, references, and formatting for 23+ languages.
   </Card>
-  <Card title="Multi-Folder Workspaces" icon="open-book">
-    Open multiple project directories in a single session with per-folder git status and search.
+  <Card title="Integrated Terminal" icon="seti:shell">
+    Full terminal emulator with VT escape sequence support, true color rendering, and multiple tabs.
   </Card>
-  <Card title="Multi-Cursor Editing" icon="pencil">
-    Place cursors at multiple locations with Ctrl+D, Ctrl+K L, or Alt+Click. Type, delete, and insert at all positions simultaneously.
+  <Card title="Git Built In" icon="github">
+    Stage, commit, push, inline diff view (partial and full-file), blame, and review GitHub PRs directly from the terminal.
   </Card>
-  <Card title="Theming" icon="star">
-    10 built-in themes with full customization. Every color in the editor is configurable via JSON.
+  <Card title="Multi-Cursor & Search" icon="pencil">
+    Place cursors with Ctrl+D, Ctrl+K L, or Alt+Click. Ripgrep-powered workspace search with glob filters.
+  </Card>
+  <Card title="Workspaces" icon="open-book">
+    Multi-folder projects, file explorer, quick open, and tabs. Save and restore workspace layouts with .ttt files.
   </Card>
   <Card title="Zero Config" icon="rocket">
-    Works out of the box. Single binary, no dependencies. Customize only what you want.
+    Single binary, works out of the box. Customize keybindings, settings, and themes only when you want to.
   </Card>
 </CardGrid>

--- a/docs-web/src/content/docs/reference/keybindings.md
+++ b/docs-web/src/content/docs/reference/keybindings.md
@@ -7,7 +7,7 @@ sidebar:
 
 All keybindings can be customized in `~/.config/ttt/keybindings.json`. See [`config/keybindings.json`](https://github.com/eugenioenko/ttt/blob/main/config/keybindings.json) for a complete example.
 
-You can open your keybindings file from the command palette (**Ctrl+P**) with **Preferences: Open Keyboard Shortcuts**.
+You can open your keybindings file from the command palette (**Ctrl+P**) with **Preferences: Open Keyboard Shortcuts**, or press **Ctrl+K Y**.
 
 ## General
 
@@ -15,7 +15,7 @@ You can open your keybindings file from the command palette (**Ctrl+P**) with **
 |----------|---------|-------------|
 | Ctrl+Q | `editor.quit` | Quit the editor |
 | Ctrl+P | `command.palette` | Open command palette |
-| Alt+P | `file.quickOpen` | Quick open file |
+| Ctrl+K P | `file.quickOpen` | Quick open file |
 | Escape | `editor.focus` | Focus the editor |
 
 ## File
@@ -23,6 +23,7 @@ You can open your keybindings file from the command palette (**Ctrl+P**) with **
 | Shortcut | Command | Description |
 |----------|---------|-------------|
 | Ctrl+N | `file.new` | New file |
+| Ctrl+O | `workspace.openFolder` | Open folder |
 | Ctrl+S | `file.save` | Save |
 | Ctrl+K S | `file.saveAs` | Save as |
 
@@ -37,10 +38,23 @@ You can open your keybindings file from the command palette (**Ctrl+P**) with **
 | Ctrl+X | `editor.cut` | Cut |
 | Ctrl+V | `editor.paste` | Paste |
 | Ctrl+G | `editor.goToLine` | Go to line |
+| Ctrl+/ | `editor.toggleComment` | Toggle line comment |
+| Ctrl+Enter | `editor.insertLineBelow` | Insert line below |
 | Alt+Up | `editor.moveLineUp` | Move line up |
 | Alt+Down | `editor.moveLineDown` | Move line down |
 | Ctrl+K K | `editor.deleteLine` | Delete line |
-| Ctrl+Enter | `editor.insertLineBelow` | Insert line below |
+| Ctrl+K J | `editor.joinLines` | Join lines |
+| Ctrl+K O | `editor.sortLinesAsc` | Sort lines ascending |
+| Ctrl+K M | `editor.goToMatchingBracket` | Go to matching bracket |
+
+## Word Navigation
+
+| Shortcut | Command | Description |
+|----------|---------|-------------|
+| Ctrl+Left | `editor.moveWordLeft` | Move cursor one word left |
+| Ctrl+Right | `editor.moveWordRight` | Move cursor one word right |
+| Ctrl+Shift+Left | `editor.selectWordLeft` | Select one word left |
+| Ctrl+Shift+Right | `editor.selectWordRight` | Select one word right |
 | Alt+Backspace | `editor.deleteWordLeft` | Delete word left |
 | Alt+Delete | `editor.deleteWordRight` | Delete word right |
 | Ctrl+Delete | `editor.deleteWordRight` | Delete word right |
@@ -49,11 +63,19 @@ You can open your keybindings file from the command palette (**Ctrl+P**) with **
 
 | Shortcut | Command | Description |
 |----------|---------|-------------|
-| Ctrl+D | `editor.selectNextOccurrence` | Select next occurrence of current word/selection |
-| Ctrl+K L | `editor.selectAllOccurrences` | Select all occurrences at once |
+| Ctrl+D | `multicursor.selectNext` | Select next occurrence of current word or selection |
+| Ctrl+K L | `multicursor.selectAll` | Select all occurrences at once |
+| Ctrl+K U | `multicursor.undoCursor` | Undo last cursor addition |
 | Alt+Click | *(mouse)* | Add cursor at click position |
-| Ctrl+K U | `editor.undoCursor` | Undo last cursor addition |
 | Escape | `editor.focus` | Collapse to single cursor (when multiple cursors exist) |
+
+## Code Folding
+
+| Shortcut | Command | Description |
+|----------|---------|-------------|
+| Ctrl+K [ | `fold.toggle` | Toggle fold at cursor |
+| Ctrl+K 0 | `fold.collapseAll` | Collapse all folds |
+| Ctrl+K 9 | `fold.expandAll` | Expand all folds |
 
 ## Search
 
@@ -71,17 +93,17 @@ In find/replace dialogs, use Alt+C to toggle case sensitivity and Alt+R (or Alt+
 | Shortcut | Command | Description |
 |----------|---------|-------------|
 | Ctrl+B | `sidebar.toggle` | Toggle sidebar |
-| Ctrl+J | `panel.toggle` | Toggle bottom panel |
+| Ctrl+K B | `panel.toggle` | Toggle bottom panel |
 | Ctrl+K E | `sidebar.explorer` | Show file explorer |
 | Ctrl+K F | `sidebar.search` | Search across files |
 | Ctrl+K R | `sidebar.searchReplace` | Search and replace in files |
 | Ctrl+K C | `sidebar.changes` | Show changes |
+| Ctrl+K Y | `view.keybindings` | Open keybindings |
 | Ctrl+0 | `sidebar.focus` | Focus sidebar |
 | Alt+Shift+Left | `sidebar.narrower` | Decrease sidebar width |
 | Alt+Shift+Right | `sidebar.wider` | Increase sidebar width |
 | Alt+Shift+Up | `panel.taller` | Increase panel height |
 | Alt+Shift+Down | `panel.shorter` | Decrease panel height |
-| Ctrl+K Ctrl+T | `theme.switch` | Switch theme |
 
 ## Tabs
 
@@ -96,16 +118,16 @@ In find/replace dialogs, use Alt+C to toggle case sensitivity and Alt+R (or Alt+
 | Shortcut | Command | Description |
 |----------|---------|-------------|
 | Ctrl+U | `editor.autocomplete` | Trigger autocomplete |
+| Ctrl+K I | `editor.hover` | Hover info |
+| F2 | `editor.rename` | Rename symbol |
 | F12 | `editor.goToDefinition` | Go to definition |
 | Shift+F12 | `editor.goToImplementation` | Go to implementation |
-| F2 | `editor.rename` | Rename symbol |
-| Ctrl+K I | `editor.hover` | Hover info |
+| Ctrl+L I | `editor.goToImplementation` | Go to implementation |
 | Ctrl+L F | `editor.formatDocument` | Format document |
 | Ctrl+L S | `editor.formatSelection` | Format selection |
 | Ctrl+L O | `editor.organizeImports` | Organize imports |
 | Ctrl+L X | `editor.fixAll` | Fix all |
 | Ctrl+L R | `editor.findReferences` | Find references |
-| Ctrl+L I | `editor.goToImplementation` | Go to implementation |
 | Ctrl+L T | `editor.goToTypeDefinition` | Go to type definition |
 
 ## Terminal
@@ -124,4 +146,5 @@ In find/replace dialogs, use Alt+C to toggle case sensitivity and Alt+R (or Alt+
 | Alt+E | `menu.edit` | Edit menu |
 | Alt+S | `menu.selection` | Selection menu |
 | Alt+V | `menu.view` | View menu |
+| Alt+O | `menu.options` | Options menu |
 | Alt+H | `menu.help` | Help menu |

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -9,23 +9,34 @@ Settings are stored in `~/.config/ttt/settings.json`. A complete example is avai
 
 You can open your settings file directly from the command palette (**Ctrl+P**) with **Preferences: Open Settings**.
 
-## Editor
+## Top-level
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `tabSize` | int | `4` | Number of spaces per indentation level |
-| `insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
-| `wordWrap` | bool | `false` | Wrap long lines at the editor width |
-| `lineNumbers` | bool | `true` | Show line numbers in the gutter |
-| `sidebarVisible` | bool | `true` | Show the sidebar on startup |
-| `sidebarWidth` | int | `30` | Width of the sidebar in columns |
-| `cursorStyle` | string | `""` | Cursor style: `"block"`, `"underline"`, or `"bar"` |
-| `theme` | string | `""` | Theme name |
+| `version` | int | `1` | Settings file format version |
+| `theme` | string | `""` | Theme name (e.g. `"default-dark"`) |
 | `debugMode` | bool | `false` | Enable debug logging |
-| `formatOnSave` | bool | `false` | Auto-format the document via LSP on save |
-| `insertFinalNewline` | bool | `true` | Ensure files end with a newline on load and save |
-| `bracketPairColorization` | bool | `false` | Colorize matching bracket pairs by nesting depth |
-| `borderStyle` | string | `"default"` | Border style preset: `"default"`, `"rounded"`, `"sharp"`, `"double"`, `"bold"`, `"ascii"`, `"none"`. Use `"default"` or `"theme"` to defer to the active theme. |
+
+## Editor
+
+All editor settings are nested under the `editor` key.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `editor.tabSize` | int | `4` | Number of spaces per indentation level |
+| `editor.insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
+| `editor.wordWrap` | bool | `false` | Wrap long lines at the editor width |
+| `editor.lineNumbers` | bool | `true` | Show line numbers in the gutter |
+| `editor.cursorStyle` | string | `""` | Cursor style: `"block"`, `"underline"`, or `"bar"` |
+| `editor.formatOnSave` | bool | `false` | Auto-format the document via LSP on save |
+| `editor.insertFinalNewline` | bool | `true` | Ensure files end with a newline on load and save |
+| `editor.trimTrailingWhitespace` | bool | `false` | Remove trailing whitespace from lines on save |
+| `editor.focusOnOpen` | bool | `false` | Focus the editor when opening a file |
+| `editor.syntaxHighlight` | bool | `true` | Enable syntax highlighting |
+| `editor.gitGutter` | bool | `true` | Show git change indicators in the gutter |
+| `editor.gutterStyle` | string | `"compact"` | Gutter layout: `"minimal"`, `"compact"`, or `"extended"` |
+| `editor.borderStyle` | string | `"default"` | Border style preset: `"default"`, `"rounded"`, `"sharp"`, `"double"`, `"bold"`, `"ascii"`, `"none"`. Use `"default"` or `"theme"` to defer to the active theme. |
+| `editor.bracketPairColorization` | bool | `false` | Colorize matching bracket pairs by nesting depth |
 
 ## Explorer
 
@@ -45,8 +56,12 @@ You can open your settings file directly from the command palette (**Ctrl+P**) w
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `lsp.enabled` | bool | `true` | Enable LSP support |
+| `lsp.hover` | bool | `true` | Show hover information from the language server |
+| `lsp.hoverDelay` | int | `500` | Milliseconds to wait before showing hover information |
 | `lsp.saveOnRename` | bool | `false` | Auto-save files affected by a rename operation |
 | `lsp.codeActionsOnSave` | string[] | `[]` | Code actions to run before save (e.g. `"source.organizeImports"`) |
+| `lsp.notifyAvailability` | bool | `true` | Show a notification when a language server is available but not installed |
 | `lsp.servers` | object | `{}` | Map of server key to `{ "command": [...], "languages": {...} }`. The optional `languages` field maps file extensions to language IDs for servers handling multiple file types. |
 
 ## Search
@@ -68,17 +83,25 @@ You can open your settings file directly from the command palette (**Ctrl+P**) w
 
 ```json
 {
-  "tabSize": 4,
-  "insertSpaces": true,
-  "wordWrap": false,
-  "lineNumbers": true,
-  "sidebarVisible": true,
-  "sidebarWidth": 30,
+  "version": 1,
   "theme": "default-dark",
-  "formatOnSave": true,
-  "insertFinalNewline": true,
-  "bracketPairColorization": false,
-  "borderStyle": "default",
+  "debugMode": false,
+  "editor": {
+    "tabSize": 4,
+    "insertSpaces": true,
+    "wordWrap": false,
+    "lineNumbers": true,
+    "cursorStyle": "",
+    "formatOnSave": false,
+    "insertFinalNewline": true,
+    "trimTrailingWhitespace": false,
+    "focusOnOpen": false,
+    "syntaxHighlight": true,
+    "gitGutter": true,
+    "gutterStyle": "compact",
+    "borderStyle": "default",
+    "bracketPairColorization": false
+  },
   "search": {
     "debounce": 350
   },
@@ -91,7 +114,11 @@ You can open your settings file directly from the command palette (**Ctrl+P**) w
     "scrollback": 1000
   },
   "lsp": {
-    "saveOnRename": true,
+    "enabled": true,
+    "hover": true,
+    "hoverDelay": 500,
+    "saveOnRename": false,
+    "notifyAvailability": true,
     "codeActionsOnSave": [
       "source.organizeImports",
       "source.fixAll"


### PR DESCRIPTION
## Summary

- Redesigned the landing page with 8 feature cards: GUI feel, built-in themes, LSP intelligence, integrated terminal, git with PR review, multi-cursor & search, workspaces, zero config
- Fixed wrong keybindings across all docs: `Alt+P` → `Ctrl+K P`, `Ctrl+H` → `Ctrl+R`, `Ctrl+J` → `Ctrl+K B`, removed non-existent `Ctrl+K Ctrl+T`
- Updated theme list from 10 to all 18 built-in themes (without hardcoding a count)
- Restructured settings reference from flat keys to correct nested format (`editor.*`, `lsp.*`, etc.)
- Added missing settings: `trimTrailingWhitespace`, `focusOnOpen`, `syntaxHighlight`, `gitGutter`, `gutterStyle`, `lsp.enabled`, `lsp.hover`, `lsp.hoverDelay`, `lsp.notifyAvailability`
- Removed phantom settings (`sidebarVisible`, `sidebarWidth`)
- Added missing keybindings (~20) and new sections (Code Folding, Word Navigation)
- Expanded editor guide with code folding, toggle comment, line operations, text transforms, git gutter
- Expanded git guide with partial vs full-file diff modes, better PR review docs
- Fixed Go version requirement from 1.18 to 1.24
- Added LSP settings reference table to LSP guide

## Test plan

- [ ] Build docs-web locally (`cd docs-web && pnpm dev`) and verify landing page renders 8 cards correctly
- [ ] Spot-check each guide page for formatting and broken links
- [ ] Verify settings reference JSON example is valid
- [ ] Confirm keybinding tables match `DefaultKeybindings()` in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)