### PR TITLE
feat: add NixOS flake.nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ docs-web/dist/
 *.log
 docs-web/.astro/
 chaos-output/
+
+# Nix
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ yay -S ttt
 ```
 
 
+### NixOS
+
+> **Note:** Always install from a tagged release. The `main` branch is unstable and may contain work-in-progress features.
+
+Try it without installing:
+```sh
+nix run github:eugenioenko/ttt/v0.3.5
+```
+
+Add to your `flake.nix` inputs:
+```nix
+{
+  inputs.ttt.url = "github:eugenioenko/ttt/v0.3.5";
+}
+```
+
+Then add `inputs.ttt.packages.${system}.default` to your `environment.systemPackages` or home-manager packages.
+
 ### Go Install
 
 Requires [Go](https://go.dev/) 1.18 or newer:

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "TTT Editor: Terminal Text Tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = self.shortRev or self.dirtyShortRev or "dev";
+      in
+      {
+        packages = {
+          ttt = pkgs.buildGoModule {
+            pname = "ttt";
+            inherit version;
+            src = self;
+            vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.version=${version}"
+            ];
+            subPackages = [ "cmd/ttt" ];
+            meta = with pkgs.lib; {
+              description = "Terminal Text Tool — an IDE that lives in your terminal";
+              homepage = "https://github.com/eugenioenko/ttt";
+              license = licenses.mit;
+              mainProgram = "ttt";
+            };
+          };
+          default = self.packages.${system}.ttt;
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` for NixOS users to build and install ttt via the Nix package manager
- Add NixOS installation section to README with instructions to install from tagged releases (main is unstable)
- Add `result` symlink to `.gitignore` (Nix build artifact)

**Note:** The `vendorHash` in `flake.nix` is a placeholder — it needs to be replaced with the correct hash on first build. Nix will print the expected hash when the build fails.

