### PR TITLE
feat: debug commands for testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,38 @@ Every new feature or bug fix should include tests at multiple levels:
 
 Functional tests with `tui` are the highest-value tests. Use `tui.exec("Command Name")` for command palette, `tui.pressChord("ctrl+k", "x")` for keybindings, and `tui.snapshot()` to verify results.
 
+### Debug harness (`--exec`, `--plugin`, `--size`, `--debug`)
+
+**USE THIS FOR DEBUGGING AND TESTING.** The editor has a built-in scripted interaction system that is faster than TUI tests and gives you direct access to internal state. Before investigating UI bugs manually, use `--exec` to reproduce and inspect them programmatically.
+
+**`--exec "commands"`** — Execute semicolon-separated commands after startup. Run the real binary, interact with it, capture state, and exit — all in one command:
+
+```bash
+bin/ttt --size 120x40 --exec "wait 200; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
+cat /tmp/screen.txt   # see what's rendered
+cat /tmp/state.json   # see full widget tree, focus, selection, panels
+```
+
+Supported commands:
+- `click X Y` — simulate mouse click at coordinates
+- `key COMBO` — simulate key press (e.g. `key ctrl+p`, `key enter`, `key ctrl+k x`)
+- `type TEXT` — type a string of text
+- `exec "Command Name"` — run a command by title (same as command palette)
+- `screenshot PATH` — save screen text to file
+- `debug PATH` — save debug state JSON (screen, cursor, buffer, focus, panels, tabs, selection, output log, full widget tree with rect/focus/props per node)
+- `wait MS` — wait milliseconds
+- `quit` — exit the editor
+
+**`--size WxH`** — Force screen dimensions for deterministic layout (e.g. `--size 120x40`). Essential for reproducible screenshots and coordinate-based click tests.
+
+**`--plugin FILE`** — Load a Lua plugin file on startup with full permissions. For more complex test scenarios that need callbacks, state, or event handling.
+
+**`--debug`** — Enable debug mode regardless of config setting.
+
+**Lua API equivalents** — Plugins can also call `ttt.screenshot(path)`, `ttt.debug(path)`, `ttt.click(x, y)`, and `ttt.quit()` directly.
+
+**Command palette** — `Debug: Screenshot`, `Debug: Dump State`, `Debug: Simulate Click`, `Debug: Run Current File as Plugin` are available for interactive debugging.
+
 ### Implementation patterns
 
 - **Undo contract**: all buffer mutations must go through the undo system via an `EditCommand` (in `internal/core/undo/`). Never modify `Buf.Lines` directly — create or reuse a command struct so undo/redo works.

--- a/README.md
+++ b/README.md
@@ -620,18 +620,18 @@ Each crash is saved as a JSON report with the random seed and full event log, so
 
 ## Debug & Testing CLI Flags
 
-TTT includes flags for scripted interaction, automated testing, and debugging.
+TTT includes a built-in scripted interaction system designed for AI agent interactivity and automated debugging. Think of `--exec` as a fast Playwright for the terminal — full click, keyboard, and command simulation with screenshot and state dump capture, all without the overhead of a terminal emulation layer.
 
 | Flag | Description |
 |------|-------------|
 | `--exec "commands"` | Execute semicolon-separated commands after startup |
 | `--plugin FILE` | Load a Lua plugin file on startup with full permissions |
-| `--size WxH` | Force screen dimensions (e.g. `120x40`) |
+| `--size WxH` | Force screen dimensions (e.g. `120x40`) for deterministic layout |
 | `--debug` | Enable debug mode regardless of config |
 
 ### `--exec` Commands
 
-The `--exec` flag accepts a semicolon-separated string of commands that run sequentially after the editor starts:
+The `--exec` flag accepts a semicolon-separated string of commands that run sequentially after the editor starts. AI agents (like Claude Code) can use this to interact with the editor, inspect UI state, and verify behavior programmatically — no manual interaction needed:
 
 | Command | Description |
 |---------|-------------|

--- a/README.md
+++ b/README.md
@@ -618,6 +618,38 @@ CHAOS_REPLAY=chaos-output/crash-<seed>-<iter>.json go test ./tests/chaos/ -run T
 
 Each crash is saved as a JSON report with the random seed and full event log, so any panic can be replayed and debugged deterministically.
 
+## Debug & Testing CLI Flags
+
+TTT includes flags for scripted interaction, automated testing, and debugging.
+
+| Flag | Description |
+|------|-------------|
+| `--exec "commands"` | Execute semicolon-separated commands after startup |
+| `--plugin FILE` | Load a Lua plugin file on startup with full permissions |
+| `--size WxH` | Force screen dimensions (e.g. `120x40`) |
+| `--debug` | Enable debug mode regardless of config |
+
+### `--exec` Commands
+
+The `--exec` flag accepts a semicolon-separated string of commands that run sequentially after the editor starts:
+
+| Command | Description |
+|---------|-------------|
+| `click X Y` | Simulate a mouse click at screen coordinates |
+| `key COMBO` | Simulate a key press (e.g. `key ctrl+p`, `key enter`) |
+| `type TEXT` | Type a string of text character by character |
+| `exec "Command Name"` | Run a command palette command by title |
+| `screenshot PATH` | Save the current screen text to a file |
+| `debug PATH` | Save the editor's debug state as JSON to a file |
+| `wait MS` | Wait for the given number of milliseconds |
+| `quit` | Exit the editor |
+
+Example — capture a screenshot and debug state, then quit:
+
+```sh
+ttt --size 120x40 --exec "wait 200; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
+```
+
 ## Architecture
 
 The codebase follows a strict layered architecture: **core -> view -> render -> term -> ui**.

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -62,14 +62,38 @@ func handlePanic(screen *term.TcellScreen) {
 	os.Exit(1)
 }
 
-func findConfigFlag() string {
+type cliFlags struct {
+	configFile string
+	pluginFile string
+	sizeW, sizeH int
+	debug      bool
+}
+
+func parseFlags() cliFlags {
+	var f cliFlags
 	args := os.Args[1:]
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--config" && i+1 < len(args) {
-			return args[i+1]
+		switch args[i] {
+		case "--config":
+			if i+1 < len(args) {
+				f.configFile = args[i+1]
+				i++
+			}
+		case "--plugin":
+			if i+1 < len(args) {
+				f.pluginFile = args[i+1]
+				i++
+			}
+		case "--size":
+			if i+1 < len(args) {
+				fmt.Sscanf(args[i+1], "%dx%d", &f.sizeW, &f.sizeH)
+				i++
+			}
+		case "--debug":
+			f.debug = true
 		}
 	}
-	return ""
+	return f
 }
 
 func main() {
@@ -111,8 +135,13 @@ Docs: https://tttedit.dev
 		defer startProfiler()()
 	}
 
