### PR TITLE
fix: new file always creates a fresh tab

### DIFF
--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/eugenioenko/ttt/internal/command"
-	"github.com/eugenioenko/ttt/internal/core/buffer"
 	"github.com/eugenioenko/ttt/internal/ui"
 )
 
@@ -102,14 +101,14 @@ func (a *App) CloseTab() {
 }
 
 func (a *App) NewFile() {
-	a.EditorGroup.OpenBuffer("untitled", &buffer.Buffer{Lines: []string{""}})
+	a.EditorGroup.NewFile()
 	a.Root.SetFocus(a.EditorGroup)
 }
 
 func (a *App) SaveFileAs() {
 	current := a.EditorGroup.ActiveFilePath()
 	initial := ""
-	if current != "untitled" {
+	if !a.EditorGroup.IsActiveVirtual() {
 		initial = current
 	}
 	a.ShowInputDialog("Save As", "Filename", initial, func(path string) {
@@ -122,7 +121,7 @@ func (a *App) SaveFileAs() {
 func (a *App) SaveFile() {
 	path := a.EditorGroup.ActiveFilePath()
 	buf := a.EditorGroup.ActiveBuffer()
-	if buf != nil && path != "untitled" && buf.DiskChanged(path) {
+	if buf != nil && !a.EditorGroup.IsActiveVirtual() && buf.DiskChanged(path) {
 		a.ShowConfirmDialog(
 			fmt.Sprintf("%s was modified on disk. Overwrite with your version?", filepath.Base(path)),
 			[]string{"Overwrite", "Cancel"},

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -152,7 +152,7 @@ func (a *App) ExplorerRemoveRoot() {
 
 func (a *App) activeFilePath() string {
 	path := a.EditorGroup.ActiveFilePath()
-	if path == "untitled" {
+	if a.EditorGroup.IsActiveVirtual() {
 		return ""
 	}
 	path = strings.TrimSuffix(path, " (diff)")

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -273,7 +273,7 @@ func registerGitCommands(app *App) {
 		Keywords: []string{"git", "github", "link", "url", "permalink", "copy"},
 		Handler: func() {
 			filePath := app.EditorGroup.ActiveFilePath()
-			if filePath == "" || filePath == "untitled" {
+			if filePath == "" || app.EditorGroup.IsActiveVirtual() {
 				app.StatusWarn("No file open")
 				return
 			}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -78,7 +78,7 @@ func RunEventLoop(
 		}
 
 		repoDir := ""
-		if filePath != "" && filePath != "untitled" {
+		if filePath != "" && !app.EditorGroup.IsActiveVirtual() {
 			if folder := app.Workspace.FolderForFile(filePath); folder != nil && folder.IsRepo {
 				repoDir = folder.Path
 			}

--- a/internal/app/gitgutter.go
+++ b/internal/app/gitgutter.go
@@ -24,7 +24,7 @@ func (a *App) RequestGitGutter(filePath string, bufferLines []string) {
 	if !a.Settings.Editor.IsGitGutterEnabled() {
 		return
 	}
-	if filePath == "" || filePath == "untitled" {
+	if filePath == "" || a.EditorGroup.IsActiveVirtual() {
 		return
 	}
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -218,27 +218,6 @@ func (g *EditorGroupWidget) OpenFile(path string) {
 	}
 }
 
-func (g *EditorGroupWidget) OpenBuffer(path string, buf *buffer.Buffer) {
-	for i, t := range g.tabs {
-		if t.FilePath == path {
-			g.SwitchTab(i)
-			return
-		}
-	}
-	folds := fold.NewState()
-	folds.SetRanges(fold.ComputeIndentRanges(buf.Lines))
-	g.tabs = append(g.tabs, editorTab{
-		FilePath: path,
-		Buf:      buf,
-		Cur:      &cursor.Cursor{},
-		Vp:       &view.Viewport{},
-		Undo:     &undo.UndoStack{},
-		Sel:      &selection.Selection{},
-		Folds:    folds,
-	})
-	g.SwitchTab(len(g.tabs) - 1)
-}
-
 func (g *EditorGroupWidget) NewFile() {
 	name := g.nextUntitledName()
 	g.tabs = append(g.tabs, editorTab{

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -55,6 +55,7 @@ type editorTab struct {
 	UseTabs     bool
 	Content     Widget
 	Pinned      bool
+	Virtual     bool
 	LineChanges []diff.LineChangeKind
 }
 
@@ -122,6 +123,7 @@ func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool
 		Vp:       editor.Viewport,
 		Undo:     undoStack,
 		Sel:      sel,
+		Virtual:  true,
 	}}
 	g.syncTabs()
 	return g
@@ -237,6 +239,38 @@ func (g *EditorGroupWidget) OpenBuffer(path string, buf *buffer.Buffer) {
 	g.SwitchTab(len(g.tabs) - 1)
 }
 
+func (g *EditorGroupWidget) NewFile() {
+	name := g.nextUntitledName()
+	g.tabs = append(g.tabs, editorTab{
+		FilePath: name,
+		Buf:      &buffer.Buffer{Lines: []string{""}},
+		Cur:      &cursor.Cursor{},
+		Vp:       &view.Viewport{},
+		Undo:     &undo.UndoStack{},
+		Sel:      &selection.Selection{},
+		Virtual:  true,
+	})
+	g.SwitchTab(len(g.tabs) - 1)
+}
+
+func (g *EditorGroupWidget) nextUntitledName() string {
+	taken := make(map[string]bool)
+	for _, t := range g.tabs {
+		if t.Virtual {
+			taken[t.FilePath] = true
+		}
+	}
+	if !taken["untitled"] {
+		return "untitled"
+	}
+	for n := 2; ; n++ {
+		name := fmt.Sprintf("untitled-%d", n)
+		if !taken[name] {
+			return name
+		}
+	}
+}
+
 func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, newLines []string, extended bool) {
 	tabName := path + " (diff)"
 	for i, t := range g.tabs {
@@ -312,7 +346,7 @@ func (g *EditorGroupWidget) OpenFilePaths() []string {
 		if t.Content != nil || t.Buf == nil {
 			continue
 		}
-		if t.FilePath == "" || t.FilePath == "untitled" {
+		if t.FilePath == "" || t.Virtual {
 			continue
 		}
 		paths = append(paths, t.FilePath)
@@ -439,7 +473,7 @@ func (g *EditorGroupWidget) CloseTab() {
 		return
 	}
 	closing := g.tabs[g.active]
-	if g.OnFileClose != nil && closing.Highlighter != nil && closing.FilePath != "untitled" {
+	if g.OnFileClose != nil && closing.Highlighter != nil && !closing.Virtual {
 		g.OnFileClose(closing.FilePath, closing.Highlighter.Language())
 	}
 	g.tabs = append(g.tabs[:g.active], g.tabs[g.active+1:]...)
@@ -451,6 +485,7 @@ func (g *EditorGroupWidget) CloseTab() {
 			Vp:       &view.Viewport{},
 			Undo:     &undo.UndoStack{},
 			Sel:      &selection.Selection{},
+			Virtual:  true,
 		}}
 		g.active = 0
 	} else if g.active >= len(g.tabs) {
@@ -477,6 +512,7 @@ func (g *EditorGroupWidget) CloseAllTabs() {
 		Vp:       &view.Viewport{},
 		Undo:     &undo.UndoStack{},
 		Sel:      &selection.Selection{},
+		Virtual:  true,
 	}}
 	g.active = 0
 	g.syncTabs()
@@ -487,7 +523,7 @@ func (g *EditorGroupWidget) Save() bool {
 	if t == nil || t.Content != nil {
 		return false
 	}
-	if t.FilePath == "untitled" {
+	if t.Virtual {
 		return false
 	}
 	if err := t.Buf.SaveFile(t.FilePath); err != nil {
@@ -507,6 +543,7 @@ func (g *EditorGroupWidget) SaveAs(path string) {
 		return
 	}
 	t.FilePath = path
+	t.Virtual = false
 	if g.SyntaxHighlight {
 		t.Highlighter = highlight.New(path)
 	} else {
@@ -520,6 +557,13 @@ func (g *EditorGroupWidget) ActiveFilePath() string {
 		return t.FilePath
 	}
 	return ""
+}
+
+func (g *EditorGroupWidget) IsActiveVirtual() bool {
+	if t := g.activeTab(); t != nil {
+		return t.Virtual
+	}
+	return true
 }
 
 // ActiveBuffer returns the buffer backing the active tab, or nil if the active
@@ -1002,7 +1046,7 @@ func (g *EditorGroupWidget) syncTabs() {
 			dirty = ts.Buf.Dirty
 		}
 		closable := true
-		if len(g.tabs) == 1 && ts.FilePath == "untitled" && ts.Buf != nil && !ts.Buf.Dirty && len(ts.Buf.Lines) <= 1 && (len(ts.Buf.Lines) == 0 || ts.Buf.Lines[0] == "") {
+		if len(g.tabs) == 1 && ts.Virtual && ts.Buf != nil && !ts.Buf.Dirty && len(ts.Buf.Lines) <= 1 && (len(ts.Buf.Lines) == 0 || ts.Buf.Lines[0] == "") {
 			closable = false
 		}
 		uiTabs = append(uiTabs, Tab{

--- a/internal/ui/editor_group_test.go
+++ b/internal/ui/editor_group_test.go
@@ -6,6 +6,73 @@ import (
 	"testing"
 )
 
+func TestInitialTabIsVirtual(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+	if !g.tabs[0].Virtual {
+		t.Fatal("expected initial tab to be virtual")
+	}
+}
+
+func TestNewFileAlwaysCreatesTab(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+	if len(g.tabs) != 1 || g.tabs[0].FilePath != "untitled" {
+		t.Fatal("expected initial untitled tab")
+	}
+
+	g.tabs[0].Buf.Lines = []string{"some content"}
+	g.tabs[0].Buf.Dirty = true
+
+	g.NewFile()
+	if len(g.tabs) != 2 {
+		t.Fatalf("expected 2 tabs, got %d", len(g.tabs))
+	}
+	if g.tabs[1].FilePath != "untitled-2" {
+		t.Errorf("expected 'untitled-2', got %q", g.tabs[1].FilePath)
+	}
+	if g.active != 1 {
+		t.Errorf("expected active tab 1, got %d", g.active)
+	}
+}
+
+func TestNewFileSequentialNaming(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+
+	g.NewFile()
+	g.NewFile()
+	g.NewFile()
+
+	if len(g.tabs) != 4 {
+		t.Fatalf("expected 4 tabs, got %d", len(g.tabs))
+	}
+	expected := []string{"untitled", "untitled-2", "untitled-3", "untitled-4"}
+	for i, want := range expected {
+		if g.tabs[i].FilePath != want {
+			t.Errorf("tab %d: got %q, want %q", i, g.tabs[i].FilePath, want)
+		}
+	}
+}
+
+func TestNewFileReusesNameAfterClose(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+	g.NewFile() // untitled-2
+
+	g.SwitchTab(0)
+	g.CloseTab()
+
+	if g.tabs[0].FilePath != "untitled-2" {
+		t.Fatalf("expected remaining tab 'untitled-2', got %q", g.tabs[0].FilePath)
+	}
+
+	g.NewFile()
+	names := make(map[string]bool)
+	for _, tab := range g.tabs {
+		names[tab.FilePath] = true
+	}
+	if !names["untitled"] {
+		t.Error("expected 'untitled' to be reused after close")
+	}
+}
+
 func TestEditorGroupOpenFileNotFound(t *testing.T) {
 	g := NewEditorGroupWidget(nil, 4, false, "extended")
 	var errMsg string
@@ -46,6 +113,7 @@ func TestEditorGroupSaveError(t *testing.T) {
 	g.OnError = func(msg string) { errMsg = msg }
 
 	g.tabs[0].FilePath = "/nonexistent/dir/file.txt"
+	g.tabs[0].Virtual = false
 	g.tabs[0].Buf.Lines = []string{"test"}
 
 	ok := g.Save()
@@ -66,6 +134,7 @@ func TestEditorGroupSaveSuccess(t *testing.T) {
 	g.OnError = func(msg string) { errMsg = msg }
 
 	g.tabs[0].FilePath = path
+	g.tabs[0].Virtual = false
 	g.tabs[0].Buf.Lines = []string{"saved content"}
 
 	ok := g.Save()
@@ -113,5 +182,8 @@ func TestEditorGroupSaveAsSuccess(t *testing.T) {
 	}
 	if g.tabs[0].FilePath != path {
 		t.Fatalf("expected FilePath to be %s, got %s", path, g.tabs[0].FilePath)
+	}
+	if g.tabs[0].Virtual {
+		t.Fatal("SaveAs should clear Virtual flag")
 	}
 }

--- a/tests/e2e/editor_test.go
+++ b/tests/e2e/editor_test.go
@@ -35,8 +35,8 @@ func TestNewFile(t *testing.T) {
 	defer h.stop()
 
 	h.exec("file.new")
-	if h.app.EditorGroup.ActiveFilePath() != "untitled" {
-		t.Errorf("expected path 'untitled', got %q", h.app.EditorGroup.ActiveFilePath())
+	if !h.app.EditorGroup.IsActiveVirtual() {
+		t.Error("expected new file tab to be virtual")
 	}
 	h.assertContains("untitled")
 }

--- a/tests/e2e/fold_test.go
+++ b/tests/e2e/fold_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eugenioenko/ttt/internal/core/buffer"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/gdamore/tcell/v2"
 )
@@ -249,10 +248,9 @@ func TestScrollDown_FoldAware(t *testing.T) {
 func TestOpenBuffer_HasFoldState(t *testing.T) {
 	h := newTestHarness(t, 80, 30)
 
-	buf := &buffer.Buffer{
-		Lines: []string{"func main() {", "\ta()", "\tb()", "}"},
-	}
-	h.app.EditorGroup.OpenBuffer("test.go", buf)
+	path := filepath.Join(h.dir, "test.go")
+	os.WriteFile(path, []byte("func main() {\n\ta()\n\tb()\n}"), 0644)
+	h.app.EditorGroup.OpenFile(path)
 	h.redraw()
 
 	folds := h.app.EditorGroup.Editor.Folds

--- a/tests/e2e/new_file_test.go
+++ b/tests/e2e/new_file_test.go
@@ -1,0 +1,53 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestNewFileCreatesSecondTab(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	// Start with default untitled tab, type something
+	h.exec("file.new")
+	h.pressRune('x')
+
+	if !h.app.EditorGroup.IsActiveVirtual() {
+		t.Fatal("expected virtual tab")
+	}
+	firstPath := h.app.EditorGroup.ActiveFilePath()
+
+	// New file should create a second tab, not reuse the one with content
+	h.exec("file.new")
+	secondPath := h.app.EditorGroup.ActiveFilePath()
+
+	if !h.app.EditorGroup.IsActiveVirtual() {
+		t.Fatal("expected virtual tab")
+	}
+	if firstPath == secondPath {
+		t.Fatalf("new file reused existing tab %q instead of creating a new one", firstPath)
+	}
+
+	// New buffer should be empty
+	buf := h.app.EditorGroup.ActiveBuffer()
+	if buf == nil {
+		t.Fatal("expected active buffer")
+	}
+	if len(buf.Lines) != 1 || buf.Lines[0] != "" {
+		t.Errorf("expected empty buffer, got %v", buf.Lines)
+	}
+}
+
+func TestNewFileOnEmptyUntitledStillCreates(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	// Even on an empty untitled buffer, new file creates another tab
+	first := h.app.EditorGroup.ActiveFilePath()
+	h.exec("file.new")
+	second := h.app.EditorGroup.ActiveFilePath()
+
+	if first == second {
+		t.Fatal("expected new file to create a distinct tab even when current is empty")
+	}
+}

--- a/tests/functional/new-file.test.js
+++ b/tests/functional/new-file.test.js
@@ -25,6 +25,25 @@ describe("new file", () => {
     expect(snap).toContain("untitled");
   });
 
+  it("should create a distinct tab when current untitled has content", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "existing.txt", "Existing content");
+
+    tui.start(file);
+    tui.waitFor("existing.txt");
+
+    tui.press("ctrl+n");
+    tui.waitFor("untitled");
+    tui.type("some text");
+    tui.waitStable();
+
+    tui.press("ctrl+n");
+    tui.waitStable();
+
+    const snap = tui.snapshot();
+    expect(snap).toContain("untitled-");
+  });
+
   it("should save a new file via Save As", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "existing.txt", "Existing content");


### PR DESCRIPTION
## Summary
- Add `Virtual` field to `editorTab` to distinguish tabs backed by files on disk from untitled scratch buffers
- `file.new` always creates a new tab with a unique name (`untitled`, `untitled-2`, ...) instead of reusing an existing untitled buffer
- `SaveAs` clears the `Virtual` flag, so the tab becomes a real file
- All checks that previously string-matched against `"untitled"` now use the `Virtual` flag — users can name files "untitled" without confusion

Closes #254

## Test plan
- [x] Unit tests: `TestInitialTabIsVirtual`, `TestNewFileAlwaysCreatesTab`, `TestNewFileSequentialNaming`, `TestNewFileReusesNameAfterClose`, SaveAs clears Virtual
- [x] E2E tests: `TestNewFileCreatesSecondTab`, `TestNewFileOnEmptyUntitledStillCreates`
- [x] Functional test: creates distinct tab when current untitled has content
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)