### PR TITLE
feat: add bracketed paste support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/eugenioenko/vt10x v0.0.0-20260527232601-d49d2c8355db
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/gdamore/tcell/v2 v2.13.7
+	github.com/gdamore/tcell/v2 v2.13.8
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uh
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.13.7 h1:yfHdeC7ODIYCc6dgRos8L1VujQtXHmUpU6UZotzD6os=
 github.com/gdamore/tcell/v2 v2.13.7/go.mod h1:+Wfe208WDdB7INEtCsNrAN6O2m+wsTPk1RAovjaILlo=
+github.com/gdamore/tcell/v2 v2.13.8 h1:Mys/Kl5wfC/GcC5Cx4C2BIQH9dbnhnkPgS9/wF3RlfU=
+github.com/gdamore/tcell/v2 v2.13.8/go.mod h1:+Wfe208WDdB7INEtCsNrAN6O2m+wsTPk1RAovjaILlo=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -482,6 +482,22 @@ func (a *App) Paste() {
 	a.EditorGroup.Paste()
 }
 
+func (a *App) PasteText(text string) {
+	if tp, ok := a.Root.Focused.(*ui.TerminalPanelWidget); ok && tp.WantsRawKeys() {
+		if tw, ok := tp.ActiveWidget().(*ui.TerminalWidget); ok {
+			tw.PasteText(text)
+		}
+		return
+	}
+	if holder, ok := a.Root.Focused.(ui.InputHolder); ok {
+		if inp := holder.FocusedInput(); inp != nil {
+			inp.PasteText(text)
+			return
+		}
+	}
+	a.EditorGroup.PasteText(text)
+}
+
 func (a *App) ShowDialog(w ui.Widget) {
 	a.Root.PushOverlay(ui.Overlay{Widget: w, Modal: true})
 	a.Root.SetFocus(w)

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -139,6 +139,27 @@ func RunEventLoop(
 	for *running {
 		ev := screen.PollEvent()
 		switch tev := ev.(type) {
+		case *tcell.EventPaste:
+			if tev.Start() {
+				var pasteKeys []*tcell.EventKey
+				for {
+					pev := screen.PollEvent()
+					if pe, ok := pev.(*tcell.EventPaste); ok && !pe.Start() {
+						break
+					}
+					if ke, ok := pev.(*tcell.EventKey); ok {
+						pasteKeys = append(pasteKeys, ke)
+					}
+				}
+				text := term.CollectPasteText(pasteKeys)
+				if text != "" {
+					app.PasteText(text)
+					app.FlushEditorOnChange()
+					syncStatus()
+					redraw()
+				}
+			}
+
 		case *tcell.EventKey:
 			app.DismissHover()
 			if app.EditorGroup.SignatureHelp != nil {

--- a/internal/term/paste.go
+++ b/internal/term/paste.go
@@ -1,0 +1,31 @@
+package term
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// CollectPasteText reconstructs text from a sequence of tcell key events
+// delivered during a bracketed paste. tcell delivers \r as KeyEnter and
+// \n as KeyCtrlJ; CRLF line endings produce both in sequence. This function
+// normalizes all line endings to \n.
+func CollectPasteText(events []*tcell.EventKey) string {
+	var buf strings.Builder
+	for _, ev := range events {
+		switch ev.Key() {
+		case tcell.KeyRune:
+			buf.WriteRune(ev.Rune())
+		case tcell.KeyEnter:
+			buf.WriteRune('\r')
+		case tcell.KeyCtrlJ:
+			buf.WriteRune('\n')
+		case tcell.KeyTab:
+			buf.WriteRune('\t')
+		}
+	}
+	text := buf.String()
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	return text
+}

--- a/internal/term/paste_test.go
+++ b/internal/term/paste_test.go
@@ -1,6 +1,7 @@
 package term
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -10,91 +11,42 @@ func key(k tcell.Key, r rune, mod tcell.ModMask) *tcell.EventKey {
 	return tcell.NewEventKey(k, r, mod)
 }
 
-func TestCollectPasteText_Runes(t *testing.T) {
-	events := []*tcell.EventKey{
-		key(tcell.KeyRune, 'H', tcell.ModNone),
-		key(tcell.KeyRune, 'i', tcell.ModNone),
+func runeKey(r rune) *tcell.EventKey {
+	return key(tcell.KeyRune, r, tcell.ModNone)
+}
+
+// keysFromString simulates how tcell encodes each byte of a string during
+// bracketed paste. This mirrors tcell's input.go inpStateInit switch exactly:
+//   - \t → KeyTab
+//   - \r → KeyEnter
+//   - \b, 0x7F → KeyBackspace
+//   - r < ' ' → KeyCtrlSpace+Key(r) with ModCtrl  (covers \n as KeyCtrlJ)
+//   - r >= ' ' → KeyRune
+func keysFromString(s string) []*tcell.EventKey {
+	var events []*tcell.EventKey
+	for _, r := range s {
+		switch {
+		case r == '\t':
+			events = append(events, key(tcell.KeyTab, 0, tcell.ModNone))
+		case r == '\b' || r == 0x7F:
+			events = append(events, key(tcell.KeyBackspace, 0, tcell.ModNone))
+		case r == '\r':
+			events = append(events, key(tcell.KeyEnter, 0, tcell.ModNone))
+		case r < ' ':
+			events = append(events, key(tcell.KeyCtrlSpace+tcell.Key(r), 0, tcell.ModCtrl))
+		default:
+			events = append(events, runeKey(r))
+		}
 	}
-	got := CollectPasteText(events)
+	return events
+}
+
+// --- Basic functionality ---
+
+func TestCollectPasteText_Runes(t *testing.T) {
+	got := CollectPasteText(keysFromString("Hi"))
 	if got != "Hi" {
 		t.Errorf("got %q, want %q", got, "Hi")
-	}
-}
-
-func TestCollectPasteText_Unicode(t *testing.T) {
-	events := []*tcell.EventKey{
-		key(tcell.KeyRune, '┌', tcell.ModNone),
-		key(tcell.KeyRune, '─', tcell.ModNone),
-		key(tcell.KeyRune, '┐', tcell.ModNone),
-	}
-	got := CollectPasteText(events)
-	if got != "┌─┐" {
-		t.Errorf("got %q, want %q", got, "┌─┐")
-	}
-}
-
-func TestCollectPasteText_UnixNewlines(t *testing.T) {
-	// Unix \n arrives as KeyCtrlJ
-	events := []*tcell.EventKey{
-		key(tcell.KeyRune, 'a', tcell.ModNone),
-		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),
-		key(tcell.KeyRune, 'b', tcell.ModNone),
-	}
-	got := CollectPasteText(events)
-	if got != "a\nb" {
-		t.Errorf("got %q, want %q", got, "a\nb")
-	}
-}
-
-func TestCollectPasteText_CRLFNewlines(t *testing.T) {
-	// Windows \r\n arrives as KeyEnter followed by KeyCtrlJ
-	events := []*tcell.EventKey{
-		key(tcell.KeyRune, 'a', tcell.ModNone),
-		key(tcell.KeyEnter, 0, tcell.ModNone),
-		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),
-		key(tcell.KeyRune, 'b', tcell.ModNone),
-	}
-	got := CollectPasteText(events)
-	if got != "a\nb" {
-		t.Errorf("got %q, want %q", got, "a\nb")
-	}
-}
-
-func TestCollectPasteText_CROnly(t *testing.T) {
-	// Old Mac \r arrives as KeyEnter, normalized to \n
-	events := []*tcell.EventKey{
-		key(tcell.KeyRune, 'a', tcell.ModNone),
-		key(tcell.KeyEnter, 0, tcell.ModNone),
-		key(tcell.KeyRune, 'b', tcell.ModNone),
-	}
-	got := CollectPasteText(events)
-	if got != "a\nb" {
-		t.Errorf("got %q, want %q", got, "a\nb")
-	}
-}
-
-func TestCollectPasteText_Tab(t *testing.T) {
-	events := []*tcell.EventKey{
-		key(tcell.KeyTab, 0, tcell.ModNone),
-		key(tcell.KeyRune, 'x', tcell.ModNone),
-	}
-	got := CollectPasteText(events)
-	if got != "\tx" {
-		t.Errorf("got %q, want %q", got, "\tx")
-	}
-}
-
-func TestCollectPasteText_ControlKeysSkipped(t *testing.T) {
-	events := []*tcell.EventKey{
-		key(tcell.KeyRune, 'a', tcell.ModNone),
-		key(tcell.KeyEscape, 0, tcell.ModNone),
-		key(tcell.KeyBackspace, 0, tcell.ModNone),
-		key(tcell.KeyUp, 0, tcell.ModNone),
-		key(tcell.KeyRune, 'b', tcell.ModNone),
-	}
-	got := CollectPasteText(events)
-	if got != "ab" {
-		t.Errorf("got %q, want %q", got, "ab")
 	}
 }
 
@@ -105,20 +57,435 @@ func TestCollectPasteText_Empty(t *testing.T) {
 	}
 }
 
-func TestCollectPasteText_MixedLineEndings(t *testing.T) {
-	// Mix of \r\n, \n, and \r in one paste
-	events := []*tcell.EventKey{
-		key(tcell.KeyRune, 'a', tcell.ModNone),
-		key(tcell.KeyEnter, 0, tcell.ModNone),       // \r (part of \r\n)
-		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),        // \n
-		key(tcell.KeyRune, 'b', tcell.ModNone),
-		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),        // standalone \n
-		key(tcell.KeyRune, 'c', tcell.ModNone),
-		key(tcell.KeyEnter, 0, tcell.ModNone),         // standalone \r
-		key(tcell.KeyRune, 'd', tcell.ModNone),
+func TestCollectPasteText_Tab(t *testing.T) {
+	got := CollectPasteText(keysFromString("\tx"))
+	if got != "\tx" {
+		t.Errorf("got %q, want %q", got, "\tx")
 	}
-	got := CollectPasteText(events)
+}
+
+// --- Full ASCII printable range ---
+
+func TestCollectPasteText_AllPrintableASCII(t *testing.T) {
+	var want strings.Builder
+	for r := rune(' '); r <= '~'; r++ {
+		want.WriteRune(r)
+	}
+	input := want.String()
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("printable ASCII mismatch:\ngot  %q\nwant %q", got, input)
+	}
+}
+
+func TestCollectPasteText_Digits(t *testing.T) {
+	got := CollectPasteText(keysFromString("0123456789"))
+	if got != "0123456789" {
+		t.Errorf("got %q, want %q", got, "0123456789")
+	}
+}
+
+func TestCollectPasteText_Punctuation(t *testing.T) {
+	input := "!@#$%^&*()_+-=[]{}|;':\",./<>?"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+// --- Line ending normalization ---
+
+func TestCollectPasteText_UnixNewlines(t *testing.T) {
+	got := CollectPasteText(keysFromString("a\nb"))
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
+	}
+}
+
+func TestCollectPasteText_CRLFNewlines(t *testing.T) {
+	got := CollectPasteText(keysFromString("a\r\nb"))
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
+	}
+}
+
+func TestCollectPasteText_CROnly(t *testing.T) {
+	got := CollectPasteText(keysFromString("a\rb"))
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
+	}
+}
+
+func TestCollectPasteText_MixedLineEndings(t *testing.T) {
+	got := CollectPasteText(keysFromString("a\r\nb\nc\rd"))
 	if got != "a\nb\nc\nd" {
 		t.Errorf("got %q, want %q", got, "a\nb\nc\nd")
+	}
+}
+
+func TestCollectPasteText_ConsecutiveLF(t *testing.T) {
+	got := CollectPasteText(keysFromString("a\n\nb"))
+	if got != "a\n\nb" {
+		t.Errorf("got %q, want %q", got, "a\n\nb")
+	}
+}
+
+func TestCollectPasteText_ConsecutiveCRLF(t *testing.T) {
+	got := CollectPasteText(keysFromString("a\r\n\r\nb"))
+	if got != "a\n\nb" {
+		t.Errorf("got %q, want %q", got, "a\n\nb")
+	}
+}
+
+func TestCollectPasteText_ConsecutiveCR(t *testing.T) {
+	got := CollectPasteText(keysFromString("a\r\rb"))
+	if got != "a\n\nb" {
+		t.Errorf("got %q, want %q", got, "a\n\nb")
+	}
+}
+
+func TestCollectPasteText_OnlyNewlines(t *testing.T) {
+	got := CollectPasteText(keysFromString("\n\r\n\r"))
+	if got != "\n\n\n" {
+		t.Errorf("got %q, want %q", got, "\n\n\n")
+	}
+}
+
+func TestCollectPasteText_TrailingNewline(t *testing.T) {
+	got := CollectPasteText(keysFromString("hello\n"))
+	if got != "hello\n" {
+		t.Errorf("got %q, want %q", got, "hello\n")
+	}
+}
+
+func TestCollectPasteText_TrailingCRLF(t *testing.T) {
+	got := CollectPasteText(keysFromString("hello\r\n"))
+	if got != "hello\n" {
+		t.Errorf("got %q, want %q", got, "hello\n")
+	}
+}
+
+// --- Unicode coverage ---
+
+func TestCollectPasteText_BoxDrawing(t *testing.T) {
+	input := "┌──────┐\n│ test │\n└──────┘"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_CJK(t *testing.T) {
+	input := "你好世界"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_Emoji(t *testing.T) {
+	input := "Hello 🌍🎉🚀"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_EmojiSequences(t *testing.T) {
+	input := "👨‍👩‍👧‍👦 family"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_CombiningCharacters(t *testing.T) {
+	input := "é ñ" // é ñ via combining marks
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_Arabic(t *testing.T) {
+	input := "مرحبا بالعالم"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_Japanese(t *testing.T) {
+	input := "こんにちは世界"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_Korean(t *testing.T) {
+	input := "안녕하세요"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_MathSymbols(t *testing.T) {
+	input := "∑∏∫∂√∞≈≠≤≥"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_CurrencySymbols(t *testing.T) {
+	input := "$€£¥₹₿"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_MixedScripts(t *testing.T) {
+	input := "Hello 你好 مرحبا こんにちは 🌍"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+// --- Control character handling (intentionally dropped) ---
+// tcell encodes control chars (0x00-0x1F except \t,\r,\n) as KeyCtrl*
+// and we intentionally skip them. These tests lock down that behavior.
+
+func TestCollectPasteText_NullByteDropped(t *testing.T) {
+	events := []*tcell.EventKey{
+		runeKey('a'),
+		key(tcell.KeyCtrlSpace, 0, tcell.ModCtrl), // 0x00
+		runeKey('b'),
+	}
+	got := CollectPasteText(events)
+	if got != "ab" {
+		t.Errorf("got %q, want %q", got, "ab")
+	}
+}
+
+func TestCollectPasteText_AllControlCharsDropped(t *testing.T) {
+	// 0x01 through 0x08 (CtrlA-CtrlH), 0x0B-0x0C (CtrlK-CtrlL),
+	// 0x0E-0x1A (CtrlN-CtrlZ) — all should be dropped
+	droppedKeys := []tcell.Key{
+		tcell.KeyCtrlA, tcell.KeyCtrlB, tcell.KeyCtrlC, tcell.KeyCtrlD,
+		tcell.KeyCtrlE, tcell.KeyCtrlF, tcell.KeyCtrlG, tcell.KeyCtrlH,
+		tcell.KeyCtrlK, tcell.KeyCtrlL,
+		tcell.KeyCtrlN, tcell.KeyCtrlO, tcell.KeyCtrlP, tcell.KeyCtrlQ,
+		tcell.KeyCtrlR, tcell.KeyCtrlS, tcell.KeyCtrlT, tcell.KeyCtrlU,
+		tcell.KeyCtrlV, tcell.KeyCtrlW, tcell.KeyCtrlX, tcell.KeyCtrlY,
+		tcell.KeyCtrlZ,
+	}
+	for _, dk := range droppedKeys {
+		events := []*tcell.EventKey{
+			runeKey('x'),
+			key(dk, 0, tcell.ModCtrl),
+			runeKey('y'),
+		}
+		got := CollectPasteText(events)
+		if got != "xy" {
+			t.Errorf("key %d not dropped: got %q, want %q", dk, got, "xy")
+		}
+	}
+}
+
+func TestCollectPasteText_BackspaceDropped(t *testing.T) {
+	events := []*tcell.EventKey{
+		runeKey('a'),
+		key(tcell.KeyBackspace, 0, tcell.ModNone), // 0x7F
+		runeKey('b'),
+	}
+	got := CollectPasteText(events)
+	if got != "ab" {
+		t.Errorf("got %q, want %q", got, "ab")
+	}
+}
+
+func TestCollectPasteText_EscapeDropped(t *testing.T) {
+	events := []*tcell.EventKey{
+		runeKey('a'),
+		key(tcell.KeyEscape, 0, tcell.ModNone),
+		runeKey('b'),
+	}
+	got := CollectPasteText(events)
+	if got != "ab" {
+		t.Errorf("got %q, want %q", got, "ab")
+	}
+}
+
+func TestCollectPasteText_ArrowKeysDropped(t *testing.T) {
+	events := []*tcell.EventKey{
+		runeKey('a'),
+		key(tcell.KeyUp, 0, tcell.ModNone),
+		key(tcell.KeyDown, 0, tcell.ModNone),
+		key(tcell.KeyLeft, 0, tcell.ModNone),
+		key(tcell.KeyRight, 0, tcell.ModNone),
+		runeKey('b'),
+	}
+	got := CollectPasteText(events)
+	if got != "ab" {
+		t.Errorf("got %q, want %q", got, "ab")
+	}
+}
+
+func TestCollectPasteText_FunctionKeysDropped(t *testing.T) {
+	events := []*tcell.EventKey{
+		runeKey('a'),
+		key(tcell.KeyF1, 0, tcell.ModNone),
+		key(tcell.KeyF12, 0, tcell.ModNone),
+		key(tcell.KeyHome, 0, tcell.ModNone),
+		key(tcell.KeyEnd, 0, tcell.ModNone),
+		key(tcell.KeyPgUp, 0, tcell.ModNone),
+		key(tcell.KeyPgDn, 0, tcell.ModNone),
+		key(tcell.KeyInsert, 0, tcell.ModNone),
+		key(tcell.KeyDelete, 0, tcell.ModNone),
+		runeKey('b'),
+	}
+	got := CollectPasteText(events)
+	if got != "ab" {
+		t.Errorf("got %q, want %q", got, "ab")
+	}
+}
+
+// --- Realistic paste scenarios ---
+
+func TestCollectPasteText_GoCodeSnippet(t *testing.T) {
+	input := "func main() {\n\tfmt.Println(\"hello\")\n}\n"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_PythonCodeSnippet(t *testing.T) {
+	input := "def greet(name):\n    print(f\"Hello, {name}!\")\n\ngreet(\"world\")\n"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_HTMLSnippet(t *testing.T) {
+	input := "<div class=\"container\">\n\t<p>Hello &amp; world</p>\n</div>"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_JSONSnippet(t *testing.T) {
+	input := "{\n\t\"name\": \"ttt\",\n\t\"version\": \"1.0.0\",\n\t\"tags\": [\"editor\", \"terminal\"]\n}"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_WindowsCodeSnippet(t *testing.T) {
+	input := "func main() {\r\n\tfmt.Println(\"hello\")\r\n}\r\n"
+	want := "func main() {\n\tfmt.Println(\"hello\")\n}\n"
+	got := CollectPasteText(keysFromString(input))
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCollectPasteText_ShellCommand(t *testing.T) {
+	input := "grep -rn 'TODO' . | sort | head -20"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_URLWithSpecialChars(t *testing.T) {
+	input := "https://example.com/search?q=hello+world&lang=en#results"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_FilePath(t *testing.T) {
+	input := "/home/user/.config/ttt/settings.json"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_WindowsPath(t *testing.T) {
+	input := "C:\\Users\\dev\\Documents\\project\\main.go"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+// --- Scale tests ---
+
+func TestCollectPasteText_LargePaste(t *testing.T) {
+	var input strings.Builder
+	for i := 0; i < 1000; i++ {
+		input.WriteString("Line with unicode: 你好 émoji 🎉 and tabs\t!\n")
+	}
+	want := input.String()
+	got := CollectPasteText(keysFromString(want))
+	if got != want {
+		t.Errorf("large paste: length got %d, want %d", len(got), len(want))
+	}
+}
+
+func TestCollectPasteText_SingleCharacter(t *testing.T) {
+	got := CollectPasteText(keysFromString("x"))
+	if got != "x" {
+		t.Errorf("got %q, want %q", got, "x")
+	}
+}
+
+func TestCollectPasteText_SingleNewline(t *testing.T) {
+	got := CollectPasteText(keysFromString("\n"))
+	if got != "\n" {
+		t.Errorf("got %q, want %q", got, "\n")
+	}
+}
+
+func TestCollectPasteText_SingleTab(t *testing.T) {
+	got := CollectPasteText(keysFromString("\t"))
+	if got != "\t" {
+		t.Errorf("got %q, want %q", got, "\t")
+	}
+}
+
+// --- Whitespace handling ---
+
+func TestCollectPasteText_MixedWhitespace(t *testing.T) {
+	input := "  \t  \t\t  "
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_IndentedCode(t *testing.T) {
+	input := "\t\tif x > 0 {\n\t\t\treturn x\n\t\t}\n"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+}
+
+func TestCollectPasteText_SpaceIndentedCode(t *testing.T) {
+	input := "    def foo():\n        return 42\n"
+	got := CollectPasteText(keysFromString(input))
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
 	}
 }

--- a/internal/term/paste_test.go
+++ b/internal/term/paste_test.go
@@ -1,0 +1,124 @@
+package term
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func key(k tcell.Key, r rune, mod tcell.ModMask) *tcell.EventKey {
+	return tcell.NewEventKey(k, r, mod)
+}
+
+func TestCollectPasteText_Runes(t *testing.T) {
+	events := []*tcell.EventKey{
+		key(tcell.KeyRune, 'H', tcell.ModNone),
+		key(tcell.KeyRune, 'i', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "Hi" {
+		t.Errorf("got %q, want %q", got, "Hi")
+	}
+}
+
+func TestCollectPasteText_Unicode(t *testing.T) {
+	events := []*tcell.EventKey{
+		key(tcell.KeyRune, '┌', tcell.ModNone),
+		key(tcell.KeyRune, '─', tcell.ModNone),
+		key(tcell.KeyRune, '┐', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "┌─┐" {
+		t.Errorf("got %q, want %q", got, "┌─┐")
+	}
+}
+
+func TestCollectPasteText_UnixNewlines(t *testing.T) {
+	// Unix \n arrives as KeyCtrlJ
+	events := []*tcell.EventKey{
+		key(tcell.KeyRune, 'a', tcell.ModNone),
+		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),
+		key(tcell.KeyRune, 'b', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
+	}
+}
+
+func TestCollectPasteText_CRLFNewlines(t *testing.T) {
+	// Windows \r\n arrives as KeyEnter followed by KeyCtrlJ
+	events := []*tcell.EventKey{
+		key(tcell.KeyRune, 'a', tcell.ModNone),
+		key(tcell.KeyEnter, 0, tcell.ModNone),
+		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),
+		key(tcell.KeyRune, 'b', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
+	}
+}
+
+func TestCollectPasteText_CROnly(t *testing.T) {
+	// Old Mac \r arrives as KeyEnter, normalized to \n
+	events := []*tcell.EventKey{
+		key(tcell.KeyRune, 'a', tcell.ModNone),
+		key(tcell.KeyEnter, 0, tcell.ModNone),
+		key(tcell.KeyRune, 'b', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
+	}
+}
+
+func TestCollectPasteText_Tab(t *testing.T) {
+	events := []*tcell.EventKey{
+		key(tcell.KeyTab, 0, tcell.ModNone),
+		key(tcell.KeyRune, 'x', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "\tx" {
+		t.Errorf("got %q, want %q", got, "\tx")
+	}
+}
+
+func TestCollectPasteText_ControlKeysSkipped(t *testing.T) {
+	events := []*tcell.EventKey{
+		key(tcell.KeyRune, 'a', tcell.ModNone),
+		key(tcell.KeyEscape, 0, tcell.ModNone),
+		key(tcell.KeyBackspace, 0, tcell.ModNone),
+		key(tcell.KeyUp, 0, tcell.ModNone),
+		key(tcell.KeyRune, 'b', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "ab" {
+		t.Errorf("got %q, want %q", got, "ab")
+	}
+}
+
+func TestCollectPasteText_Empty(t *testing.T) {
+	got := CollectPasteText(nil)
+	if got != "" {
+		t.Errorf("got %q, want %q", got, "")
+	}
+}
+
+func TestCollectPasteText_MixedLineEndings(t *testing.T) {
+	// Mix of \r\n, \n, and \r in one paste
+	events := []*tcell.EventKey{
+		key(tcell.KeyRune, 'a', tcell.ModNone),
+		key(tcell.KeyEnter, 0, tcell.ModNone),       // \r (part of \r\n)
+		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),        // \n
+		key(tcell.KeyRune, 'b', tcell.ModNone),
+		key(tcell.KeyCtrlJ, 0, tcell.ModCtrl),        // standalone \n
+		key(tcell.KeyRune, 'c', tcell.ModNone),
+		key(tcell.KeyEnter, 0, tcell.ModNone),         // standalone \r
+		key(tcell.KeyRune, 'd', tcell.ModNone),
+	}
+	got := CollectPasteText(events)
+	if got != "a\nb\nc\nd" {
+		t.Errorf("got %q, want %q", got, "a\nb\nc\nd")
+	}
+}

--- a/internal/term/tcell_screen.go
+++ b/internal/term/tcell_screen.go
@@ -32,6 +32,7 @@ func NewTcellScreen() (*TcellScreen, error) {
 		return nil, err
 	}
 	s.EnableMouse()
+	s.EnablePaste()
 	return &TcellScreen{scr: s, styleMap: DefaultStyleMap()}, nil
 }
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -960,6 +960,16 @@ func (g *EditorGroupWidget) Paste() {
 	g.Editor.pasteText(text)
 }
 
+func (g *EditorGroupWidget) PasteText(text string) {
+	if !g.IsEditorActive() {
+		return
+	}
+	if text == "" {
+		return
+	}
+	g.Editor.pasteText(text)
+}
+
 func (g *EditorGroupWidget) syncTabs() {
 	t := g.activeTab()
 	if t == nil {

--- a/internal/ui/input_widget.go
+++ b/internal/ui/input_widget.go
@@ -477,6 +477,22 @@ func (inp *InputWidget) PasteClipboard() {
 	inp.notify()
 }
 
+func (inp *InputWidget) PasteText(text string) {
+	if inp.HasSelection() {
+		inp.deleteSelection()
+	}
+	text = sanitizePaste(text)
+	if text == "" {
+		return
+	}
+	runes := []rune(inp.Text)
+	pasted := []rune(text)
+	runes = append(runes[:inp.CursorPos], append(pasted, runes[inp.CursorPos:]...)...)
+	inp.Text = string(runes)
+	inp.CursorPos += len(pasted)
+	inp.notify()
+}
+
 func sanitizePaste(text string) string {
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 	text = strings.ReplaceAll(text, "\r", "\n")

--- a/internal/ui/terminal_widget.go
+++ b/internal/ui/terminal_widget.go
@@ -50,6 +50,21 @@ func (tw *TerminalWidget) SetFocused(f bool) { tw.focused = f }
 
 func (tw *TerminalWidget) WantsRawKeys() bool { return tw.focused }
 
+func (tw *TerminalWidget) PasteText(text string) {
+	if tw.Term == nil || text == "" {
+		return
+	}
+	if tw.Term.Mode()&vt10x.ModeBracketedPaste != 0 {
+		tw.Term.WriteString("\x1b[200~")
+		tw.Term.WriteString(text)
+		tw.Term.WriteString("\x1b[201~")
+	} else {
+		tw.Term.WriteString(text)
+	}
+	tw.ClearSelection()
+	tw.scrollOffset = 0
+}
+
 func (tw *TerminalWidget) CursorPosition() (x, y int, visible bool) {
 	if tw.Term == nil {
 		return 0, 0, false

--- a/tests/e2e/bracketed_paste_test.go
+++ b/tests/e2e/bracketed_paste_test.go
@@ -1,0 +1,132 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/app"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func runEventLoopBriefly(h *testHarness, inject func()) {
+	h.t.Helper()
+	running := true
+
+	go app.RunEventLoop(
+		h.app.Screen,
+		h.app.Renderer,
+		h.app,
+		&running,
+		func(panelID string) {},
+	)
+
+	inject()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify the app isn't stuck by injecting a regular key
+	h.screen.InjectKey(tcell.KeyRune, 'Z', tcell.ModNone)
+	time.Sleep(100 * time.Millisecond)
+
+	running = false
+	h.screen.PostEvent(tcell.NewEventInterrupt(nil))
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestBracketedPasteSimple(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	h.exec("file.new")
+
+	runEventLoopBriefly(h, func() {
+		h.screen.PostEvent(tcell.NewEventPaste(true))
+		h.screen.InjectKey(tcell.KeyRune, 'h', tcell.ModNone)
+		h.screen.InjectKey(tcell.KeyRune, 'i', tcell.ModNone)
+		h.screen.PostEvent(tcell.NewEventPaste(false))
+	})
+
+	buf := h.app.EditorGroup.ActiveBuffer()
+	if buf == nil {
+		t.Fatal("expected active buffer")
+	}
+	if buf.Lines[0] != "hiZ" {
+		t.Errorf("expected 'hiZ', got %q", buf.Lines[0])
+	}
+}
+
+func TestBracketedPasteMultiLine(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	h.exec("file.new")
+
+	runEventLoopBriefly(h, func() {
+		h.screen.PostEvent(tcell.NewEventPaste(true))
+		// "line1\nline2\nline3"
+		for _, r := range "line1" {
+			h.screen.InjectKey(tcell.KeyRune, r, tcell.ModNone)
+		}
+		h.screen.InjectKey(tcell.KeyEnter, 0, tcell.ModNone)
+		for _, r := range "line2" {
+			h.screen.InjectKey(tcell.KeyRune, r, tcell.ModNone)
+		}
+		h.screen.InjectKey(tcell.KeyEnter, 0, tcell.ModNone)
+		for _, r := range "line3" {
+			h.screen.InjectKey(tcell.KeyRune, r, tcell.ModNone)
+		}
+		h.screen.PostEvent(tcell.NewEventPaste(false))
+	})
+
+	buf := h.app.EditorGroup.ActiveBuffer()
+	if buf == nil {
+		t.Fatal("expected active buffer")
+	}
+	// Should have 3 lines from paste + Z appended to last line
+	if len(buf.Lines) < 3 {
+		t.Errorf("expected at least 3 lines, got %d: %v", len(buf.Lines), buf.Lines)
+	}
+	if buf.Lines[0] != "line1" {
+		t.Errorf("line 0: expected 'line1', got %q", buf.Lines[0])
+	}
+	if buf.Lines[1] != "line2" {
+		t.Errorf("line 1: expected 'line2', got %q", buf.Lines[1])
+	}
+}
+
+func TestBracketedPasteKeyboardWorksAfter(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	h.exec("file.new")
+
+	running := true
+	go app.RunEventLoop(
+		h.app.Screen,
+		h.app.Renderer,
+		h.app,
+		&running,
+		func(panelID string) {},
+	)
+
+	// Paste
+	h.screen.PostEvent(tcell.NewEventPaste(true))
+	h.screen.InjectKey(tcell.KeyRune, 'A', tcell.ModNone)
+	h.screen.PostEvent(tcell.NewEventPaste(false))
+	time.Sleep(100 * time.Millisecond)
+
+	// Type after paste — if pasteActive is stuck, this goes to buffer
+	h.screen.InjectKey(tcell.KeyRune, 'B', tcell.ModNone)
+	time.Sleep(100 * time.Millisecond)
+
+	running = false
+	h.screen.PostEvent(tcell.NewEventInterrupt(nil))
+	time.Sleep(100 * time.Millisecond)
+
+	buf := h.app.EditorGroup.ActiveBuffer()
+	if buf == nil {
+		t.Fatal("expected active buffer")
+	}
+	if buf.Lines[0] != "AB" {
+		t.Errorf("expected 'AB', got %q — keyboard may be stuck after paste", buf.Lines[0])
+	}
+}
+

--- a/tests/functional/bracketed-paste.test.js
+++ b/tests/functional/bracketed-paste.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function sendRaw(text) {
+  execFileSync("tui-use", ["type", text], {
+    encoding: "utf8",
+    timeout: 10000,
+  });
+}
+
+describe("bracketed paste", () => {
+  it("should handle small bracketed paste", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "paste.txt", "before");
+
+    tui.start(file);
+    tui.waitFor("before");
+
+    tui.press("end");
+
+    // Send bracketed paste: \e[200~ ... \e[201~
+    sendRaw("\x1b[200~hello\x1b[201~");
+    tui.waitStable(500);
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("beforehello");
+  });
+
+  it("should handle multiline bracketed paste", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "paste-multi.txt", "start");
+
+    tui.start(file);
+    tui.waitFor("start");
+
+    tui.press("end");
+
+    // Paste "line1\nline2\nline3"
+    sendRaw("\x1b[200~line1\nline2\nline3\x1b[201~");
+    tui.waitStable(500);
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("line1");
+    expect(snap).toContain("line2");
+    expect(snap).toContain("line3");
+  });
+
+  it("should handle large bracketed paste without hanging", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "paste-large.txt", "");
+
+    tui.start(file);
+    tui.waitStable();
+
+    // Test with multi-byte UTF-8 (box-drawing chars are 3 bytes each)
+    const content = "┌──────────────────┐\n│  Layout  (File)  │\n└──────────────────┘\n".repeat(100);
+    sendRaw("\x1b[200~" + content + "\x1b[201~");
+    tui.waitStable(10000);
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("Layout");
+  });
+
+  it("should allow normal typing after paste", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "paste-after.txt", "");
+
+    tui.start(file);
+    tui.waitStable();
+
+    sendRaw("\x1b[200~pasted\x1b[201~");
+    tui.waitStable(500);
+
+    tui.type("typed");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("pastedtyped");
+  });
+});


### PR DESCRIPTION
## Summary
- Enable bracketed paste mode (`EnablePaste()`) so terminals like Foot that intercept Ctrl+V can deliver pasted content via escape sequences instead of letter-by-letter key events
- Upgrade tcell from v2.13.7 to v2.13.8 to fix a deadlock when pasting multi-byte UTF-8 content (partial characters at 128-byte chunk boundaries caused `scanInput` to corrupt the input stream)
- Extract paste key remapping into `CollectPasteText()` in `internal/term/paste.go` with CRLF normalization — handles Unix (\n), Windows (\r\n), and old Mac (\r) line endings
- Route pasted text through `App.PasteText()` to support editor, input widgets, and the integrated terminal (with re-wrapping in bracketed paste markers for shells that expect them)

## Test plan
- [x] Unit tests for `CollectPasteText()` covering runes, unicode, Unix/Windows/mixed line endings, tabs, control key filtering, and empty input
- [x] E2E tests using `PostEvent` to inject `EventPaste` events (simple, multiline, keyboard-after-paste)
- [x] Functional tests using `tui-use sendRaw` to inject real bracketed paste escape sequences including a large multi-byte UTF-8 stress test
- [ ] Manual test: paste in Foot terminal with Ctrl+V (triggers bracketed paste)
- [ ] Manual test: paste in Alacritty with Ctrl+Shift+V

🤖 Generated with [Claude Code](https://claude.com/claude-code)