-	cfg := config.Load(findConfigFlag())
+	flags := parseFlags()
+	cfg := config.Load(flags.configFile)
 	config.ParseKeyBindings(cfg.Keybindings)
+
+	if flags.debug {
+		cfg.Settings.DebugMode = true
+	}
 
 	logFile := initLogger(cfg.Settings.DebugMode)
 	if logFile != nil {
@@ -239,7 +268,14 @@ Docs: https://tttedit.dev
 	}
 
 	w, h := screen.Size()
+	if flags.sizeW > 0 && flags.sizeH > 0 {
+		w, h = flags.sizeW, flags.sizeH
+	}
 	editor.Root.SetSize(w, h)
+
+	if flags.pluginFile != "" {
+		app.LoadPluginFromFile(editor, flags.pluginFile)
+	}
 
 	app.RunEventLoop(screen, renderer, editor, &running, editor.CloseTerminal)
 }

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -65,6 +65,7 @@ func handlePanic(screen *term.TcellScreen) {
 type cliFlags struct {
 	configFile string
 	pluginFile string
+	exec       string
 	sizeW, sizeH int
 	debug      bool
 }
@@ -82,6 +83,11 @@ func parseFlags() cliFlags {
 		case "--plugin":
 			if i+1 < len(args) {
 				f.pluginFile = args[i+1]
+				i++
+			}
+		case "--exec":
+			if i+1 < len(args) {
+				f.exec = args[i+1]
 				i++
 			}
 		case "--size":
@@ -115,6 +121,7 @@ Options:
   --version, -v       Show version
   --workspace <file>  Open a saved workspace (.ttt file)
   --config <file>     Use a custom config file
+  --exec "commands"   Execute semicolon-separated commands after startup
 
 Examples:
   ttt                                           Open current directory
@@ -275,6 +282,10 @@ Docs: https://tttedit.dev
 
 	if flags.pluginFile != "" {
 		app.LoadPluginFromFile(editor, flags.pluginFile)
+	}
+
+	if flags.exec != "" {
+		go app.RunExecScript(editor, flags.exec)
 	}
 
 	app.RunEventLoop(screen, renderer, editor, &running, editor.CloseTerminal)

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -102,6 +102,24 @@ func parseFlags() cliFlags {
 	return f
 }
 
+func initTerminalScreen() *term.TcellScreen {
+	screen, err := term.NewTcellScreen()
+	if err != nil {
+		panic(err)
+	}
+	return screen
+}
+
+func initSimulationScreen(w, h int) *term.TcellScreen {
+	if w <= 0 || h <= 0 {
+		w, h = 80, 25
+	}
+	sim := tcell.NewSimulationScreen("")
+	_ = sim.Init()
+	sim.SetSize(w, h)
+	return term.NewTcellScreenFrom(sim)
+}
+
 func main() {
 	for _, arg := range os.Args[1:] {
 		switch arg {
@@ -156,9 +174,11 @@ Docs: https://tttedit.dev
 	}
 	slog.Info("starting", "debugMode", cfg.Settings.DebugMode)
 
-	screen, err := term.NewTcellScreen()
-	if err != nil {
-		panic(err)
+	var screen *term.TcellScreen
+	if flags.exec != "" {
+		screen = initSimulationScreen(flags.sizeW, flags.sizeH)
+	} else {
+		screen = initTerminalScreen()
 	}
 	defer screen.Fini()
 	defer handlePanic(screen)

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -21,6 +21,7 @@ func RegisterCommands(app *App) {
 	registerOptionsCommands(app)
 	registerSettingsCommands(app)
 	registerPluginCommands(app)
+	registerDebugCommands(app)
 	registerWidgetCallbacks(app)
 	RegisterEscapeDismissers(app)
 }

--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/plugin"
+	"github.com/eugenioenko/ttt/internal/view"
+	"github.com/eugenioenko/ttt/internal/widgets"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func registerDebugCommands(app *App) {
+	reg := app.Reg
+
+	reg.Register(command.Command{
+		ID:       "debug.simulateClick",
+		Title:    "Debug: Simulate Click",
+		Keywords: []string{"debug", "click", "mouse", "test"},
+		Handler:  func() { app.debugSimulateClick() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "debug.runPlugin",
+		Title:    "Debug: Run Current File as Plugin",
+		Keywords: []string{"debug", "plugin", "lua", "test", "run"},
+		Handler:  func() { app.debugRunPlugin() },
+	})
+}
+
+func (a *App) debugSimulateClick() {
+	submit := func(text string) {
+		a.DismissDialog()
+		parts := strings.Fields(text)
+		if len(parts) < 2 {
+			a.Status.SetNotification("Usage: x y", view.NotifyWarning, 3*time.Second)
+			return
+		}
+		x, err1 := strconv.Atoi(parts[0])
+		y, err2 := strconv.Atoi(parts[1])
+		if err1 != nil || err2 != nil {
+			a.Status.SetNotification("Invalid coordinates", view.NotifyWarning, 3*time.Second)
+			return
+		}
+		go func() {
+			a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button1, tcell.ModNone))
+			time.Sleep(50 * time.Millisecond)
+			a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+		}()
+	}
+
+	input := widgets.NewInputWidget(widgets.InputConfig{
+		Placeholder: "x y",
+		OnSubmit:    submit,
+	})
+
+	dialog := widgets.NewDialogWidget(40)
+	dialog.Title = "Simulate Click"
+	dialog.Borders = *a.Borders
+	dialog.Buttons = []widgets.DialogButton{
+		{Label: "Click", Handler: func() { submit(input.Text()) }},
+	}
+	dialog.SetContent(input)
+	a.ShowDialog(dialog)
+}
+
+func (a *App) debugRunPlugin() {
+	if a.EditorGroup.Editor == nil {
+		a.Status.SetNotification("No active editor", view.NotifyWarning, 3*time.Second)
+		return
+	}
+
+	source := strings.Join(a.EditorGroup.Editor.Buf.Lines, "\n")
+	if strings.TrimSpace(source) == "" {
+		a.Status.SetNotification("Buffer is empty", view.NotifyWarning, 3*time.Second)
+		return
+	}
+
+	path := a.EditorGroup.ActiveFilePath()
+	name := "debug-plugin"
+	if path != "" {
+		parts := strings.Split(path, "/")
+		name = strings.TrimSuffix(parts[len(parts)-1], ".lua")
+	}
+
+	p := &plugin.Plugin{
+		Name:    name,
+		Dir:     ".",
+		Enabled: true,
+		Manifest: plugin.Manifest{
+			Name:  name,
+			Entry: "inline",
+		},
+		Granted: plugin.PermissionSet{
+			PanelSidebar: true,
+			PanelBottom:  true,
+			PanelDrawer:  true,
+			PanelEditor:  true,
+			Commands:     true,
+			Keybindings:  true,
+			EditorRead:   true,
+			EditorWrite:  true,
+			FsRead:       true,
+			FsWrite:      true,
+			SystemEnv:    true,
+			NetworkHTTP:  true,
+			EventsFile:   true,
+			EventsEditor: true,
+		},
+	}
+
+	if err := p.InitFromSource(source); err != nil {
+		a.Status.SetNotification("Plugin error: "+err.Error(), view.NotifyError, 5*time.Second)
+		return
+	}
+
+	a.PluginManager.RegisterDebugPlugin(p)
+	a.wirePlugin(p)
+
+	hasSidebar := p.SidebarTitle != ""
+	hasBottom := p.BottomTitle != ""
+
+	if hasSidebar {
+		a.Sidebar.SetActivePanel("plugin." + p.Name)
+	}
+	if hasBottom {
+		a.BottomPanel.SetActivePanel("plugin." + p.Name)
+	}
+
+	a.Status.SetNotification("Plugin loaded: "+name, view.NotifyInfo, 3*time.Second)
+}

--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"log/slog"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -28,6 +31,20 @@ func registerDebugCommands(app *App) {
 		Title:    "Debug: Run Current File as Plugin",
 		Keywords: []string{"debug", "plugin", "lua", "test", "run"},
 		Handler:  func() { app.debugRunPlugin() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "debug.screenshot",
+		Title:    "Debug: Screenshot",
+		Keywords: []string{"debug", "screenshot", "capture"},
+		Handler:  func() { app.debugScreenshot() },
+	})
+
+	reg.Register(command.Command{
+		ID:       "debug.dumpState",
+		Title:    "Debug: Dump State",
+		Keywords: []string{"debug", "dump", "state", "json"},
+		Handler:  func() { app.debugDumpState() },
 	})
 }
 
@@ -131,4 +148,67 @@ func (a *App) debugRunPlugin() {
 	}
 
 	a.Status.SetNotification("Plugin loaded: "+name, view.NotifyInfo, 3*time.Second)
+}
+
+func (a *App) debugScreenshot() {
+	path := "screenshot.txt"
+	if err := a.DumpScreenshot(path); err != nil {
+		a.Status.SetNotification("Screenshot error: "+err.Error(), view.NotifyError, 3*time.Second)
+		return
+	}
+	a.Status.SetNotification("Screenshot saved: "+path, view.NotifyInfo, 3*time.Second)
+}
+
+func (a *App) debugDumpState() {
+	path := "debug-state.json"
+	if err := a.DumpDebugState(path); err != nil {
+		a.Status.SetNotification("Dump error: "+err.Error(), view.NotifyError, 3*time.Second)
+		return
+	}
+	a.Status.SetNotification("State saved: "+path, view.NotifyInfo, 3*time.Second)
+}
+
+func LoadPluginFromFile(a *App, path string) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		slog.Error("load plugin file", "path", path, "error", err)
+		return
+	}
+
+	name := strings.TrimSuffix(filepath.Base(path), ".lua")
+	p := &plugin.Plugin{
+		Name:    name,
+		Dir:     filepath.Dir(path),
+		Enabled: true,
+		Manifest: plugin.Manifest{
+			Name:  name,
+			Entry: "inline",
+		},
+		Granted: plugin.PermissionSet{
+			PanelSidebar: true,
+			PanelBottom:  true,
+			PanelDrawer:  true,
+			PanelEditor:  true,
+			Commands:     true,
+			Keybindings:  true,
+			EditorRead:   true,
+			EditorWrite:  true,
+			FsRead:       true,
+			FsWrite:      true,
+			SystemEnv:    true,
+			NetworkHTTP:  true,
+			EventsFile:   true,
+			EventsEditor: true,
+		},
+	}
+
+	if err := p.InitFromSource(string(source)); err != nil {
+		slog.Error("init plugin from file", "path", path, "error", err)
+		return
+	}
+
+	a.PluginManager.RegisterDebugPlugin(p)
+	a.wirePlugin(p)
+
+	slog.Info("plugin loaded from file", "path", path, "name", name)
 }

