### PR TITLE
fix: re-focus find bar on repeated Ctrl+F and allow Ctrl+P over find bar

### DIFF
--- a/internal/app/commands_palette.go
+++ b/internal/app/commands_palette.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (a *App) OpenCommandPalette(fileMode bool, initialText ...string) {
-	if a.Root.HasOverlay() {
+	if a.Root.HasModalOverlay() {
 		return
 	}
 	palette := ui.NewSelectDialogWidget(a.Reg.List())

--- a/internal/app/commands_search.go
+++ b/internal/app/commands_search.go
@@ -7,6 +7,9 @@ import (
 
 func (a *App) OpenFind() {
 	if a.Root.HasOverlay() {
+		if fb, ok := a.Root.TopOverlayWidget().(*ui.FindBarWidget); ok {
+			fb.Focus()
+		}
 		return
 	}
 	dv := a.EditorGroup.ActiveDiffWidget()

--- a/internal/ui/findbar_widget.go
+++ b/internal/ui/findbar_widget.go
@@ -75,6 +75,10 @@ func (f *FindBarWidget) barLayout() (barX, barY, barW, barH int) {
 
 func (f *FindBarWidget) Focusable() bool { return true }
 
+func (f *FindBarWidget) Focus() {
+	f.focused = true
+}
+
 func (f *FindBarWidget) CursorPosition() (int, int, bool) {
 	if !f.focused {
 		return 0, 0, false

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -278,6 +278,22 @@ func (r *Root) HasOverlay() bool {
 	return len(r.Overlays) > 0
 }
 
+func (r *Root) HasModalOverlay() bool {
+	for _, o := range r.Overlays {
+		if o.Modal {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Root) TopOverlayWidget() Widget {
+	if len(r.Overlays) == 0 {
+		return nil
+	}
+	return r.Overlays[len(r.Overlays)-1].Widget
+}
+
 func (r *Root) PushOverlay(o Overlay) {
 	r.Overlays = append(r.Overlays, o)
 	slog.Debug("root", "action", "pushOverlay", "count", len(r.Overlays), "modal", o.Modal)

--- a/tests/e2e/editor_test.go
+++ b/tests/e2e/editor_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -98,6 +99,57 @@ func TestFindDialog(t *testing.T) {
 	h.pressKey(tcell.KeyEscape, tcell.ModNone)
 	if len(h.app.Root.Overlays) != 0 {
 		t.Fatalf("expected 0 overlays after Escape, got %d", len(h.app.Root.Overlays))
+	}
+}
+
+func TestFindDialogRefocus(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("search.find")
+	if len(h.app.Root.Overlays) != 1 {
+		t.Fatalf("expected 1 overlay, got %d", len(h.app.Root.Overlays))
+	}
+
+	fb, ok := h.app.Root.TopOverlayWidget().(*ui.FindBarWidget)
+	if !ok {
+		t.Fatal("expected FindBarWidget overlay")
+	}
+
+	h.click(40, 12)
+	_, _, vis := fb.CursorPosition()
+	if vis {
+		t.Fatal("expected find bar cursor hidden after clicking editor")
+	}
+
+	h.exec("search.find")
+	if len(h.app.Root.Overlays) != 1 {
+		t.Fatalf("expected still 1 overlay, got %d", len(h.app.Root.Overlays))
+	}
+	_, _, vis = fb.CursorPosition()
+	if !vis {
+		t.Fatal("expected find bar cursor visible after re-invoking search.find")
+	}
+}
+
+func TestCommandPaletteOpensOverFindBar(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("search.find")
+	if len(h.app.Root.Overlays) != 1 {
+		t.Fatalf("expected 1 overlay, got %d", len(h.app.Root.Overlays))
+	}
+	if _, ok := h.app.Root.TopOverlayWidget().(*ui.FindBarWidget); !ok {
+		t.Fatal("expected FindBarWidget overlay")
+	}
+
+	h.exec("command.palette")
+	if len(h.app.Root.Overlays) != 2 {
+		t.Fatalf("expected 2 overlays after command.palette, got %d", len(h.app.Root.Overlays))
+	}
+	if _, ok := h.app.Root.TopOverlayWidget().(*ui.SelectDialogWidget); !ok {
+		t.Fatalf("expected SelectDialogWidget on top, got %T", h.app.Root.TopOverlayWidget())
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Ctrl+F re-focus**: When the find bar is already open but unfocused (after clicking in the editor), pressing Ctrl+F now re-focuses it instead of doing nothing
- **Ctrl+P over find bar**: Command palette now opens over the non-modal find bar instead of being blocked by `HasOverlay()`

## Changes
- Added `FindBarWidget.Focus()` method to re-set internal focus
- Added `Root.HasModalOverlay()` to distinguish modal vs non-modal overlays
- Added `Root.TopOverlayWidget()` accessor for type-checking the top overlay
- `OpenCommandPalette` now uses `HasModalOverlay()` instead of `HasOverlay()`
- `OpenFind` re-focuses existing find bar when overlay is already a `FindBarWidget`

Closes #263

## Test plan
- [x] E2E: `TestFindDialogRefocus` — open find bar, click editor to unfocus, re-invoke `search.find`, verify cursor re-appears
- [x] E2E: `TestCommandPaletteOpensOverFindBar` — open find bar, invoke `command.palette`, verify both overlays coexist
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)