### PR TITLE
fix: prevent horizontal scroll when content fits viewport

### DIFF
--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -124,6 +124,21 @@ func (e *EditorPaneWidget) InvalidateMaxLineWidth() {
 	e.maxLineWidthDirty = true
 }
 
+func (e *EditorPaneWidget) clampLeftCol() {
+	editorW := e.Viewport.Width
+	maxW := e.computeMaxLineWidth()
+	max := maxW - editorW
+	if max < 0 {
+		max = 0
+	}
+	if e.Viewport.LeftCol > max {
+		e.Viewport.LeftCol = max
+	}
+	if e.Viewport.LeftCol < 0 {
+		e.Viewport.LeftCol = 0
+	}
+}
+
 func (e *EditorPaneWidget) buildSearchIndex() {
 	e.searchByLine = make(map[int][]int, len(e.SearchMatches))
 	for i, m := range e.SearchMatches {
@@ -664,6 +679,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		if newLeft, consumed := e.hscrollbar.HandleEvent(ev); consumed {
 			e.Viewport.LeftCol = newLeft
+			e.clampLeftCol()
 			if e.hscrollbar.IsDragging() {
 				return EventCaptured
 			}
@@ -677,9 +693,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		if btn&tcell.WheelUp != 0 {
 			if mod&tcell.ModShift != 0 {
 				e.Viewport.LeftCol -= 4
-				if e.Viewport.LeftCol < 0 {
-					e.Viewport.LeftCol = 0
-				}
+				e.clampLeftCol()
 			} else {
 				e.scrollUp(3)
 			}
@@ -688,6 +702,7 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		if btn&tcell.WheelDown != 0 {
 			if mod&tcell.ModShift != 0 {
 				e.Viewport.LeftCol += 4
+				e.clampLeftCol()
 			} else {
 				e.scrollDown(3)
 			}
@@ -695,13 +710,12 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		if btn&tcell.WheelLeft != 0 {
 			e.Viewport.LeftCol -= 4
-			if e.Viewport.LeftCol < 0 {
-				e.Viewport.LeftCol = 0
-			}
+			e.clampLeftCol()
 			return EventConsumed
 		}
 		if btn&tcell.WheelRight != 0 {
 			e.Viewport.LeftCol += 4
+			e.clampLeftCol()
 			return EventConsumed
 		}
 

--- a/internal/ui/editor_widget_test.go
+++ b/internal/ui/editor_widget_test.go
@@ -228,5 +228,46 @@ func TestEditorLineNumbersCursorOffset(t *testing.T) {
 	}
 }
 
+func TestHorizontalScrollClampNoOverflow(t *testing.T) {
+	e := newTestEditor()
+	e.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+	e.Viewport.Width = 20
+
+	ev := tcell.NewEventMouse(10, 5, tcell.WheelRight, tcell.ModNone)
+	e.HandleEvent(ev)
+
+	if e.Viewport.LeftCol != 0 {
+		t.Errorf("expected LeftCol 0 when content fits, got %d", e.Viewport.LeftCol)
+	}
+}
+
+func TestHorizontalScrollClampShiftWheel(t *testing.T) {
+	e := newTestEditor()
+	e.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+	e.Viewport.Width = 20
+
+	ev := tcell.NewEventMouse(10, 5, tcell.WheelDown, tcell.ModShift)
+	e.HandleEvent(ev)
+
+	if e.Viewport.LeftCol != 0 {
+		t.Errorf("expected LeftCol 0 when content fits with shift+wheel, got %d", e.Viewport.LeftCol)
+	}
+}
+
+func TestHorizontalScrollAllowedWhenOverflow(t *testing.T) {
+	buf := &buffer.Buffer{Lines: []string{"a]very long line that definitely overflows the viewport width of twenty chars"}}
+	cur := &cursor.Cursor{Line: 0, Col: 0}
+	vp := &view.Viewport{TopLine: 0, LeftCol: 0, Width: 20, Height: 10}
+	e := NewEditorPaneWidget(buf, cur, vp)
+	e.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+
+	ev := tcell.NewEventMouse(10, 5, tcell.WheelRight, tcell.ModNone)
+	e.HandleEvent(ev)
+
+	if e.Viewport.LeftCol == 0 {
+		t.Error("expected LeftCol > 0 when content overflows")
+	}
+}
+
 // ensure term import is used
 var _ = term.Cell{}


### PR DESCRIPTION
## Summary
- Add `clampLeftCol()` to `EditorPaneWidget` that caps `LeftCol` at `maxLineWidth - editorWidth` (floored at 0)
- Apply clamp to all horizontal scroll paths: WheelLeft/WheelRight, Shift+WheelUp/Down, and scrollbar drag
- When content fits the viewport width, horizontal scrolling is now a no-op — matching VS Code behavior

## Test plan
- [x] Unit tests: `TestHorizontalScrollClampNoOverflow`, `TestHorizontalScrollClampShiftWheel`, `TestHorizontalScrollAllowedWhenOverflow`
- [x] Manual: open a short file, Shift+scroll does not shift content sideways
- [x] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)