--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -151,21 +151,31 @@ func (a *App) debugRunPlugin() {
 }
 
 func (a *App) debugScreenshot() {
-	path := "screenshot.txt"
-	if err := a.DumpScreenshot(path); err != nil {
-		a.Status.SetNotification("Screenshot error: "+err.Error(), view.NotifyError, 3*time.Second)
-		return
-	}
-	a.Status.SetNotification("Screenshot saved: "+path, view.NotifyInfo, 3*time.Second)
+	a.DismissDialog()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		path := "screenshot.txt"
+		if err := a.DumpScreenshot(path); err != nil {
+			a.Status.SetNotification("Screenshot error: "+err.Error(), view.NotifyError, 3*time.Second)
+		} else {
+			a.Status.SetNotification("Screenshot saved: "+path, view.NotifyInfo, 3*time.Second)
+		}
+		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	}()
 }
 
 func (a *App) debugDumpState() {
-	path := "debug-state.json"
-	if err := a.DumpDebugState(path); err != nil {
-		a.Status.SetNotification("Dump error: "+err.Error(), view.NotifyError, 3*time.Second)
-		return
-	}
-	a.Status.SetNotification("State saved: "+path, view.NotifyInfo, 3*time.Second)
+	a.DismissDialog()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		path := "debug-state.json"
+		if err := a.DumpDebugState(path); err != nil {
+			a.Status.SetNotification("Dump error: "+err.Error(), view.NotifyError, 3*time.Second)
+		} else {
+			a.Status.SetNotification("State saved: "+path, view.NotifyInfo, 3*time.Second)
+		}
+		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	}()
 }
 
 func LoadPluginFromFile(a *App, path string) {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -296,6 +296,18 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 			a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
 		}()
 	}
+	p.ScreenshotToFile = func(path string) error {
+		return a.DumpScreenshot(path)
+	}
+	p.DebugDumpToFile = func(path string) error {
+		return a.DumpDebugState(path)
+	}
+	p.QuitApp = func() {
+		if a.Running != nil {
+			*a.Running = false
+		}
+		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	}
 	p.PostAsync = func(result *plugin.PluginAsyncResult) {
 		a.Screen.PostEvent(tcell.NewEventInterrupt(result))
 	}

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -289,6 +289,13 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 	p.RequestRedraw = func() {
 		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
 	}
+	p.SimulateClick = func(x, y int) {
+		go func() {
+			a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button1, tcell.ModNone))
+			time.Sleep(50 * time.Millisecond)
+			a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+		}()
+	}
 	p.PostAsync = func(result *plugin.PluginAsyncResult) {
 		a.Screen.PostEvent(tcell.NewEventInterrupt(result))
 	}

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -296,6 +296,20 @@ func (a *App) wirePlugin(p *plugin.Plugin) {
 			a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
 		}()
 	}
+	p.SimulateDrag = func(x1, y1, x2, y2 int) {
+		go func() {
+			a.Screen.PostEvent(tcell.NewEventMouse(x1, y1, tcell.Button1, tcell.ModNone))
+			time.Sleep(30 * time.Millisecond)
+			steps := 10
+			for i := 1; i <= steps; i++ {
+				mx := x1 + (x2-x1)*i/steps
+				my := y1 + (y2-y1)*i/steps
+				a.Screen.PostEvent(tcell.NewEventMouse(mx, my, tcell.Button1, tcell.ModNone))
+				time.Sleep(15 * time.Millisecond)
+			}
+			a.Screen.PostEvent(tcell.NewEventMouse(x2, y2, tcell.ButtonNone, tcell.ModNone))
+		}()
+	}
 	p.ScreenshotToFile = func(path string) error {
 		return a.DumpScreenshot(path)
 	}

--- a/internal/app/debug_dump.go
+++ b/internal/app/debug_dump.go
@@ -1,0 +1,378 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
+)
+
+type DebugState struct {
+	Screen      DebugScreen      `json:"screen"`
+	Cursor      DebugCursor      `json:"cursor"`
+	Buffer      *DebugBuffer     `json:"buffer"`
+	Focus       string           `json:"focus"`
+	Sidebar     DebugPanel       `json:"sidebar"`
+	BottomPanel DebugPanel       `json:"bottom_panel"`
+	Tabs        []DebugTab       `json:"tabs"`
+	ActiveTab   int              `json:"active_tab"`
+	Overlay     *DebugOverlay    `json:"overlay"`
+	Selection   DebugSelection   `json:"selection"`
+	Output      []string         `json:"output"`
+	WidgetTree  *DebugWidgetNode `json:"widget_tree"`
+}
+
+type DebugScreen struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type DebugCursor struct {
+	Line int `json:"line"`
+	Col  int `json:"col"`
+}
+
+type DebugBuffer struct {
+	Path     string `json:"path"`
+	Lines    int    `json:"lines"`
+	Modified bool   `json:"modified"`
+}
+
+type DebugPanel struct {
+	Visible bool     `json:"visible"`
+	Active  string   `json:"active"`
+	Panels  []string `json:"panels"`
+}
+
+type DebugTab struct {
+	Path     string `json:"path"`
+	Modified bool   `json:"modified"`
+}
+
+type DebugOverlay struct {
+	Type  string `json:"type"`
+	Title string `json:"title,omitempty"`
+}
+
+type DebugSelection struct {
+	Active bool       `json:"active"`
+	Start  *DebugPos  `json:"start,omitempty"`
+	End    *DebugPos  `json:"end,omitempty"`
+}
+
+type DebugPos struct {
+	Line int `json:"line"`
+	Col  int `json:"col"`
+}
+
+type DebugWidgetNode struct {
+	Type     string            `json:"type"`
+	Rect     DebugRect         `json:"rect"`
+	Focused  bool              `json:"focused,omitempty"`
+	Visible  bool              `json:"visible"`
+	Props    map[string]any    `json:"props,omitempty"`
+	Children []*DebugWidgetNode `json:"children,omitempty"`
+}
+
+type DebugRect struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+	W int `json:"w"`
+	H int `json:"h"`
+}
+
+func (a *App) BuildDebugState() *DebugState {
+	w, h := a.Screen.Size()
+	state := &DebugState{
+		Screen: DebugScreen{Width: w, Height: h},
+	}
+
+	if a.EditorGroup.Editor != nil {
+		line, col := a.EditorGroup.ActiveCursor()
+		state.Cursor = DebugCursor{Line: line, Col: col}
+	}
+
+	if buf := a.EditorGroup.ActiveBuffer(); buf != nil {
+		state.Buffer = &DebugBuffer{
+			Path:     a.EditorGroup.ActiveFilePath(),
+			Lines:    len(buf.Lines),
+			Modified: buf.Dirty,
+		}
+	}
+
+	state.Focus = a.describeFocus()
+
+	state.Sidebar = DebugPanel{
+		Visible: a.Sidebar.Visible,
+		Active:  a.Sidebar.ActivePanel,
+		Panels:  a.Sidebar.PanelIDs(),
+	}
+
+	state.BottomPanel = DebugPanel{
+		Visible: a.ContentSplit.ShowBottom,
+		Active:  a.BottomPanel.ActivePanel,
+		Panels:  a.BottomPanel.PanelIDs(),
+	}
+
+	for i := range a.EditorGroup.TabCount() {
+		path, modified := a.EditorGroup.TabInfo(i)
+		state.Tabs = append(state.Tabs, DebugTab{Path: path, Modified: modified})
+	}
+	state.ActiveTab = a.EditorGroup.ActiveTabIndex()
+
+	if len(a.Root.Overlays) > 0 {
+		top := a.Root.Overlays[len(a.Root.Overlays)-1]
+		state.Overlay = describeOverlay(top.Widget)
+	}
+
+	if active, sl, sc, el, ec := a.EditorGroup.ActiveSelection(); active {
+		state.Selection = DebugSelection{
+			Active: true,
+			Start:  &DebugPos{Line: sl, Col: sc},
+			End:    &DebugPos{Line: el, Col: ec},
+		}
+	}
+
+	if a.Output != nil {
+		for _, line := range a.Output.Lines {
+			state.Output = append(state.Output, line.Time+" ["+line.PluginName+"] "+line.Message)
+		}
+	}
+
+	state.WidgetTree = walkWidget(a.Root.Main)
+
+	return state
+}
+
+func (a *App) describeFocus() string {
+	f := a.Root.Focused
+	if f == nil {
+		return ""
+	}
+	switch f.(type) {
+	case *ui.EditorPaneWidget:
+		return "editor"
+	case *ui.SidebarWidget:
+		return "sidebar"
+	case *ui.BottomPanelWidget:
+		return "bottom_panel"
+	case *ui.SearchWidget:
+		return "search"
+	default:
+		return "other"
+	}
+}
+
+func describeOverlay(w widgets.Widget) *DebugOverlay {
+	switch v := w.(type) {
+	case *widgets.DialogWidget:
+		return &DebugOverlay{Type: "dialog", Title: v.Title}
+	case *widgets.DrawerWidget:
+		return &DebugOverlay{Type: "drawer"}
+	default:
+		return &DebugOverlay{Type: "unknown"}
+	}
+}
+
+func walkWidget(w widgets.Widget) *DebugWidgetNode {
+	if w == nil {
+		return nil
+	}
+	node := &DebugWidgetNode{
+		Type:    widgetTypeName(w),
+		Rect:    rectToDebug(w.GetRect()),
+		Visible: true,
+	}
+
+	if fw, ok := w.(widgets.FocusableWidget); ok {
+		node.Focused = fw.IsFocused()
+	}
+
+	switch v := w.(type) {
+	case *widgets.VStackWidget:
+		for _, child := range v.Children {
+			node.Children = append(node.Children, walkWidget(child))
+		}
+	case *widgets.HStackWidget:
+		for _, child := range v.Children {
+			node.Children = append(node.Children, walkWidget(child))
+		}
+	case *widgets.BoxWidget:
+		if v.Child != nil {
+			node.Children = append(node.Children, walkWidget(v.Child))
+		}
+	case *widgets.ScrollViewWidget:
+		if v.Child != nil {
+			node.Children = append(node.Children, walkWidget(v.Child.(widgets.Widget)))
+		}
+	case *widgets.TreeWidget:
+		node.Props = map[string]any{
+			"items":    len(v.FlatList()),
+			"selected": v.SelectedIndex(),
+		}
+	case *widgets.InputWidget:
+		node.Props = map[string]any{
+			"text":        v.Text(),
+			"placeholder": v.Config.Placeholder,
+		}
+	case *widgets.LabelWidget:
+		node.Props = map[string]any{
+			"text": v.Config.Text,
+		}
+	case *widgets.ButtonWidget:
+		node.Props = map[string]any{
+			"label": v.Config.Label,
+		}
+	case *widgets.DividerWidget:
+		// no props
+	case *widgets.DropdownWidget:
+		node.Props = map[string]any{
+			"label": v.Config.Label,
+		}
+	case *widgets.DialogWidget:
+		node.Props = map[string]any{
+			"title": v.Title,
+		}
+		if v.Content != nil {
+			node.Children = append(node.Children, walkWidget(v.Content))
+		}
+	case *widgets.DrawerWidget:
+		node.Props = map[string]any{
+			"width": v.Config.Width,
+		}
+		if v.Content != nil {
+			node.Children = append(node.Children, walkWidget(v.Content))
+		}
+	case *widgets.TabbedWidget:
+		activeIdx := -1
+		for i, item := range v.Tabs.Config.Items {
+			if item.Active {
+				activeIdx = i
+				break
+			}
+		}
+		node.Props = map[string]any{
+			"active": activeIdx,
+			"count":  len(v.Children),
+		}
+		for _, child := range v.Children {
+			node.Children = append(node.Children, walkWidget(child))
+		}
+
+	// UI-level widgets
+	case *ui.SplitPanelWidget:
+		node.Props = map[string]any{
+			"show_left":    v.ShowLeft,
+			"divider_pos":  v.DividerPos,
+		}
+		if v.Left != nil {
+			node.Children = append(node.Children, walkWidget(v.Left))
+		}
+		if v.Right != nil {
+			node.Children = append(node.Children, walkWidget(v.Right))
+		}
+	case *ui.ContentSplitWidget:
+		node.Props = map[string]any{
+			"show_bottom": v.ShowBottom,
+			"bottom_h":    v.BottomH,
+		}
+		if v.Top != nil {
+			node.Children = append(node.Children, walkWidget(v.Top))
+		}
+		if v.Bottom != nil {
+			node.Children = append(node.Children, walkWidget(v.Bottom))
+		}
+	case *ui.SidebarWidget:
+		node.Props = map[string]any{
+			"visible": v.Visible,
+			"active":  v.ActivePanel,
+			"panels":  v.PanelIDs(),
+		}
+		if aw := v.ActiveWidget(); aw != nil {
+			node.Children = append(node.Children, walkWidget(aw))
+		}
+	case *ui.BottomPanelWidget:
+		node.Props = map[string]any{
+			"visible": v.Visible,
+			"active":  v.ActivePanel,
+			"panels":  v.PanelIDs(),
+		}
+		if aw := v.ActiveWidget(); aw != nil {
+			node.Children = append(node.Children, walkWidget(aw))
+		}
+	case *ui.EditorGroupWidget:
+		paths := make([]string, v.TabCount())
+		for i := range v.TabCount() {
+			paths[i], _ = v.TabInfo(i)
+		}
+		node.Props = map[string]any{
+			"active_tab": v.ActiveTabIndex(),
+			"tabs":       paths,
+			"path":       v.ActiveFilePath(),
+		}
+		if v.Editor != nil {
+			line, col := v.ActiveCursor()
+			node.Props["cursor_line"] = line
+			node.Props["cursor_col"] = col
+		}
+	case *ui.StatusBarWidget:
+		node.Props = map[string]any{}
+	case *ui.MenuBarWidget:
+		node.Props = map[string]any{}
+	case *ui.EditorPaneWidget:
+		node.Props = map[string]any{}
+	case *ui.WidgetAdapter:
+		if inner := v.Inner(); inner != nil {
+			node.Children = append(node.Children, walkWidget(inner))
+		}
+	}
+
+	return node
+}
+
+func widgetTypeName(w widgets.Widget) string {
+	s := fmt.Sprintf("%T", w)
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.TrimPrefix(s, "*")
+	s = strings.TrimSuffix(s, "Widget")
+	return s
+}
+
+func rectToDebug(r widgets.Rect) DebugRect {
+	return DebugRect{X: r.X, Y: r.Y, W: r.W, H: r.H}
+}
+
+func (a *App) Screenshot() string {
+	w, h := a.Screen.Size()
+	var lines []string
+	for y := 0; y < h; y++ {
+		var line strings.Builder
+		for x := 0; x < w; x++ {
+			ch, _, _, _ := a.Screen.GetContent(x, y)
+			if ch == 0 {
+				ch = ' '
+			}
+			line.WriteRune(ch)
+		}
+		lines = append(lines, strings.TrimRight(line.String(), " "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (a *App) DumpDebugState(path string) error {
+	state := a.BuildDebugState()
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func (a *App) DumpScreenshot(path string) error {
+	return os.WriteFile(path, []byte(a.Screenshot()), 0644)
+}

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -29,6 +29,8 @@ func RunExecScript(a *App, script string) {
 		switch action {
 		case "click":
 			execClick(a, args)
+		case "drag":
+			execDrag(a, args)
 		case "key":
 			execKey(a, args)
 		case "type":
@@ -85,6 +87,35 @@ func execClick(a *App, args string) {
 	time.Sleep(50 * time.Millisecond)
 	// Release
 	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+}
+
+func execDrag(a *App, args string) {
+	parts := strings.Fields(args)
+	if len(parts) < 4 {
+		slog.Error("exec_script: drag requires X1 Y1 X2 Y2", "args", args)
+		return
+	}
+	x1, err1 := strconv.Atoi(parts[0])
+	y1, err2 := strconv.Atoi(parts[1])
+	x2, err3 := strconv.Atoi(parts[2])
+	y2, err4 := strconv.Atoi(parts[3])
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		slog.Error("exec_script: invalid drag coordinates", "args", args)
+		return
+	}
+
+	a.Screen.PostEvent(tcell.NewEventMouse(x1, y1, tcell.Button1, tcell.ModNone))
+	time.Sleep(30 * time.Millisecond)
+
+	steps := 10
+	for i := 1; i <= steps; i++ {
+		mx := x1 + (x2-x1)*i/steps
+		my := y1 + (y2-y1)*i/steps
+		a.Screen.PostEvent(tcell.NewEventMouse(mx, my, tcell.Button1, tcell.ModNone))
+		time.Sleep(15 * time.Millisecond)
+	}
+
+	a.Screen.PostEvent(tcell.NewEventMouse(x2, y2, tcell.ButtonNone, tcell.ModNone))
 }
 
 func execKey(a *App, args string) {

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -1,0 +1,206 @@
+package app
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/config"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// RunExecScript parses a semicolon-separated script string and executes
+// each command sequentially. Intended to be run in a goroutine after
+// the event loop starts.
+func RunExecScript(a *App, script string) {
+	commands := strings.Split(script, ";")
+	for _, raw := range commands {
+		cmd := strings.TrimSpace(raw)
+		if cmd == "" {
+			continue
+		}
+		action, args := parseExecCommand(cmd)
+		slog.Debug("exec_script", "action", action, "args", args)
+
+		switch action {
+		case "click":
+			execClick(a, args)
+		case "key":
+			execKey(a, args)
+		case "type":
+			execType(a, args)
+		case "exec":
+			execCommand(a, args)
+		case "screenshot":
+			execScreenshot(a, args)
+		case "debug":
+			execDebug(a, args)
+		case "wait":
+			execWait(args)
+		case "quit":
+			execQuit(a)
+		default:
+			slog.Error("exec_script: unknown command", "action", action)
+		}
+
+		// Small implicit delay between commands to let the event loop process
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// parseExecCommand splits a command string into action and arguments.
+// Handles quoted strings for the exec command (e.g., exec "Command Name").
+func parseExecCommand(cmd string) (string, string) {
+	// Find the first space to split action from args
+	idx := strings.IndexByte(cmd, ' ')
+	if idx < 0 {
+		return cmd, ""
+	}
+	return cmd[:idx], strings.TrimSpace(cmd[idx+1:])
+}
+
+func execClick(a *App, args string) {
+	parts := strings.Fields(args)
+	if len(parts) < 2 {
+		slog.Error("exec_script: click requires X Y", "args", args)
+		return
+	}
+	x, err := strconv.Atoi(parts[0])
+	if err != nil {
+		slog.Error("exec_script: invalid click X", "value", parts[0], "error", err)
+		return
+	}
+	y, err := strconv.Atoi(parts[1])
+	if err != nil {
+		slog.Error("exec_script: invalid click Y", "value", parts[1], "error", err)
+		return
+	}
+
+	// Press
+	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button1, tcell.ModNone))
+	time.Sleep(50 * time.Millisecond)
+	// Release
+	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+}
+
+func execKey(a *App, args string) {
+	combo := strings.TrimSpace(args)
+	if combo == "" {
+		slog.Error("exec_script: key requires a key combo")
+		return
+	}
+
+	steps, err := config.ParseKeyString(combo)
+	if err != nil {
+		slog.Error("exec_script: invalid key combo", "combo", combo, "error", err)
+		return
+	}
+
+	for _, step := range steps {
+		key, mod, ch := comboToTcell(step)
+		a.Screen.PostEvent(tcell.NewEventKey(key, ch, mod))
+		time.Sleep(30 * time.Millisecond)
+	}
+}
+
+func execType(a *App, args string) {
+	text := stripQuotes(args)
+	for _, r := range text {
+		a.Screen.PostEvent(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone))
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func execCommand(a *App, args string) {
+	title := stripQuotes(strings.TrimSpace(args))
+	if title == "" {
+		slog.Error("exec_script: exec requires a command title")
+		return
+	}
+
+	cmd, ok := a.Reg.FindByTitle(title)
+	if !ok {
+		slog.Error("exec_script: command not found", "title", title)
+		return
+	}
+	a.Reg.Execute(cmd.ID)
+}
+
+func execScreenshot(a *App, args string) {
+	path := stripQuotes(strings.TrimSpace(args))
+	if path == "" {
+		slog.Error("exec_script: screenshot requires a file path")
+		return
+	}
+	// Trigger a redraw so the screen is up-to-date
+	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	time.Sleep(50 * time.Millisecond)
+
+	if err := a.DumpScreenshot(path); err != nil {
+		slog.Error("exec_script: screenshot failed", "path", path, "error", err)
+	}
+}
+
+func execDebug(a *App, args string) {
+	path := stripQuotes(strings.TrimSpace(args))
+	if path == "" {
+		slog.Error("exec_script: debug requires a file path")
+		return
+	}
+	// Trigger a redraw so state is current
+	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	time.Sleep(50 * time.Millisecond)
+
+	if err := a.DumpDebugState(path); err != nil {
+		slog.Error("exec_script: debug dump failed", "path", path, "error", err)
+	}
+}
+
+func execWait(args string) {
+	ms := strings.TrimSpace(args)
+	if ms == "" {
+		slog.Error("exec_script: wait requires milliseconds")
+		return
+	}
+	n, err := strconv.Atoi(ms)
+	if err != nil {
+		slog.Error("exec_script: invalid wait duration", "value", ms, "error", err)
+		return
+	}
+	time.Sleep(time.Duration(n) * time.Millisecond)
+}
+
+func execQuit(a *App) {
+	*a.Running = false
+	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+}
+
+// stripQuotes removes surrounding double quotes from a string if present.
+func stripQuotes(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// ExecScriptUsage returns the usage text for the --exec flag.
+func ExecScriptUsage() string {
+	return fmt.Sprintf(`--exec "commands"  Execute semicolon-separated commands after startup
+
+Supported commands:
+  click X Y          Simulate mouse click at coordinates
+  key COMBO          Simulate key press (e.g., key ctrl+p, key enter)
+  type TEXT           Type a string of text
+  exec "Command"     Run a command palette command by title
+  screenshot PATH    Save screen text to file
+  debug PATH         Save debug state JSON to file
+  wait MS            Wait milliseconds
+  quit               Exit the editor
+
+Example:
+  %s --exec "wait 200; screenshot /tmp/s1.txt; quit"`, os.Args[0])
+}

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -34,6 +34,21 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 			i++
 			continue
 		}
+		if args[i] == "--exec" && i+1 < len(args) {
+			i++
+			continue
+		}
+		if args[i] == "--plugin" && i+1 < len(args) {
+			i++
+			continue
+		}
+		if args[i] == "--size" && i+1 < len(args) {
+			i++
+			continue
+		}
+		if args[i] == "--debug" {
+			continue
+		}
 		if isPRURL(args[i]) {
 			if _, _, _, err := github.ParsePRURL(args[i]); err == nil {
 				prURLs = append(prURLs, args[i])

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -50,6 +50,15 @@ func (r *Registry) ClearAllShortcuts() {
 	}
 }
 
+func (r *Registry) FindByTitle(title string) (Command, bool) {
+	for _, cmd := range r.commands {
+		if cmd.Title == title {
+			return cmd, true
+		}
+	}
+	return Command{}, false
+}
+
 func (r *Registry) List() []Command {
 	cmds := make([]Command, 0, len(r.commands))
 	for _, cmd := range r.commands {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -150,6 +150,19 @@ func (m *Manager) ApproveAndLoad(p *Plugin) error {
 	return nil
 }
 
+func (m *Manager) RegisterDebugPlugin(p *Plugin) {
+	for i, existing := range m.plugins {
+		if existing.Name == p.Name {
+			existing.Destroy()
+			m.plugins[i] = p
+			m.collectRegistrations(p)
+			return
+		}
+	}
+	m.plugins = append(m.plugins, p)
+	m.collectRegistrations(p)
+}
+
 func (m *Manager) SetEditorAPI(api EditorAPI) {
 	for _, p := range m.plugins {
 		p.Editor = api

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -49,6 +49,7 @@ type Plugin struct {
 	ShowInfoDialog    func(title string, entries []widgets.KeyValueEntry)
 	ShowConfirmDialog func(message string, onConfirm func())
 	SimulateClick     func(x, y int)
+	SimulateDrag      func(x1, y1, x2, y2 int)
 	ScreenshotToFile  func(path string) error
 	DebugDumpToFile   func(path string) error
 	QuitApp           func()

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -49,6 +49,9 @@ type Plugin struct {
 	ShowInfoDialog    func(title string, entries []widgets.KeyValueEntry)
 	ShowConfirmDialog func(message string, onConfirm func())
 	SimulateClick     func(x, y int)
+	ScreenshotToFile  func(path string) error
+	DebugDumpToFile   func(path string) error
+	QuitApp           func()
 	OpenDrawer        func(renderFunc *lua.LFunction, width, minWidth int)
 	CloseDrawer       func()
 	OpenTab           func(id string, renderFunc, eventFunc *lua.LFunction)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -87,6 +87,28 @@ func (p *Plugin) Init() error {
 	return nil
 }
 
+func (p *Plugin) InitFromSource(source string) error {
+	p.EventListeners = make(map[string][]*lua.LFunction)
+	p.State = NewSandbox()
+	setupTTTModule(p.State, p)
+	setupEditorModule(p.State, p)
+	setupFsModule(p.State, p)
+	setupSystemModule(p.State, p)
+	setupNetModule(p.State, p)
+	setupEventsModule(p.State, p)
+
+	if err := p.State.DoString(source); err != nil {
+		p.LastError = err
+		p.State.Close()
+		p.State = nil
+		p.logError("init", err)
+		return err
+	}
+
+	p.Enabled = true
+	return nil
+}
+
 func (p *Plugin) logError(context string, err error) {
 	slog.Error("plugin error", "plugin", p.Name, "context", context, "error", err)
 	if p.Log != nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -48,6 +48,7 @@ type Plugin struct {
 	ShowContextMenu func(entries []widgets.MenuEntry, x, y int, onCommand func(cmd string))
 	ShowInfoDialog    func(title string, entries []widgets.KeyValueEntry)
 	ShowConfirmDialog func(message string, onConfirm func())
+	SimulateClick     func(x, y int)
 	OpenDrawer        func(renderFunc *lua.LFunction, width, minWidth int)
 	CloseDrawer       func()
 	OpenTab           func(id string, renderFunc, eventFunc *lua.LFunction)

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -299,6 +299,33 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "screenshot", L.NewFunction(func(L *lua.LState) int {
+			path := L.CheckString(1)
+			if p.ScreenshotToFile != nil {
+				if err := p.ScreenshotToFile(path); err != nil {
+					L.ArgError(1, err.Error())
+				}
+			}
+			return 0
+		}))
+
+		L.SetField(mod, "debug", L.NewFunction(func(L *lua.LState) int {
+			path := L.CheckString(1)
+			if p.DebugDumpToFile != nil {
+				if err := p.DebugDumpToFile(path); err != nil {
+					L.ArgError(1, err.Error())
+				}
+			}
+			return 0
+		}))
+
+		L.SetField(mod, "quit", L.NewFunction(func(L *lua.LState) int {
+			if p.QuitApp != nil {
+				p.QuitApp()
+			}
+			return 0
+		}))
+
 		L.SetField(mod, "markdown", L.NewFunction(func(L *lua.LState) int {
 			text := L.CheckString(1)
 			rendered := markdown.Render(text)

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -299,6 +299,17 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "drag", L.NewFunction(func(L *lua.LState) int {
+			x1 := L.CheckInt(1)
+			y1 := L.CheckInt(2)
+			x2 := L.CheckInt(3)
+			y2 := L.CheckInt(4)
+			if p.SimulateDrag != nil {
+				p.SimulateDrag(x1, y1, x2, y2)
+			}
+			return 0
+		}))
+
 		L.SetField(mod, "screenshot", L.NewFunction(func(L *lua.LState) int {
 			path := L.CheckString(1)
 			if p.ScreenshotToFile != nil {

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -290,6 +290,15 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "click", L.NewFunction(func(L *lua.LState) int {
+			x := L.CheckInt(1)
+			y := L.CheckInt(2)
+			if p.SimulateClick != nil {
+				p.SimulateClick(x, y)
+			}
+			return 0
+		}))
+
 		L.SetField(mod, "markdown", L.NewFunction(func(L *lua.LState) int {
 			text := L.CheckString(1)
 			rendered := markdown.Render(text)

--- a/internal/term/tcell_screen.go
+++ b/internal/term/tcell_screen.go
@@ -141,6 +141,10 @@ func (t *TcellScreen) PostEvent(ev tcell.Event) error {
 	return t.scr.PostEvent(ev)
 }
 
+func (t *TcellScreen) GetContent(x, y int) (rune, []rune, tcell.Style, int) {
+	return t.scr.GetContent(x, y)
+}
+
 func (t *TcellScreen) Tty() (tcell.Tty, bool) {
 	return t.scr.Tty()
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -604,6 +604,32 @@ func (g *EditorGroupWidget) ActiveCursor() (line, col int) {
 	return t.Cur.Line, t.Cur.Col
 }
 
+func (g *EditorGroupWidget) TabCount() int {
+	return len(g.tabs)
+}
+
+func (g *EditorGroupWidget) ActiveTabIndex() int {
+	return g.active
+}
+
+func (g *EditorGroupWidget) TabInfo(index int) (path string, modified bool) {
+	if index < 0 || index >= len(g.tabs) {
+		return "", false
+	}
+	t := &g.tabs[index]
+	dirty := t.Buf != nil && t.Buf.Dirty
+	return t.FilePath, dirty
+}
+
+func (g *EditorGroupWidget) ActiveSelection() (active bool, sl, sc, el, ec int) {
+	t := g.activeTab()
+	if t == nil || t.Content != nil || t.Sel == nil || !t.Sel.Active {
+		return false, 0, 0, 0, 0
+	}
+	start, end := t.Sel.Range(t.Cur.Line, t.Cur.Col)
+	return true, start.Line, start.Col, end.Line, end.Col
+}
+
 func (g *EditorGroupWidget) ActiveFileName() string {
 	t := g.activeTab()
 	if t == nil {

--- a/internal/ui/tree_widget_adapter.go
+++ b/internal/ui/tree_widget_adapter.go
@@ -44,6 +44,8 @@ func (a *WidgetAdapter) wireTabbedCallbacks(w widgets.Widget) {
 	}
 }
 
+func (a *WidgetAdapter) Inner() widgets.Widget { return a.W }
+
 func (a *WidgetAdapter) Focusable() bool { return true }
 
 func (a *WidgetAdapter) Render(surface Surface) {

--- a/scripts/test-confirm.lua
+++ b/scripts/test-confirm.lua
@@ -1,0 +1,15 @@
+local ttt = require("ttt")
+
+ttt.register({
+  commands = {
+    {
+      id = "test.confirmDialog",
+      title = "Test: Confirm Dialog",
+      handler = function()
+        ttt.confirm("Do you want to continue?", function()
+          ttt.log("info", "User confirmed: YES")
+        end)
+      end,
+    },
+  },
+})

--- a/scripts/test-confirm.lua
+++ b/scripts/test-confirm.lua
@@ -11,5 +11,13 @@ ttt.register({
         end)
       end,
     },
+    {
+      id = "test.clickAt",
+      title = "Test: Click At 10,5",
+      handler = function()
+        ttt.click(10, 5)
+        ttt.log("info", "Clicked at 10, 5")
+      end,
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Adds `Debug: Simulate Click` command — posts synthetic mouse press+release at given x,y coordinates
- Adds `Debug: Run Current File as Plugin` command — loads the active buffer as a fully-permissioned Lua plugin
- Adds `Debug: Screenshot` and `Debug: Dump State` command palette commands
- Adds Lua APIs: `ttt.click(x, y)`, `ttt.screenshot(path)`, `ttt.debug(path)`, `ttt.quit()`
- Adds CLI flags: `--plugin <file>`, `--size WxH`, `--debug`
- Full widget tree walker with type, rect, focus, visibility, and type-specific props
- Debug state dump includes: screen, cursor, buffer, focus, panels, tabs, selection, output log, widget tree

## Test plan
- [x] `make build` and `make test` pass
- [x] Manual: Simulate Click opens dialog, accepts coordinates, fires click
- [x] Manual: Run plugin loads Lua from editor buffer, registers commands/panels
- [ ] Manual: `ttt --plugin scripts/test-confirm.lua --size 120x40` loads plugin on startup
- [ ] Manual: `Debug: Screenshot` saves screen text to file
- [ ] Manual: `Debug: Dump State` saves JSON state with widget tree


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm