### PR TITLE
Widget system polish: focus, new widgets, tests, drawer

### DIFF
--- a/audit/widget-polish.md
+++ b/audit/widget-polish.md
@@ -1,0 +1,354 @@
+# Widget Polish & Pre-Release Checklist
+
+## 1. Tree View Ellipsis
+
+When tree node labels exceed available width, they clip mid-character with no visual indicator.
+
+**What to do:**
+- In `internal/widgets/tree.go` `renderNode()`, the label loop (line ~338) breaks at `maxX` silently.
+- When label runes would exceed `maxX`, stop 1 char early and render `…` (U+2026) at the truncation point.
+- Same treatment for badge text (line ~355) and icon text.
+- `maxX` is already computed as `w - 2 - rightSideWidth(node)`, accounting for scrollbar and right-side elements (dropdown menu icon). No layout changes needed.
+
+**Test:** `--exec` test with a narrow `--size` that forces truncation. Verify `…` appears.
+
+---
+
+## 2. Dialog Button Left/Right Navigation
+
+Dialog footer buttons (OK, Cancel) respond to Tab but not Left/Right arrows. VS Code uses both.
+
+**What to do:**
+- In `internal/widgets/dialog.go` `HandleEvent()` (line ~170), before delegating to `d.footer.HandleEvent(e)`:
+  - On `KeyLeft`: find the focused button in `d.footer.Children`, focus the previous one.
+  - On `KeyRight`: focus the next one.
+- The footer is an HStack of ButtonWidgets. Need a small focus helper — iterate `d.footer.Children`, find the one where `IsFocused() == true`, then `SetFocused(false)` on it and `SetFocused(true)` on the neighbor.
+- Don't wrap around (Left on first button = no-op, Right on last = no-op).
+
+**Test:** Unit test: build a dialog with 2-3 buttons, send KeyRight/KeyLeft events, verify focus moves.
+
+---
+
+## 3. Box Model Consistency
+
+Every widget embeds `BaseWidget` which has `BoxModel` and `RenderBox()`. Most widgets already call `RenderBox()` in their `Render()` — three don't.
+
+**Already using `RenderBox()` (box model works):**
+label, title, button, input, checkbox, divider, hstack, vstack, paragraph, tabbed, tabs, box
+
+**Dropdown** delegates to an inner ButtonWidget which calls `RenderBox()` — box model works transitively.
+
+**Missing `RenderBox()` — these three need fixing:**
+
+**Tree** (`tree.go`): Render directly draws at `x=0, y=0`. Wrap with `RenderBox()` so margins/padding work. After this change, `panel:tree({margin_top = 1})` will work. Also need `Height()` to account for `BoxOverheadH()`.
+
+**ScrollView** (`scrollview.go`): Renders child directly at hardcoded positions. Wrap with `RenderBox()` for outer margin/padding.
+
+**KeyValueList** (`keyvaluelist.go`): Renders at hardcoded positions. Wrap with `RenderBox()`.
+
+**Lua parser gap:** `lua_panel.go` calls `parseBoxModel()` for label, title, keyvalue, input, box — but NOT for tree, list, button, vstack, hstack, divider, scrollview, dropdown. Extend `parseBoxModel()` calls to all widget parsers so the full API is exposed from Lua. The Go side (`widget_builder.go` `applyBoxModel`) already applies to any widget that embeds `BaseWidget`.
+
+**Test:** Lua plugin test: render a tree with `margin_top = 2`, verify the tree content starts 2 rows lower than without margin.
+
+---
+
+## 4. New Widgets (Progress Bar, Table)
+
+Build the two missing widget primitives in `internal/widgets/` and wire them into the Lua plugin API. See #7a and #7b for full specs.
+
+- **Progress bar** — ~50 lines, straightforward. New `progress.go`, Lua wiring in `lua_panel.go` + `widget_builder.go`.
+- **Table** — ~200-300 lines, medium effort. New `table.go`, Lua wiring. Column layout, row selection, keyboard nav, scrolling.
+
+Both get box model via `RenderBox()` from day one.
+
+---
+
+## 5. Global Focus Traversal
+
+Two new commands to cycle focus between major UI regions with F6 / Shift+F6.
+
+**Commands:**
+- `focus.nextGroup` (F6) — cycle forward through visible regions
+- `focus.prevGroup` (Shift+F6) — cycle backward
+- `focus.menuBar` (F10) — focus menu bar directly (matching VS Code, not part of F6 cycle)
+- `focus.terminal` (no shortcut, command palette only) — focus terminal if bottom panel is open, otherwise open it. Escape returns to editor.
+
+**Focus regions** (in cycle order, only if visible):
+1. Editor (EditorGroup)
+2. Sidebar (if visible)
+3. Bottom panel active tab (if visible — terminal, problems, output, plugin panel)
+
+**Tab switching within panels:**
+Currently the tab bars (sidebar tabs, bottom panel tabs) are mouse-only. Instead of making tab pills focusable, add context-aware commands:
+- `panel.nextTab` / `panel.prevTab` — checks `Root.Focused` type: if `*ui.SidebarWidget` cycles sidebar tabs, if `*ui.BottomPanelWidget` cycles bottom panel tabs, if editor cycles editor tabs
+- One shortcut each (e.g. `Ctrl+PageDown` / `Ctrl+PageUp`, or a chord if those conflict)
+- Focus stays on the content — the command just calls `SetActivePanel` on the next/prev tab
+
+**Implementation:** A helper in `app.go` that:
+1. Builds a list of visible regions: `[EditorGroup, Sidebar?, BottomPanel?]`
+2. Checks which region currently has focus (is `Root.Focused` equal to or inside the region)
+3. Calls `Root.SetFocus()` on the next/prev region
+
+For bottom panel, focus the active tab's widget — same logic `OnBottomClick` already uses. No changes to Root or FocusManager needed — just two command handlers and one helper function. Tab bar focus requires making the tab widget focusable and wiring it into the panel's focus group.
+
+**Risk:** Low-medium. F6 cycling is simple. Tab bar focus adds a new focusable element to each panel.
+
+---
+
+## 6. Widget Testing
+
+**Missing unit tests:** box, button, checkbox, dialog, dropdown, hstack, scrollview, tabs, tree, vstack.
+
+**Approach:** Go unit tests with `VirtualSurface` for both rendering and interaction testing. For each widget, first audit all functionality, user interactions, and click areas, then write tests covering every one. The `VirtualSurface` lets us verify rendered cell content at exact coordinates, then send mouse events at those same coordinates to confirm hit regions match rendering — 100% precision, no timing issues.
+
+For Lua-to-widget integration testing (callbacks fire, panel renders correctly), use `--exec --plugin` with small Lua fixture scripts and debug JSON assertions. These are secondary — the Go unit tests are the primary coverage.
+
+**Process per widget:**
+1. Read the widget source and catalog: all render regions, all keyboard handlers, all mouse click areas, all callbacks, all edge cases (empty data, overflow, boundary)
+2. Write tests for every item in the catalog
+3. Use `VirtualSurface` cell scanning to find where elements rendered, then click those exact coordinates
+
+**Priority order and test coverage:**
+
+### 6.1 Tree (`tree.go`) — highest complexity
+**Rendering:**
+- Basic: items render at correct Y positions with correct indentation per depth
+- Icons: expand/collapse chevrons at correct X position
+- Actions: action icons render at right edge, correct X positions per action
+- Dropdown menu icon: renders at rightmost position when `NodeMenu` configured
+- Selection: selected row renders with highlight style
+- Scrollbar: appears when items exceed height
+- Ellipsis: label truncation with `…` when text exceeds available width (after item #1)
+- Badge: badge text renders at correct position
+- Muted: muted nodes use muted style
+
+**Keyboard:**
+- Up/Down: move selection, wrap or clamp at boundaries
+- Left: collapse expanded node, or move to parent
+- Right: expand collapsed node
+- Enter: activate selected node (fires `OnSelect`)
+- `key_commands`: single-char keys fire `OnCommand` with correct command string
+- Page Up/Down: scroll by page
+- Home/End: jump to first/last item
+
+**Mouse clicks:**
+- Click on row label: selects row and activates
+- Click on action icon (exact X): fires `OnCommand` with correct action command
+- Click on dropdown menu icon (exact X): fires `OnMenu`
+- Right-click on row: fires `OnMenu` (context menu)
+- Mouse wheel up/down: scrolls, clamps at bounds
+- Scrollbar drag: updates scroll position
+- Click outside bounds: ignored
+
+**Edge cases:**
+- Empty tree (no items)
+- Single item
+- Deeply nested items (3+ levels)
+- Scroll to last item, then collapse parent (scroll should adjust)
+
+### 6.2 Dialog (`dialog.go`)
+**Rendering:**
+- Title renders centered
+- Content widget renders in body area
+- Footer buttons render horizontally
+- Border renders around dialog
+
+**Keyboard:**
+- Tab: cycles focus between footer buttons
+- Left/Right: moves focus between footer buttons (after item #2)
+- Enter: activates focused button (fires callback)
+- Escape: dismisses dialog (returns `EventDismissed`)
+
+**Mouse clicks:**
+- Click on button (exact coordinates): fires that button's callback
+- Click on close button (if present): dismisses
+
+### 6.3 ScrollView (`scrollview.go`)
+**Rendering:**
+- Child content renders within bounds
+- Scrollbar appears when content overflows
+- Content clips at container boundary
+
+**Keyboard/Mouse:**
+- Mouse wheel up/down: scrolls content, clamps at 0 and max
+- Scrollbar click: jumps to position
+- Scroll at top + wheel up: no-op (stays at 0)
+- Scroll at bottom + wheel down: no-op (stays at max)
+
+**Edge cases:**
+- Content smaller than container (no scrollbar)
+- Content exactly fits (no scrollbar)
+- Content 1 row taller than container
+
+### 6.4 HStack / VStack (`hstack.go`, `vstack.go`)
+**Rendering:**
+- Children positioned correctly with gap spacing
+- HStack: first child grows to fill, others fixed width
+- VStack: children stack vertically with correct Y offsets
+- Box model applied correctly (margins, padding affect child layout)
+
+**Mouse clicks:**
+- Click on child N: correct child receives the event
+- Click on gap between children: no child receives event
+
+### 6.5 Button (`button.go`)
+**Rendering:**
+- Label renders centered
+- Accelerator character (`&` prefix) renders underlined
+- Focus ring visible when focused
+
+**Interactions:**
+- Click: fires `OnClick` callback
+- Enter key when focused: fires `OnClick`
+- Accelerator key: fires `OnClick`
+
+### 6.6 Dropdown (`dropdown.go`)
+**Rendering:**
+- Label renders on button
+- Caret/indicator visible
+
+**Interactions:**
+- Click: opens menu (fires callback or returns popup)
+- Enter when focused: opens menu
+
+### 6.7 Box (`box.go`)
+**Rendering:**
+- Border renders when enabled (all 4 sides, corners correct)
+- Fixed height respected
+- Child renders inside border/padding area
+
+### 6.8 Checkbox (`checkbox.go`)
+**Rendering:**
+- Unchecked: `[ ]` + label
+- Checked: `[x]` + label
+
+**Interactions:**
+- Click: toggles checked state, fires `OnChange`
+- Enter/Space when focused: toggles
+
+### 6.9 Tabs (`tabs.go`)
+**Rendering:**
+- Tab labels render horizontally
+- Active tab has highlight style
+- Inactive tabs have default style
+
+**Mouse clicks:**
+- Click on tab N (exact X range): switches to that tab, fires `OnSelect`
+- Click between tabs: no-op or nearest tab
+
+**Test pattern:**
+```go
+// Render + click precision test
+surface := widgets.NewVirtualSurface(40, 10)
+tree := widgets.NewTreeWidget(config) // config has 3 items with actions
+tree.SetRect(widgets.Rect{X: 0, Y: 0, W: 40, H: 10})
+tree.Render(surface)
+
+// Scan surface to find where action icon "×" was rendered
+actionX, actionY := surface.FindCell('×')
+
+// Click that exact coordinate
+clickedCmd := ""
+config.OnCommand = func(cmd string, n *TreeNode) { clickedCmd = cmd }
+ev := tcell.NewEventMouse(actionX, actionY, tcell.Button1, tcell.ModNone)
+tree.HandleEvent(ev)
+assert(clickedCmd == "close") // the action at that position
+```
+
+---
+
+## 7. New Widgets
+
+The widget system is missing a few primitives that tview/bubbles offer and that plugins would benefit from. These also matter if the widget system is ever extracted as a standalone library — the box model is the differentiator, but the primitive set needs to be complete.
+
+### 7a. Progress Bar
+
+A horizontal bar showing completion percentage. Common in plugins (build progress, download, scan).
+
+**API:**
+```lua
+panel:progress({
+  value = 0.65,          -- 0.0 to 1.0
+  style = "success",     -- bar fill color
+  height = 1,            -- always 1 row
+})
+```
+
+**Implementation:** `internal/widgets/progress.go`. Simple: fill `value * width` cells with a block character (e.g. `█`), rest with a dimmed character (e.g. `░`). Call `RenderBox()` for box model. About 40-50 lines.
+
+**Lua wiring:** New `panelProgressWidget` in `lua_panel.go`, new `WidgetProgress` kind, create/update in `widget_builder.go`.
+
+### 7b. Table
+
+A columnar data widget with headers, sortable columns, and row selection. The highest-effort new widget but high value — many plugin use cases (docker containers, test results, git log, HTTP headers).
+
+**API:**
+```lua
+panel:table({
+  columns = {
+    { label = "Name", width = 20 },
+    { label = "Status", width = 10 },
+    { label = "CPU", width = 8, align = "right" },
+  },
+  rows = {
+    { "web-app", "Running", "12%" },
+    { "db", "Stopped", "0%" },
+  },
+  on_select = function(row_index) end,
+  on_command = function(command, row_index) end,
+  node_menu = { ... },
+})
+```
+
+**Implementation:** `internal/widgets/table.go`. Needs:
+- Column layout: fixed widths, optional grow column, header row
+- Row rendering with selection highlight
+- Keyboard: Up/Down for selection, Enter for activate, context menu
+- Scrolling: reuse scroll logic from TreeWidget
+- Box model via `RenderBox()`
+
+Estimate: 200-300 lines. Could reuse `SelectableList` logic for keyboard/scroll.
+
+### 7c. Menu Bar (Skip)
+
+MenuBarWidget is 109 lines, only used once, and the menu system's complexity is in the app-level wiring (`menus.go` — overlay management, left/right navigation between menus, shortcut resolution), not the bar widget itself. Plugins already have `dropdown` for menu trigger buttons. Not worth moving.
+
+### 7d. Split Widget (Deferred)
+
+SplitPanelWidget and ContentSplitWidget could be unified into a generic `SplitWidget`, but the border corner rendering is very app-specific — `RightBorderStartY`, `BottomTee` junction, tab bar row click routing, scrollbar column avoidance. Generalizing these details would add complexity without clear benefit. Keep them in `internal/ui/` for now. Revisit if a third split variant is needed or if the widget library is extracted.
+
+---
+
+## 8. Testing Infrastructure
+
+Two gaps found during `--exec` testing that make plugin panel testing painful:
+
+### 8a. `panel.show <id>` command
+
+No way to switch to a specific bottom panel tab programmatically. Currently the only way is clicking the tab, which requires knowing exact coordinates and the tab being visible (not behind `»` overflow). Add a command that takes a panel ID (e.g. `plugin.test_ellipsis`) and activates it — calls `BottomPanel.SetActivePanel(id)` and `ContentSplit.ShowBottom = true`.
+
+### 8b. `ttt.open_drawer()` at init time
+
+Calling `ttt.open_drawer()` during plugin init silently does nothing because the event loop hasn't started and `OpenDrawer` callback isn't wired yet. Buffer the call and replay it after wiring, or document that drawers must be opened from a command/timer.
+
+---
+
+## 9. Markdown Parser (Defer)
+
+Keep the custom parser in `internal/markdown/`. Surface area is small (headings, bold, italic, code, code blocks, lists, links). Only revisit if users report rendering bugs in the markdown preview plugin.
+
+---
+
+## Execution Order
+
+| Phase | Items | Scope |
+|-------|-------|-------|
+| A | Tree ellipsis (#1) | `tree.go` — single function change |
+| A | Dialog button nav (#2) | `dialog.go` — single function change |
+| A | Testing infra (#8a, #8b) | `commands_view.go`, `sandbox.go` — small additions |
+| B | Box model on tree, scrollview, keyvaluelist (#3) | `tree.go`, `scrollview.go`, `keyvaluelist.go`, `lua_panel.go` |
+| C | Progress bar widget (#4, #7a) | New `progress.go`, Lua wiring |
+| D | Table widget (#4, #7b) | New `table.go`, Lua wiring |
+| E | Widget tests — tree, dialog, scrollview (#6) | New test files, no behavior changes |
+| F | Widget tests — hstack, vstack, button, remaining (#6) | New test files |
+| G | Global focus (#5) | Root, app wiring — biggest risk |

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -264,13 +264,13 @@ func registerEditorCommands(app *App) {
 	reg.Register(command.Command{
 		ID: "tab.next", Title: "Next Tab",
 		Keywords: []string{"tab", "switch"},
-		Handler:  func() { app.EditorGroup.NextTab() },
+		Handler:  func() { app.contextNextTab() },
 	})
 
 	reg.Register(command.Command{
 		ID: "tab.prev", Title: "Previous Tab",
 		Keywords: []string{"tab", "switch"},
-		Handler:  func() { app.EditorGroup.PrevTab() },
+		Handler:  func() { app.contextPrevTab() },
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -384,10 +384,11 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 		a.Root.SetFocus(menu)
 	}
 
-	p.OpenDrawer = func(panel *plugin.PluginPanelWidget, width, minWidth int) {
+	p.OpenDrawer = func(panel *plugin.PluginPanelWidget, width, minWidth int, side string) {
 		drawer := widgets.NewDrawerWidget(widgets.DrawerConfig{
 			Width:    width,
 			MinWidth: minWidth,
+			Side:     side,
 			Borders:  *a.Borders,
 			OnDismiss: func() {
 				a.DismissDialog()
@@ -423,6 +424,7 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	}
 
 	a.registerPluginCommandsAndKeys(p)
+	p.FlushPendingDrawer()
 }
 
 func (a *App) wirePluginLog(p *plugin.Plugin) {

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -228,6 +228,25 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "panel.show", Title: "Show Panel Tab",
+		Keywords: []string{"view", "bottom", "tab", "switch"},
+		Handler: func() {
+			ids := app.BottomPanel.PanelIDs()
+			if len(ids) == 0 {
+				return
+			}
+			var items []widgets.SelectItem
+			for _, id := range ids {
+				items = append(items, widgets.SelectItem{ID: id, Label: id})
+			}
+			app.ShowSelectDialog("Show Panel", items, func(id string) {
+				app.BottomPanel.SetActivePanel(id)
+				app.FocusPanel()
+			}, nil)
+		},
+	})
+
+	reg.Register(command.Command{
 		ID: "panel.taller", Title: "Increase Panel Height",
 		Keywords: []string{"view", "resize", "bottom"},
 		Handler: func() {

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -31,6 +31,119 @@ func (a *App) ToggleTerminalFullscreen() {
 	}
 }
 
+func (a *App) focusedRegion() string {
+	switch a.Root.Focused.(type) {
+	case *ui.SidebarWidget:
+		return "sidebar"
+	case *ui.BottomPanelWidget:
+		return "bottom"
+	default:
+		return "editor"
+	}
+}
+
+func (a *App) focusNextGroup() {
+	regions := []string{"editor"}
+	if a.Sidebar.Visible {
+		regions = append(regions, "sidebar")
+	}
+	if a.ContentSplit.ShowBottom {
+		regions = append(regions, "bottom")
+	}
+	current := a.focusedRegion()
+	for i, r := range regions {
+		if r == current {
+			next := regions[(i+1)%len(regions)]
+			a.focusRegion(next)
+			return
+		}
+	}
+	a.FocusEditor()
+}
+
+func (a *App) focusPrevGroup() {
+	regions := []string{"editor"}
+	if a.Sidebar.Visible {
+		regions = append(regions, "sidebar")
+	}
+	if a.ContentSplit.ShowBottom {
+		regions = append(regions, "bottom")
+	}
+	current := a.focusedRegion()
+	for i, r := range regions {
+		if r == current {
+			prev := i - 1
+			if prev < 0 {
+				prev = len(regions) - 1
+			}
+			a.focusRegion(regions[prev])
+			return
+		}
+	}
+	a.FocusEditor()
+}
+
+func (a *App) focusRegion(region string) {
+	switch region {
+	case "editor":
+		a.FocusEditor()
+	case "sidebar":
+		a.FocusSidebar()
+	case "bottom":
+		a.FocusPanel()
+	}
+}
+
+func (a *App) contextNextTab() {
+	switch a.focusedRegion() {
+	case "sidebar":
+		a.Sidebar.NextPanel()
+		if w := a.Sidebar.ActiveWidget(); w != nil {
+			a.Root.SetFocus(w)
+		}
+	case "bottom":
+		a.BottomPanel.NextPanel()
+		if w := a.BottomPanel.ActiveWidget(); w != nil {
+			a.Root.SetFocus(w)
+		}
+	default:
+		a.EditorGroup.NextTab()
+	}
+}
+
+func (a *App) contextPrevTab() {
+	switch a.focusedRegion() {
+	case "sidebar":
+		a.Sidebar.PrevPanel()
+		if w := a.Sidebar.ActiveWidget(); w != nil {
+			a.Root.SetFocus(w)
+		}
+	case "bottom":
+		a.BottomPanel.PrevPanel()
+		if w := a.BottomPanel.ActiveWidget(); w != nil {
+			a.Root.SetFocus(w)
+		}
+	default:
+		a.EditorGroup.PrevTab()
+	}
+}
+
+func (a *App) focusTerminal() {
+	if !a.ContentSplit.ShowBottom {
+		r := a.ContentSplit.GetRect()
+		maxH := r.H - 4
+		if a.ContentSplit.BottomH <= 1 || a.ContentSplit.BottomH > maxH {
+			a.ContentSplit.BottomH = min(r.H/2, maxH)
+		}
+		a.showTerminalPanel()
+		return
+	}
+	a.BottomPanel.SetActivePanel("terminal")
+	if w := a.BottomPanel.ActiveWidget(); w != nil {
+		a.Root.SetFocus(w)
+	}
+}
+
 func (a *App) FocusPanel() {
 	if !a.ContentSplit.ShowBottom {
 		a.ContentSplit.ShowBottom = true
@@ -265,6 +378,24 @@ func registerViewCommands(app *App) {
 				app.ContentSplit.BottomH--
 			}
 		},
+	})
+
+	reg.Register(command.Command{
+		ID: "focus.nextGroup", Title: "Focus Next Group",
+		Keywords: []string{"focus", "panel", "sidebar", "editor"},
+		Handler:  app.focusNextGroup,
+	})
+
+	reg.Register(command.Command{
+		ID: "focus.prevGroup", Title: "Focus Previous Group",
+		Keywords: []string{"focus", "panel", "sidebar", "editor"},
+		Handler:  app.focusPrevGroup,
+	})
+
+	reg.Register(command.Command{
+		ID: "focus.terminal", Title: "Focus Terminal",
+		Keywords: []string{"focus", "terminal", "shell"},
+		Handler:  app.focusTerminal,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -43,6 +43,8 @@ func RunExecScript(a *App, script string) {
 			execDebug(a, args)
 		case "wait":
 			execWait(args)
+		case "panel":
+			execPanel(a, args)
 		case "quit":
 			execQuit(a)
 		default:
@@ -203,6 +205,31 @@ func execWait(args string) {
 		return
 	}
 	time.Sleep(time.Duration(n) * time.Millisecond)
+}
+
+func execPanel(a *App, args string) {
+	id := stripQuotes(strings.TrimSpace(args))
+	if id == "" {
+		slog.Error("exec_script: panel requires a panel ID")
+		return
+	}
+	if !a.BottomPanel.HasPanel(id) {
+		slog.Error("exec_script: panel not found", "id", id)
+		return
+	}
+	a.BottomPanel.SetActivePanel(id)
+	if !a.ContentSplit.ShowBottom {
+		r := a.ContentSplit.GetRect()
+		maxH := r.H - 4
+		if a.ContentSplit.BottomH <= 1 || a.ContentSplit.BottomH > maxH {
+			a.ContentSplit.BottomH = min(r.H/2, maxH)
+		}
+		a.ContentSplit.ShowBottom = true
+	}
+	if w := a.BottomPanel.ActiveWidget(); w != nil {
+		a.Root.SetFocus(w)
+	}
+	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
 }
 
 func execQuit(a *App) {

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -342,6 +342,8 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "ctrl+k y", Command: "view.keybindings"},
 		{Key: "ctrl+t", Command: "terminal.toggle"},
 		{Key: "alt+t", Command: "terminal.fullscreen"},
+		{Key: "f6", Command: "focus.nextGroup"},
+		{Key: "shift+f6", Command: "focus.prevGroup"},
 		{Key: "f10", Command: "menu.file"},
 		{Key: "alt+f", Command: "menu.file"},
 		{Key: "alt+e", Command: "menu.edit"},

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -330,6 +330,7 @@ func panelTreeWidget(L *lua.LState) int {
 		desc.KeyCommands = parseLuaKeyCommands(L, kc)
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetTree, desc)
 	return 0
 }
@@ -359,6 +360,7 @@ func panelListWidget(L *lua.LState) int {
 		desc.KeyCommands = parseLuaKeyCommands(L, kc)
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetList, desc)
 	return 0
 }
@@ -379,6 +381,7 @@ func panelButtonWidget(L *lua.LState) int {
 		desc.OnClick = proxy.wrapSimpleCallback(fn)
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetButton, desc)
 	return 0
 }
@@ -408,6 +411,7 @@ func panelInputWidget(L *lua.LState) int {
 		desc.ClearOnSubmit = lua.LVAsBool(v)
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetInput, desc)
 	return 0
 }
@@ -495,6 +499,7 @@ func panelVStackWidget(L *lua.LState) int {
 		desc.Gap = int(lua.LVAsNumber(v))
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetVStack, desc)
 	return 0
 }
@@ -518,6 +523,7 @@ func panelHStackWidget(L *lua.LState) int {
 		desc.FixedHeight = int(lua.LVAsNumber(v))
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetHStack, desc)
 	return 0
 }
@@ -546,6 +552,7 @@ func panelScrollViewWidget(L *lua.LState) int {
 		desc.Children = collectChildren(L, proxy, fn)
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetScrollView, desc)
 	return 0
 }
@@ -607,6 +614,7 @@ func panelDropdownWidget(L *lua.LState) int {
 		desc.OnMenu = proxy.wrapStringCallback(fn)
 	}
 
+	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetDropdown, desc)
 	return 0
 }

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -97,6 +97,8 @@ func RegisterPanelType(L *lua.LState) {
 		"scrollview": panelScrollViewWidget,
 		"hstack":    panelHStackWidget,
 		"divider":   panelDividerWidget,
+		"progress":  panelProgressWidget,
+		"table":     panelTableWidget,
 		"redraw":    panelRedraw,
 	}))
 }
@@ -616,6 +618,103 @@ func panelDropdownWidget(L *lua.LState) int {
 
 	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetDropdown, desc)
+	return 0
+}
+
+func panelProgressWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if v := L.GetField(tbl, "value"); v != lua.LNil {
+		desc.Value = float64(lua.LVAsNumber(v))
+	}
+	if v := L.GetField(tbl, "style"); v != lua.LNil {
+		desc.StyleName = v.String()
+	}
+	if v := L.GetField(tbl, "char"); v != lua.LNil {
+		s := v.String()
+		if len([]rune(s)) > 0 {
+			desc.Char = []rune(s)[0]
+		}
+	}
+
+	parseBoxModel(L, tbl, &desc)
+	proxy.appendDesc(WidgetProgress, desc)
+	return 0
+}
+
+func panelTableWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if cols, ok := L.GetField(tbl, "columns").(*lua.LTable); ok {
+		cols.ForEach(func(_, v lua.LValue) {
+			ct, ok := v.(*lua.LTable)
+			if !ok {
+				return
+			}
+			col := widgets.TableColumn{
+				Label: L.GetField(ct, "label").String(),
+			}
+			if w := L.GetField(ct, "width"); w != lua.LNil {
+				col.Width = int(lua.LVAsNumber(w))
+			}
+			if a := L.GetField(ct, "align"); a != lua.LNil {
+				col.Align = a.String()
+			}
+			desc.Columns = append(desc.Columns, col)
+		})
+	}
+
+	if rows, ok := L.GetField(tbl, "rows").(*lua.LTable); ok {
+		rows.ForEach(func(_, rv lua.LValue) {
+			rt, ok := rv.(*lua.LTable)
+			if !ok {
+				return
+			}
+			var row []string
+			rt.ForEach(func(_, cv lua.LValue) {
+				row = append(row, cv.String())
+			})
+			desc.Rows = append(desc.Rows, row)
+		})
+	}
+
+	if fn, ok := L.GetField(tbl, "on_select").(*lua.LFunction); ok {
+		luaFn := fn
+		desc.OnSelectIndex = func(rowIndex int) {
+			if proxy.plugin != nil && proxy.plugin.State != nil {
+				proxy.plugin.CallLuaFunc(luaFn, lua.LNumber(rowIndex+1))
+			}
+		}
+	}
+	if fn, ok := L.GetField(tbl, "on_command").(*lua.LFunction); ok {
+		luaFn := fn
+		desc.OnCommandStr = func(command string, rowIndex int) {
+			if proxy.plugin != nil && proxy.plugin.State != nil {
+				proxy.plugin.CallLuaFunc(luaFn, lua.LString(command), lua.LNumber(rowIndex+1))
+			}
+		}
+	}
+	if menu, ok := L.GetField(tbl, "node_menu").(*lua.LTable); ok {
+		desc.NodeMenu = parseLuaMenuEntries(L, menu)
+	}
+	if kc, ok := L.GetField(tbl, "key_commands").(*lua.LTable); ok {
+		desc.KeyCommands = parseLuaKeyCommands(L, kc)
+	}
+
+	parseBoxModel(L, tbl, &desc)
+	proxy.appendDesc(WidgetTable, desc)
 	return 0
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -62,7 +62,7 @@ type Plugin struct {
 	ShowContextMenu   func(entries []widgets.MenuEntry, x, y int, onCommand func(cmd string))
 	ShowInfoDialog    func(title string, entries []widgets.KeyValueEntry)
 	ShowConfirmDialog func(message string, onConfirm func())
-	OpenDrawer        func(panel *PluginPanelWidget, width, minWidth int)
+	OpenDrawer        func(panel *PluginPanelWidget, width, minWidth int, side string)
 	CloseDrawer       func()
 	OpenTab           func(id string, panel *PluginPanelWidget)
 	CloseTab          func(id string)
@@ -81,7 +81,23 @@ type Plugin struct {
 
 	EventListeners map[string][]*lua.LFunction
 
-	LastError error
+	pendingDrawer *pendingDrawerCall
+	LastError     error
+}
+
+type pendingDrawerCall struct {
+	panel    *PluginPanelWidget
+	width    int
+	minWidth int
+	side     string
+}
+
+func (p *Plugin) FlushPendingDrawer() {
+	if p.pendingDrawer != nil && p.OpenDrawer != nil {
+		pd := p.pendingDrawer
+		p.pendingDrawer = nil
+		p.OpenDrawer(pd.panel, pd.width, pd.minWidth, pd.side)
+	}
 }
 
 func (p *Plugin) Init() error {

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -227,9 +227,19 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 					minWidth = int(n)
 				}
 			}
+			side := "right"
+			if s := L.GetField(tbl, "side"); s != lua.LNil {
+				if sv := s.String(); sv == "left" || sv == "right" {
+					side = sv
+				}
+			}
+			panel := NewPluginPanelWidget(p, renderFunc, nil)
 			if p.OpenDrawer != nil {
-				panel := NewPluginPanelWidget(p, renderFunc, nil)
-				p.OpenDrawer(panel, width, minWidth)
+				p.OpenDrawer(panel, width, minWidth, side)
+			} else {
+				p.pendingDrawer = &pendingDrawerCall{
+					panel: panel, width: width, minWidth: minWidth, side: side,
+				}
 			}
 			return 0
 		}))

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -69,6 +69,10 @@ func createWidget(desc WidgetDesc, p *Plugin) widgets.Widget {
 		return createDividerWidget(desc)
 	case WidgetDropdown:
 		return createDropdownWidget(desc, p)
+	case WidgetProgress:
+		return createProgressWidget(desc)
+	case WidgetTable:
+		return createTableWidget(desc)
 	}
 	return widgets.NewLabelWidget(widgets.LabelConfig{Text: "unknown widget"})
 }
@@ -147,6 +151,23 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 				}
 			}
 		}
+	case WidgetProgress:
+		if pw, ok := w.(*widgets.ProgressWidget); ok {
+			pw.Config.Value = desc.Value
+			if desc.Char != 0 {
+				pw.Config.Char = desc.Char
+			}
+			if desc.StyleName != "" {
+				pw.Config.Style = resolveStyleName(desc.StyleName)
+			}
+		}
+	case WidgetTable:
+		if tw, ok := w.(*widgets.TableWidget); ok {
+			tw.Config.Columns = desc.Columns
+			tw.Config.Rows = desc.Rows
+			tw.Config.OnSelect = desc.OnSelectIndex
+			tw.Config.OnCommand = desc.OnCommandStr
+		}
 	}
 }
 
@@ -187,6 +208,12 @@ func widgetMatchesKind(w widgets.Widget, kind WidgetKind) bool {
 		return ok
 	case WidgetDropdown:
 		_, ok := w.(*widgets.DropdownWidget)
+		return ok
+	case WidgetProgress:
+		_, ok := w.(*widgets.ProgressWidget)
+		return ok
+	case WidgetTable:
+		_, ok := w.(*widgets.TableWidget)
 		return ok
 	}
 	return false
@@ -425,4 +452,32 @@ func wireInputCallbacks(iw *widgets.InputWidget, desc WidgetDesc, _ *Plugin) {
 			}
 		}
 	}
+}
+
+func createProgressWidget(desc WidgetDesc) *widgets.ProgressWidget {
+	style := resolveStyleName(desc.StyleName)
+	ch := desc.Char
+	if ch == 0 {
+		ch = '█'
+	}
+	pw := widgets.NewProgressWidget(widgets.ProgressConfig{
+		Value: desc.Value,
+		Style: style,
+		Char:  ch,
+	})
+	applyBoxModel(&pw.Box, desc)
+	return pw
+}
+
+func createTableWidget(desc WidgetDesc) *widgets.TableWidget {
+	tw := widgets.NewTableWidget(widgets.TableConfig{
+		Columns:     desc.Columns,
+		Rows:        desc.Rows,
+		OnSelect:    desc.OnSelectIndex,
+		OnCommand:   desc.OnCommandStr,
+		NodeMenu:    desc.NodeMenu,
+		KeyCommands: desc.KeyCommands,
+	})
+	applyBoxModel(&tw.Box, desc)
+	return tw
 }

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -458,7 +458,7 @@ func createProgressWidget(desc WidgetDesc) *widgets.ProgressWidget {
 	style := resolveStyleName(desc.StyleName)
 	ch := desc.Char
 	if ch == 0 {
-		ch = '█'
+		ch = '▄'
 	}
 	pw := widgets.NewProgressWidget(widgets.ProgressConfig{
 		Value: desc.Value,

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -20,6 +20,8 @@ const (
 	WidgetScrollView
 	WidgetHStack
 	WidgetDivider
+	WidgetProgress
+	WidgetTable
 )
 
 func (k WidgetKind) String() string {
@@ -50,6 +52,10 @@ func (k WidgetKind) String() string {
 		return "hstack"
 	case WidgetDivider:
 		return "divider"
+	case WidgetProgress:
+		return "progress"
+	case WidgetTable:
+		return "table"
 	}
 	return "unknown"
 }
@@ -101,4 +107,13 @@ type WidgetDesc struct {
 	Entries         []widgets.MenuEntry
 	OnMenu         func(command string)
 	KeyValueEntries []widgets.KeyValueEntry
+
+	Value     float64
+	Char      rune
+	StyleName string
+
+	Columns       []widgets.TableColumn
+	Rows          [][]string
+	OnSelectIndex func(int)
+	OnCommandStr  func(command string, rowIndex int)
 }

--- a/internal/ui/scrollbar.go
+++ b/internal/ui/scrollbar.go
@@ -43,9 +43,9 @@ func (s *Scrollbar) Render(surface Surface, rx, ry int) {
 	thumbTop, thumbH := s.ThumbPos()
 	for y := 0; y < s.Height; y++ {
 		if y >= thumbTop && y < thumbTop+thumbH {
-			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbarThumb})
+			surface.SetCell(rx, ry+y, term.Cell{Ch: '▄', Style: term.StyleScrollbarThumb})
 		} else {
-			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbar})
+			surface.SetCell(rx, ry+y, term.Cell{Ch: '▄', Style: term.StyleScrollbar})
 		}
 	}
 }

--- a/internal/ui/scrollbar.go
+++ b/internal/ui/scrollbar.go
@@ -43,9 +43,9 @@ func (s *Scrollbar) Render(surface Surface, rx, ry int) {
 	thumbTop, thumbH := s.ThumbPos()
 	for y := 0; y < s.Height; y++ {
 		if y >= thumbTop && y < thumbTop+thumbH {
-			surface.SetCell(rx, ry+y, term.Cell{Ch: '▄', Style: term.StyleScrollbarThumb})
+			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbarThumb})
 		} else {
-			surface.SetCell(rx, ry+y, term.Cell{Ch: '▄', Style: term.StyleScrollbar})
+			surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: term.StyleScrollbar})
 		}
 	}
 }

--- a/internal/ui/tabbed_panel.go
+++ b/internal/ui/tabbed_panel.go
@@ -88,6 +88,35 @@ func (tp *TabbedPanel) PanelCount() int {
 	return len(tp.panels)
 }
 
+func (tp *TabbedPanel) NextPanel() {
+	if len(tp.panels) <= 1 {
+		return
+	}
+	for i, p := range tp.panels {
+		if p.ID == tp.ActivePanel {
+			next := (i + 1) % len(tp.panels)
+			tp.SetActivePanel(tp.panels[next].ID)
+			return
+		}
+	}
+}
+
+func (tp *TabbedPanel) PrevPanel() {
+	if len(tp.panels) <= 1 {
+		return
+	}
+	for i, p := range tp.panels {
+		if p.ID == tp.ActivePanel {
+			prev := i - 1
+			if prev < 0 {
+				prev = len(tp.panels) - 1
+			}
+			tp.SetActivePanel(tp.panels[prev].ID)
+			return
+		}
+	}
+}
+
 func (tp *TabbedPanel) HasPanel(id string) bool {
 	for _, p := range tp.panels {
 		if p.ID == id {

--- a/internal/widgets/box_test.go
+++ b/internal/widgets/box_test.go
@@ -1,0 +1,329 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestBoxRenderWithBorder(t *testing.T) {
+	borders := term.SingleBorderSet()
+	box := NewBoxWithBorder(borders)
+	box.Child = NewLabelWidget(LabelConfig{Text: "Hi"})
+
+	// Label height=1, box overhead = border top(1) + border bottom(1) = 2, total = 3
+	s := renderWidget(box, 0, 0, 10, 3)
+
+	// Top-left corner
+	if s.cells[0][0].Ch != borders.TopLeft {
+		t.Errorf("expected top-left corner %c, got %c", borders.TopLeft, s.cells[0][0].Ch)
+	}
+	// Top-right corner
+	if s.cells[0][9].Ch != borders.TopRight {
+		t.Errorf("expected top-right corner %c, got %c", borders.TopRight, s.cells[0][9].Ch)
+	}
+	// Bottom-left corner
+	if s.cells[2][0].Ch != borders.BottomLeft {
+		t.Errorf("expected bottom-left corner %c, got %c", borders.BottomLeft, s.cells[2][0].Ch)
+	}
+	// Bottom-right corner
+	if s.cells[2][9].Ch != borders.BottomRight {
+		t.Errorf("expected bottom-right corner %c, got %c", borders.BottomRight, s.cells[2][9].Ch)
+	}
+	// Top horizontal border
+	if s.cells[0][1].Ch != borders.Horizontal {
+		t.Errorf("expected horizontal border %c at top, got %c", borders.Horizontal, s.cells[0][1].Ch)
+	}
+	// Bottom horizontal border
+	if s.cells[2][1].Ch != borders.Horizontal {
+		t.Errorf("expected horizontal border %c at bottom, got %c", borders.Horizontal, s.cells[2][1].Ch)
+	}
+	// Left vertical border
+	if s.cells[1][0].Ch != borders.Vertical {
+		t.Errorf("expected vertical border %c on left, got %c", borders.Vertical, s.cells[1][0].Ch)
+	}
+	// Right vertical border
+	if s.cells[1][9].Ch != borders.Vertical {
+		t.Errorf("expected vertical border %c on right, got %c", borders.Vertical, s.cells[1][9].Ch)
+	}
+}
+
+func TestBoxRenderWithoutBorder(t *testing.T) {
+	box := NewBoxWidget(BoxModel{})
+	box.Child = NewLabelWidget(LabelConfig{Text: "No border"})
+
+	s := renderWidget(box, 0, 0, 20, 1)
+
+	// No border characters should appear
+	borders := term.SingleBorderSet()
+	for x := range 20 {
+		ch := s.cells[0][x].Ch
+		if ch == borders.TopLeft || ch == borders.TopRight ||
+			ch == borders.BottomLeft || ch == borders.BottomRight ||
+			ch == borders.Horizontal || ch == borders.Vertical {
+			t.Errorf("unexpected border character %c at x=%d", ch, x)
+		}
+	}
+	// The label text should render directly
+	if s.cells[0][0].Ch != 'N' {
+		t.Errorf("expected 'N' at x=0, got %c", s.cells[0][0].Ch)
+	}
+}
+
+func TestBoxFixedHeight(t *testing.T) {
+	box := NewBoxWidget(BoxModel{})
+	box.FixedHeight = 5
+	box.Child = NewLabelWidget(LabelConfig{Text: "Fixed"})
+
+	h := box.Height()
+	if h != 5 {
+		t.Errorf("expected fixed height=5, got %d", h)
+	}
+}
+
+func TestBoxFixedWidth(t *testing.T) {
+	box := NewBoxWidget(BoxModel{})
+	box.FixedWidth = 15
+	box.Child = NewLabelWidget(LabelConfig{Text: "Fixed"})
+
+	w := box.Width()
+	if w != 15 {
+		t.Errorf("expected fixed width=15, got %d", w)
+	}
+}
+
+func TestBoxHeightFromChild(t *testing.T) {
+	borders := term.SingleBorderSet()
+	box := NewBoxWithBorder(borders)
+	label := NewLabelWidget(LabelConfig{Text: "Hi"})
+	box.Child = label
+
+	// Label height = 1, box overhead = 2 (top + bottom border)
+	h := box.Height()
+	expected := 1 + 2
+	if h != expected {
+		t.Errorf("expected height=%d, got %d", expected, h)
+	}
+}
+
+func TestBoxChildRendersInsideBorder(t *testing.T) {
+	borders := term.SingleBorderSet()
+	box := NewBoxWithBorder(borders)
+	box.Child = NewLabelWidget(LabelConfig{Text: "AB"})
+
+	s := renderWidget(box, 0, 0, 10, 3)
+
+	// Child content should appear inside the border (row 1, starting at col 1)
+	if s.cells[1][1].Ch != 'A' {
+		t.Errorf("expected 'A' inside border at (1,1), got %c", s.cells[1][1].Ch)
+	}
+	if s.cells[1][2].Ch != 'B' {
+		t.Errorf("expected 'B' inside border at (2,1), got %c", s.cells[1][2].Ch)
+	}
+}
+
+func TestBoxChildRendersInsidePadding(t *testing.T) {
+	box := NewBoxWithPadding(1)
+	box.Child = NewLabelWidget(LabelConfig{Text: "XY"})
+
+	// Padding 1 on all sides, label height=1, overhead=2 (top+bottom pad), total h=3
+	s := renderWidget(box, 0, 0, 10, 3)
+
+	// Child content should appear at (1,1) due to padding
+	if s.cells[1][1].Ch != 'X' {
+		t.Errorf("expected 'X' inside padding at (1,1), got %c", s.cells[1][1].Ch)
+	}
+	if s.cells[1][2].Ch != 'Y' {
+		t.Errorf("expected 'Y' inside padding at (2,1), got %c", s.cells[1][2].Ch)
+	}
+}
+
+func TestBoxChildRendersInsideBorderAndPadding(t *testing.T) {
+	borders := term.SingleBorderSet()
+	box := NewBoxWithBorderAndPadding(borders, 1)
+	box.Child = NewLabelWidget(LabelConfig{Text: "Z"})
+
+	// Border(1) + padding(1) on each side: overhead = 4 vertical, label height=1, total=5
+	s := renderWidget(box, 0, 0, 10, 5)
+
+	// Border at row 0 and 4, padding at row 1 and 3, content at row 2
+	if s.cells[0][0].Ch != borders.TopLeft {
+		t.Errorf("expected border top-left, got %c", s.cells[0][0].Ch)
+	}
+	// Content at (2,2): border(1) + padding(1) = offset 2
+	if s.cells[2][2].Ch != 'Z' {
+		t.Errorf("expected 'Z' at (2,2), got %c", s.cells[2][2].Ch)
+	}
+}
+
+func TestBoxNestedBox(t *testing.T) {
+	borders := term.SingleBorderSet()
+	outer := NewBoxWithBorder(borders)
+	inner := NewBoxWithBorder(borders)
+	inner.Child = NewLabelWidget(LabelConfig{Text: "N"})
+	outer.Child = inner
+
+	// outer border: 2, inner border: 2, label: 1 = 5
+	s := renderWidget(outer, 0, 0, 12, 5)
+
+	// Outer border at (0,0)
+	if s.cells[0][0].Ch != borders.TopLeft {
+		t.Errorf("expected outer top-left corner, got %c", s.cells[0][0].Ch)
+	}
+	// Inner border at (1,1)
+	if s.cells[1][1].Ch != borders.TopLeft {
+		t.Errorf("expected inner top-left corner at (1,1), got %c", s.cells[1][1].Ch)
+	}
+	// Content "N" at (2,2)
+	if s.cells[2][2].Ch != 'N' {
+		t.Errorf("expected 'N' at (2,2), got %c", s.cells[2][2].Ch)
+	}
+}
+
+func TestBoxMargins(t *testing.T) {
+	box := NewBoxWidget(BoxModel{
+		MarginTop:    1,
+		MarginLeft:   2,
+		BorderTop:    true,
+		BorderBottom: true,
+		BorderLeft:   true,
+		BorderRight:  true,
+		Borders:      term.SingleBorderSet(),
+	})
+	box.Child = NewLabelWidget(LabelConfig{Text: "M"})
+
+	s := renderWidget(box, 0, 0, 20, 5)
+
+	// Margin top=1, margin left=2, so border starts at (2,1)
+	borders := term.SingleBorderSet()
+	if s.cells[1][2].Ch != borders.TopLeft {
+		t.Errorf("expected top-left corner at (2,1) after margins, got %c", s.cells[1][2].Ch)
+	}
+	// Content at (3,2) -- margin left(2) + border(1) = 3, margin top(1) + border(1) = 2
+	if s.cells[2][3].Ch != 'M' {
+		t.Errorf("expected 'M' at (3,2), got %c", s.cells[2][3].Ch)
+	}
+}
+
+func TestBoxHeightWithOverhead(t *testing.T) {
+	box := NewBoxWidget(BoxModel{
+		MarginTop:     1,
+		MarginBottom:  1,
+		PaddingTop:    1,
+		PaddingBottom: 1,
+		BorderTop:     true,
+		BorderBottom:  true,
+		BorderLeft:    true,
+		BorderRight:   true,
+		Borders:       term.SingleBorderSet(),
+	})
+	box.Child = NewLabelWidget(LabelConfig{Text: "Test"})
+
+	// Label height=1, overhead = margins(2) + padding(2) + borders(2) = 6, total = 7
+	h := box.Height()
+	if h != 7 {
+		t.Errorf("expected height=7, got %d", h)
+	}
+}
+
+func TestBoxWidthFromChild(t *testing.T) {
+	borders := term.SingleBorderSet()
+	box := NewBoxWithBorder(borders)
+	label := NewLabelWidget(LabelConfig{Text: "Test"})
+	label.FixedWidth = 10
+	box.Child = label
+
+	// Label width=10, box overhead = border left(1) + border right(1) = 2
+	w := box.Width()
+	expected := 10 + 2
+	if w != expected {
+		t.Errorf("expected width=%d, got %d", expected, w)
+	}
+}
+
+func TestBoxNilChild(t *testing.T) {
+	box := NewBoxWithBorder(term.SingleBorderSet())
+	// No child set
+
+	// Should not panic
+	s := renderWidget(box, 0, 0, 10, 3)
+	_ = s
+
+	// Height with nil child should be 0
+	if box.Height() != 0 {
+		t.Errorf("expected height=0 with nil child, got %d", box.Height())
+	}
+}
+
+func TestBoxHandleEventDelegatesToChild(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "Inside",
+		OnClick: func() { clicked = true },
+	})
+
+	box := NewBoxWithBorder(term.SingleBorderSet())
+	box.Child = btn
+
+	// Render to set rects
+	renderWidget(box, 5, 5, 20, 3)
+
+	// Click inside the button (which is inside the box)
+	r := btn.GetRect()
+	ev := mouseClick(r.X+1, r.Y)
+	result := box.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("box should delegate event to child")
+	}
+	if !clicked {
+		t.Error("child button OnClick should have been triggered")
+	}
+}
+
+func TestBoxHandleEventNilChild(t *testing.T) {
+	box := NewBoxWidget(BoxModel{})
+	// No child
+
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := box.HandleEvent(ev)
+	if result != EventIgnored {
+		t.Error("box with nil child should return EventIgnored")
+	}
+}
+
+func TestBoxWidgetChildren(t *testing.T) {
+	box := NewBoxWidget(BoxModel{})
+
+	// No child
+	children := box.WidgetChildren()
+	if children != nil {
+		t.Error("WidgetChildren should return nil when no child")
+	}
+
+	// With child
+	label := NewLabelWidget(LabelConfig{Text: "child"})
+	box.Child = label
+	children = box.WidgetChildren()
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+	if children[0] != label {
+		t.Error("WidgetChildren should return the child widget")
+	}
+}
+
+func TestBoxDoubleBorder(t *testing.T) {
+	borders := term.DoubleBorderSet()
+	box := NewBoxWithBorder(borders)
+	box.Child = NewLabelWidget(LabelConfig{Text: "D"})
+
+	s := renderWidget(box, 0, 0, 10, 3)
+
+	if s.cells[0][0].Ch != borders.TopLeft {
+		t.Errorf("expected double top-left %c, got %c", borders.TopLeft, s.cells[0][0].Ch)
+	}
+	if s.cells[0][5].Ch != borders.Horizontal {
+		t.Errorf("expected double horizontal %c, got %c", borders.Horizontal, s.cells[0][5].Ch)
+	}
+}

--- a/internal/widgets/button_test.go
+++ b/internal/widgets/button_test.go
@@ -1,0 +1,278 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+// surfaceRowText extracts the text from row y of the surface as a string.
+func surfaceRowText(s *testSurface, y int) string {
+	if y < 0 || y >= len(s.cells) {
+		return ""
+	}
+	runes := make([]rune, len(s.cells[y]))
+	for x, c := range s.cells[y] {
+		if c.Ch == 0 {
+			runes[x] = ' '
+		} else {
+			runes[x] = c.Ch
+		}
+	}
+	return string(runes)
+}
+
+func TestButtonRenderLabel(t *testing.T) {
+	btn := NewButtonWidget(ButtonConfig{Label: "OK"})
+	s := renderWidget(btn, 0, 0, 20, 1)
+	row := surfaceRowText(s, 0)
+	// Default BoxModel has PaddingLeft=1, PaddingRight=1, so label starts at x=1
+	if row[1] != 'O' || row[2] != 'K' {
+		t.Errorf("expected label 'OK' at offset 1, got row: %q", row)
+	}
+}
+
+func TestButtonAcceleratorUnderline(t *testing.T) {
+	btn := NewButtonWidget(ButtonConfig{Label: "&Save"})
+	s := renderWidget(btn, 0, 0, 20, 1)
+
+	// Accelerator removes '&', so label is "Save". "S" is at accelIndex=0.
+	// With PaddingLeft=1, the 'S' cell is at surface column 1.
+	if btn.accelIndex != 0 {
+		t.Fatalf("expected accelIndex=0, got %d", btn.accelIndex)
+	}
+	if btn.accelRune != 'S' {
+		t.Fatalf("expected accelRune='S', got %c", btn.accelRune)
+	}
+	if btn.label != "Save" {
+		t.Fatalf("expected label='Save', got %q", btn.label)
+	}
+	// The underline should be set on the cell at the accel position
+	cell := s.cells[0][1] // PaddingLeft=1, so accelIndex=0 maps to surface x=1
+	if !cell.Underline {
+		t.Error("accelerator rune 'S' should be underlined")
+	}
+	if cell.Ch != 'S' {
+		t.Errorf("expected 'S' at accel position, got %c", cell.Ch)
+	}
+	// Non-accel characters should NOT be underlined
+	cell2 := s.cells[0][2]
+	if cell2.Underline {
+		t.Error("non-accelerator rune should not be underlined")
+	}
+}
+
+func TestButtonAcceleratorMiddle(t *testing.T) {
+	btn := NewButtonWidget(ButtonConfig{Label: "E&xit"})
+	if btn.label != "Exit" {
+		t.Fatalf("expected label='Exit', got %q", btn.label)
+	}
+	if btn.accelIndex != 1 {
+		t.Fatalf("expected accelIndex=1, got %d", btn.accelIndex)
+	}
+	if btn.accelRune != 'x' {
+		t.Fatalf("expected accelRune='x', got %c", btn.accelRune)
+	}
+}
+
+func TestButtonClickFiresOnClick(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "Click Me",
+		OnClick: func() { clicked = true },
+	})
+	renderWidget(btn, 5, 3, 20, 1)
+
+	// Click inside the button rect
+	ev := mouseClick(6, 3)
+	result := btn.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("click inside button should be consumed")
+	}
+	if !clicked {
+		t.Error("OnClick should have been called")
+	}
+}
+
+func TestButtonClickOutsideBounds(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "Button",
+		OnClick: func() { clicked = true },
+	})
+	renderWidget(btn, 5, 3, 20, 1)
+
+	// Click outside the button rect
+	ev := mouseClick(0, 0)
+	result := btn.HandleEvent(ev)
+	if result == EventConsumed {
+		t.Error("click outside button should not be consumed")
+	}
+	if clicked {
+		t.Error("OnClick should not be called for click outside bounds")
+	}
+}
+
+func TestButtonEnterKeyFiresOnClick(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "Submit",
+		OnClick: func() { clicked = true },
+	})
+	btn.SetFocused(true)
+
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := btn.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("enter key on focused button should be consumed")
+	}
+	if !clicked {
+		t.Error("OnClick should be called on Enter when focused")
+	}
+}
+
+func TestButtonSpaceKeyFiresOnClick(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "Submit",
+		OnClick: func() { clicked = true },
+	})
+	btn.SetFocused(true)
+
+	ev := tcell.NewEventKey(tcell.KeyRune, ' ', tcell.ModNone)
+	result := btn.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("space key on focused button should be consumed")
+	}
+	if !clicked {
+		t.Error("OnClick should be called on Space when focused")
+	}
+}
+
+func TestButtonEnterKeyIgnoredWhenNotFocused(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "Submit",
+		OnClick: func() { clicked = true },
+	})
+	// Not focused
+
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := btn.HandleEvent(ev)
+	// Enter should not trigger if not focused (no accel match either)
+	if clicked {
+		t.Error("OnClick should not be called on Enter when not focused")
+	}
+	if result == EventConsumed {
+		t.Error("enter key on unfocused button should not be consumed")
+	}
+}
+
+func TestButtonFocusStyling(t *testing.T) {
+	btn := NewButtonWidget(ButtonConfig{Label: "Test"})
+
+	// Render unfocused
+	btn.SetFocused(false)
+	s1 := renderWidget(btn, 0, 0, 20, 1)
+	unfocusedStyle := s1.cells[0][1].Style // PaddingLeft=1, label starts at x=1
+	if unfocusedStyle == term.StyleButtonFocused {
+		t.Error("unfocused button should not use StyleButtonFocused")
+	}
+
+	// Render focused
+	btn.SetFocused(true)
+	s2 := renderWidget(btn, 0, 0, 20, 1)
+	focusedStyle := s2.cells[0][1].Style
+	if focusedStyle != term.StyleButtonFocused {
+		t.Errorf("focused button should use StyleButtonFocused, got %v", focusedStyle)
+	}
+}
+
+func TestButtonFocusable(t *testing.T) {
+	btn := NewButtonWidget(ButtonConfig{Label: "X"})
+	if !btn.Focusable() {
+		t.Error("button should be focusable")
+	}
+	btn.SetFocused(true)
+	if !btn.IsFocused() {
+		t.Error("button should report focused after SetFocused(true)")
+	}
+	btn.SetFocused(false)
+	if btn.IsFocused() {
+		t.Error("button should not report focused after SetFocused(false)")
+	}
+}
+
+func TestButtonHeightIncludesBoxOverhead(t *testing.T) {
+	btn := NewButtonWidget(ButtonConfig{
+		Label: "Test",
+		Box: &BoxModel{
+			MarginTop:    1,
+			MarginBottom: 1,
+			PaddingTop:   1,
+			PaddingBottom: 1,
+		},
+	})
+	// Height = 1 (label line) + margin top(1) + margin bottom(1) + padding top(1) + padding bottom(1) = 5
+	expected := 1 + 1 + 1 + 1 + 1
+	if btn.Height() != expected {
+		t.Errorf("expected height=%d, got %d", expected, btn.Height())
+	}
+}
+
+func TestButtonWidth(t *testing.T) {
+	btn := NewButtonWidget(ButtonConfig{Label: "Save"})
+	// Width = len("Save")=4 + PaddingLeft(1) + PaddingRight(1) = 6
+	if btn.Width() != 6 {
+		t.Errorf("expected width=6, got %d", btn.Width())
+	}
+}
+
+func TestButtonOnCommand(t *testing.T) {
+	var received string
+	btn := NewButtonWidget(ButtonConfig{
+		Label:     "Run",
+		Command:   "editor.run",
+		OnCommand: func(cmd string) { received = cmd },
+	})
+	btn.SetFocused(true)
+	btn.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+	if received != "editor.run" {
+		t.Errorf("expected command 'editor.run', got %q", received)
+	}
+}
+
+func TestButtonAcceleratorKeyTrigger(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "&Save",
+		OnClick: func() { clicked = true },
+	})
+	// Not focused, but accel key 's' should trigger
+	ev := tcell.NewEventKey(tcell.KeyRune, 's', tcell.ModNone)
+	result := btn.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("accelerator key should be consumed")
+	}
+	if !clicked {
+		t.Error("OnClick should be called via accelerator key")
+	}
+}
+
+func TestButtonAcceleratorKeyCaseInsensitive(t *testing.T) {
+	clicked := false
+	btn := NewButtonWidget(ButtonConfig{
+		Label:   "&Save",
+		OnClick: func() { clicked = true },
+	})
+	// Uppercase 'S' should also match
+	ev := tcell.NewEventKey(tcell.KeyRune, 'S', tcell.ModNone)
+	result := btn.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("accelerator key (uppercase) should be consumed")
+	}
+	if !clicked {
+		t.Error("OnClick should be called via uppercase accelerator key")
+	}
+}

--- a/internal/widgets/checkbox_test.go
+++ b/internal/widgets/checkbox_test.go
@@ -1,0 +1,236 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestCheckboxRenderUnchecked(t *testing.T) {
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "Option A"})
+	s := renderWidget(cb, 0, 0, 30, 1)
+
+	// Unchecked checkbox renders: " [ ] Option A"
+	// Cells: 0=' ', 1='[', 2=' ', 3=']', 4=' ', 5='O', ...
+	if s.cells[0][1].Ch != '[' {
+		t.Errorf("expected '[' at x=1, got %c", s.cells[0][1].Ch)
+	}
+	if s.cells[0][2].Ch != ' ' {
+		t.Errorf("expected ' ' (unchecked) at x=2, got %c", s.cells[0][2].Ch)
+	}
+	if s.cells[0][3].Ch != ']' {
+		t.Errorf("expected ']' at x=3, got %c", s.cells[0][3].Ch)
+	}
+	if s.cells[0][5].Ch != 'O' {
+		t.Errorf("expected 'O' at x=5, got %c", s.cells[0][5].Ch)
+	}
+}
+
+func TestCheckboxRenderChecked(t *testing.T) {
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "Option B", Checked: true})
+	s := renderWidget(cb, 0, 0, 30, 1)
+
+	// Checked checkbox renders: " [x] Option B"
+	if s.cells[0][2].Ch != 'x' {
+		t.Errorf("expected 'x' (checked) at x=2, got %c", s.cells[0][2].Ch)
+	}
+}
+
+func TestCheckboxClickToggles(t *testing.T) {
+	var changed bool
+	var newState bool
+	cb := NewCheckboxWidget(CheckboxConfig{
+		Label: "Toggle",
+		OnChange: func(checked bool) {
+			changed = true
+			newState = checked
+		},
+	})
+	renderWidget(cb, 5, 3, 20, 1)
+
+	// Initially unchecked
+	if cb.Config.Checked {
+		t.Fatal("checkbox should start unchecked")
+	}
+
+	// Click inside the checkbox rect
+	ev := mouseClick(6, 3)
+	result := cb.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("click inside checkbox should be consumed")
+	}
+	if !changed {
+		t.Error("OnChange should have been called")
+	}
+	if !newState {
+		t.Error("checkbox should be checked after toggle")
+	}
+	if !cb.Config.Checked {
+		t.Error("Config.Checked should be true after toggle")
+	}
+
+	// Click again to uncheck
+	changed = false
+	ev2 := mouseClick(7, 3)
+	cb.HandleEvent(ev2)
+	if !changed {
+		t.Error("OnChange should have been called on second toggle")
+	}
+	if newState {
+		t.Error("checkbox should be unchecked after second toggle")
+	}
+}
+
+func TestCheckboxClickOutside(t *testing.T) {
+	clicked := false
+	cb := NewCheckboxWidget(CheckboxConfig{
+		Label:    "Test",
+		OnChange: func(bool) { clicked = true },
+	})
+	renderWidget(cb, 5, 3, 20, 1)
+
+	ev := mouseClick(0, 0)
+	result := cb.HandleEvent(ev)
+	if result == EventConsumed {
+		t.Error("click outside checkbox should not be consumed")
+	}
+	if clicked {
+		t.Error("OnChange should not be called for click outside bounds")
+	}
+}
+
+func TestCheckboxEnterKeyToggles(t *testing.T) {
+	toggled := false
+	cb := NewCheckboxWidget(CheckboxConfig{
+		Label:    "Enter Test",
+		OnChange: func(bool) { toggled = true },
+	})
+	cb.SetFocused(true)
+
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := cb.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("enter key on focused checkbox should be consumed")
+	}
+	if !toggled {
+		t.Error("OnChange should be called on Enter when focused")
+	}
+	if !cb.Config.Checked {
+		t.Error("checkbox should be checked after Enter toggle")
+	}
+}
+
+func TestCheckboxSpaceKeyToggles(t *testing.T) {
+	toggled := false
+	cb := NewCheckboxWidget(CheckboxConfig{
+		Label:    "Space Test",
+		OnChange: func(bool) { toggled = true },
+	})
+	cb.SetFocused(true)
+
+	ev := tcell.NewEventKey(tcell.KeyRune, ' ', tcell.ModNone)
+	result := cb.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("space key on focused checkbox should be consumed")
+	}
+	if !toggled {
+		t.Error("OnChange should be called on Space when focused")
+	}
+}
+
+func TestCheckboxKeyIgnoredWhenNotFocused(t *testing.T) {
+	toggled := false
+	cb := NewCheckboxWidget(CheckboxConfig{
+		Label:    "Unfocused",
+		OnChange: func(bool) { toggled = true },
+	})
+	// Not focused
+
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := cb.HandleEvent(ev)
+	if result == EventConsumed {
+		t.Error("enter key on unfocused checkbox should not be consumed")
+	}
+	if toggled {
+		t.Error("OnChange should not be called when checkbox is not focused")
+	}
+}
+
+func TestCheckboxFocusStyling(t *testing.T) {
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "Styled"})
+
+	// Render unfocused
+	cb.SetFocused(false)
+	s1 := renderWidget(cb, 0, 0, 30, 1)
+	unfocusedStyle := s1.cells[0][1].Style
+	if unfocusedStyle == term.StyleButtonFocused {
+		t.Error("unfocused checkbox should not use StyleButtonFocused")
+	}
+
+	// Render focused
+	cb.SetFocused(true)
+	s2 := renderWidget(cb, 0, 0, 30, 1)
+	focusedStyle := s2.cells[0][1].Style
+	if focusedStyle != term.StyleButtonFocused {
+		t.Errorf("focused checkbox should use StyleButtonFocused, got %v", focusedStyle)
+	}
+}
+
+func TestCheckboxFocusable(t *testing.T) {
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "F"})
+	if !cb.Focusable() {
+		t.Error("checkbox should be focusable")
+	}
+	cb.SetFocused(true)
+	if !cb.IsFocused() {
+		t.Error("checkbox should report focused after SetFocused(true)")
+	}
+	cb.SetFocused(false)
+	if cb.IsFocused() {
+		t.Error("checkbox should not report focused after SetFocused(false)")
+	}
+}
+
+func TestCheckboxHeight(t *testing.T) {
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "Test"})
+	if cb.Height() != 1 {
+		t.Errorf("expected height=1, got %d", cb.Height())
+	}
+}
+
+func TestCheckboxHeightWithBoxModel(t *testing.T) {
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "Test"})
+	cb.SetBoxModel(BoxModel{
+		MarginTop:    1,
+		MarginBottom: 1,
+	})
+	// Height = 1 + margin top(1) + margin bottom(1) = 3
+	if cb.Height() != 3 {
+		t.Errorf("expected height=3, got %d", cb.Height())
+	}
+}
+
+func TestCheckboxNoOnChangeCallback(t *testing.T) {
+	// Ensure toggling works even without OnChange callback (no panic)
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "No callback"})
+	cb.SetFocused(true)
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	cb.HandleEvent(ev)
+	if !cb.Config.Checked {
+		t.Error("checkbox should toggle even without OnChange callback")
+	}
+}
+
+func TestCheckboxLabelRendered(t *testing.T) {
+	cb := NewCheckboxWidget(CheckboxConfig{Label: "Hello"})
+	s := renderWidget(cb, 0, 0, 30, 1)
+
+	// Label starts at x=5: " [x] Hello"
+	expected := "Hello"
+	for i, ch := range expected {
+		if s.cells[0][5+i].Ch != ch {
+			t.Errorf("expected %c at x=%d, got %c", ch, 5+i, s.cells[0][5+i].Ch)
+		}
+	}
+}

--- a/internal/widgets/dialog.go
+++ b/internal/widgets/dialog.go
@@ -167,6 +167,31 @@ func (d *DialogWidget) Render(surface Surface) {
 	}
 }
 
+func (d *DialogWidget) moveFocusButton(forward bool) {
+	children := d.footer.Children
+	cur := -1
+	for i, c := range children {
+		if fw, ok := c.(FocusableWidget); ok && fw.IsFocused() {
+			cur = i
+			break
+		}
+	}
+	next := cur
+	if forward && cur < len(children)-1 {
+		next = cur + 1
+	} else if !forward && cur > 0 {
+		next = cur - 1
+	}
+	if next != cur {
+		if fw, ok := children[cur].(FocusableWidget); ok {
+			fw.SetFocused(false)
+		}
+		if fw, ok := children[next].(FocusableWidget); ok {
+			fw.SetFocused(true)
+		}
+	}
+}
+
 func (d *DialogWidget) HandleEvent(ev tcell.Event) EventResult {
 	switch e := ev.(type) {
 	case *tcell.EventKey:
@@ -174,6 +199,10 @@ func (d *DialogWidget) HandleEvent(ev tcell.Event) EventResult {
 			if d.OnDismiss != nil {
 				d.OnDismiss()
 			}
+			return EventConsumed
+		}
+		if d.footer != nil && (e.Key() == tcell.KeyLeft || e.Key() == tcell.KeyRight) {
+			d.moveFocusButton(e.Key() == tcell.KeyRight)
 			return EventConsumed
 		}
 		if d.footer != nil {

--- a/internal/widgets/dialog_test.go
+++ b/internal/widgets/dialog_test.go
@@ -1,0 +1,904 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// surfaceHasText checks whether any row in the surface contains the given substring.
+func surfaceHasText(s *testSurface, substr string) bool {
+	for row := range s.cells {
+		text := surfaceRowText(s, row)
+		for i := 0; i <= len(text)-len(substr); i++ {
+			if text[i:i+len(substr)] == substr {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Construction & Setup
+// ---------------------------------------------------------------------------
+
+func TestDialogNewWithWidth(t *testing.T) {
+	d := NewDialogWidget(50)
+	if d.BoxWidth != 50 {
+		t.Fatalf("expected BoxWidth=50, got %d", d.BoxWidth)
+	}
+	if d.Borders.TopLeft != '╔' {
+		t.Fatal("expected DoubleBorderSet by default")
+	}
+}
+
+func TestDialogNewWithNegativeWidth(t *testing.T) {
+	d := NewDialogWidget(-5)
+	if d.BoxWidth != 40 {
+		t.Fatalf("expected default BoxWidth=40 for negative input, got %d", d.BoxWidth)
+	}
+}
+
+func TestDialogSetTitle(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Title = "My Title"
+	if d.Title != "My Title" {
+		t.Fatalf("expected title 'My Title', got '%s'", d.Title)
+	}
+}
+
+func TestDialogSetContentWidget(t *testing.T) {
+	d := NewDialogWidget(40)
+	content := NewLabelWidget(LabelConfig{Text: "Hello"})
+	d.SetContent(content)
+	if d.Content != content {
+		t.Fatal("SetContent did not set the content widget")
+	}
+}
+
+func TestDialogWidgetChildrenBoth(t *testing.T) {
+	d := NewDialogWidget(40)
+	content := NewLabelWidget(LabelConfig{Text: "content"})
+	d.SetContent(content)
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	children := d.WidgetChildren()
+	if len(children) != 2 {
+		t.Fatalf("expected 2 children (content + footer), got %d", len(children))
+	}
+	if children[0] != content {
+		t.Fatal("first child should be the content widget")
+	}
+	if children[1] != d.footer {
+		t.Fatal("second child should be the footer")
+	}
+}
+
+func TestDialogWidgetChildrenFooterOnly(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	children := d.WidgetChildren()
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child (footer only), got %d", len(children))
+	}
+}
+
+func TestDialogWidgetChildrenEmpty(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Build()
+
+	children := d.WidgetChildren()
+	if len(children) != 0 {
+		t.Fatalf("expected 0 children, got %d", len(children))
+	}
+}
+
+func TestDialogWidthReturnsBoxWidth(t *testing.T) {
+	d := NewDialogWidget(60)
+	if d.Width() != 60 {
+		t.Fatalf("Width() should return BoxWidth, got %d", d.Width())
+	}
+}
+
+func TestDialogHeightReturnsZero(t *testing.T) {
+	d := NewDialogWidget(40)
+	if d.Height() != 0 {
+		t.Fatalf("Height() should return 0, got %d", d.Height())
+	}
+}
+
+func TestDialogBuildFooterPadding(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	if d.footer.Box.PaddingLeft != 1 {
+		t.Errorf("expected footer PaddingLeft=1, got %d", d.footer.Box.PaddingLeft)
+	}
+	if d.footer.Box.PaddingRight != 1 {
+		t.Errorf("expected footer PaddingRight=1, got %d", d.footer.Box.PaddingRight)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+func TestDialogRenderTitle(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.Title = "Confirm"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "Are you sure?"}))
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	if !surfaceHasText(s, "Confirm") {
+		t.Error("dialog should render the title text")
+	}
+}
+
+func TestDialogRenderBorderCorners(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.Title = "Test"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "Body"}))
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	bs := term.DoubleBorderSet()
+
+	// Verify all four corners
+	if s.cells[d.boxY][d.boxX].Ch != bs.TopLeft {
+		t.Errorf("expected top-left '╔', got '%c'", s.cells[d.boxY][d.boxX].Ch)
+	}
+	if s.cells[d.boxY][d.boxX+d.boxW-1].Ch != bs.TopRight {
+		t.Errorf("expected top-right '╗', got '%c'", s.cells[d.boxY][d.boxX+d.boxW-1].Ch)
+	}
+	if s.cells[d.boxY+d.boxH-1][d.boxX].Ch != bs.BottomLeft {
+		t.Errorf("expected bottom-left '╚', got '%c'", s.cells[d.boxY+d.boxH-1][d.boxX].Ch)
+	}
+	if s.cells[d.boxY+d.boxH-1][d.boxX+d.boxW-1].Ch != bs.BottomRight {
+		t.Errorf("expected bottom-right '╝', got '%c'", s.cells[d.boxY+d.boxH-1][d.boxX+d.boxW-1].Ch)
+	}
+}
+
+func TestDialogRenderHorizontalBorders(t *testing.T) {
+	d := NewDialogWidget(20)
+	d.Title = "T"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "B"}))
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	bs := term.DoubleBorderSet()
+
+	// Check horizontal border chars along top edge (between corners)
+	topY := d.boxY
+	for x := d.boxX + 1; x < d.boxX+d.boxW-1; x++ {
+		if s.cells[topY][x].Ch != bs.Horizontal {
+			t.Errorf("expected horizontal border '═' at (%d,%d), got '%c'", x, topY, s.cells[topY][x].Ch)
+			break
+		}
+	}
+}
+
+func TestDialogRenderVerticalBorders(t *testing.T) {
+	d := NewDialogWidget(20)
+	d.Title = "T"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "B"}))
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	bs := term.DoubleBorderSet()
+
+	// Check vertical border chars along left edge (between corners)
+	leftX := d.boxX
+	for y := d.boxY + 1; y < d.boxY+d.boxH-1; y++ {
+		if s.cells[y][leftX].Ch != bs.Vertical {
+			t.Errorf("expected vertical border '║' at (%d,%d), got '%c'", leftX, y, s.cells[y][leftX].Ch)
+			break
+		}
+	}
+}
+
+func TestDialogRenderContentWidget(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Title = "Info"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "Hello World"}))
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	if !surfaceHasText(s, "Hello World") {
+		t.Error("dialog should render the content widget text")
+	}
+}
+
+func TestDialogRenderFooterButtons(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Buttons = []DialogButton{
+		{Label: "Save"},
+		{Label: "Cancel"},
+	}
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	if !surfaceHasText(s, "Save") {
+		t.Error("dialog should render 'Save' button label")
+	}
+	if !surfaceHasText(s, "Cancel") {
+		t.Error("dialog should render 'Cancel' button label")
+	}
+}
+
+func TestDialogRenderNoTitle(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "Content"}))
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	if !surfaceHasText(s, "Content") {
+		t.Error("dialog without title should still render content")
+	}
+}
+
+func TestDialogRenderSmallSurface(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.Title = "Test"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Build()
+
+	// Surface too small (4x4) should bail out without crashing
+	s := renderWidget(d, 0, 0, 4, 4)
+	if surfaceHasText(s, "Test") {
+		t.Error("dialog should not render on surface <= 4x4")
+	}
+}
+
+func TestDialogRenderBoxWidthClamped(t *testing.T) {
+	d := NewDialogWidget(100)
+	d.Title = "Wide"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Build()
+
+	renderWidget(d, 0, 0, 30, 20)
+
+	// Should clamp boxW to sw-4 = 26
+	if d.boxW > 26 {
+		t.Errorf("boxW should be clamped to %d, got %d", 26, d.boxW)
+	}
+}
+
+func TestDialogTitleRendersWithBoldAndStyle(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.Title = "Styled"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	titleY := d.boxY + 1
+	titleStartX := d.boxX + 2 // innerX + 1
+	c := s.cells[titleY][titleStartX]
+	if c.Ch != 'S' {
+		t.Errorf("expected first title char 'S' at (%d,%d), got '%c'", titleStartX, titleY, c.Ch)
+	}
+	if c.Style != term.StylePaletteItem {
+		t.Errorf("title should use StylePaletteItem, got %v", c.Style)
+	}
+	if !c.Bold {
+		t.Error("title should be rendered with Bold=true")
+	}
+}
+
+func TestDialogRenderFullDialog(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Title = "Save Changes"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "You have unsaved changes."}))
+	d.Buttons = []DialogButton{
+		{Label: "Save"},
+		{Label: "Don't Save"},
+		{Label: "Cancel"},
+	}
+	d.Build()
+
+	s := renderWidget(d, 0, 0, 80, 24)
+
+	if !surfaceHasText(s, "Save Changes") {
+		t.Error("dialog should render title")
+	}
+	if !surfaceHasText(s, "You have unsaved changes.") {
+		t.Error("dialog should render content")
+	}
+	if !surfaceHasText(s, "Cancel") {
+		t.Error("dialog should render Cancel button")
+	}
+
+	// Verify border corners
+	bs := term.DoubleBorderSet()
+	if s.cells[d.boxY][d.boxX].Ch != bs.TopLeft {
+		t.Errorf("expected top-left border '╔', got '%c'", s.cells[d.boxY][d.boxX].Ch)
+	}
+	if s.cells[d.boxY+d.boxH-1][d.boxX+d.boxW-1].Ch != bs.BottomRight {
+		t.Errorf("expected bottom-right border '╝', got '%c'", s.cells[d.boxY+d.boxH-1][d.boxX+d.boxW-1].Ch)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard Navigation
+// ---------------------------------------------------------------------------
+
+func TestDialogEscapeWithoutOnDismiss(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Build()
+	// No OnDismiss set — should not panic
+
+	result := d.HandleEvent(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone))
+	if result != EventConsumed {
+		t.Error("Escape should return EventConsumed even without OnDismiss")
+	}
+}
+
+func TestDialogEnterActivatesFocusedButton(t *testing.T) {
+	clicked := ""
+	d := NewDialogWidget(40)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Buttons = []DialogButton{
+		{Label: "OK", Handler: func() { clicked = "ok" }},
+		{Label: "Cancel", Handler: func() { clicked = "cancel" }},
+	}
+	d.Build()
+
+	// Focus the first button
+	d.footer.Children[0].(FocusableWidget).SetFocused(true)
+
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+	if clicked != "ok" {
+		t.Fatalf("Enter on focused 'OK' button should trigger its handler, got '%s'", clicked)
+	}
+}
+
+func TestDialogLeftRightNavigateButtons(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Buttons = []DialogButton{
+		{Label: "A"},
+		{Label: "B"},
+		{Label: "C"},
+	}
+	d.Build()
+
+	btn0 := d.footer.Children[0].(FocusableWidget)
+	btn1 := d.footer.Children[1].(FocusableWidget)
+	btn2 := d.footer.Children[2].(FocusableWidget)
+
+	// Start with first button focused
+	btn0.SetFocused(true)
+
+	// Right: A -> B
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	if btn0.IsFocused() {
+		t.Error("A should not be focused after Right")
+	}
+	if !btn1.IsFocused() {
+		t.Error("B should be focused after Right")
+	}
+
+	// Right: B -> C
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	if !btn2.IsFocused() {
+		t.Error("C should be focused after second Right")
+	}
+	if btn1.IsFocused() {
+		t.Error("B should not be focused after second Right")
+	}
+
+	// Right on last: no wrap, C stays
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	if !btn2.IsFocused() {
+		t.Error("C should remain focused on Right at end (no wrap)")
+	}
+
+	// Left: C -> B
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone))
+	if !btn1.IsFocused() {
+		t.Error("B should be focused after Left from C")
+	}
+	if btn2.IsFocused() {
+		t.Error("C should not be focused after Left")
+	}
+
+	// Left: B -> A
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone))
+	if !btn0.IsFocused() {
+		t.Error("A should be focused after Left from B")
+	}
+
+	// Left on first: no wrap, A stays
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone))
+	if !btn0.IsFocused() {
+		t.Error("A should remain focused on Left at start (no wrap)")
+	}
+}
+
+func TestDialogEnterOnSecondButton(t *testing.T) {
+	clicked := ""
+	d := NewDialogWidget(40)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Buttons = []DialogButton{
+		{Label: "Save", Handler: func() { clicked = "save" }},
+		{Label: "Cancel", Handler: func() { clicked = "cancel" }},
+	}
+	d.Build()
+
+	d.footer.Children[0].(FocusableWidget).SetFocused(true)
+	// Move right to Cancel
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+	if clicked != "cancel" {
+		t.Fatalf("Enter should activate focused Cancel button, got '%s'", clicked)
+	}
+}
+
+func TestDialogSpaceActivatesButton(t *testing.T) {
+	clicked := false
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{
+		{Label: "Go", Handler: func() { clicked = true }},
+	}
+	d.Build()
+
+	d.footer.Children[0].(FocusableWidget).SetFocused(true)
+
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRune, ' ', tcell.ModNone))
+	if !clicked {
+		t.Error("Space on focused button should activate it")
+	}
+}
+
+func TestDialogArrowKeyConsumedResult(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{{Label: "A"}, {Label: "B"}}
+	d.Build()
+	d.footer.Children[0].(FocusableWidget).SetFocused(true)
+
+	result := d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	if result != EventConsumed {
+		t.Error("Right arrow should return EventConsumed")
+	}
+
+	result = d.HandleEvent(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone))
+	if result != EventConsumed {
+		t.Error("Left arrow should return EventConsumed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Edge Cases: button counts
+// ---------------------------------------------------------------------------
+
+func TestDialogSingleButtonNavigation(t *testing.T) {
+	clicked := false
+	d := NewDialogWidget(40)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "Confirm?"}))
+	d.Buttons = []DialogButton{
+		{Label: "OK", Handler: func() { clicked = true }},
+	}
+	d.Build()
+
+	if len(d.footer.Children) != 1 {
+		t.Fatalf("expected 1 footer child, got %d", len(d.footer.Children))
+	}
+
+	btn := d.footer.Children[0].(FocusableWidget)
+	btn.SetFocused(true)
+
+	// Left/Right should be no-ops on single button
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	if !btn.IsFocused() {
+		t.Error("single button should remain focused after Right")
+	}
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone))
+	if !btn.IsFocused() {
+		t.Error("single button should remain focused after Left")
+	}
+
+	// Enter triggers the handler
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+	if !clicked {
+		t.Error("Enter on single focused button should trigger handler")
+	}
+}
+
+func TestDialogThreeButtonsNavigateToLast(t *testing.T) {
+	clicked := ""
+	d := NewDialogWidget(50)
+	d.Buttons = []DialogButton{
+		{Label: "Yes", Handler: func() { clicked = "yes" }},
+		{Label: "No", Handler: func() { clicked = "no" }},
+		{Label: "Cancel", Handler: func() { clicked = "cancel" }},
+	}
+	d.Build()
+
+	if len(d.footer.Children) != 3 {
+		t.Fatalf("expected 3 footer children, got %d", len(d.footer.Children))
+	}
+
+	// Focus first button, navigate to third
+	d.footer.Children[0].(FocusableWidget).SetFocused(true)
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+
+	if !d.footer.Children[2].(FocusableWidget).IsFocused() {
+		t.Error("third button should be focused after two Rights")
+	}
+
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+	if clicked != "cancel" {
+		t.Fatalf("expected 'cancel', got '%s'", clicked)
+	}
+}
+
+func TestDialogNoButtonsNoFooter(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Title = "Info"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "Read only info"}))
+	d.Build()
+
+	if d.footer != nil {
+		t.Fatal("dialog with no buttons should have no footer")
+	}
+
+	// Render should still work
+	s := renderWidget(d, 0, 0, 80, 24)
+	if !surfaceHasText(s, "Read only info") {
+		t.Error("dialog with no buttons should still render content")
+	}
+
+	// Arrow keys should not panic (footer is nil, Left/Right skip)
+	result := d.HandleEvent(tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone))
+	if result != EventConsumed {
+		t.Error("dialog should still consume key events even without buttons")
+	}
+
+	result = d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	if result != EventConsumed {
+		t.Error("dialog should still consume Right key even without buttons")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mouse Events
+// ---------------------------------------------------------------------------
+
+func TestDialogMouseClickOnFooterButton(t *testing.T) {
+	clicked := false
+	d := NewDialogWidget(40)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Buttons = []DialogButton{
+		{Label: "Click Me", Handler: func() { clicked = true }},
+	}
+	d.Build()
+
+	renderWidget(d, 0, 0, 80, 24)
+
+	// Get the button rect to click inside it
+	btn := d.footer.Children[0].(*ButtonWidget)
+	r := btn.GetRect()
+
+	if r.W == 0 || r.H == 0 {
+		t.Fatal("button rect should be set after render")
+	}
+
+	// Click inside the button
+	click := mouseClick(r.X+1, r.Y)
+	d.HandleEvent(click)
+	if !clicked {
+		t.Error("mouse click on button should trigger handler")
+	}
+}
+
+func TestDialogMouseEventDoesNotPanic(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Build()
+	// No footer, no content — mouse events should not panic
+	click := mouseClick(10, 10)
+	d.HandleEvent(click)
+}
+
+// ---------------------------------------------------------------------------
+// Content Height
+// ---------------------------------------------------------------------------
+
+func TestDialogContentHeightForWidthUsed(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Title = "Wrap"
+	d.SetContent(NewParagraphWidget("This is a paragraph that should wrap."))
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	renderWidget(d, 0, 0, 80, 24)
+
+	if d.boxW <= 0 || d.boxH <= 0 {
+		t.Errorf("dialog should have positive dimensions, got W=%d H=%d", d.boxW, d.boxH)
+	}
+}
+
+func TestDialogContentHeightFixedHeightWidget(t *testing.T) {
+	d := NewDialogWidget(40)
+	// Label has Height() = 1
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "Fixed"}))
+
+	h := d.contentHeight(36)
+	if h != 1 {
+		t.Fatalf("contentHeight for a label should be 1, got %d", h)
+	}
+}
+
+func TestDialogContentHeightNilContent(t *testing.T) {
+	d := NewDialogWidget(40)
+
+	h := d.contentHeight(36)
+	if h != 1 {
+		t.Fatalf("contentHeight with nil content should default to 1, got %d", h)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Box Dimensions
+// ---------------------------------------------------------------------------
+
+func TestDialogBoxDimensionsWithTitleAndButtons(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.Title = "My Dialog"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "content"}))
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	renderWidget(d, 0, 0, 80, 24)
+
+	// boxH = 2 (border top+bottom) + 1 (title) + 1 (gap title-content) + 1 (content) + 1 (gap content-btn) + 1 (button) = 7
+	if d.boxH != 7 {
+		t.Errorf("expected boxH=7 with title+content+buttons, got %d", d.boxH)
+	}
+
+	// boxY is always 2
+	if d.boxY != 2 {
+		t.Errorf("expected boxY=2, got %d", d.boxY)
+	}
+
+	// boxW should be 30 (fits in 80-wide surface)
+	if d.boxW != 30 {
+		t.Errorf("expected boxW=30, got %d", d.boxW)
+	}
+
+	// boxX should be centered: (80-30)/2 = 25
+	if d.boxX != 25 {
+		t.Errorf("expected boxX=25, got %d", d.boxX)
+	}
+}
+
+func TestDialogBoxDimensionsNoTitle(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "content"}))
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	renderWidget(d, 0, 0, 80, 24)
+
+	// boxH = 2 (border) + 0 (no title) + 1 (content) + 1 (gap content-btn) + 1 (button) = 5
+	if d.boxH != 5 {
+		t.Errorf("expected boxH=5 without title, got %d", d.boxH)
+	}
+}
+
+func TestDialogBoxDimensionsNoButtons(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.Title = "Info"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "content"}))
+	d.Build()
+
+	renderWidget(d, 0, 0, 80, 24)
+
+	// boxH = 2 (border) + 1 (title) + 1 (gap title-content) + 1 (content) = 5
+	if d.boxH != 5 {
+		t.Errorf("expected boxH=5 with title but no buttons, got %d", d.boxH)
+	}
+}
+
+func TestDialogBoxHeightClampedToSurface(t *testing.T) {
+	d := NewDialogWidget(30)
+	d.Title = "Big Dialog"
+	d.SetContent(NewParagraphWidget("Line one. Line two. Line three. Line four. Line five. This is a very long paragraph that should wrap to many lines in a narrow dialog."))
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	renderWidget(d, 0, 0, 40, 8)
+
+	// boxH should be clamped: boxY=2, sh=8, so max boxH = 8-2 = 6
+	if d.boxH > 6 {
+		t.Errorf("boxH should be clamped to sh-boxY=6, got %d", d.boxH)
+	}
+}
+
+func TestDialogBoxCenteredHorizontally(t *testing.T) {
+	d := NewDialogWidget(20)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Build()
+
+	renderWidget(d, 0, 0, 60, 20)
+
+	expected := (60 - 20) / 2
+	if d.boxX != expected {
+		t.Errorf("expected boxX=%d (centered), got %d", expected, d.boxX)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multiple handlers
+// ---------------------------------------------------------------------------
+
+func TestDialogMultipleButtonHandlers(t *testing.T) {
+	calls := []string{}
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{
+		{Label: "A", Handler: func() { calls = append(calls, "a") }},
+		{Label: "B", Handler: func() { calls = append(calls, "b") }},
+	}
+	d.Build()
+
+	// Activate A
+	d.footer.Children[0].(FocusableWidget).SetFocused(true)
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+
+	// Move to B and activate
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone))
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+
+	if len(calls) != 2 || calls[0] != "a" || calls[1] != "b" {
+		t.Fatalf("expected [a, b], got %v", calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Button with nil handler
+// ---------------------------------------------------------------------------
+
+func TestDialogButtonNilHandlerNoPanic(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{
+		{Label: "No Handler"}, // Handler is nil
+	}
+	d.Build()
+
+	d.footer.Children[0].(FocusableWidget).SetFocused(true)
+
+	// Should not panic
+	d.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+}
+
+// ---------------------------------------------------------------------------
+// All events consumed (modal)
+// ---------------------------------------------------------------------------
+
+func TestDialogConsumesAllKeyEvents(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "body"}))
+	d.Buttons = []DialogButton{{Label: "OK"}}
+	d.Build()
+
+	keys := []tcell.Key{
+		tcell.KeyUp, tcell.KeyDown, tcell.KeyBackspace, tcell.KeyDelete,
+	}
+	for _, k := range keys {
+		result := d.HandleEvent(tcell.NewEventKey(k, 0, tcell.ModNone))
+		if result != EventConsumed {
+			t.Errorf("dialog should consume all key events (modal), but key %v was not consumed", k)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gap calculation
+// ---------------------------------------------------------------------------
+
+func TestDialogGapsBetweenSections(t *testing.T) {
+	// Title + Content + Buttons: 2 gaps
+	d := NewDialogWidget(30)
+	d.Title = "T"
+	d.SetContent(NewLabelWidget(LabelConfig{Text: "C"}))
+	d.Buttons = []DialogButton{{Label: "B"}}
+	d.Build()
+
+	renderWidget(d, 0, 0, 80, 24)
+
+	// boxH = 2 (border) + 1 (title) + 1 (gap) + 1 (content) + 1 (gap) + 1 (button) = 7
+	if d.boxH != 7 {
+		t.Errorf("expected boxH=7 with all sections, got %d", d.boxH)
+	}
+
+	// Title + Content, no buttons: 1 gap
+	d2 := NewDialogWidget(30)
+	d2.Title = "T"
+	d2.SetContent(NewLabelWidget(LabelConfig{Text: "C"}))
+	d2.Build()
+
+	renderWidget(d2, 0, 0, 80, 24)
+
+	// boxH = 2 (border) + 1 (title) + 1 (gap) + 1 (content) = 5
+	if d2.boxH != 5 {
+		t.Errorf("expected boxH=5 with title+content only, got %d", d2.boxH)
+	}
+
+	// Content + Buttons, no title: 1 gap
+	d3 := NewDialogWidget(30)
+	d3.SetContent(NewLabelWidget(LabelConfig{Text: "C"}))
+	d3.Buttons = []DialogButton{{Label: "B"}}
+	d3.Build()
+
+	renderWidget(d3, 0, 0, 80, 24)
+
+	// boxH = 2 (border) + 1 (content) + 1 (gap) + 1 (button) = 5
+	if d3.boxH != 5 {
+		t.Errorf("expected boxH=5 with content+buttons only, got %d", d3.boxH)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// moveFocusButton edge: forward/backward from edges
+// ---------------------------------------------------------------------------
+
+func TestDialogMoveFocusButtonForwardFromLast(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{{Label: "A"}, {Label: "B"}}
+	d.Build()
+
+	btn0 := d.footer.Children[0].(FocusableWidget)
+	btn1 := d.footer.Children[1].(FocusableWidget)
+
+	btn1.SetFocused(true) // start at last
+
+	d.moveFocusButton(true) // try forward
+	// Should be a no-op
+	if !btn1.IsFocused() {
+		t.Error("B should remain focused (no wrap forward)")
+	}
+	if btn0.IsFocused() {
+		t.Error("A should not gain focus on forward from last")
+	}
+}
+
+func TestDialogMoveFocusButtonBackwardFromFirst(t *testing.T) {
+	d := NewDialogWidget(40)
+	d.Buttons = []DialogButton{{Label: "A"}, {Label: "B"}}
+	d.Build()
+
+	btn0 := d.footer.Children[0].(FocusableWidget)
+	btn1 := d.footer.Children[1].(FocusableWidget)
+
+	btn0.SetFocused(true) // start at first
+
+	d.moveFocusButton(false) // try backward
+	// Should be a no-op
+	if !btn0.IsFocused() {
+		t.Error("A should remain focused (no wrap backward)")
+	}
+	if btn1.IsFocused() {
+		t.Error("B should not gain focus on backward from first")
+	}
+}

--- a/internal/widgets/drawer.go
+++ b/internal/widgets/drawer.go
@@ -8,6 +8,7 @@ import (
 type DrawerConfig struct {
 	Width     int
 	MinWidth  int
+	Side      string // "left" or "right" (default)
 	Borders   term.BorderSet
 	OnDismiss func()
 }
@@ -52,12 +53,11 @@ func (d *DrawerWidget) Reset() {
 func (d *DrawerWidget) Height() int { return 0 }
 func (d *DrawerWidget) Width() int  { return 0 }
 
-func (d *DrawerWidget) Render(surface Surface) {
-	sw, sh := surface.Size()
-	if sw <= 4 || sh <= 2 {
-		return
-	}
+func (d *DrawerWidget) isLeft() bool {
+	return d.Config.Side == "left"
+}
 
+func (d *DrawerWidget) clampWidth(sw int) int {
 	w := d.width
 	if w > sw-2 {
 		w = sw - 2
@@ -65,26 +65,43 @@ func (d *DrawerWidget) Render(surface Surface) {
 	if w < d.Config.MinWidth {
 		w = d.Config.MinWidth
 	}
+	return w
+}
 
-	x := sw - w
+func (d *DrawerWidget) Render(surface Surface) {
+	sw, sh := surface.Size()
+	if sw <= 4 || sh <= 2 {
+		return
+	}
+
+	w := d.clampWidth(sw)
+
+	var x int
+	if d.isLeft() {
+		x = 0
+	} else {
+		x = sw - w
+	}
+	rx := x + w - 1
+
 	b := d.Config.Borders
 	bs := term.StyleBorder
 
 	surface.SetCell(x, 0, term.Cell{Ch: b.TopLeft, Style: bs})
-	for ix := x + 1; ix < sw-1; ix++ {
+	for ix := x + 1; ix < rx; ix++ {
 		surface.SetCell(ix, 0, term.Cell{Ch: b.Horizontal, Style: bs})
 	}
-	surface.SetCell(sw-1, 0, term.Cell{Ch: b.TopRight, Style: bs})
+	surface.SetCell(rx, 0, term.Cell{Ch: b.TopRight, Style: bs})
 
 	surface.SetCell(x, sh-1, term.Cell{Ch: b.BottomLeft, Style: bs})
-	for ix := x + 1; ix < sw-1; ix++ {
+	for ix := x + 1; ix < rx; ix++ {
 		surface.SetCell(ix, sh-1, term.Cell{Ch: b.Horizontal, Style: bs})
 	}
-	surface.SetCell(sw-1, sh-1, term.Cell{Ch: b.BottomRight, Style: bs})
+	surface.SetCell(rx, sh-1, term.Cell{Ch: b.BottomRight, Style: bs})
 
 	for iy := 1; iy < sh-1; iy++ {
 		surface.SetCell(x, iy, term.Cell{Ch: b.Vertical, Style: bs})
-		surface.SetCell(sw-1, iy, term.Cell{Ch: b.Vertical, Style: bs})
+		surface.SetCell(rx, iy, term.Cell{Ch: b.Vertical, Style: bs})
 	}
 
 	innerX := x + 1
@@ -132,15 +149,24 @@ func (d *DrawerWidget) HandleEvent(ev tcell.Event) EventResult {
 	d.wasPressed = pressed
 
 	sw := r.W
-	w := d.width
-	if w > sw-2 {
-		w = sw - 2
+	w := d.clampWidth(sw)
+	left := d.isLeft()
+
+	var borderX int
+	if left {
+		borderX = r.X + w - 1
+	} else {
+		borderX = r.X + sw - w
 	}
-	borderX := r.X + sw - w
 
 	if d.dragging {
 		if pressed {
-			newW := r.X + sw - mx
+			var newW int
+			if left {
+				newW = mx - r.X + 1
+			} else {
+				newW = r.X + sw - mx
+			}
 			if newW < d.Config.MinWidth {
 				newW = d.Config.MinWidth
 			}
@@ -157,16 +183,28 @@ func (d *DrawerWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventConsumed
 	}
 
-	if freshClick && mx >= borderX-1 && mx <= borderX {
-		d.dragging = true
-		return EventConsumed
-	}
-
-	if freshClick && mx < borderX {
-		if d.Config.OnDismiss != nil {
-			d.Config.OnDismiss()
+	if left {
+		if freshClick && mx >= borderX && mx <= borderX+1 {
+			d.dragging = true
+			return EventConsumed
 		}
-		return EventConsumed
+		if freshClick && mx > borderX+1 {
+			if d.Config.OnDismiss != nil {
+				d.Config.OnDismiss()
+			}
+			return EventConsumed
+		}
+	} else {
+		if freshClick && mx >= borderX-1 && mx <= borderX {
+			d.dragging = true
+			return EventConsumed
+		}
+		if freshClick && mx < borderX-1 {
+			if d.Config.OnDismiss != nil {
+				d.Config.OnDismiss()
+			}
+			return EventConsumed
+		}
 	}
 
 	if d.Content != nil {

--- a/internal/widgets/dropdown_test.go
+++ b/internal/widgets/dropdown_test.go
@@ -1,0 +1,274 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestDropdownRenderLabel(t *testing.T) {
+	dd := NewDropdownWidget(DropdownConfig{
+		Label: "Actions",
+		Entries: []MenuEntry{
+			{Label: "Copy", Command: "copy"},
+		},
+	})
+	s := renderWidget(dd, 0, 0, 15, 1)
+
+	// The label "Actions" should appear on the button surface
+	text := extractText(s, 0, 0, 7)
+	// Button has PaddingLeft=1 by default, so label starts at x=1
+	textPadded := extractText(s, 1, 0, 7)
+	if text != "Actions" && textPadded != "Actions" {
+		t.Errorf("dropdown should render label 'Actions', got %q / padded %q", text, textPadded)
+	}
+}
+
+func TestDropdownDefaultLabel(t *testing.T) {
+	dd := NewDropdownWidget(DropdownConfig{
+		Entries: []MenuEntry{
+			{Label: "Copy", Command: "copy"},
+		},
+	})
+	// Default label is "⋮"
+	s := renderWidget(dd, 0, 0, 10, 1)
+
+	// Check with padding offset
+	found := false
+	for x := 0; x < 5; x++ {
+		if s.cells[0][x].Ch == '⋮' {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("dropdown with empty label should default to '⋮'")
+	}
+}
+
+func TestDropdownClickFiresOnMenu(t *testing.T) {
+	var receivedEntries []MenuEntry
+	var receivedX, receivedY int
+	called := false
+
+	entries := []MenuEntry{
+		{Label: "Copy", Command: "copy"},
+		{Label: "Paste", Command: "paste"},
+	}
+
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Menu",
+		Entries: entries,
+		OnMenu: func(e []MenuEntry, sx, sy int) {
+			called = true
+			receivedEntries = e
+			receivedX = sx
+			receivedY = sy
+		},
+	})
+	renderWidget(dd, 5, 10, 10, 1)
+
+	// Click inside the dropdown rect
+	click := mouseClick(6, 10)
+	result := dd.HandleEvent(click)
+
+	if !called {
+		t.Fatal("clicking dropdown should fire OnMenu")
+	}
+	if result != EventConsumed {
+		t.Error("click should be consumed")
+	}
+	if len(receivedEntries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(receivedEntries))
+	}
+	if receivedEntries[0].Command != "copy" {
+		t.Errorf("first entry command should be 'copy', got %q", receivedEntries[0].Command)
+	}
+
+	// Screen coordinates: X = rect.X = 5, Y = rect.Y + rect.H = 10 + 1 = 11
+	if receivedX != 5 {
+		t.Errorf("screenX should be 5, got %d", receivedX)
+	}
+	if receivedY != 11 {
+		t.Errorf("screenY should be 11 (below dropdown), got %d", receivedY)
+	}
+}
+
+func TestDropdownClickOutsideBounds(t *testing.T) {
+	called := false
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Menu",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+		OnMenu: func(e []MenuEntry, sx, sy int) {
+			called = true
+		},
+	})
+	renderWidget(dd, 5, 10, 10, 1)
+
+	// Click outside
+	click := mouseClick(0, 0)
+	result := dd.HandleEvent(click)
+
+	if called {
+		t.Error("click outside should not fire OnMenu")
+	}
+	if result == EventConsumed {
+		t.Error("click outside should not be consumed")
+	}
+}
+
+func TestDropdownClickRightEdge(t *testing.T) {
+	called := false
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Go",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+		OnMenu: func(e []MenuEntry, sx, sy int) {
+			called = true
+		},
+	})
+	renderWidget(dd, 5, 10, 10, 1)
+
+	// Click at x=14 (just inside right edge: X=5, W=10, so max X is 14)
+	click := mouseClick(14, 10)
+	result := dd.HandleEvent(click)
+
+	if !called {
+		t.Error("click at right edge should fire OnMenu")
+	}
+	if result != EventConsumed {
+		t.Error("click at right edge should be consumed")
+	}
+}
+
+func TestDropdownClickJustOutsideRight(t *testing.T) {
+	called := false
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Go",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+		OnMenu: func(e []MenuEntry, sx, sy int) {
+			called = true
+		},
+	})
+	renderWidget(dd, 5, 10, 10, 1)
+
+	// Click at x=15 (just outside: X=5, W=10, so x=15 is out)
+	click := mouseClick(15, 10)
+	dd.HandleEvent(click)
+
+	if called {
+		t.Error("click just outside right edge should not fire OnMenu")
+	}
+}
+
+func TestDropdownNoEntriesNoCallback(t *testing.T) {
+	called := false
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Empty",
+		Entries: []MenuEntry{},
+		OnMenu: func(e []MenuEntry, sx, sy int) {
+			called = true
+		},
+	})
+	renderWidget(dd, 0, 0, 10, 1)
+
+	click := mouseClick(1, 0)
+	result := dd.HandleEvent(click)
+
+	if called {
+		t.Error("dropdown with empty entries should not fire OnMenu")
+	}
+	if result == EventConsumed {
+		t.Error("dropdown with empty entries should not consume click")
+	}
+}
+
+func TestDropdownNoOnMenuCallback(t *testing.T) {
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "NoHandler",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+		OnMenu:  nil,
+	})
+	renderWidget(dd, 0, 0, 15, 1)
+
+	// Should not panic
+	click := mouseClick(1, 0)
+	result := dd.HandleEvent(click)
+
+	if result == EventConsumed {
+		t.Error("dropdown with nil OnMenu should not consume click")
+	}
+}
+
+func TestDropdownHeightAndWidth(t *testing.T) {
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Test",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+	})
+
+	// Height and Width delegate to the inner button
+	h := dd.Height()
+	w := dd.Width()
+
+	if h < 1 {
+		t.Errorf("dropdown height should be at least 1, got %d", h)
+	}
+	if w < 1 {
+		t.Errorf("dropdown width should be at least 1, got %d", w)
+	}
+}
+
+func TestDropdownNonMouseEventIgnored(t *testing.T) {
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Test",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+	})
+	renderWidget(dd, 0, 0, 10, 1)
+
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := dd.HandleEvent(ev)
+
+	if result == EventConsumed {
+		t.Error("non-mouse events should be ignored")
+	}
+}
+
+func TestDropdownBoxModel(t *testing.T) {
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "B",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+		Box: &BoxModel{
+			PaddingLeft:  2,
+			PaddingRight: 2,
+		},
+	})
+
+	// The box model should propagate to the inner button
+	w := dd.Width()
+	// "B" is 1 char + padding 2+2 = 5
+	if w != 5 {
+		t.Errorf("dropdown width with box padding should be 5, got %d", w)
+	}
+}
+
+func TestDropdownRightClickIgnored(t *testing.T) {
+	called := false
+	dd := NewDropdownWidget(DropdownConfig{
+		Label:   "Menu",
+		Entries: []MenuEntry{{Label: "A", Command: "a"}},
+		OnMenu: func(e []MenuEntry, sx, sy int) {
+			called = true
+		},
+	})
+	renderWidget(dd, 0, 0, 10, 1)
+
+	// Right-click (Button2) should not trigger
+	rightClick := tcell.NewEventMouse(1, 0, tcell.Button2, tcell.ModNone)
+	result := dd.HandleEvent(rightClick)
+
+	if called {
+		t.Error("right-click should not fire OnMenu")
+	}
+	if result == EventConsumed {
+		t.Error("right-click should not be consumed")
+	}
+}

--- a/internal/widgets/hstack_test.go
+++ b/internal/widgets/hstack_test.go
@@ -1,0 +1,378 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+// --- HStackWidget rendering verification ---
+
+func TestHStackRenderFirstChildGrowsRemainingFillsWidth(t *testing.T) {
+	// First child grows (Width()==0), second child has fixed width
+	grow := NewLabelWidget(LabelConfig{Text: "GROW"})
+	fixed := NewLabelWidget(LabelConfig{Text: "FIX"})
+	fixed.FixedWidth = 5
+
+	hs := NewHStackWidget(grow, fixed)
+	s := renderWidget(hs, 0, 0, 20, 5)
+
+	// Grow child text at X=0
+	if s.cells[0][0].Ch != 'G' {
+		t.Errorf("expected 'G' at (0,0), got %q", s.cells[0][0].Ch)
+	}
+
+	rg := grow.GetRect()
+	rf := fixed.GetRect()
+
+	// Grow child should fill remaining: 20 - 5 = 15
+	if rg.W != 15 {
+		t.Errorf("grow child should have W=15, got W=%d", rg.W)
+	}
+	// Fixed child at X=15
+	if rf.X != 15 || rf.W != 5 {
+		t.Errorf("fixed child should have X=15 W=5, got X=%d W=%d", rf.X, rf.W)
+	}
+
+	// Fixed child text at X=15
+	if s.cells[0][15].Ch != 'F' {
+		t.Errorf("expected 'F' at (15,0), got %q", s.cells[0][15].Ch)
+	}
+}
+
+func TestHStackRenderGapSpacing(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "AA"})
+	a.FixedWidth = 3
+	b := NewLabelWidget(LabelConfig{Text: "BB"})
+	b.FixedWidth = 3
+	hs := NewHStackWidget(a, b)
+	hs.Gap = 2
+
+	s := renderWidget(hs, 0, 0, 20, 5)
+
+	// A at X=0
+	if s.cells[0][0].Ch != 'A' {
+		t.Errorf("expected 'A' at (0,0), got %q", s.cells[0][0].Ch)
+	}
+	// Gap at X=3 and X=4 should be empty
+	if s.cells[0][3].Ch != 0 {
+		t.Errorf("expected empty at (3,0) in gap, got %q", s.cells[0][3].Ch)
+	}
+	if s.cells[0][4].Ch != 0 {
+		t.Errorf("expected empty at (4,0) in gap, got %q", s.cells[0][4].Ch)
+	}
+	// B at X=5 (3 width + 2 gap)
+	if s.cells[0][5].Ch != 'B' {
+		t.Errorf("expected 'B' at (5,0), got %q", s.cells[0][5].Ch)
+	}
+}
+
+func TestHStackFixedHeightRespected(t *testing.T) {
+	hs := NewHStackWidget()
+	hs.FixedHeight = 7
+
+	if hs.Height() != 7 {
+		t.Errorf("expected FixedHeight=7, got %d", hs.Height())
+	}
+}
+
+func TestHStackHeightZeroWithoutFixedHeight(t *testing.T) {
+	hs := NewHStackWidget()
+	if hs.Height() != 0 {
+		t.Errorf("expected Height()=0 without FixedHeight, got %d", hs.Height())
+	}
+}
+
+func TestHStackMouseClickRoutesToCorrectChild(t *testing.T) {
+	a := &clickableWidget{fixedWidget: fixedWidget{h: 0, w: 5}}
+	b := &clickableWidget{fixedWidget: fixedWidget{h: 0, w: 5}}
+	c := &clickableWidget{fixedWidget: fixedWidget{h: 0, w: 5}}
+	hs := NewHStackWidget(a, b, c)
+
+	renderWidget(hs, 10, 5, 15, 10)
+
+	// Click in child A's area (X: 10..14)
+	click := mouseClick(12, 7)
+	result := hs.HandleEvent(click)
+	if result != EventConsumed {
+		t.Error("click inside child A should be consumed")
+	}
+	if !a.clicked {
+		t.Error("child A should have received the click")
+	}
+	if b.clicked || c.clicked {
+		t.Error("children B and C should not have received the click")
+	}
+
+	// Reset
+	a.clicked, b.clicked, c.clicked = false, false, false
+
+	// Click in child B's area (X: 15..19)
+	click = mouseClick(17, 7)
+	result = hs.HandleEvent(click)
+	if result != EventConsumed {
+		t.Error("click inside child B should be consumed")
+	}
+	if !b.clicked {
+		t.Error("child B should have received the click")
+	}
+	if a.clicked || c.clicked {
+		t.Error("children A and C should not have received the click")
+	}
+
+	// Reset
+	a.clicked, b.clicked, c.clicked = false, false, false
+
+	// Click in child C's area (X: 20..24)
+	click = mouseClick(22, 7)
+	result = hs.HandleEvent(click)
+	if result != EventConsumed {
+		t.Error("click inside child C should be consumed")
+	}
+	if !c.clicked {
+		t.Error("child C should have received the click")
+	}
+}
+
+func TestHStackMouseClickOutsideAllChildren(t *testing.T) {
+	a := &clickableWidget{fixedWidget: fixedWidget{h: 0, w: 5}}
+	hs := NewHStackWidget(a)
+
+	renderWidget(hs, 10, 10, 5, 5)
+
+	// Click outside the container
+	click := mouseClick(0, 0)
+	result := hs.HandleEvent(click)
+	if result == EventConsumed {
+		t.Error("click outside all children should not be consumed")
+	}
+	if a.clicked {
+		t.Error("child should not have been clicked")
+	}
+}
+
+func TestHStackEmptyRendersNothing(t *testing.T) {
+	hs := NewHStackWidget()
+	s := renderWidget(hs, 0, 0, 20, 10)
+
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 20; x++ {
+			if s.cells[y][x].Ch != 0 {
+				t.Errorf("empty hstack should render nothing, but found %q at (%d,%d)", s.cells[y][x].Ch, x, y)
+			}
+		}
+	}
+}
+
+func TestHStackSingleChildFillsEntireWidth(t *testing.T) {
+	child := NewLabelWidget(LabelConfig{Text: "Only child"})
+	hs := NewHStackWidget(child)
+
+	renderWidget(hs, 0, 0, 30, 5)
+
+	r := child.GetRect()
+	if r.W != 30 {
+		t.Errorf("single grow child should fill entire width 30, got W=%d", r.W)
+	}
+	if r.X != 0 {
+		t.Errorf("single child should start at X=0, got X=%d", r.X)
+	}
+}
+
+func TestHStackSingleFixedChildWidth(t *testing.T) {
+	child := NewLabelWidget(LabelConfig{Text: "Fixed"})
+	child.FixedWidth = 8
+	hs := NewHStackWidget(child)
+
+	renderWidget(hs, 0, 0, 30, 5)
+
+	r := child.GetRect()
+	if r.W != 8 {
+		t.Errorf("single fixed child should keep its width 8, got W=%d", r.W)
+	}
+}
+
+func TestHStackMultipleFixedWidthChildrenPositioned(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "AA"})
+	a.FixedWidth = 4
+	b := NewLabelWidget(LabelConfig{Text: "BB"})
+	b.FixedWidth = 6
+	c := NewLabelWidget(LabelConfig{Text: "CC"})
+	c.FixedWidth = 3
+	hs := NewHStackWidget(a, b, c)
+
+	s := renderWidget(hs, 0, 0, 30, 5)
+
+	ra := a.GetRect()
+	rb := b.GetRect()
+	rc := c.GetRect()
+
+	if ra.X != 0 || ra.W != 4 {
+		t.Errorf("child A: expected X=0 W=4, got X=%d W=%d", ra.X, ra.W)
+	}
+	if rb.X != 4 || rb.W != 6 {
+		t.Errorf("child B: expected X=4 W=6, got X=%d W=%d", rb.X, rb.W)
+	}
+	if rc.X != 10 || rc.W != 3 {
+		t.Errorf("child C: expected X=10 W=3, got X=%d W=%d", rc.X, rc.W)
+	}
+
+	// Verify rendered text
+	if s.cells[0][0].Ch != 'A' {
+		t.Errorf("expected 'A' at (0,0), got %q", s.cells[0][0].Ch)
+	}
+	if s.cells[0][4].Ch != 'B' {
+		t.Errorf("expected 'B' at (4,0), got %q", s.cells[0][4].Ch)
+	}
+	if s.cells[0][10].Ch != 'C' {
+		t.Errorf("expected 'C' at (10,0), got %q", s.cells[0][10].Ch)
+	}
+}
+
+func TestHStackChildrenGetFullHeight(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "A"})
+	a.FixedWidth = 5
+	b := NewLabelWidget(LabelConfig{Text: "B"})
+	b.FixedWidth = 5
+	hs := NewHStackWidget(a, b)
+
+	renderWidget(hs, 0, 0, 20, 15)
+
+	ra := a.GetRect()
+	rb := b.GetRect()
+
+	if ra.H != 15 {
+		t.Errorf("child A should get full height 15, got H=%d", ra.H)
+	}
+	if rb.H != 15 {
+		t.Errorf("child B should get full height 15, got H=%d", rb.H)
+	}
+}
+
+func TestHStackWidgetChildren(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "A"})
+	b := NewLabelWidget(LabelConfig{Text: "B"})
+	hs := NewHStackWidget(a, b)
+
+	children := hs.WidgetChildren()
+	if len(children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(children))
+	}
+}
+
+func TestHStackWidthReturnsZero(t *testing.T) {
+	hs := NewHStackWidget()
+	if hs.Width() != 0 {
+		t.Errorf("HStack Width() should always return 0, got %d", hs.Width())
+	}
+}
+
+func TestHStackEmptyHandleEventReturnsIgnored(t *testing.T) {
+	hs := NewHStackWidget()
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := hs.HandleEvent(ev)
+	if result != EventIgnored {
+		t.Error("empty HStack should return EventIgnored")
+	}
+}
+
+func TestHStackRenderChildrenWithStyle(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "Warn", Style: term.StyleWarning})
+	a.FixedWidth = 6
+	b := NewLabelWidget(LabelConfig{Text: "Danger", Style: term.StyleDanger})
+	b.FixedWidth = 8
+	hs := NewHStackWidget(a, b)
+
+	s := renderWidget(hs, 0, 0, 20, 5)
+
+	if s.cells[0][0].Style != term.StyleWarning {
+		t.Errorf("expected StyleWarning at (0,0), got %v", s.cells[0][0].Style)
+	}
+	if s.cells[0][6].Style != term.StyleDanger {
+		t.Errorf("expected StyleDanger at (6,0), got %v", s.cells[0][6].Style)
+	}
+}
+
+func TestHStackGrowChildWithMultipleFixed(t *testing.T) {
+	// Pattern: fixed(5) | grow | fixed(5) — grow should fill the middle
+	left := NewLabelWidget(LabelConfig{Text: "LEFT"})
+	left.FixedWidth = 5
+	middle := NewLabelWidget(LabelConfig{Text: "MIDDLE"})
+	right := NewLabelWidget(LabelConfig{Text: "RIGHT"})
+	right.FixedWidth = 5
+	hs := NewHStackWidget(left, middle, right)
+
+	s := renderWidget(hs, 0, 0, 30, 5)
+
+	rl := left.GetRect()
+	rm := middle.GetRect()
+	rr := right.GetRect()
+
+	if rl.X != 0 || rl.W != 5 {
+		t.Errorf("left: expected X=0 W=5, got X=%d W=%d", rl.X, rl.W)
+	}
+	// Middle grows: 30 - 5 - 5 = 20
+	if rm.X != 5 || rm.W != 20 {
+		t.Errorf("middle (grow): expected X=5 W=20, got X=%d W=%d", rm.X, rm.W)
+	}
+	if rr.X != 25 || rr.W != 5 {
+		t.Errorf("right: expected X=25 W=5, got X=%d W=%d", rr.X, rr.W)
+	}
+
+	// Verify rendered text positions
+	if s.cells[0][0].Ch != 'L' {
+		t.Errorf("expected 'L' at (0,0), got %q", s.cells[0][0].Ch)
+	}
+	if s.cells[0][5].Ch != 'M' {
+		t.Errorf("expected 'M' at (5,0), got %q", s.cells[0][5].Ch)
+	}
+	if s.cells[0][25].Ch != 'R' {
+		t.Errorf("expected 'R' at (25,0), got %q", s.cells[0][25].Ch)
+	}
+}
+
+func TestHStackGapWithGrowChild(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "A"})
+	a.FixedWidth = 3
+	b := NewLabelWidget(LabelConfig{Text: "B"})
+	// b is grow (Width()==0)
+	hs := NewHStackWidget(a, b)
+	hs.Gap = 2
+
+	renderWidget(hs, 0, 0, 20, 5)
+
+	ra := a.GetRect()
+	rb := b.GetRect()
+
+	if ra.X != 0 || ra.W != 3 {
+		t.Errorf("child A: expected X=0 W=3, got X=%d W=%d", ra.X, ra.W)
+	}
+	// B starts at 3 + 2 gap = 5, fills remaining: 20 - 3 - 2 = 15
+	if rb.X != 5 || rb.W != 15 {
+		t.Errorf("child B: expected X=5 W=15, got X=%d W=%d", rb.X, rb.W)
+	}
+}
+
+func TestHStackBoxModelApplied(t *testing.T) {
+	label := NewLabelWidget(LabelConfig{Text: "Hello"})
+	label.FixedWidth = 10
+	hs := NewHStackWidget(label)
+	hs.Box = BoxModel{
+		MarginTop:   1,
+		MarginLeft:  2,
+		PaddingTop:  1,
+		PaddingLeft: 1,
+	}
+
+	s := renderWidget(hs, 0, 0, 20, 10)
+
+	// With margin_top=1, padding_top=1, the inner content starts at Y=2
+	// With margin_left=2, padding_left=1, the inner content starts at X=3
+	if s.cells[2][3].Ch != 'H' {
+		t.Errorf("expected 'H' at (3,2) with box model offsets, got %q", s.cells[2][3].Ch)
+	}
+	if s.cells[0][0].Ch != 0 {
+		t.Errorf("expected empty at (0,0) due to margins, got %q", s.cells[0][0].Ch)
+	}
+}

--- a/internal/widgets/interactive_test.go
+++ b/internal/widgets/interactive_test.go
@@ -202,25 +202,6 @@ func TestButtonAccelTriggersUnfocused(t *testing.T) {
 	}
 }
 
-func TestButtonOnCommand(t *testing.T) {
-	var received string
-	btn := NewButtonWidget(ButtonConfig{
-		Label:   "Run",
-		Command: "editor.run",
-		OnCommand: func(cmd string) {
-			received = cmd
-		},
-	})
-	btn.SetFocused(true)
-	renderWidget(btn, 0, 0, 10, 1)
-
-	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
-	btn.HandleEvent(ev)
-	if received != "editor.run" {
-		t.Errorf("expected command 'editor.run', got %q", received)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // CheckboxWidget tests
 // ---------------------------------------------------------------------------
@@ -350,37 +331,6 @@ func TestCheckboxRenderCheckedVsUnchecked(t *testing.T) {
 // ---------------------------------------------------------------------------
 // DialogWidget tests
 // ---------------------------------------------------------------------------
-
-func TestDialogBuildCreatesFooter(t *testing.T) {
-	d := NewDialogWidget(40)
-	d.Buttons = []DialogButton{
-		{Label: "OK", Handler: func() {}},
-		{Label: "Cancel", Handler: func() {}},
-	}
-	d.Build()
-
-	if d.footer == nil {
-		t.Fatal("Build() should create footer HStack")
-	}
-	if len(d.footer.Children) != 2 {
-		t.Errorf("expected 2 footer children, got %d", len(d.footer.Children))
-	}
-	if d.footer.Align != "right" {
-		t.Errorf("expected footer align 'right', got %q", d.footer.Align)
-	}
-	if d.footer.Gap != 1 {
-		t.Errorf("expected footer gap 1, got %d", d.footer.Gap)
-	}
-}
-
-func TestDialogBuildNoButtons(t *testing.T) {
-	d := NewDialogWidget(40)
-	d.Build()
-
-	if d.footer != nil {
-		t.Error("Build() with no buttons should leave footer nil")
-	}
-}
 
 func TestDialogEscapeDismissal(t *testing.T) {
 	dismissed := false

--- a/internal/widgets/keyvaluelist.go
+++ b/internal/widgets/keyvaluelist.go
@@ -20,7 +20,7 @@ func NewKeyValueListWidget(entries []KeyValueEntry) *KeyValueListWidget {
 	return &KeyValueListWidget{Entries: entries}
 }
 
-func (kv *KeyValueListWidget) Height() int { return len(kv.Entries) }
+func (kv *KeyValueListWidget) Height() int { return len(kv.Entries) + kv.BoxOverheadH() }
 func (kv *KeyValueListWidget) Width() int  { return 0 }
 
 func (kv *KeyValueListWidget) ScrollSize() (int, int) {
@@ -45,6 +45,7 @@ func (kv *KeyValueListWidget) keyColWidth() int {
 }
 
 func (kv *KeyValueListWidget) Render(surface Surface) {
+	surface = kv.RenderBox(surface)
 	w, h := surface.Size()
 	if w <= 0 || h <= 0 {
 		return

--- a/internal/widgets/progress.go
+++ b/internal/widgets/progress.go
@@ -1,0 +1,61 @@
+package widgets
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+type ProgressConfig struct {
+	Value float64
+	Style term.Style
+	Char  rune
+}
+
+type ProgressWidget struct {
+	BaseWidget
+	Config ProgressConfig
+}
+
+func NewProgressWidget(config ProgressConfig) *ProgressWidget {
+	return &ProgressWidget{Config: config}
+}
+
+func (p *ProgressWidget) Height() int { return 1 + p.BoxOverheadH() }
+func (p *ProgressWidget) Width() int  { return 0 }
+
+func (p *ProgressWidget) Render(surface Surface) {
+	inner := p.RenderBox(surface)
+	w, _ := inner.Size()
+	if w <= 0 {
+		return
+	}
+
+	style := p.Config.Style
+	if style == 0 {
+		style = term.StyleSuccess
+	}
+
+	value := p.Config.Value
+	if value < 0 {
+		value = 0
+	} else if value > 1 {
+		value = 1
+	}
+
+	ch := p.Config.Char
+	if ch == 0 {
+		ch = '█'
+	}
+
+	filled := int(value * float64(w))
+	for x := 0; x < filled; x++ {
+		inner.SetCell(x, 0, term.Cell{Ch: ch, Style: style})
+	}
+	for x := filled; x < w; x++ {
+		inner.SetCell(x, 0, term.Cell{Ch: '░', Style: term.StyleMuted})
+	}
+}
+
+func (p *ProgressWidget) HandleEvent(ev tcell.Event) EventResult {
+	return EventIgnored
+}

--- a/internal/widgets/progress.go
+++ b/internal/widgets/progress.go
@@ -44,7 +44,7 @@ func (p *ProgressWidget) Render(surface Surface) {
 
 	ch := p.Config.Char
 	if ch == 0 {
-		ch = '█'
+		ch = '▄'
 	}
 
 	filled := int(value * float64(w))

--- a/internal/widgets/progress_test.go
+++ b/internal/widgets/progress_test.go
@@ -1,0 +1,198 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestProgressRenderZero(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 0})
+	s := renderWidget(p, 0, 0, 20, 1)
+
+	// All cells should be unfilled ('░' with StyleMuted)
+	for x := 0; x < 20; x++ {
+		if s.cells[0][x].Ch != '░' {
+			t.Errorf("x=%d: expected '░', got '%c'", x, s.cells[0][x].Ch)
+		}
+		if s.cells[0][x].Style != term.StyleMuted {
+			t.Errorf("x=%d: expected StyleMuted, got %v", x, s.cells[0][x].Style)
+		}
+	}
+}
+
+func TestProgressRenderFull(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 1.0})
+	s := renderWidget(p, 0, 0, 20, 1)
+
+	// All cells should be filled ('▄' with StyleSuccess)
+	for x := 0; x < 20; x++ {
+		if s.cells[0][x].Ch != '▄' {
+			t.Errorf("x=%d: expected '▄', got '%c'", x, s.cells[0][x].Ch)
+		}
+		if s.cells[0][x].Style != term.StyleSuccess {
+			t.Errorf("x=%d: expected StyleSuccess, got %v", x, s.cells[0][x].Style)
+		}
+	}
+}
+
+func TestProgressRenderHalf(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 0.5})
+	w := 20
+	s := renderWidget(p, 0, 0, w, 1)
+
+	filled := int(0.5 * float64(w)) // 10
+	for x := 0; x < filled; x++ {
+		if s.cells[0][x].Ch != '▄' {
+			t.Errorf("filled x=%d: expected '▄', got '%c'", x, s.cells[0][x].Ch)
+		}
+		if s.cells[0][x].Style != term.StyleSuccess {
+			t.Errorf("filled x=%d: expected StyleSuccess, got %v", x, s.cells[0][x].Style)
+		}
+	}
+	for x := filled; x < w; x++ {
+		if s.cells[0][x].Ch != '░' {
+			t.Errorf("unfilled x=%d: expected '░', got '%c'", x, s.cells[0][x].Ch)
+		}
+		if s.cells[0][x].Style != term.StyleMuted {
+			t.Errorf("unfilled x=%d: expected StyleMuted, got %v", x, s.cells[0][x].Style)
+		}
+	}
+}
+
+func TestProgressDefaultChar(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 1.0})
+	s := renderWidget(p, 0, 0, 10, 1)
+
+	if s.cells[0][0].Ch != '▄' {
+		t.Errorf("default char should be '▄', got '%c'", s.cells[0][0].Ch)
+	}
+}
+
+func TestProgressCustomChar(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 1.0, Char: '#'})
+	s := renderWidget(p, 0, 0, 10, 1)
+
+	for x := 0; x < 10; x++ {
+		if s.cells[0][x].Ch != '#' {
+			t.Errorf("x=%d: expected '#', got '%c'", x, s.cells[0][x].Ch)
+		}
+	}
+}
+
+func TestProgressDefaultStyleIsSuccess(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 1.0})
+	s := renderWidget(p, 0, 0, 10, 1)
+
+	if s.cells[0][0].Style != term.StyleSuccess {
+		t.Errorf("default style should be StyleSuccess, got %v", s.cells[0][0].Style)
+	}
+}
+
+func TestProgressCustomStyle(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 1.0, Style: term.StyleDanger})
+	s := renderWidget(p, 0, 0, 10, 1)
+
+	if s.cells[0][0].Style != term.StyleDanger {
+		t.Errorf("custom style should be StyleDanger, got %v", s.cells[0][0].Style)
+	}
+}
+
+func TestProgressClampNegative(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: -0.5})
+	s := renderWidget(p, 0, 0, 10, 1)
+
+	// All unfilled
+	for x := 0; x < 10; x++ {
+		if s.cells[0][x].Ch != '░' {
+			t.Errorf("x=%d: negative value should clamp to 0, expected '░', got '%c'", x, s.cells[0][x].Ch)
+		}
+	}
+}
+
+func TestProgressClampAboveOne(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 2.5})
+	s := renderWidget(p, 0, 0, 10, 1)
+
+	// All filled
+	for x := 0; x < 10; x++ {
+		if s.cells[0][x].Ch != '▄' {
+			t.Errorf("x=%d: value > 1 should clamp to 1, expected '▄', got '%c'", x, s.cells[0][x].Ch)
+		}
+	}
+}
+
+func TestProgressHeight(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 0.5})
+	if p.Height() != 1 {
+		t.Errorf("default height should be 1, got %d", p.Height())
+	}
+}
+
+func TestProgressHeightWithBoxModel(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 0.5})
+	p.Box.MarginTop = 1
+	p.Box.MarginBottom = 1
+	p.Box.PaddingTop = 2
+	p.Box.PaddingBottom = 2
+
+	// Height = 1 + BoxOverheadH = 1 + (1+1+2+2) = 7
+	expected := 1 + p.BoxOverheadH()
+	if p.Height() != expected {
+		t.Errorf("height with box model should be %d, got %d", expected, p.Height())
+	}
+}
+
+func TestProgressWidthIsZero(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 0.5})
+	if p.Width() != 0 {
+		t.Errorf("width should be 0 (fills parent), got %d", p.Width())
+	}
+}
+
+func TestProgressHandleEventIgnored(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 0.5})
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	if p.HandleEvent(ev) != EventIgnored {
+		t.Error("progress widget should ignore all events")
+	}
+}
+
+func TestProgressUnfilledStyleMuted(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 0.0})
+	s := renderWidget(p, 0, 0, 5, 1)
+
+	for x := 0; x < 5; x++ {
+		if s.cells[0][x].Style != term.StyleMuted {
+			t.Errorf("x=%d: unfilled portion should use StyleMuted, got %v", x, s.cells[0][x].Style)
+		}
+		if s.cells[0][x].Ch != '░' {
+			t.Errorf("x=%d: unfilled portion should use '░', got '%c'", x, s.cells[0][x].Ch)
+		}
+	}
+}
+
+func TestProgressRenderWithBoxModel(t *testing.T) {
+	p := NewProgressWidget(ProgressConfig{Value: 1.0})
+	p.Box.MarginLeft = 2
+	p.Box.MarginRight = 2
+
+	s := renderWidget(p, 0, 0, 14, 1)
+
+	// Inner width = 14 - 2 - 2 = 10
+	// Cells at margin positions should be empty (zero rune)
+	if s.cells[0][0].Ch == '▄' {
+		t.Error("margin area should not have filled char")
+	}
+	// Cells inside inner area (offset by margin) should be filled
+	if s.cells[0][2].Ch != '▄' {
+		t.Errorf("inner area should be filled, got '%c'", s.cells[0][2].Ch)
+	}
+}
+
+func TestProgressZeroWidth(t *testing.T) {
+	// Should not panic when rendered with zero-width surface
+	p := NewProgressWidget(ProgressConfig{Value: 0.5})
+	renderWidget(p, 0, 0, 0, 1)
+}

--- a/internal/widgets/scrollbar.go
+++ b/internal/widgets/scrollbar.go
@@ -45,7 +45,7 @@ func (s *scrollbar) Render(surface Surface, rx, ry int) {
 		if y >= thumbTop && y < thumbTop+thumbH {
 			style = term.StyleScrollbarThumb
 		}
-		surface.SetCell(rx, ry+y, term.Cell{Ch: '▄', Style: style})
+		surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: style})
 	}
 }
 

--- a/internal/widgets/scrollbar.go
+++ b/internal/widgets/scrollbar.go
@@ -45,7 +45,7 @@ func (s *scrollbar) Render(surface Surface, rx, ry int) {
 		if y >= thumbTop && y < thumbTop+thumbH {
 			style = term.StyleScrollbarThumb
 		}
-		surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: style})
+		surface.SetCell(rx, ry+y, term.Cell{Ch: '▄', Style: style})
 	}
 }
 

--- a/internal/widgets/scrollview.go
+++ b/internal/widgets/scrollview.go
@@ -148,14 +148,15 @@ func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
 		mx, my := e.Position()
 		r := sv.rect
 
-		if btn&tcell.WheelLeft != 0 {
+		mod := e.Modifiers()
+		if btn&tcell.WheelLeft != 0 || (btn&tcell.WheelUp != 0 && mod&tcell.ModShift != 0) {
 			sv.scrollX -= 3
 			if sv.scrollX < 0 {
 				sv.scrollX = 0
 			}
 			return EventConsumed
 		}
-		if btn&tcell.WheelRight != 0 {
+		if btn&tcell.WheelRight != 0 || (btn&tcell.WheelDown != 0 && mod&tcell.ModShift != 0) {
 			sv.scrollHRight(3)
 			return EventConsumed
 		}

--- a/internal/widgets/scrollview.go
+++ b/internal/widgets/scrollview.go
@@ -71,6 +71,7 @@ func (sv *ScrollViewWidget) viewportSize(w, h, contentW, contentH int) (int, int
 }
 
 func (sv *ScrollViewWidget) Render(surface Surface) {
+	surface = sv.RenderBox(surface)
 	w, h := surface.Size()
 	if w <= 0 || h <= 0 || sv.Child == nil {
 		return

--- a/internal/widgets/scrollview.go
+++ b/internal/widgets/scrollview.go
@@ -132,7 +132,7 @@ func (sv *ScrollViewWidget) renderHBar(surface Surface, barW, y, totalW int) {
 		if x >= thumbPos && x < thumbPos+thumbH {
 			style = term.StyleScrollbarThumb
 		}
-		surface.SetCell(x, y, term.Cell{Ch: '█', Style: style})
+		surface.SetCell(x, y, term.Cell{Ch: '▄', Style: style})
 	}
 }
 
@@ -145,6 +145,20 @@ func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
 	switch e := ev.(type) {
 	case *tcell.EventMouse:
 		btn := e.Buttons()
+		mx, my := e.Position()
+		r := sv.rect
+
+		if btn&tcell.WheelLeft != 0 {
+			sv.scrollX -= 3
+			if sv.scrollX < 0 {
+				sv.scrollX = 0
+			}
+			return EventConsumed
+		}
+		if btn&tcell.WheelRight != 0 {
+			sv.scrollHRight(3)
+			return EventConsumed
+		}
 		if btn&tcell.WheelUp != 0 {
 			sv.scrollY -= 3
 			if sv.scrollY < 0 {
@@ -165,12 +179,53 @@ func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 			return EventConsumed
 		}
+
+		if btn&tcell.Button1 != 0 && sv.Child != nil {
+			contentW, contentH := sv.Child.ScrollSize()
+			_, viewH := sv.viewportSize(r.W, r.H, contentW, contentH)
+			hasHBar := contentW > r.W
+			if hasHBar && my == r.Y+r.H-1 && mx >= r.X && mx < r.X+r.W {
+				sv.scrollHToClick(mx-r.X, r.W, contentW)
+				return EventConsumed
+			}
+			_ = viewH
+		}
 	}
 
 	if sv.Child != nil {
 		return sv.Child.HandleEvent(ev)
 	}
 	return EventIgnored
+}
+
+func (sv *ScrollViewWidget) scrollHRight(amount int) {
+	sv.scrollX += amount
+	if sv.Child != nil {
+		contentW, _ := sv.Child.ScrollSize()
+		r := sv.rect
+		maxX := contentW - r.W
+		if maxX < 0 {
+			maxX = 0
+		}
+		if sv.scrollX > maxX {
+			sv.scrollX = maxX
+		}
+	}
+}
+
+func (sv *ScrollViewWidget) scrollHToClick(clickX, barW, totalW int) {
+	if barW <= 0 || totalW <= barW {
+		return
+	}
+	ratio := float64(clickX) / float64(barW)
+	sv.scrollX = int(ratio * float64(totalW-barW))
+	if sv.scrollX < 0 {
+		sv.scrollX = 0
+	}
+	maxX := totalW - barW
+	if sv.scrollX > maxX {
+		sv.scrollX = maxX
+	}
 }
 
 func (sv *ScrollViewWidget) Focusable() bool           { return true }

--- a/internal/widgets/scrollview_test.go
+++ b/internal/widgets/scrollview_test.go
@@ -1,0 +1,293 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+// scrollTestChild is a simple scrollable widget for testing.
+type scrollTestChild struct {
+	BaseWidget
+	contentW int
+	contentH int
+}
+
+func newScrollTestChild(w, h int) *scrollTestChild {
+	return &scrollTestChild{contentW: w, contentH: h}
+}
+
+func (c *scrollTestChild) Height() int                          { return 0 }
+func (c *scrollTestChild) Width() int                           { return 0 }
+func (c *scrollTestChild) ScrollSize() (int, int)               { return c.contentW, c.contentH }
+func (c *scrollTestChild) HandleEvent(ev tcell.Event) EventResult { return EventIgnored }
+
+func (c *scrollTestChild) Render(surface Surface) {
+	w, h := surface.Size()
+	for y := 0; y < h && y < c.contentH; y++ {
+		for x := 0; x < w && x < c.contentW; x++ {
+			// Fill each row with a letter based on the row number (A, B, C, ...)
+			ch := rune('A' + y%26)
+			surface.SetCell(x, y, term.Cell{Ch: ch, Style: term.StyleDefault})
+		}
+	}
+}
+
+func TestScrollViewContentSmallerThanViewport(t *testing.T) {
+	child := newScrollTestChild(10, 5)
+	sv := NewScrollViewWidget(child)
+
+	// Viewport is 20x10 but content is only 10x5: no scrollbar needed
+	s := renderWidget(sv, 0, 0, 20, 10)
+
+	// Content should render at top
+	if s.cells[0][0].Ch != 'A' {
+		t.Errorf("expected 'A' at row 0, got %c", s.cells[0][0].Ch)
+	}
+	if s.cells[4][0].Ch != 'E' {
+		t.Errorf("expected 'E' at row 4, got %c", s.cells[4][0].Ch)
+	}
+
+	// No scrollbar in the rightmost column (content fits)
+	scrollbarStyle := s.cells[0][19].Style
+	if scrollbarStyle == term.StyleScrollbar || scrollbarStyle == term.StyleScrollbarThumb {
+		t.Error("should not have scrollbar when content fits in viewport")
+	}
+}
+
+func TestScrollViewContentTallerThanViewport(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+
+	// Viewport is 20x10, content is 15x30: vertical scrollbar needed
+	s := renderWidget(sv, 0, 0, 20, 10)
+
+	// Content renders at top
+	if s.cells[0][0].Ch != 'A' {
+		t.Errorf("expected 'A' at row 0, got %c", s.cells[0][0].Ch)
+	}
+
+	// Scrollbar should be visible on the right edge (x=19)
+	hasScrollbar := false
+	for y := 0; y < 10; y++ {
+		style := s.cells[y][19].Style
+		if style == term.StyleScrollbar || style == term.StyleScrollbarThumb {
+			hasScrollbar = true
+			break
+		}
+	}
+	if !hasScrollbar {
+		t.Error("should have vertical scrollbar when content is taller than viewport")
+	}
+}
+
+func TestScrollViewWheelDown(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+
+	if sv.scrollY != 0 {
+		t.Fatalf("initial scrollY should be 0, got %d", sv.scrollY)
+	}
+
+	// Scroll down
+	wheelDown := tcell.NewEventMouse(5, 5, tcell.WheelDown, tcell.ModNone)
+	result := sv.HandleEvent(wheelDown)
+	if result != EventConsumed {
+		t.Error("wheel down should be consumed")
+	}
+	if sv.scrollY != 3 {
+		t.Errorf("expected scrollY=3 after wheel down, got %d", sv.scrollY)
+	}
+
+	// Scroll down again
+	sv.HandleEvent(wheelDown)
+	if sv.scrollY != 6 {
+		t.Errorf("expected scrollY=6 after second wheel down, got %d", sv.scrollY)
+	}
+}
+
+func TestScrollViewWheelUp(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+
+	// Scroll down first
+	wheelDown := tcell.NewEventMouse(5, 5, tcell.WheelDown, tcell.ModNone)
+	sv.HandleEvent(wheelDown)
+	sv.HandleEvent(wheelDown)
+	if sv.scrollY != 6 {
+		t.Fatalf("scrollY should be 6, got %d", sv.scrollY)
+	}
+
+	// Scroll up
+	wheelUp := tcell.NewEventMouse(5, 5, tcell.WheelUp, tcell.ModNone)
+	result := sv.HandleEvent(wheelUp)
+	if result != EventConsumed {
+		t.Error("wheel up should be consumed")
+	}
+	if sv.scrollY != 3 {
+		t.Errorf("expected scrollY=3 after wheel up, got %d", sv.scrollY)
+	}
+}
+
+func TestScrollViewClampsAtTop(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+
+	// Try to scroll up from 0
+	wheelUp := tcell.NewEventMouse(5, 5, tcell.WheelUp, tcell.ModNone)
+	sv.HandleEvent(wheelUp)
+	if sv.scrollY != 0 {
+		t.Errorf("scrollY should clamp at 0, got %d", sv.scrollY)
+	}
+
+	// Scroll up multiple times
+	for i := 0; i < 10; i++ {
+		sv.HandleEvent(wheelUp)
+	}
+	if sv.scrollY != 0 {
+		t.Errorf("scrollY should remain 0 after many wheel ups, got %d", sv.scrollY)
+	}
+}
+
+func TestScrollViewClampsAtBottom(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+
+	// Scroll down many times to exceed content
+	wheelDown := tcell.NewEventMouse(5, 5, tcell.WheelDown, tcell.ModNone)
+	for i := 0; i < 20; i++ {
+		sv.HandleEvent(wheelDown)
+	}
+
+	// Content height = 30, viewport height = 10, max scrollY = 20
+	maxScroll := 30 - 10
+	if sv.scrollY > maxScroll {
+		t.Errorf("scrollY should clamp at %d, got %d", maxScroll, sv.scrollY)
+	}
+	if sv.scrollY < 0 {
+		t.Errorf("scrollY should not be negative, got %d", sv.scrollY)
+	}
+}
+
+func TestScrollViewContentRendersWithScroll(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+
+	// First render at top
+	s := renderWidget(sv, 0, 0, 20, 10)
+	if s.cells[0][0].Ch != 'A' {
+		t.Errorf("expected 'A' at row 0 before scroll, got %c", s.cells[0][0].Ch)
+	}
+
+	// Scroll down 3 rows
+	wheelDown := tcell.NewEventMouse(5, 5, tcell.WheelDown, tcell.ModNone)
+	sv.HandleEvent(wheelDown)
+
+	// Re-render after scroll
+	s2 := renderWidget(sv, 0, 0, 20, 10)
+	// After scrolling 3, row 0 of viewport shows content row 3 = 'D'
+	if s2.cells[0][0].Ch != 'D' {
+		t.Errorf("expected 'D' at row 0 after scrolling 3, got %c", s2.cells[0][0].Ch)
+	}
+}
+
+func TestScrollViewFocusable(t *testing.T) {
+	child := newScrollTestChild(10, 10)
+	sv := NewScrollViewWidget(child)
+
+	if !sv.Focusable() {
+		t.Error("scroll view should be focusable")
+	}
+	sv.SetFocused(true)
+	if !sv.IsFocused() {
+		t.Error("scroll view should report focused after SetFocused(true)")
+	}
+	sv.SetFocused(false)
+	if sv.IsFocused() {
+		t.Error("scroll view should not report focused after SetFocused(false)")
+	}
+}
+
+func TestScrollViewWidgetChildren(t *testing.T) {
+	child := newScrollTestChild(10, 10)
+	sv := NewScrollViewWidget(child)
+
+	children := sv.WidgetChildren()
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+
+	sv2 := &ScrollViewWidget{}
+	children2 := sv2.WidgetChildren()
+	if children2 != nil {
+		t.Error("WidgetChildren should return nil when no child")
+	}
+}
+
+func TestScrollViewHeightWidth(t *testing.T) {
+	child := newScrollTestChild(10, 10)
+	sv := NewScrollViewWidget(child)
+
+	// ScrollView returns 0 for both (flexible sizing)
+	if sv.Height() != 0 {
+		t.Errorf("expected Height()=0, got %d", sv.Height())
+	}
+	if sv.Width() != 0 {
+		t.Errorf("expected Width()=0, got %d", sv.Width())
+	}
+}
+
+func TestScrollViewBoxModelApplied(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+	sv.SetBoxModel(BoxModel{
+		PaddingTop:  1,
+		PaddingLeft: 2,
+	})
+
+	s := renderWidget(sv, 0, 0, 25, 15)
+
+	// With padding top=1, left=2, the content should start at (2,1)
+	// The first content row starts at y=1 (after padding top)
+	// and at x=2 (after padding left)
+	if s.cells[1][2].Ch != 'A' {
+		t.Errorf("expected 'A' at (2,1) after padding, got %c", s.cells[1][2].Ch)
+	}
+}
+
+func TestScrollViewEnsureVisible(t *testing.T) {
+	child := newScrollTestChild(15, 30)
+	sv := NewScrollViewWidget(child)
+	sv.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+
+	// Initially scrollY=0, viewport shows rows 0-9
+	// Ensure row 15 is visible: should scroll down
+	sv.EnsureVisible(0, 15)
+	if sv.scrollY <= 0 {
+		t.Error("EnsureVisible to row 15 should scroll down")
+	}
+	// Row 15 should be within [scrollY, scrollY+viewH)
+	// viewH is 10 (no scrollbar on x since 15 < 20)
+	if sv.scrollY > 15 {
+		t.Errorf("scrollY should be <= 15 to show row 15, got %d", sv.scrollY)
+	}
+
+	// Ensure row 0 is visible: should scroll back up
+	sv.EnsureVisible(0, 0)
+	if sv.scrollY != 0 {
+		t.Errorf("EnsureVisible to row 0 should set scrollY=0, got %d", sv.scrollY)
+	}
+}
+
+func TestScrollViewNoChildRender(t *testing.T) {
+	sv := &ScrollViewWidget{}
+
+	// Should not panic when rendering with nil child
+	s := renderWidget(sv, 0, 0, 20, 10)
+	_ = s
+}

--- a/internal/widgets/scrollview_test.go
+++ b/internal/widgets/scrollview_test.go
@@ -291,3 +291,95 @@ func TestScrollViewNoChildRender(t *testing.T) {
 	s := renderWidget(sv, 0, 0, 20, 10)
 	_ = s
 }
+
+func TestScrollViewHorizontalWheelRight(t *testing.T) {
+	child := newScrollTestChild(60, 5)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+
+	ev := tcell.NewEventMouse(5, 5, tcell.WheelRight, tcell.ModNone)
+	result := sv.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("WheelRight should be consumed")
+	}
+	if sv.scrollX != 3 {
+		t.Errorf("expected scrollX=3 after WheelRight, got %d", sv.scrollX)
+	}
+}
+
+func TestScrollViewHorizontalWheelLeft(t *testing.T) {
+	child := newScrollTestChild(60, 5)
+	sv := NewScrollViewWidget(child)
+	sv.scrollX = 10
+	renderWidget(sv, 0, 0, 20, 10)
+
+	ev := tcell.NewEventMouse(5, 5, tcell.WheelLeft, tcell.ModNone)
+	result := sv.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("WheelLeft should be consumed")
+	}
+	if sv.scrollX != 7 {
+		t.Errorf("expected scrollX=7 after WheelLeft, got %d", sv.scrollX)
+	}
+}
+
+func TestScrollViewHorizontalWheelLeftClampsAtZero(t *testing.T) {
+	child := newScrollTestChild(60, 5)
+	sv := NewScrollViewWidget(child)
+	sv.scrollX = 1
+	renderWidget(sv, 0, 0, 20, 10)
+
+	ev := tcell.NewEventMouse(5, 5, tcell.WheelLeft, tcell.ModNone)
+	sv.HandleEvent(ev)
+	if sv.scrollX != 0 {
+		t.Errorf("expected scrollX=0 after WheelLeft clamp, got %d", sv.scrollX)
+	}
+}
+
+func TestScrollViewHorizontalWheelRightClampsAtMax(t *testing.T) {
+	child := newScrollTestChild(60, 5)
+	sv := NewScrollViewWidget(child)
+	sv.scrollX = 38
+	renderWidget(sv, 0, 0, 20, 10)
+
+	ev := tcell.NewEventMouse(5, 5, tcell.WheelRight, tcell.ModNone)
+	sv.HandleEvent(ev)
+	if sv.scrollX > 40 {
+		t.Errorf("scrollX should be clamped, got %d", sv.scrollX)
+	}
+}
+
+func TestScrollViewHorizontalBarClick(t *testing.T) {
+	child := newScrollTestChild(60, 15)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+
+	// hbar is at bottom row (y=9), click in the middle
+	ev := tcell.NewEventMouse(10, 9, tcell.Button1, tcell.ModNone)
+	result := sv.HandleEvent(ev)
+	if result != EventConsumed {
+		t.Error("click on horizontal scrollbar should be consumed")
+	}
+	if sv.scrollX == 0 {
+		t.Error("clicking in middle of hbar should scroll horizontally")
+	}
+}
+
+func TestScrollViewHorizontalBarRendersHalfBlock(t *testing.T) {
+	child := newScrollTestChild(60, 5)
+	sv := NewScrollViewWidget(child)
+	s := renderWidget(sv, 0, 0, 20, 10)
+
+	// No hbar needed since content height (5) fits in viewport (10)
+	// but content width (60) > viewport width (20), so hbar at y=9
+	foundHBar := false
+	for x := range 20 {
+		if s.cells[9][x].Ch == '▄' {
+			foundHBar = true
+			break
+		}
+	}
+	if !foundHBar {
+		t.Error("expected horizontal scrollbar with '▄' character")
+	}
+}

--- a/internal/widgets/table.go
+++ b/internal/widgets/table.go
@@ -1,0 +1,356 @@
+package widgets
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+type TableColumn struct {
+	Label string
+	Width int
+	Align string // "left" (default), "right", "center"
+}
+
+type TableConfig struct {
+	Columns     []TableColumn
+	Rows        [][]string
+	OnSelect    func(rowIndex int)
+	OnCommand   func(command string, rowIndex int)
+	NodeMenu    []MenuEntry
+	KeyCommands map[rune]string
+}
+
+type TableWidget struct {
+	BaseWidget
+	Config    TableConfig
+	selected  int
+	scrollTop int
+	lastSel   int
+	focused   bool
+
+	scrollbar scrollbar
+	contentW  int
+}
+
+func NewTableWidget(cfg TableConfig) *TableWidget {
+	return &TableWidget{Config: cfg}
+}
+
+func (t *TableWidget) Height() int        { return 0 }
+func (t *TableWidget) Width() int         { return 0 }
+func (t *TableWidget) Focusable() bool    { return true }
+func (t *TableWidget) SetFocused(f bool)  { t.focused = f }
+func (t *TableWidget) IsFocused() bool    { return t.focused }
+func (t *TableWidget) SelectedIndex() int { return t.selected }
+
+func (t *TableWidget) SetSelectedIndex(i int) {
+	t.selected = i
+	t.clampSelected()
+}
+
+func (t *TableWidget) clampSelected() {
+	if t.selected >= len(t.Config.Rows) {
+		t.selected = len(t.Config.Rows) - 1
+	}
+	if t.selected < 0 {
+		t.selected = 0
+	}
+}
+
+func (t *TableWidget) ensureVisible(visibleH int) {
+	if t.selected != t.lastSel {
+		t.lastSel = t.selected
+		if t.selected < t.scrollTop {
+			t.scrollTop = t.selected
+		}
+		if t.selected >= t.scrollTop+visibleH {
+			t.scrollTop = t.selected - visibleH + 1
+		}
+	}
+}
+
+func (t *TableWidget) Render(surface Surface) {
+	surface = t.RenderBox(surface)
+	w, h := surface.Size()
+	surface.Fill(term.Cell{Ch: ' '})
+
+	if h <= 0 || w <= 0 || len(t.Config.Columns) == 0 {
+		return
+	}
+
+	// Header takes 2 lines (labels + separator)
+	headerH := 2
+	dataH := h - headerH
+	if dataH < 0 {
+		dataH = 0
+	}
+
+	maxScroll := len(t.Config.Rows) - dataH
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if t.scrollTop > maxScroll {
+		t.scrollTop = maxScroll
+	}
+
+	t.ensureVisible(dataH)
+
+	t.scrollbar.X = t.rect.X + w - 1
+	t.scrollbar.Y = t.rect.Y + headerH
+	t.scrollbar.Height = dataH
+	t.scrollbar.TotalItems = len(t.Config.Rows)
+	t.scrollbar.TopItem = t.scrollTop
+
+	t.contentW = w
+	if t.scrollbar.visible() {
+		t.contentW = w - 1
+	}
+
+	t.renderHeader(surface, t.contentW)
+
+	for i := range dataH {
+		idx := t.scrollTop + i
+		if idx >= len(t.Config.Rows) {
+			break
+		}
+		t.renderRow(surface, idx, headerH+i, t.contentW)
+	}
+
+	t.scrollbar.Render(surface, w-1, headerH)
+}
+
+func (t *TableWidget) renderHeader(surface Surface, w int) {
+	style := term.StyleHoverBold
+	x := 0
+	for i, col := range t.Config.Columns {
+		if i > 0 {
+			if x < w {
+				surface.SetCell(x, 0, term.Cell{Ch: ' ', Style: style})
+				x++
+			}
+			if x < w {
+				surface.SetCell(x, 0, term.Cell{Ch: ' ', Style: style})
+				x++
+			}
+		}
+		t.renderCell(surface, col.Label, col, x, 0, style)
+		x += col.Width
+	}
+	// Fill remaining header space
+	for fx := x; fx < w; fx++ {
+		surface.SetCell(fx, 0, term.Cell{Ch: ' ', Style: style})
+	}
+
+	// Separator line
+	sepStyle := term.StyleBorder
+	for sx := 0; sx < w; sx++ {
+		surface.SetCell(sx, 1, term.Cell{Ch: '─', Style: sepStyle})
+	}
+}
+
+func (t *TableWidget) renderRow(surface Surface, idx, y, w int) {
+	style := term.StyleDefault
+	if idx == t.selected && t.focused {
+		style = term.StyleSidebarSelected
+	}
+
+	for fx := 0; fx < w; fx++ {
+		surface.SetCell(fx, y, term.Cell{Ch: ' ', Style: style})
+	}
+
+	row := t.Config.Rows[idx]
+	x := 0
+	for i, col := range t.Config.Columns {
+		if i > 0 {
+			if x < w {
+				surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+				x++
+			}
+			if x < w {
+				surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+				x++
+			}
+		}
+		cellText := ""
+		if i < len(row) {
+			cellText = row[i]
+		}
+		t.renderCell(surface, cellText, col, x, y, style)
+		x += col.Width
+	}
+}
+
+func (t *TableWidget) renderCell(surface Surface, text string, col TableColumn, x, y int, style term.Style) {
+	runes := []rune(text)
+	colW := col.Width
+	if colW <= 0 {
+		return
+	}
+
+	if len(runes) > colW {
+		// Truncate with ellipsis
+		for i := 0; i < colW-1 && x+i < t.contentW; i++ {
+			surface.SetCell(x+i, y, term.Cell{Ch: runes[i], Style: style})
+		}
+		if x+colW-1 < t.contentW {
+			surface.SetCell(x+colW-1, y, term.Cell{Ch: '…', Style: style})
+		}
+		return
+	}
+
+	padding := colW - len(runes)
+	switch col.Align {
+	case "right":
+		for i := 0; i < padding && x+i < t.contentW; i++ {
+			surface.SetCell(x+i, y, term.Cell{Ch: ' ', Style: style})
+		}
+		for i, ch := range runes {
+			px := x + padding + i
+			if px < t.contentW {
+				surface.SetCell(px, y, term.Cell{Ch: ch, Style: style})
+			}
+		}
+	case "center":
+		leftPad := padding / 2
+		for i := 0; i < leftPad && x+i < t.contentW; i++ {
+			surface.SetCell(x+i, y, term.Cell{Ch: ' ', Style: style})
+		}
+		for i, ch := range runes {
+			px := x + leftPad + i
+			if px < t.contentW {
+				surface.SetCell(px, y, term.Cell{Ch: ch, Style: style})
+			}
+		}
+	default: // left
+		for i, ch := range runes {
+			if x+i < t.contentW {
+				surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: style})
+			}
+		}
+	}
+}
+
+func (t *TableWidget) HandleEvent(ev tcell.Event) EventResult {
+	if newTop, consumed := t.scrollbar.HandleEvent(ev); consumed {
+		t.scrollTop = newTop
+		return EventConsumed
+	}
+
+	prev := t.selected
+	var result EventResult
+	switch tev := ev.(type) {
+	case *tcell.EventMouse:
+		result = t.handleMouse(tev)
+	case *tcell.EventKey:
+		result = t.handleKey(tev)
+	default:
+		return EventIgnored
+	}
+	if t.selected != prev && t.Config.OnSelect != nil {
+		t.Config.OnSelect(t.selected)
+	}
+	return result
+}
+
+func (t *TableWidget) handleMouse(ev *tcell.EventMouse) EventResult {
+	btn := ev.Buttons()
+	mx, my := ev.Position()
+	r := t.rect
+
+	if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
+		return EventIgnored
+	}
+
+	headerH := 2
+
+	if btn&tcell.WheelUp != 0 {
+		t.scrollTop -= 3
+		if t.scrollTop < 0 {
+			t.scrollTop = 0
+		}
+		return EventConsumed
+	}
+	if btn&tcell.WheelDown != 0 {
+		dataH := r.H - headerH
+		if dataH < 0 {
+			dataH = 0
+		}
+		max := len(t.Config.Rows) - dataH
+		if max < 0 {
+			max = 0
+		}
+		t.scrollTop += 3
+		if t.scrollTop > max {
+			t.scrollTop = max
+		}
+		return EventConsumed
+	}
+
+	localY := my - r.Y
+	if localY < headerH {
+		return EventIgnored
+	}
+
+	idx := t.scrollTop + (localY - headerH)
+	if idx < 0 || idx >= len(t.Config.Rows) {
+		return EventIgnored
+	}
+
+	if btn&tcell.Button2 != 0 {
+		t.selected = idx
+		if t.Config.OnCommand != nil && len(t.Config.NodeMenu) > 0 {
+			// Right-click fires the first menu entry's command as a convention,
+			// but typically this is handled via the context menu system.
+		}
+		return EventConsumed
+	}
+
+	if btn&tcell.Button1 != 0 {
+		t.selected = idx
+		if t.Config.OnSelect != nil {
+			t.Config.OnSelect(idx)
+		}
+		return EventConsumed
+	}
+
+	return EventIgnored
+}
+
+func (t *TableWidget) handleKey(ev *tcell.EventKey) EventResult {
+	switch ev.Key() {
+	case tcell.KeyUp:
+		if t.selected > 0 {
+			t.selected--
+		}
+		return EventConsumed
+	case tcell.KeyDown:
+		if t.selected < len(t.Config.Rows)-1 {
+			t.selected++
+		}
+		return EventConsumed
+	case tcell.KeyEnter:
+		if t.Config.OnSelect != nil && t.selected >= 0 && t.selected < len(t.Config.Rows) {
+			t.Config.OnSelect(t.selected)
+		}
+		return EventConsumed
+	case tcell.KeyRune:
+		if t.handleShortcutKey(ev.Rune()) == EventConsumed {
+			return EventConsumed
+		}
+	}
+	return EventIgnored
+}
+
+func (t *TableWidget) handleShortcutKey(r rune) EventResult {
+	if t.Config.KeyCommands == nil {
+		return EventIgnored
+	}
+	cmd, ok := t.Config.KeyCommands[r]
+	if !ok {
+		return EventIgnored
+	}
+	if t.Config.OnCommand != nil && t.selected >= 0 && t.selected < len(t.Config.Rows) {
+		t.Config.OnCommand(cmd, t.selected)
+	}
+	return EventConsumed
+}

--- a/internal/widgets/table_test.go
+++ b/internal/widgets/table_test.go
@@ -1,0 +1,632 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+func newBasicTable() *TableWidget {
+	return NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Name", Width: 10},
+			{Label: "Age", Width: 5},
+		},
+		Rows: [][]string{
+			{"Alice", "30"},
+			{"Bob", "25"},
+			{"Charlie", "35"},
+		},
+	})
+}
+
+func TestTableRenderHeader(t *testing.T) {
+	tbl := newBasicTable()
+	s := renderWidget(tbl, 0, 0, 20, 10)
+
+	// Row 0 should contain column header labels
+	// "Name" starts at x=0
+	headerText := extractText(s, 0, 0, 4)
+	if headerText != "Name" {
+		t.Errorf("expected header 'Name', got %q", headerText)
+	}
+
+	// Header style should be StyleHoverBold
+	if s.cells[0][0].Style != term.StyleHoverBold {
+		t.Errorf("header style should be StyleHoverBold, got %v", s.cells[0][0].Style)
+	}
+}
+
+func TestTableRenderSeparator(t *testing.T) {
+	tbl := newBasicTable()
+	s := renderWidget(tbl, 0, 0, 20, 10)
+
+	// Row 1 should be separator line with '─'
+	if s.cells[1][0].Ch != '─' {
+		t.Errorf("separator should use '─', got '%c'", s.cells[1][0].Ch)
+	}
+	if s.cells[1][0].Style != term.StyleBorder {
+		t.Errorf("separator style should be StyleBorder, got %v", s.cells[1][0].Style)
+	}
+}
+
+func TestTableRenderDataRows(t *testing.T) {
+	tbl := newBasicTable()
+	s := renderWidget(tbl, 0, 0, 20, 10)
+
+	// Data rows start at y=2 (after header + separator)
+	// Row 0: "Alice" at x=0
+	row0Text := extractText(s, 0, 2, 5)
+	if row0Text != "Alice" {
+		t.Errorf("expected 'Alice' in first data row, got %q", row0Text)
+	}
+
+	// Row 1: "Bob" at x=0
+	row1Text := extractText(s, 0, 3, 3)
+	if row1Text != "Bob" {
+		t.Errorf("expected 'Bob' in second data row, got %q", row1Text)
+	}
+}
+
+func TestTableColumnAlignLeft(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10, Align: "left"},
+		},
+		Rows: [][]string{
+			{"Hi"},
+		},
+	})
+	s := renderWidget(tbl, 0, 0, 15, 5)
+
+	// "Hi" should start at x=0 in data row (y=2)
+	if s.cells[2][0].Ch != 'H' || s.cells[2][1].Ch != 'i' {
+		t.Errorf("left-aligned text should start at x=0, got '%c%c'", s.cells[2][0].Ch, s.cells[2][1].Ch)
+	}
+}
+
+func TestTableColumnAlignRight(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10, Align: "right"},
+		},
+		Rows: [][]string{
+			{"Hi"},
+		},
+	})
+	s := renderWidget(tbl, 0, 0, 15, 5)
+
+	// "Hi" is 2 chars, column is 10 wide, so padding=8, text starts at x=8
+	if s.cells[2][8].Ch != 'H' || s.cells[2][9].Ch != 'i' {
+		t.Errorf("right-aligned: expected 'Hi' at x=8..9, got '%c%c'", s.cells[2][8].Ch, s.cells[2][9].Ch)
+	}
+}
+
+func TestTableColumnAlignCenter(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10, Align: "center"},
+		},
+		Rows: [][]string{
+			{"Hi"},
+		},
+	})
+	s := renderWidget(tbl, 0, 0, 15, 5)
+
+	// "Hi" is 2 chars, column is 10 wide, padding=8, leftPad=4, text starts at x=4
+	if s.cells[2][4].Ch != 'H' || s.cells[2][5].Ch != 'i' {
+		t.Errorf("center-aligned: expected 'Hi' at x=4..5, got '%c%c'", s.cells[2][4].Ch, s.cells[2][5].Ch)
+	}
+}
+
+func TestTableCellTruncation(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 5},
+		},
+		Rows: [][]string{
+			{"LongText123"},
+		},
+	})
+	s := renderWidget(tbl, 0, 0, 10, 5)
+
+	// "LongText123" is 11 chars, column is 5, so we show first 4 chars + '…'
+	text := extractText(s, 0, 2, 4)
+	if text != "Long" {
+		t.Errorf("truncated text prefix should be 'Long', got %q", text)
+	}
+	if s.cells[2][4].Ch != '…' {
+		t.Errorf("truncated text should end with '…', got '%c'", s.cells[2][4].Ch)
+	}
+}
+
+func TestTableKeyboardUp(t *testing.T) {
+	tbl := newBasicTable()
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 20, 10)
+
+	// Initial selection is 0
+	if tbl.SelectedIndex() != 0 {
+		t.Fatalf("initial selected should be 0, got %d", tbl.SelectedIndex())
+	}
+
+	// Move down then up
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	if tbl.SelectedIndex() != 1 {
+		t.Fatalf("after down, selected should be 1, got %d", tbl.SelectedIndex())
+	}
+
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone))
+	if tbl.SelectedIndex() != 0 {
+		t.Fatalf("after up, selected should be 0, got %d", tbl.SelectedIndex())
+	}
+}
+
+func TestTableKeyboardDownClamp(t *testing.T) {
+	tbl := newBasicTable()
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 20, 10)
+
+	// Move down past end
+	for i := 0; i < 10; i++ {
+		tbl.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	}
+	if tbl.SelectedIndex() != 2 {
+		t.Fatalf("down clamp: selected should be 2 (last row), got %d", tbl.SelectedIndex())
+	}
+}
+
+func TestTableKeyboardUpClamp(t *testing.T) {
+	tbl := newBasicTable()
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 20, 10)
+
+	// Already at 0, pressing up should stay at 0
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone))
+	if tbl.SelectedIndex() != 0 {
+		t.Fatalf("up clamp: selected should remain 0, got %d", tbl.SelectedIndex())
+	}
+}
+
+func TestTableKeyboardEnterFiresOnSelect(t *testing.T) {
+	selected := -1
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{
+			{"Row0"},
+			{"Row1"},
+		},
+		OnSelect: func(idx int) { selected = idx },
+	})
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 15, 10)
+
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+
+	if selected != 1 {
+		t.Fatalf("enter should fire OnSelect with row 1, got %d", selected)
+	}
+}
+
+func TestTableKeyCommands(t *testing.T) {
+	var cmd string
+	var row int
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{
+			{"Row0"},
+			{"Row1"},
+		},
+		KeyCommands: map[rune]string{
+			'd': "delete",
+			'r': "rename",
+		},
+		OnCommand: func(c string, idx int) {
+			cmd = c
+			row = idx
+		},
+	})
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 15, 10)
+
+	result := tbl.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'd', tcell.ModNone))
+	if result != EventConsumed {
+		t.Error("key command 'd' should be consumed")
+	}
+	if cmd != "delete" {
+		t.Errorf("expected command 'delete', got %q", cmd)
+	}
+	if row != 0 {
+		t.Errorf("expected row 0, got %d", row)
+	}
+}
+
+func TestTableKeyCommandUnknownKey(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{{"Row0"}},
+		KeyCommands: map[rune]string{
+			'd': "delete",
+		},
+	})
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 15, 10)
+
+	result := tbl.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'x', tcell.ModNone))
+	if result == EventConsumed {
+		t.Error("unknown key should not be consumed")
+	}
+}
+
+func TestTableMouseClickSelectsRow(t *testing.T) {
+	selected := -1
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{
+			{"Row0"},
+			{"Row1"},
+			{"Row2"},
+		},
+		OnSelect: func(idx int) { selected = idx },
+	})
+	renderWidget(tbl, 0, 0, 15, 10)
+
+	// Data starts at y=2 (header=0, separator=1)
+	// Click on row 1 (y=3)
+	click := mouseClick(1, 3)
+	result := tbl.HandleEvent(click)
+
+	if result != EventConsumed {
+		t.Error("click on data row should be consumed")
+	}
+	if selected != 1 {
+		t.Errorf("click on row 1 should select it, got %d", selected)
+	}
+	if tbl.SelectedIndex() != 1 {
+		t.Errorf("selected index should be 1, got %d", tbl.SelectedIndex())
+	}
+}
+
+func TestTableMouseClickOutsideBounds(t *testing.T) {
+	tbl := newBasicTable()
+	renderWidget(tbl, 5, 5, 15, 10)
+
+	// Click outside the table rect
+	click := mouseClick(0, 0)
+	result := tbl.HandleEvent(click)
+
+	if result == EventConsumed {
+		t.Error("click outside table rect should be ignored")
+	}
+}
+
+func TestTableMouseClickOnHeader(t *testing.T) {
+	tbl := newBasicTable()
+	renderWidget(tbl, 0, 0, 20, 10)
+
+	// Click on header row (y=0)
+	click := mouseClick(1, 0)
+	result := tbl.HandleEvent(click)
+
+	if result == EventConsumed {
+		t.Error("click on header row should be ignored")
+	}
+}
+
+func TestTableMouseClickPastLastRow(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{
+			{"Row0"},
+		},
+	})
+	renderWidget(tbl, 0, 0, 15, 10)
+
+	// Only 1 data row at y=2, click at y=5 is past it
+	click := mouseClick(1, 5)
+	result := tbl.HandleEvent(click)
+
+	if result == EventConsumed {
+		t.Error("click past last data row should be ignored")
+	}
+}
+
+func TestTableMouseWheelUp(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: makeRows(20),
+	})
+	renderWidget(tbl, 0, 0, 15, 7) // dataH = 7 - 2 = 5
+
+	// Scroll down first
+	tbl.scrollTop = 10
+
+	wheel := tcell.NewEventMouse(1, 3, tcell.WheelUp, tcell.ModNone)
+	result := tbl.HandleEvent(wheel)
+
+	if result != EventConsumed {
+		t.Error("wheel up should be consumed")
+	}
+	if tbl.scrollTop != 7 { // 10 - 3 = 7
+		t.Errorf("scrollTop should be 7 after wheel up, got %d", tbl.scrollTop)
+	}
+}
+
+func TestTableMouseWheelDown(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: makeRows(20),
+	})
+	renderWidget(tbl, 0, 0, 15, 7) // dataH = 5
+
+	wheel := tcell.NewEventMouse(1, 3, tcell.WheelDown, tcell.ModNone)
+	result := tbl.HandleEvent(wheel)
+
+	if result != EventConsumed {
+		t.Error("wheel down should be consumed")
+	}
+	if tbl.scrollTop != 3 { // 0 + 3 = 3
+		t.Errorf("scrollTop should be 3 after wheel down, got %d", tbl.scrollTop)
+	}
+}
+
+func TestTableMouseWheelUpClamp(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: makeRows(20),
+	})
+	renderWidget(tbl, 0, 0, 15, 7)
+
+	tbl.scrollTop = 1
+	wheel := tcell.NewEventMouse(1, 3, tcell.WheelUp, tcell.ModNone)
+	tbl.HandleEvent(wheel)
+
+	if tbl.scrollTop != 0 {
+		t.Errorf("scrollTop should clamp to 0, got %d", tbl.scrollTop)
+	}
+}
+
+func TestTableScrollingEnsureVisible(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: makeRows(20),
+	})
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 15, 7) // dataH = 5
+
+	// Move selection beyond visible area
+	for i := 0; i < 8; i++ {
+		tbl.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	}
+	// After moving, re-render to trigger ensureVisible
+	renderWidget(tbl, 0, 0, 15, 7)
+
+	if tbl.SelectedIndex() != 8 {
+		t.Fatalf("selected should be 8, got %d", tbl.SelectedIndex())
+	}
+	// scrollTop should adjust so selected is visible: scrollTop <= 8 and scrollTop + 5 > 8
+	if tbl.scrollTop > 8 || tbl.scrollTop+5 <= 8 {
+		t.Errorf("scrollTop should make row 8 visible, scrollTop=%d, dataH=5", tbl.scrollTop)
+	}
+}
+
+func TestTableSelectedFocusedStyle(t *testing.T) {
+	tbl := newBasicTable()
+	tbl.SetFocused(true)
+	s := renderWidget(tbl, 0, 0, 20, 10)
+
+	// Selected row (0) when focused should use StyleSidebarSelected
+	// Data row 0 is at y=2
+	if s.cells[2][0].Style != term.StyleSidebarSelected {
+		t.Errorf("selected+focused row should use StyleSidebarSelected, got %v", s.cells[2][0].Style)
+	}
+
+	// Non-selected row (1) should use StyleDefault
+	if s.cells[3][0].Style != term.StyleDefault {
+		t.Errorf("non-selected row should use StyleDefault, got %v", s.cells[3][0].Style)
+	}
+}
+
+func TestTableSelectedUnfocusedStyle(t *testing.T) {
+	tbl := newBasicTable()
+	tbl.SetFocused(false)
+	s := renderWidget(tbl, 0, 0, 20, 10)
+
+	// Selected row when unfocused should use StyleDefault (not selected style)
+	if s.cells[2][0].Style != term.StyleDefault {
+		t.Errorf("selected but unfocused row should use StyleDefault, got %v", s.cells[2][0].Style)
+	}
+}
+
+func TestTableEmptyNoRows(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{},
+	})
+	// Should not panic
+	renderWidget(tbl, 0, 0, 15, 5)
+
+	if tbl.SelectedIndex() != 0 {
+		t.Errorf("empty table selected should be 0, got %d", tbl.SelectedIndex())
+	}
+}
+
+func TestTableEmptyNoColumns(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{},
+		Rows:    [][]string{{"a"}},
+	})
+	// Should not panic (early return in Render)
+	renderWidget(tbl, 0, 0, 15, 5)
+}
+
+func TestTableSingleRow(t *testing.T) {
+	selected := -1
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{
+			{"Only"},
+		},
+		OnSelect: func(idx int) { selected = idx },
+	})
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 15, 5)
+
+	// Down should not move past single row
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	if tbl.SelectedIndex() != 0 {
+		t.Errorf("single row: down should stay at 0, got %d", tbl.SelectedIndex())
+	}
+
+	// Enter should fire OnSelect
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+	if selected != 0 {
+		t.Errorf("enter on single row should fire OnSelect(0), got %d", selected)
+	}
+}
+
+func TestTableSetSelectedIndex(t *testing.T) {
+	tbl := newBasicTable()
+
+	tbl.SetSelectedIndex(2)
+	if tbl.SelectedIndex() != 2 {
+		t.Errorf("SetSelectedIndex(2) should set to 2, got %d", tbl.SelectedIndex())
+	}
+
+	// Clamp beyond range
+	tbl.SetSelectedIndex(100)
+	if tbl.SelectedIndex() != 2 {
+		t.Errorf("SetSelectedIndex(100) should clamp to 2, got %d", tbl.SelectedIndex())
+	}
+
+	tbl.SetSelectedIndex(-5)
+	if tbl.SelectedIndex() != 0 {
+		t.Errorf("SetSelectedIndex(-5) should clamp to 0, got %d", tbl.SelectedIndex())
+	}
+}
+
+func TestTableFocusable(t *testing.T) {
+	tbl := newBasicTable()
+
+	if !tbl.Focusable() {
+		t.Error("table should be focusable")
+	}
+
+	tbl.SetFocused(true)
+	if !tbl.IsFocused() {
+		t.Error("table should be focused after SetFocused(true)")
+	}
+
+	tbl.SetFocused(false)
+	if tbl.IsFocused() {
+		t.Error("table should not be focused after SetFocused(false)")
+	}
+}
+
+func TestTableOnSelectFiredOnNavigation(t *testing.T) {
+	// OnSelect should fire when selection changes via keyboard
+	selections := []int{}
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "Col", Width: 10},
+		},
+		Rows: [][]string{
+			{"Row0"},
+			{"Row1"},
+			{"Row2"},
+		},
+		OnSelect: func(idx int) { selections = append(selections, idx) },
+	})
+	tbl.SetFocused(true)
+	renderWidget(tbl, 0, 0, 15, 10)
+
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	tbl.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+
+	if len(selections) != 2 {
+		t.Fatalf("expected 2 OnSelect calls, got %d", len(selections))
+	}
+	if selections[0] != 1 || selections[1] != 2 {
+		t.Errorf("expected selections [1, 2], got %v", selections)
+	}
+}
+
+func TestTableColumnSeparatorSpacing(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{
+			{Label: "A", Width: 3},
+			{Label: "B", Width: 3},
+		},
+		Rows: [][]string{
+			{"ab", "cd"},
+		},
+	})
+	s := renderWidget(tbl, 0, 0, 20, 5)
+
+	// Column A is 3 wide (x=0..2), then 2 space separators (x=3,4), column B at x=5
+	// In data row (y=2), "ab" at x=0..1, spaces, then "cd" at x=5..6
+	row0 := extractText(s, 0, 2, 8)
+	if len(row0) < 7 {
+		t.Logf("row0 text: %q", row0)
+	}
+	// Verify second column value location
+	if s.cells[2][5].Ch != 'c' || s.cells[2][6].Ch != 'd' {
+		t.Errorf("second column should start at x=5, got '%c%c' at x=5,6", s.cells[2][5].Ch, s.cells[2][6].Ch)
+	}
+}
+
+func TestTableHeightAndWidthZero(t *testing.T) {
+	tbl := newBasicTable()
+	if tbl.Height() != 0 {
+		t.Errorf("table Height() should be 0 (fills parent), got %d", tbl.Height())
+	}
+	if tbl.Width() != 0 {
+		t.Errorf("table Width() should be 0 (fills parent), got %d", tbl.Width())
+	}
+}
+
+// --- helpers ---
+
+func makeRows(n int) [][]string {
+	rows := make([][]string, n)
+	for i := range n {
+		rows[i] = []string{string(rune('A' + i%26))}
+	}
+	return rows
+}
+
+func extractText(s *testSurface, x, y, length int) string {
+	runes := make([]rune, 0, length)
+	for i := 0; i < length; i++ {
+		ch := s.cells[y][x+i].Ch
+		if ch == 0 {
+			break
+		}
+		runes = append(runes, ch)
+	}
+	return string(runes)
+}

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -318,8 +318,15 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		if idx == t.selected {
 			iconStyle = style
 		}
-		for _, ch := range node.Icon {
+		iconRunes := []rune(node.Icon)
+		iconFits := x+len(iconRunes) <= maxX
+		for i, ch := range iconRunes {
 			if x >= maxX {
+				break
+			}
+			if !iconFits && x == maxX-1 && i < len(iconRunes)-1 {
+				surface.SetCell(x, y, term.Cell{Ch: '…', Style: iconStyle})
+				x++
 				break
 			}
 			surface.SetCell(x, y, term.Cell{Ch: ch, Style: iconStyle})
@@ -335,8 +342,15 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 	if node.Muted && idx != t.selected {
 		labelStyle = term.StyleMuted
 	}
-	for _, ch := range node.Label {
+	labelRunes := []rune(node.Label)
+	labelFits := x+len(labelRunes) <= maxX
+	for i, ch := range labelRunes {
 		if x >= maxX {
+			break
+		}
+		if !labelFits && x == maxX-1 && i < len(labelRunes)-1 {
+			surface.SetCell(x, y, term.Cell{Ch: '…', Style: labelStyle})
+			x++
 			break
 		}
 		surface.SetCell(x, y, term.Cell{Ch: ch, Style: labelStyle})
@@ -352,8 +366,15 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 			badgeStyle = style
 		}
 		x++
-		for _, ch := range node.Badge {
+		badgeRunes := []rune(node.Badge)
+		badgeFits := x+len(badgeRunes) <= maxX
+		for i, ch := range badgeRunes {
 			if x >= maxX {
+				break
+			}
+			if !badgeFits && x == maxX-1 && i < len(badgeRunes)-1 {
+				surface.SetCell(x, y, term.Cell{Ch: '…', Style: badgeStyle})
+				x++
 				break
 			}
 			surface.SetCell(x, y, term.Cell{Ch: ch, Style: badgeStyle})

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -189,6 +189,7 @@ func (t *TreeWidget) ensureVisible(visibleH int) {
 }
 
 func (t *TreeWidget) Render(surface Surface) {
+	surface = t.RenderBox(surface)
 	w, h := surface.Size()
 	surface.Fill(term.Cell{Ch: ' '})
 

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -1,0 +1,1421 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+// --- helpers ---
+
+// makeTreeItems builds a simple flat list of tree nodes.
+func makeTreeItems(ids ...string) []*TreeNode {
+	nodes := make([]*TreeNode, len(ids))
+	for i, id := range ids {
+		nodes[i] = &TreeNode{ID: id, Label: id}
+	}
+	return nodes
+}
+
+// pressKey sends a key event to the tree widget.
+func pressKey(t *TreeWidget, key tcell.Key) {
+	t.HandleEvent(tcell.NewEventKey(key, 0, tcell.ModNone))
+}
+
+// pressRune sends a rune event to the tree widget.
+func pressRune(t *TreeWidget, r rune) {
+	t.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone))
+}
+
+// --- Rendering tests ---
+
+func TestTreeRenderItemPositions(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("Alpha", "Beta", "Gamma"),
+	})
+	tree.SetFocused(true)
+	s := renderWidget(tree, 0, 0, 20, 10)
+
+	// Each item renders on its own row: 0, 1, 2
+	row0 := surfaceRowText(s, 0)
+	row1 := surfaceRowText(s, 1)
+	row2 := surfaceRowText(s, 2)
+
+	if len(row0) < 5 || row0[:5] != "Alpha" {
+		t.Errorf("row 0 should start with Alpha, got %q", row0)
+	}
+	if len(row1) < 4 || row1[:4] != "Beta" {
+		t.Errorf("row 1 should start with Beta, got %q", row1)
+	}
+	if len(row2) < 5 || row2[:5] != "Gamma" {
+		t.Errorf("row 2 should start with Gamma, got %q", row2)
+	}
+}
+
+func TestTreeRenderIndentation(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+		Indent: 4,
+	})
+	s := renderWidget(tree, 0, 0, 30, 10)
+
+	// Root is at depth 0, so label starts at x=0 after the chevron (2 chars: chevron + space)
+	// Root has children so chevron at x=0
+	if s.cells[0][0].Ch != '▼' {
+		t.Errorf("root should show expanded chevron, got %c", s.cells[0][0].Ch)
+	}
+
+	// Child is at depth 1 with indent=4, so it starts at x=4
+	// Child has no children, so no chevron — label starts at x=4
+	row1 := surfaceRowText(s, 1)
+	if len(row1) < 9 || row1[4:9] != "Child" {
+		t.Errorf("child should be indented to x=4, got row %q", row1)
+	}
+}
+
+func TestTreeRenderDefaultIndent(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+		// Indent defaults to 2
+	})
+	s := renderWidget(tree, 0, 0, 30, 10)
+
+	// Child at depth 1, indent=2 => starts at x=2
+	row1 := surfaceRowText(s, 1)
+	if len(row1) < 7 || row1[2:7] != "Child" {
+		t.Errorf("child with default indent should start at x=2, got row %q", row1)
+	}
+}
+
+func TestTreeRenderNegativeIndent(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+		Indent: -1, // should be clamped to 0
+	})
+	s := renderWidget(tree, 0, 0, 30, 10)
+
+	// With indent=0, child at depth 1 starts at x=0*1=0
+	row1 := surfaceRowText(s, 1)
+	if len(row1) < 5 || row1[0:5] != "Child" {
+		t.Errorf("child with indent=0 should start at x=0, got row %q", row1)
+	}
+}
+
+func TestTreeRenderChevrons(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "collapsed",
+				Label: "Collapsed",
+				Children: []*TreeNode{
+					{ID: "c1", Label: "C1"},
+				},
+			},
+			{
+				ID:       "expanded",
+				Label:    "Expanded",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "c2", Label: "C2"},
+				},
+			},
+			{ID: "leaf", Label: "Leaf"},
+		},
+	})
+	s := renderWidget(tree, 0, 0, 30, 10)
+
+	// Row 0: collapsed node has right-pointing chevron
+	if s.cells[0][0].Ch != '▶' {
+		t.Errorf("collapsed node should show ▶, got %c", s.cells[0][0].Ch)
+	}
+
+	// Row 1: expanded node has down-pointing chevron
+	if s.cells[1][0].Ch != '▼' {
+		t.Errorf("expanded node should show ▼, got %c", s.cells[1][0].Ch)
+	}
+
+	// Row 3: leaf node (after expanded + its child C2 at row 2) has no chevron
+	// Leaf is at flatList index 3 (collapsed, expanded, c2, leaf) but
+	// collapsed is not expanded, so flatList is: collapsed, expanded, c2, leaf
+	// rows: 0=collapsed, 1=expanded, 2=c2, 3=leaf
+	row3 := surfaceRowText(s, 3)
+	if len(row3) < 4 || row3[:4] != "Leaf" {
+		t.Errorf("leaf node should have no chevron, label at x=0, got row %q", row3)
+	}
+}
+
+func TestTreeRenderExpandableNoChildren(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{ID: "lazy", Label: "Lazy", Expandable: true},
+		},
+	})
+	s := renderWidget(tree, 0, 0, 30, 10)
+
+	// Expandable flag without children should still show a chevron
+	if s.cells[0][0].Ch != '▶' {
+		t.Errorf("expandable node should show ▶, got %c", s.cells[0][0].Ch)
+	}
+}
+
+func TestTreeRenderEllipsisTruncation(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{ID: "long", Label: "ThisIsAVeryLongLabelThatShouldBeTruncated"},
+		},
+	})
+	// Use a narrow width so the label can't fit
+	s := renderWidget(tree, 0, 0, 12, 5)
+
+	// maxX = w - 2 - rightSideWidth = 12 - 2 - 0 = 10
+	// Label should be truncated with '...' before maxX
+	row := surfaceRowText(s, 0)
+	found := false
+	for _, ch := range row {
+		if ch == '…' {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("long label should be truncated with ellipsis, got %q", row)
+	}
+}
+
+func TestTreeRenderSelectionHighlight(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("Alpha", "Beta"),
+	})
+	tree.SetFocused(true)
+	s := renderWidget(tree, 0, 0, 20, 10)
+
+	// Row 0 is selected by default, should use StyleSidebarSelected when focused
+	if s.cells[0][0].Style != term.StyleSidebarSelected {
+		t.Errorf("selected+focused row should use StyleSidebarSelected, got %v", s.cells[0][0].Style)
+	}
+
+	// Row 1 is not selected, should use StyleDefault
+	if s.cells[1][0].Style != term.StyleDefault {
+		t.Errorf("unselected row should use StyleDefault, got %v", s.cells[1][0].Style)
+	}
+}
+
+func TestTreeRenderSelectionNotHighlightedWhenUnfocused(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("Alpha", "Beta"),
+	})
+	// Not focused
+	tree.SetFocused(false)
+	s := renderWidget(tree, 0, 0, 20, 10)
+
+	// Row 0 is selected but tree is not focused, so it should use StyleDefault
+	if s.cells[0][0].Style != term.StyleDefault {
+		t.Errorf("selected but unfocused row should use StyleDefault, got %v", s.cells[0][0].Style)
+	}
+}
+
+func TestTreeRenderEmptyText(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items:     []*TreeNode{},
+		EmptyText: "No items",
+	})
+	s := renderWidget(tree, 0, 0, 20, 5)
+
+	// EmptyText renders at y=0, starting at x=1
+	row := surfaceRowText(s, 0)
+	if len(row) < 9 || row[1:9] != "No items" {
+		t.Errorf("empty tree should show EmptyText, got row %q", row)
+	}
+}
+
+func TestTreeRenderEmptyNoEmptyText(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{},
+	})
+	s := renderWidget(tree, 0, 0, 20, 5)
+
+	// With no EmptyText and no items, row should be empty (all spaces/zeroes)
+	row := surfaceRowText(s, 0)
+	for _, ch := range row {
+		if ch != ' ' && ch != 0 {
+			t.Errorf("empty tree with no EmptyText should be blank, got %q", row)
+			break
+		}
+	}
+}
+
+func TestTreeRenderIcon(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{ID: "a", Label: "File", Icon: "F"},
+		},
+	})
+	s := renderWidget(tree, 0, 0, 20, 5)
+
+	// Leaf node, no chevron. Icon "F" at x=0, space at x=1, label "File" starting at x=2
+	if s.cells[0][0].Ch != 'F' {
+		t.Errorf("icon should render at x=0, got %c", s.cells[0][0].Ch)
+	}
+	row := surfaceRowText(s, 0)
+	if len(row) < 6 || row[2:6] != "File" {
+		t.Errorf("label should follow icon+space, got %q", row)
+	}
+}
+
+// --- Keyboard Navigation tests ---
+
+func TestTreeKeyUpDown(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B", "C"),
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	if tree.SelectedIndex() != 0 {
+		t.Fatalf("initial selection should be 0, got %d", tree.SelectedIndex())
+	}
+
+	// Down moves to next
+	pressKey(tree, tcell.KeyDown)
+	if tree.SelectedIndex() != 1 {
+		t.Errorf("down should move to 1, got %d", tree.SelectedIndex())
+	}
+
+	pressKey(tree, tcell.KeyDown)
+	if tree.SelectedIndex() != 2 {
+		t.Errorf("down should move to 2, got %d", tree.SelectedIndex())
+	}
+
+	// Down at last item clamps (no wrap)
+	pressKey(tree, tcell.KeyDown)
+	if tree.SelectedIndex() != 2 {
+		t.Errorf("down at last item should clamp at 2, got %d", tree.SelectedIndex())
+	}
+
+	// Up moves back
+	pressKey(tree, tcell.KeyUp)
+	if tree.SelectedIndex() != 1 {
+		t.Errorf("up should move to 1, got %d", tree.SelectedIndex())
+	}
+
+	pressKey(tree, tcell.KeyUp)
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("up should move to 0, got %d", tree.SelectedIndex())
+	}
+
+	// Up at first item clamps (no wrap)
+	pressKey(tree, tcell.KeyUp)
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("up at first item should clamp at 0, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeKeyLeftCollapse(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Initially root is expanded, flatList: [root, child]
+	if tree.ItemCount() != 2 {
+		t.Fatalf("expected 2 flat items, got %d", tree.ItemCount())
+	}
+
+	// Left on expanded node should collapse it
+	pressKey(tree, tcell.KeyLeft)
+	if tree.ItemCount() != 1 {
+		t.Errorf("left should collapse root, expected 1 item, got %d", tree.ItemCount())
+	}
+	if tree.Config.Items[0].Expanded {
+		t.Error("root should be collapsed after pressing left")
+	}
+}
+
+func TestTreeKeyLeftAlreadyCollapsed(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "root",
+				Label: "Root",
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Root is collapsed. Left on collapsed node does nothing (no parent to go to for root).
+	pressKey(tree, tcell.KeyLeft)
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("left on collapsed root should not change selection, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeKeyRightExpand(t *testing.T) {
+	expanded := []string{}
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "root",
+				Label: "Root",
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+		OnExpand: func(node *TreeNode) {
+			expanded = append(expanded, node.ID)
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Root is collapsed. Right should expand it.
+	pressKey(tree, tcell.KeyRight)
+	if tree.ItemCount() != 2 {
+		t.Errorf("right should expand root, expected 2 items, got %d", tree.ItemCount())
+	}
+	if !tree.Config.Items[0].Expanded {
+		t.Error("root should be expanded after pressing right")
+	}
+	if len(expanded) != 1 || expanded[0] != "root" {
+		t.Errorf("OnExpand should be called with root, got %v", expanded)
+	}
+}
+
+func TestTreeKeyRightAlreadyExpanded(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Right on already expanded node should do nothing
+	pressKey(tree, tcell.KeyRight)
+	if tree.ItemCount() != 2 {
+		t.Errorf("right on expanded node should not change items, got %d", tree.ItemCount())
+	}
+}
+
+func TestTreeKeyEnterSelect(t *testing.T) {
+	var activated []string
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{ID: "leaf", Label: "Leaf"},
+		},
+		OnCommand: func(cmd string, node *TreeNode) {
+			activated = append(activated, cmd+":"+node.ID)
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Enter on a leaf node should call OnCommand with "activate"
+	pressKey(tree, tcell.KeyEnter)
+	if len(activated) != 1 || activated[0] != "activate:leaf" {
+		t.Errorf("enter on leaf should trigger activate command, got %v", activated)
+	}
+}
+
+func TestTreeKeyEnterToggleExpandable(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "root",
+				Label: "Root",
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Enter on expandable node should toggle expansion
+	pressKey(tree, tcell.KeyEnter)
+	if !tree.Config.Items[0].Expanded {
+		t.Error("enter should expand the node")
+	}
+	if tree.ItemCount() != 2 {
+		t.Errorf("expanded root should have 2 flat items, got %d", tree.ItemCount())
+	}
+
+	// Enter again should collapse
+	pressKey(tree, tcell.KeyEnter)
+	if tree.Config.Items[0].Expanded {
+		t.Error("second enter should collapse the node")
+	}
+	if tree.ItemCount() != 1 {
+		t.Errorf("collapsed root should have 1 flat item, got %d", tree.ItemCount())
+	}
+}
+
+func TestTreeKeySpaceActivate(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "root",
+				Label: "Root",
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Space should also toggle
+	pressRune(tree, ' ')
+	if !tree.Config.Items[0].Expanded {
+		t.Error("space should expand the node")
+	}
+}
+
+func TestTreeKeyOnSelectCallback(t *testing.T) {
+	var selections []string
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B", "C"),
+		OnSelect: func(node *TreeNode) {
+			selections = append(selections, node.ID)
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Move down - should trigger OnSelect because selection changed
+	pressKey(tree, tcell.KeyDown)
+	if len(selections) != 1 || selections[0] != "B" {
+		t.Errorf("OnSelect should be called with B, got %v", selections)
+	}
+
+	pressKey(tree, tcell.KeyDown)
+	if len(selections) != 2 || selections[1] != "C" {
+		t.Errorf("OnSelect should be called with C, got %v", selections)
+	}
+
+	// Down again at boundary should not call OnSelect (no change)
+	pressKey(tree, tcell.KeyDown)
+	if len(selections) != 2 {
+		t.Errorf("OnSelect should not be called when clamped, got %d calls", len(selections))
+	}
+}
+
+func TestTreeKeyOnKey(t *testing.T) {
+	var captured []rune
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A"),
+		OnKey: func(ev *tcell.EventKey, node *TreeNode) bool {
+			captured = append(captured, ev.Rune())
+			return true
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	pressRune(tree, 'x')
+	if len(captured) != 1 || captured[0] != 'x' {
+		t.Errorf("OnKey should capture x, got %v", captured)
+	}
+}
+
+func TestTreeKeyOnKeyNotConsumed(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A"),
+		OnKey: func(ev *tcell.EventKey, node *TreeNode) bool {
+			return false // don't consume
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Space should fall through to ActivateSelected when OnKey returns false
+	// But A is a leaf, so it fires "activate" via OnCommand
+	var activated bool
+	tree.Config.OnCommand = func(cmd string, node *TreeNode) {
+		if cmd == "activate" {
+			activated = true
+		}
+	}
+	pressRune(tree, ' ')
+	if !activated {
+		t.Error("space should fall through to activate when OnKey returns false")
+	}
+}
+
+// --- Mouse tests ---
+
+func TestTreeMouseClickExpand(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "root",
+				Label: "Root",
+				Children: []*TreeNode{
+					{ID: "child", Label: "Child"},
+				},
+			},
+		},
+	})
+	renderWidget(tree, 0, 0, 30, 10)
+
+	// Click on chevron at (0, 0) to expand
+	click := mouseClick(0, 0)
+	tree.HandleEvent(click)
+
+	if !tree.Config.Items[0].Expanded {
+		t.Error("clicking on the row should expand the node")
+	}
+	if tree.ItemCount() != 2 {
+		t.Errorf("expanded root should have 2 flat items, got %d", tree.ItemCount())
+	}
+
+	// Click again to collapse
+	tree.HandleEvent(mouseClick(0, 0))
+	if tree.Config.Items[0].Expanded {
+		t.Error("clicking again should collapse the node")
+	}
+}
+
+func TestTreeMouseClickSelectsRow(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B", "C"),
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Click on row 2 (Gamma)
+	click := mouseClick(5, 2)
+	tree.HandleEvent(click)
+
+	if tree.SelectedIndex() != 2 {
+		t.Errorf("click on row 2 should select index 2, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeMouseWheelUp(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	renderWidget(tree, 0, 0, 20, 5)
+
+	// Scroll down first
+	tree.scrollTop = 10
+
+	// Wheel up should decrease scrollTop
+	wheelUp := tcell.NewEventMouse(5, 2, tcell.WheelUp, tcell.ModNone)
+	result := tree.HandleEvent(wheelUp)
+	if result != EventConsumed {
+		t.Error("wheel up should be consumed")
+	}
+	if tree.ScrollTop() != 7 { // 10 - 3
+		t.Errorf("wheel up should decrease scrollTop by 3, got %d", tree.ScrollTop())
+	}
+}
+
+func TestTreeMouseWheelDown(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	renderWidget(tree, 0, 0, 20, 5)
+
+	tree.scrollTop = 0
+
+	// Wheel down should increase scrollTop
+	wheelDown := tcell.NewEventMouse(5, 2, tcell.WheelDown, tcell.ModNone)
+	result := tree.HandleEvent(wheelDown)
+	if result != EventConsumed {
+		t.Error("wheel down should be consumed")
+	}
+	if tree.ScrollTop() != 3 {
+		t.Errorf("wheel down should increase scrollTop by 3, got %d", tree.ScrollTop())
+	}
+}
+
+func TestTreeMouseWheelUpClampsAtZero(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	renderWidget(tree, 0, 0, 20, 5)
+
+	tree.scrollTop = 1
+
+	wheelUp := tcell.NewEventMouse(5, 2, tcell.WheelUp, tcell.ModNone)
+	tree.HandleEvent(wheelUp)
+	if tree.ScrollTop() != 0 {
+		t.Errorf("wheel up from scrollTop=1 should clamp to 0, got %d", tree.ScrollTop())
+	}
+}
+
+func TestTreeMouseWheelDownClampsAtMax(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	renderWidget(tree, 0, 0, 20, 5)
+
+	// max = 20 - 5 = 15
+	tree.scrollTop = 14
+
+	wheelDown := tcell.NewEventMouse(5, 2, tcell.WheelDown, tcell.ModNone)
+	tree.HandleEvent(wheelDown)
+	if tree.ScrollTop() != 15 {
+		t.Errorf("wheel down from 14 should clamp to 15, got %d", tree.ScrollTop())
+	}
+}
+
+func TestTreeMouseRightClickSelectsRow(t *testing.T) {
+	var menuCalled bool
+	var menuNodeID string
+	tree := NewTreeWidget(TreeConfig{
+		Items:    makeTreeItems("A", "B", "C"),
+		NodeMenu: []MenuEntry{{Label: "Delete", Command: "delete"}},
+		OnMenu: func(entries []MenuEntry, node *TreeNode, screenX, screenY int) {
+			menuCalled = true
+			menuNodeID = node.ID
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Right click (Button2) on row 1
+	rightClick := tcell.NewEventMouse(5, 1, tcell.Button2, tcell.ModNone)
+	result := tree.HandleEvent(rightClick)
+
+	if result != EventConsumed {
+		t.Error("right click should be consumed")
+	}
+	if tree.SelectedIndex() != 1 {
+		t.Errorf("right click should select row 1, got %d", tree.SelectedIndex())
+	}
+	if !menuCalled {
+		t.Error("right click should trigger OnMenu")
+	}
+	if menuNodeID != "B" {
+		t.Errorf("OnMenu should be called with node B, got %s", menuNodeID)
+	}
+}
+
+func TestTreeMouseClickOutsideItems(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B"),
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Click on row 5 (beyond item count)
+	click := mouseClick(5, 5)
+	result := tree.HandleEvent(click)
+	if result == EventConsumed {
+		t.Error("click beyond items should not be consumed")
+	}
+}
+
+// --- Scrolling tests ---
+
+func TestTreeScrollTopAdjustsOnDownNavigation(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	renderWidget(tree, 0, 0, 20, 5)
+
+	// Navigate down past the viewport
+	for i := 0; i < 6; i++ {
+		pressKey(tree, tcell.KeyDown)
+	}
+	// Render to trigger ensureVisible
+	renderWidget(tree, 0, 0, 20, 5)
+
+	if tree.SelectedIndex() != 6 {
+		t.Fatalf("selection should be at 6, got %d", tree.SelectedIndex())
+	}
+	// scrollTop should have adjusted to keep selection visible
+	// selected=6, h=5 => scrollTop should be at least 6-5+1=2
+	if tree.ScrollTop() < 2 {
+		t.Errorf("scrollTop should adjust to keep selection visible, got %d", tree.ScrollTop())
+	}
+}
+
+func TestTreeScrollTopAdjustsOnUpNavigation(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	renderWidget(tree, 0, 0, 20, 5)
+
+	// Scroll down
+	tree.SetSelectedIndex(10)
+	renderWidget(tree, 0, 0, 20, 5)
+
+	// Navigate up past the viewport
+	for i := 0; i < 8; i++ {
+		pressKey(tree, tcell.KeyUp)
+	}
+	renderWidget(tree, 0, 0, 20, 5)
+
+	if tree.SelectedIndex() != 2 {
+		t.Fatalf("selection should be at 2, got %d", tree.SelectedIndex())
+	}
+	// scrollTop should be <= 2
+	if tree.ScrollTop() > 2 {
+		t.Errorf("scrollTop should adjust to keep selection visible, got %d", tree.ScrollTop())
+	}
+}
+
+func TestTreeEnsureVisible(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+
+	// Set selected to item 15, scrollTop=0, viewport=5
+	tree.SetSelectedIndex(15)
+	renderWidget(tree, 0, 0, 20, 5)
+
+	// ensureVisible should scroll to show item 15
+	// selected=15, h=5 => scrollTop should be 15-5+1=11
+	if tree.ScrollTop() < 11 {
+		t.Errorf("ensureVisible should scroll to show item 15, scrollTop=%d", tree.ScrollTop())
+	}
+}
+
+func TestTreeScrollTopClamped(t *testing.T) {
+	items := make([]*TreeNode, 3)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	tree.scrollTop = 100 // artificially high
+
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// maxScroll = 3 - 10 = negative, clamped to 0
+	if tree.ScrollTop() != 0 {
+		t.Errorf("scrollTop should be clamped to 0 when items fit, got %d", tree.ScrollTop())
+	}
+}
+
+// --- Edge case tests ---
+
+func TestTreeEmptyTree(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{Items: []*TreeNode{}})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	if tree.ItemCount() != 0 {
+		t.Errorf("empty tree should have 0 items, got %d", tree.ItemCount())
+	}
+
+	sel := tree.Selected()
+	if sel != nil {
+		t.Error("Selected() on empty tree should return nil")
+	}
+
+	// Navigation on empty tree should not panic
+	pressKey(tree, tcell.KeyDown)
+	pressKey(tree, tcell.KeyUp)
+	pressKey(tree, tcell.KeyLeft)
+	pressKey(tree, tcell.KeyRight)
+	pressKey(tree, tcell.KeyEnter)
+}
+
+func TestTreeSingleItem(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("Only"),
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	if tree.ItemCount() != 1 {
+		t.Errorf("single item tree should have 1 item, got %d", tree.ItemCount())
+	}
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("selected should be 0, got %d", tree.SelectedIndex())
+	}
+
+	// Up/Down should clamp
+	pressKey(tree, tcell.KeyDown)
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("down in single-item tree should clamp, got %d", tree.SelectedIndex())
+	}
+	pressKey(tree, tcell.KeyUp)
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("up in single-item tree should clamp, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeDeeplyNested(t *testing.T) {
+	// Build a 4-level deep tree: root > L1 > L2 > L3
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{
+						ID:       "L1",
+						Label:    "Level1",
+						Expanded: true,
+						Children: []*TreeNode{
+							{
+								ID:       "L2",
+								Label:    "Level2",
+								Expanded: true,
+								Children: []*TreeNode{
+									{ID: "L3", Label: "Level3"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Indent: 2,
+	})
+
+	s := renderWidget(tree, 0, 0, 40, 10)
+
+	// Flat list should be: root(0), L1(1), L2(2), L3(3)
+	if tree.ItemCount() != 4 {
+		t.Fatalf("deeply nested tree should have 4 flat items, got %d", tree.ItemCount())
+	}
+
+	// Check indentation: L3 at depth 3, indent=2 => x offset = 6
+	// L3 is a leaf, so label starts at x=6
+	row3 := surfaceRowText(s, 3)
+	if len(row3) < 12 || row3[6:12] != "Level3" {
+		t.Errorf("L3 should be indented to x=6, got row %q", row3)
+	}
+
+	// L2 at depth 2 has children, chevron at x=4 (2*2), then space, then label at x=6
+	if s.cells[2][4].Ch != '▼' {
+		t.Errorf("L2 should have chevron at x=4, got %c", s.cells[2][4].Ch)
+	}
+}
+
+func TestTreeCollapseParentWhileChildSelected(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "child1", Label: "Child1"},
+					{ID: "child2", Label: "Child2"},
+				},
+			},
+			{ID: "other", Label: "Other"},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// flatList: root(0), child1(1), child2(2), other(3)
+	if tree.ItemCount() != 4 {
+		t.Fatalf("expected 4 items, got %d", tree.ItemCount())
+	}
+
+	// Select child2 at index 2
+	tree.SetSelectedIndex(2)
+	if tree.Selected().ID != "child2" {
+		t.Fatalf("expected child2 selected, got %s", tree.Selected().ID)
+	}
+
+	// Collapse root via SetItems (simulating parent collapse externally)
+	tree.Config.Items[0].Expanded = false
+	tree.SetItems(tree.Config.Items)
+
+	// After collapse: flatList: root(0), other(1)
+	if tree.ItemCount() != 2 {
+		t.Fatalf("after collapse expected 2 items, got %d", tree.ItemCount())
+	}
+
+	// clampSelected should bring selection to valid range
+	if tree.SelectedIndex() >= tree.ItemCount() {
+		t.Errorf("selection should be clamped, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeCollapseViaLeftKeyClampsSelection(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "child1", Label: "Child1"},
+					{ID: "child2", Label: "Child2"},
+				},
+			},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Select root (index 0), then collapse with Left
+	tree.SetSelectedIndex(0)
+	pressKey(tree, tcell.KeyLeft)
+
+	// After collapse: only root remains
+	if tree.ItemCount() != 1 {
+		t.Errorf("after collapse expected 1 item, got %d", tree.ItemCount())
+	}
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("selection should remain 0, got %d", tree.SelectedIndex())
+	}
+}
+
+// --- FlatList and state tests ---
+
+func TestTreeFlatten(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "a",
+				Label: "A",
+				Children: []*TreeNode{
+					{ID: "a1", Label: "A1"},
+					{ID: "a2", Label: "A2"},
+				},
+			},
+			{
+				ID:       "b",
+				Label:    "B",
+				Expanded: true,
+				Children: []*TreeNode{
+					{ID: "b1", Label: "B1"},
+				},
+			},
+		},
+	})
+
+	// a is collapsed, b is expanded
+	// flatList: a, b, b1
+	fl := tree.FlatList()
+	if len(fl) != 3 {
+		t.Fatalf("expected 3 flat items, got %d", len(fl))
+	}
+	if fl[0].ID != "a" || fl[1].ID != "b" || fl[2].ID != "b1" {
+		t.Errorf("unexpected flat order: %s, %s, %s", fl[0].ID, fl[1].ID, fl[2].ID)
+	}
+}
+
+func TestTreeSetItems(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B"),
+	})
+	tree.SetSelectedIndex(1)
+
+	newItems := makeTreeItems("X", "Y", "Z")
+	tree.SetItems(newItems)
+
+	if tree.ItemCount() != 3 {
+		t.Errorf("after SetItems expected 3 items, got %d", tree.ItemCount())
+	}
+	if tree.SelectedIndex() != 1 {
+		t.Errorf("selection should be preserved, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeSetItemsClampsSelection(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B", "C"),
+	})
+	tree.SetSelectedIndex(2)
+
+	// Replace with fewer items
+	tree.SetItems(makeTreeItems("X"))
+
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("selection should be clamped to 0, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeSetSelectedIndex(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B", "C"),
+	})
+
+	tree.SetSelectedIndex(2)
+	if tree.SelectedIndex() != 2 {
+		t.Errorf("expected selected=2, got %d", tree.SelectedIndex())
+	}
+
+	// Out of bounds should clamp
+	tree.SetSelectedIndex(100)
+	if tree.SelectedIndex() != 2 {
+		t.Errorf("out of bounds should clamp to 2, got %d", tree.SelectedIndex())
+	}
+
+	tree.SetSelectedIndex(-5)
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("negative should clamp to 0, got %d", tree.SelectedIndex())
+	}
+}
+
+func TestTreeFocusable(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{})
+
+	if !tree.Focusable() {
+		t.Error("tree should be focusable")
+	}
+
+	tree.SetFocused(true)
+	if !tree.IsFocused() {
+		t.Error("tree should be focused after SetFocused(true)")
+	}
+
+	tree.SetFocused(false)
+	if tree.IsFocused() {
+		t.Error("tree should not be focused after SetFocused(false)")
+	}
+}
+
+func TestTreeHeightWidth(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{})
+
+	// Tree uses flexible sizing (returns 0)
+	if tree.Height() != 0 {
+		t.Errorf("Height should return 0, got %d", tree.Height())
+	}
+	if tree.Width() != 0 {
+		t.Errorf("Width should return 0, got %d", tree.Width())
+	}
+}
+
+// --- Collect/Restore expanded state ---
+
+func TestTreeCollectRestoreExpanded(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:       "root",
+				Label:    "Root",
+				Expanded: true,
+				Children: []*TreeNode{
+					{
+						ID:       "child",
+						Label:    "Child",
+						Expanded: true,
+						Children: []*TreeNode{
+							{ID: "grandchild", Label: "Grandchild"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	expanded := map[string]bool{}
+	tree.CollectExpanded(expanded)
+
+	if !expanded["root"] || !expanded["child"] {
+		t.Errorf("should collect root and child as expanded, got %v", expanded)
+	}
+
+	// Collapse everything
+	tree.Config.Items[0].Expanded = false
+	tree.Config.Items[0].Children[0].Expanded = false
+	tree.flatten()
+
+	// Restore
+	tree.RestoreExpanded(expanded)
+	if !tree.Config.Items[0].Children[0].Expanded {
+		t.Error("child should be restored as expanded")
+	}
+}
+
+// --- Shortcut key tests ---
+
+func TestTreeShortcutKey(t *testing.T) {
+	var commands []string
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "file",
+				Label: "File",
+				Actions: []Action{
+					{Icon: "d", Command: "delete"},
+					{Icon: "r", Command: "rename"},
+				},
+			},
+		},
+		OnCommand: func(cmd string, node *TreeNode) {
+			commands = append(commands, cmd)
+		},
+	})
+	renderWidget(tree, 0, 0, 30, 10)
+
+	// Press 'd' - should trigger delete
+	pressRune(tree, 'd')
+	if len(commands) != 1 || commands[0] != "delete" {
+		t.Errorf("pressing 'd' should trigger delete, got %v", commands)
+	}
+
+	// Press 'r' - should trigger rename
+	pressRune(tree, 'r')
+	if len(commands) != 2 || commands[1] != "rename" {
+		t.Errorf("pressing 'r' should trigger rename, got %v", commands)
+	}
+
+	// Press 'x' - no action, should not crash
+	pressRune(tree, 'x')
+	if len(commands) != 2 {
+		t.Errorf("pressing 'x' should not trigger any command, got %v", commands)
+	}
+}
+
+// --- Shift+Enter context menu ---
+
+func TestTreeShiftEnterOpensMenu(t *testing.T) {
+	var menuCalled bool
+	tree := NewTreeWidget(TreeConfig{
+		Items:    makeTreeItems("A", "B"),
+		NodeMenu: []MenuEntry{{Label: "Delete", Command: "delete"}},
+		OnMenu: func(entries []MenuEntry, node *TreeNode, screenX, screenY int) {
+			menuCalled = true
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Shift+Enter
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModShift)
+	tree.HandleEvent(ev)
+
+	if !menuCalled {
+		t.Error("Shift+Enter should trigger OnMenu")
+	}
+}
+
+// --- HandleEvent returns correct results ---
+
+func TestTreeHandleEventReturns(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A"),
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// Key events should be consumed for recognized keys
+	result := tree.HandleEvent(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone))
+	if result != EventConsumed {
+		t.Errorf("Up key should return EventConsumed, got %v", result)
+	}
+
+	result = tree.HandleEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+	if result != EventConsumed {
+		t.Errorf("Down key should return EventConsumed, got %v", result)
+	}
+
+	// Unrecognized rune key without OnKey/shortcut should be ignored
+	result = tree.HandleEvent(tcell.NewEventKey(tcell.KeyRune, 'z', tcell.ModNone))
+	if result != EventIgnored {
+		t.Errorf("unrecognized rune should return EventIgnored, got %v", result)
+	}
+}
+
+// --- Mouse click on menu icon ---
+
+func TestTreeMouseClickMenuIcon(t *testing.T) {
+	var menuCalled bool
+	var menuNodeID string
+	tree := NewTreeWidget(TreeConfig{
+		Items:    makeTreeItems("A"),
+		NodeMenu: []MenuEntry{{Label: "Delete", Command: "delete"}},
+		OnMenu: func(entries []MenuEntry, node *TreeNode, screenX, screenY int) {
+			menuCalled = true
+			menuNodeID = node.ID
+		},
+	})
+	renderWidget(tree, 0, 0, 30, 10)
+
+	// The menu icon zone starts at rect.X + contentW - menuIconWidth().
+	// menuIconWidth for default icon "⋮" with no padding = dropdown(1 rune, 0 pad).Width()+1 = 2
+	// So the zone starts at 0 + 30 - 2 = 28. Click at x=28 or x=29.
+	menuW := tree.menuIconWidth()
+	menuX := tree.rect.X + tree.contentW - menuW
+	click := mouseClick(menuX, 0)
+	tree.HandleEvent(click)
+
+	if !menuCalled {
+		t.Errorf("clicking menu icon area (x=%d, menuW=%d, contentW=%d) should trigger OnMenu", menuX, menuW, tree.contentW)
+	}
+	if menuNodeID != "A" {
+		t.Errorf("OnMenu should be called for node A, got %s", menuNodeID)
+	}
+}
+
+// --- Mouse click outside rect is ignored ---
+
+func TestTreeMouseClickOutsideRect(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A"),
+	})
+	renderWidget(tree, 10, 10, 20, 5)
+
+	// Click at (0,0) which is outside the rect at (10,10)
+	result := tree.HandleEvent(mouseClick(0, 0))
+	if result == EventConsumed {
+		t.Error("click outside rect should be ignored")
+	}
+
+	// Click at (30, 15) which is also outside (10+20=30 is edge)
+	result = tree.HandleEvent(mouseClick(30, 15))
+	if result == EventConsumed {
+		t.Error("click at right edge should be ignored")
+	}
+}
+
+// --- Scrollbar visibility ---
+
+func TestTreeScrollbarNotVisibleWhenItemsFit(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B"),
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	// 2 items in 10-high viewport: scrollbar should not be visible
+	if tree.scrollbar.visible() {
+		t.Error("scrollbar should not be visible when all items fit")
+	}
+	if tree.contentW != 20 {
+		t.Errorf("contentW should be full width (20) when no scrollbar, got %d", tree.contentW)
+	}
+}
+
+func TestTreeScrollbarVisibleWhenItemsOverflow(t *testing.T) {
+	items := make([]*TreeNode, 20)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('A' + i)), Label: string(rune('A' + i))}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	renderWidget(tree, 0, 0, 20, 5)
+
+	// 20 items in 5-high viewport: scrollbar should be visible
+	if !tree.scrollbar.visible() {
+		t.Error("scrollbar should be visible when items overflow")
+	}
+	if tree.contentW != 19 {
+		t.Errorf("contentW should be reduced by 1 for scrollbar, got %d", tree.contentW)
+	}
+}
+
+// --- ActivateSelected on leaf fires OnCommand ---
+
+func TestTreeActivateSelectedLeaf(t *testing.T) {
+	var cmds []string
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{ID: "leaf", Label: "Leaf"},
+		},
+		OnCommand: func(cmd string, node *TreeNode) {
+			cmds = append(cmds, cmd)
+		},
+	})
+
+	tree.ActivateSelected()
+	if len(cmds) != 1 || cmds[0] != "activate" {
+		t.Errorf("ActivateSelected on leaf should fire OnCommand(activate), got %v", cmds)
+	}
+}
+
+// --- ActivateSelected out of bounds ---
+
+func TestTreeActivateSelectedOutOfBounds(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{},
+	})
+
+	// Should not panic
+	tree.ActivateSelected()
+}
+
+// --- Multiple expand/collapse cycles ---
+
+func TestTreeMultipleExpandCollapseCycles(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{
+				ID:    "root",
+				Label: "Root",
+				Children: []*TreeNode{
+					{ID: "c1", Label: "C1"},
+					{ID: "c2", Label: "C2"},
+				},
+			},
+		},
+	})
+
+	for i := 0; i < 5; i++ {
+		pressKey(tree, tcell.KeyRight) // expand
+		if tree.ItemCount() != 3 {
+			t.Fatalf("cycle %d: expand should show 3 items, got %d", i, tree.ItemCount())
+		}
+		pressKey(tree, tcell.KeyLeft) // collapse
+		if tree.ItemCount() != 1 {
+			t.Fatalf("cycle %d: collapse should show 1 item, got %d", i, tree.ItemCount())
+		}
+	}
+}
+
+// --- RenderItem custom rendering ---
+
+func TestTreeRenderItemCallback(t *testing.T) {
+	var rendered []string
+	tree := NewTreeWidget(TreeConfig{
+		Items: makeTreeItems("A", "B"),
+		RenderItem: func(surface Surface, node *TreeNode, idx, y, w int, selected bool) {
+			rendered = append(rendered, node.ID)
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	if len(rendered) != 2 || rendered[0] != "A" || rendered[1] != "B" {
+		t.Errorf("RenderItem should be called for each visible item, got %v", rendered)
+	}
+}

--- a/internal/widgets/vstack_test.go
+++ b/internal/widgets/vstack_test.go
@@ -1,0 +1,370 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+// clickableWidget is a test helper that consumes mouse clicks inside its rect.
+// This allows testing position-based event routing through containers.
+type clickableWidget struct {
+	fixedWidget
+	clicked bool
+}
+
+func (c *clickableWidget) HandleEvent(ev tcell.Event) EventResult {
+	switch e := ev.(type) {
+	case *tcell.EventMouse:
+		if e.Buttons()&tcell.Button1 != 0 {
+			mx, my := e.Position()
+			r := c.GetRect()
+			if mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H {
+				c.clicked = true
+				return EventConsumed
+			}
+		}
+	}
+	return EventIgnored
+}
+
+// --- VStackWidget rendering verification ---
+
+func TestVStackRenderChildrenAtCorrectYOffsets(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "AAA"})
+	b := NewLabelWidget(LabelConfig{Text: "BBB"})
+	c := NewLabelWidget(LabelConfig{Text: "CCC"})
+	vs := NewVStackWidget(a, b, c)
+
+	s := renderWidget(vs, 0, 0, 20, 10)
+
+	// Label A at Y=0
+	if s.cells[0][0].Ch != 'A' {
+		t.Errorf("expected 'A' at (0,0), got %q", s.cells[0][0].Ch)
+	}
+	// Label B at Y=1
+	if s.cells[1][0].Ch != 'B' {
+		t.Errorf("expected 'B' at (0,1), got %q", s.cells[1][0].Ch)
+	}
+	// Label C at Y=2
+	if s.cells[2][0].Ch != 'C' {
+		t.Errorf("expected 'C' at (0,2), got %q", s.cells[2][0].Ch)
+	}
+}
+
+func TestVStackRenderWithGapSpacing(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "AAA"})
+	b := NewLabelWidget(LabelConfig{Text: "BBB"})
+	vs := NewVStackWidget(a, b)
+	vs.Gap = 2
+
+	s := renderWidget(vs, 0, 0, 20, 10)
+
+	// Label A at Y=0
+	if s.cells[0][0].Ch != 'A' {
+		t.Errorf("expected 'A' at (0,0), got %q", s.cells[0][0].Ch)
+	}
+	// Gap rows Y=1 and Y=2 should be empty
+	if s.cells[1][0].Ch != 0 {
+		t.Errorf("expected empty cell at (0,1) in gap, got %q", s.cells[1][0].Ch)
+	}
+	if s.cells[2][0].Ch != 0 {
+		t.Errorf("expected empty cell at (0,2) in gap, got %q", s.cells[2][0].Ch)
+	}
+	// Label B at Y=3 (1 height + 2 gap)
+	if s.cells[3][0].Ch != 'B' {
+		t.Errorf("expected 'B' at (0,3), got %q", s.cells[3][0].Ch)
+	}
+}
+
+func TestVStackChildGetsFullWidth(t *testing.T) {
+	label := NewLabelWidget(LabelConfig{Text: "Hello World This Is A Test"})
+	vs := NewVStackWidget(label)
+
+	renderWidget(vs, 0, 0, 30, 10)
+
+	r := label.GetRect()
+	if r.W != 30 {
+		t.Errorf("child should get full container width 30, got W=%d", r.W)
+	}
+}
+
+func TestVStackChildHeightsRespected(t *testing.T) {
+	// Labels have Height() == 1
+	a := NewLabelWidget(LabelConfig{Text: "A"})
+	b := NewLabelWidget(LabelConfig{Text: "B"})
+	vs := NewVStackWidget(a, b)
+
+	if vs.Height() != 2 {
+		t.Errorf("expected VStack Height()=2 (two labels), got %d", vs.Height())
+	}
+
+	renderWidget(vs, 0, 0, 20, 10)
+
+	ra := a.GetRect()
+	rb := b.GetRect()
+	if ra.H != 1 {
+		t.Errorf("label A should get H=1, got H=%d", ra.H)
+	}
+	if rb.H != 1 {
+		t.Errorf("label B should get H=1, got H=%d", rb.H)
+	}
+	if rb.Y != 1 {
+		t.Errorf("label B should start at Y=1, got Y=%d", rb.Y)
+	}
+}
+
+func TestVStackMouseClickRoutesToCorrectChild(t *testing.T) {
+	a := &clickableWidget{fixedWidget: fixedWidget{h: 3, w: 0}}
+	b := &clickableWidget{fixedWidget: fixedWidget{h: 3, w: 0}}
+	c := &clickableWidget{fixedWidget: fixedWidget{h: 3, w: 0}}
+	vs := NewVStackWidget(a, b, c)
+
+	renderWidget(vs, 5, 10, 20, 9)
+
+	// Click in child A's area (Y: 10..12)
+	click := mouseClick(10, 11)
+	result := vs.HandleEvent(click)
+	if result != EventConsumed {
+		t.Error("click inside child A should be consumed")
+	}
+	if !a.clicked {
+		t.Error("child A should have received the click")
+	}
+	if b.clicked || c.clicked {
+		t.Error("children B and C should not have received the click")
+	}
+
+	// Reset
+	a.clicked, b.clicked, c.clicked = false, false, false
+
+	// Click in child B's area (Y: 13..15)
+	click = mouseClick(10, 14)
+	result = vs.HandleEvent(click)
+	if result != EventConsumed {
+		t.Error("click inside child B should be consumed")
+	}
+	if !b.clicked {
+		t.Error("child B should have received the click")
+	}
+	if a.clicked || c.clicked {
+		t.Error("children A and C should not have received the click")
+	}
+
+	// Reset
+	a.clicked, b.clicked, c.clicked = false, false, false
+
+	// Click in child C's area (Y: 16..18)
+	click = mouseClick(10, 17)
+	result = vs.HandleEvent(click)
+	if result != EventConsumed {
+		t.Error("click inside child C should be consumed")
+	}
+	if !c.clicked {
+		t.Error("child C should have received the click")
+	}
+}
+
+func TestVStackMouseClickOutsideAllChildren(t *testing.T) {
+	a := &clickableWidget{fixedWidget: fixedWidget{h: 3, w: 0}}
+	vs := NewVStackWidget(a)
+
+	renderWidget(vs, 5, 10, 20, 10)
+
+	// Click outside the container entirely
+	click := mouseClick(0, 0)
+	result := vs.HandleEvent(click)
+	if result == EventConsumed {
+		t.Error("click outside all children should not be consumed")
+	}
+	if a.clicked {
+		t.Error("child should not have been clicked")
+	}
+}
+
+func TestVStackEmptyRendersNothing(t *testing.T) {
+	vs := NewVStackWidget()
+	s := renderWidget(vs, 0, 0, 20, 10)
+
+	// All cells should be empty (zero rune)
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 20; x++ {
+			if s.cells[y][x].Ch != 0 {
+				t.Errorf("empty vstack should render nothing, but found %q at (%d,%d)", s.cells[y][x].Ch, x, y)
+			}
+		}
+	}
+}
+
+func TestVStackHeightForWidthAllFixed(t *testing.T) {
+	a := &fixedWidget{h: 3, w: 10}
+	b := &fixedWidget{h: 5, w: 10}
+	vs := NewVStackWidget(a, b)
+
+	hfw := vs.HeightForWidth(20)
+	if hfw != 8 {
+		t.Errorf("HeightForWidth should be 8 (3+5) for fixed children, got %d", hfw)
+	}
+}
+
+func TestVStackHeightForWidthWithGap(t *testing.T) {
+	a := &fixedWidget{h: 3, w: 10}
+	b := &fixedWidget{h: 5, w: 10}
+	c := &fixedWidget{h: 2, w: 10}
+	vs := NewVStackWidget(a, b, c)
+	vs.Gap = 2
+
+	hfw := vs.HeightForWidth(20)
+	// 3 + 5 + 2 = 10 fixed, plus 2 gaps * 2 = 4, total = 14
+	if hfw != 14 {
+		t.Errorf("HeightForWidth should be 14, got %d", hfw)
+	}
+}
+
+func TestVStackHeightForWidthWithHeightForWidthChild(t *testing.T) {
+	// ParagraphWidget implements HeightForWidth
+	para := NewParagraphWidget("Hello world, this is a longer text that should wrap")
+	label := NewLabelWidget(LabelConfig{Text: "Title"})
+	vs := NewVStackWidget(label, para)
+
+	hfw := vs.HeightForWidth(10)
+	// label: 1 line
+	// paragraph wraps at width 10 — HeightForWidth returns wrapped line count
+	paraHFW := para.HeightForWidth(10)
+	expected := 1 + paraHFW
+	if hfw != expected {
+		t.Errorf("HeightForWidth(10) should be %d (1 label + %d para), got %d", expected, paraHFW, hfw)
+	}
+}
+
+func TestVStackHeightForWidthZeroWhenGrowChildNoHFW(t *testing.T) {
+	a := &fixedWidget{h: 3, w: 10}
+	b := &fixedWidget{h: 0, w: 10} // grow child, no HeightForWidth
+	vs := NewVStackWidget(a, b)
+
+	hfw := vs.HeightForWidth(20)
+	if hfw != 0 {
+		t.Errorf("HeightForWidth should be 0 when grow child has no HeightForWidth, got %d", hfw)
+	}
+}
+
+func TestVStackScrollSize(t *testing.T) {
+	a := &fixedWidget{h: 3, w: 10}
+	b := &fixedWidget{h: 5, w: 10}
+	vs := NewVStackWidget(a, b)
+	vs.SetRect(Rect{X: 0, Y: 0, W: 30, H: 20})
+
+	sw, sh := vs.ScrollSize()
+	if sw != 30 {
+		t.Errorf("ScrollSize width should be rect width 30, got %d", sw)
+	}
+	if sh != 8 {
+		t.Errorf("ScrollSize height should be HeightForWidth(30)=8, got %d", sh)
+	}
+}
+
+func TestVStackBoxModelApplied(t *testing.T) {
+	label := NewLabelWidget(LabelConfig{Text: "Hello"})
+	vs := NewVStackWidget(label)
+	vs.Box = BoxModel{
+		MarginTop:  1,
+		MarginLeft: 2,
+		PaddingTop: 1,
+		PaddingLeft: 1,
+	}
+
+	s := renderWidget(vs, 0, 0, 20, 10)
+
+	// With margin_top=1, padding_top=1, the inner content starts at Y=2
+	// With margin_left=2, padding_left=1, the inner content starts at X=3
+	if s.cells[2][3].Ch != 'H' {
+		t.Errorf("expected 'H' at (3,2) with box model offsets, got %q", s.cells[2][3].Ch)
+	}
+	// Original position should be empty
+	if s.cells[0][0].Ch != 0 {
+		t.Errorf("expected empty at (0,0) due to margins, got %q", s.cells[0][0].Ch)
+	}
+}
+
+func TestVStackBoxModelInHeight(t *testing.T) {
+	a := &fixedWidget{h: 3, w: 10}
+	b := &fixedWidget{h: 5, w: 10}
+	vs := NewVStackWidget(a, b)
+	vs.Box = BoxModel{
+		MarginTop:    1,
+		MarginBottom: 1,
+		PaddingTop:   2,
+		PaddingBottom: 2,
+	}
+
+	// Height = children (3+5) + BoxOverheadH (1+1+2+2 = 6) = 14
+	if got := vs.Height(); got != 14 {
+		t.Errorf("expected Height()=14 (8 children + 6 box overhead), got %d", got)
+	}
+}
+
+func TestVStackRenderWithThreeGapChildren(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "First"})
+	b := NewLabelWidget(LabelConfig{Text: "Second"})
+	c := NewLabelWidget(LabelConfig{Text: "Third"})
+	vs := NewVStackWidget(a, b, c)
+	vs.Gap = 1
+
+	s := renderWidget(vs, 0, 0, 20, 10)
+
+	// A at Y=0, gap at Y=1, B at Y=2, gap at Y=3, C at Y=4
+	if s.cells[0][0].Ch != 'F' {
+		t.Errorf("expected 'F' at (0,0), got %q", s.cells[0][0].Ch)
+	}
+	if s.cells[1][0].Ch != 0 {
+		t.Errorf("expected empty at (0,1) in gap, got %q", s.cells[1][0].Ch)
+	}
+	if s.cells[2][0].Ch != 'S' {
+		t.Errorf("expected 'S' at (0,2), got %q", s.cells[2][0].Ch)
+	}
+	if s.cells[3][0].Ch != 0 {
+		t.Errorf("expected empty at (0,3) in gap, got %q", s.cells[3][0].Ch)
+	}
+	if s.cells[4][0].Ch != 'T' {
+		t.Errorf("expected 'T' at (0,4), got %q", s.cells[4][0].Ch)
+	}
+}
+
+func TestVStackWidgetChildren(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "A"})
+	b := NewLabelWidget(LabelConfig{Text: "B"})
+	vs := NewVStackWidget(a, b)
+
+	children := vs.WidgetChildren()
+	if len(children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(children))
+	}
+}
+
+func TestVStackWidthReturnsZero(t *testing.T) {
+	vs := NewVStackWidget()
+	if vs.Width() != 0 {
+		t.Errorf("VStack Width() should always return 0, got %d", vs.Width())
+	}
+}
+
+func TestVStackRenderChildrenWithStyle(t *testing.T) {
+	a := NewLabelWidget(LabelConfig{Text: "Styled", Style: term.StyleWarning})
+	vs := NewVStackWidget(a)
+
+	s := renderWidget(vs, 0, 0, 20, 5)
+
+	if s.cells[0][0].Style != term.StyleWarning {
+		t.Errorf("expected StyleWarning, got %v", s.cells[0][0].Style)
+	}
+}
+
+func TestVStackEmptyHandleEventReturnsIgnored(t *testing.T) {
+	vs := NewVStackWidget()
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+	result := vs.HandleEvent(ev)
+	if result != EventIgnored {
+		t.Error("empty VStack should return EventIgnored")
+	}
+}

--- a/tests/e2e/problems_scrollbar_test.go
+++ b/tests/e2e/problems_scrollbar_test.go
@@ -32,10 +32,10 @@ func TestProblemsScrollbar(t *testing.T) {
 	h.redraw()
 
 	// The scrollbar should render on the rightmost column of the problems area.
-	// The scrollbar uses '█' characters.
+	// The scrollbar uses '▄' characters.
 	screen := h.screenText()
-	if !containsRune(screen, '█') {
-		t.Errorf("expected scrollbar character '█' on screen when items exceed visible height, got:\n%s", screen)
+	if !containsRune(screen, '▄') {
+		t.Errorf("expected scrollbar character '▄' on screen when items exceed visible height, got:\n%s", screen)
 	}
 
 	// Now test with fewer items that fit — scrollbar should NOT appear
@@ -46,7 +46,7 @@ func TestProblemsScrollbar(t *testing.T) {
 	h.redraw()
 
 	screen = h.screenText()
-	if containsRune(screen, '█') {
+	if containsRune(screen, '▄') {
 		t.Errorf("expected no scrollbar when items fit in visible area, got:\n%s", screen)
 	}
 }

--- a/tests/e2e/problems_scrollbar_test.go
+++ b/tests/e2e/problems_scrollbar_test.go
@@ -32,10 +32,10 @@ func TestProblemsScrollbar(t *testing.T) {
 	h.redraw()
 
 	// The scrollbar should render on the rightmost column of the problems area.
-	// The scrollbar uses '▄' characters.
+	// The scrollbar uses '█' characters.
 	screen := h.screenText()
-	if !containsRune(screen, '▄') {
-		t.Errorf("expected scrollbar character '▄' on screen when items exceed visible height, got:\n%s", screen)
+	if !containsRune(screen, '█') {
+		t.Errorf("expected scrollbar character '█' on screen when items exceed visible height, got:\n%s", screen)
 	}
 
 	// Now test with fewer items that fit — scrollbar should NOT appear
@@ -46,7 +46,7 @@ func TestProblemsScrollbar(t *testing.T) {
 	h.redraw()
 
 	screen = h.screenText()
-	if containsRune(screen, '▄') {
+	if containsRune(screen, '█') {
 		t.Errorf("expected no scrollbar when items fit in visible area, got:\n%s", screen)
 	}
 }


### PR DESCRIPTION
## Summary

- **Tree ellipsis**: Labels, icons, and badges truncate with `…` when they overflow available width
- **Dialog button nav**: Left/Right arrows navigate between footer buttons
- **Box model consistency**: Tree, ScrollView, and KeyValueList now support margin/padding via `RenderBox()`; all Lua widget parsers call `parseBoxModel()`
- **Progress bar widget**: Configurable fill char (default `▄`), value 0-1, style, box model. Lua: `p:progress({value=0.65})`
- **Table widget**: Columns with alignment (left/right/center), row selection, scrolling, keyboard shortcuts, context menus. Lua: `p:table({columns=..., rows=...})`
- **Global focus system**: F6/Shift+F6 cycle between editor, sidebar, and bottom panel. Ctrl+PageDown/PageUp now context-aware (switches tabs in whichever region is focused)
- **Left drawer support**: `ttt.open_drawer({side="left", ...})` opens drawer on the left side
- **Init-time drawer buffering**: `ttt.open_drawer()` during plugin init is buffered and replayed after wiring
- **Panel exec command**: `panel <id>` in `--exec` scripts switches bottom panel tabs
- **442 widget unit tests**: Comprehensive coverage for tree, dialog, table, progress, dropdown, button, checkbox, box, scrollview, hstack, vstack

## Test plan

- [x] `make test` — all tests pass (442 widget tests + full suite)
- [x] `go build ./...` — clean build
- [ ] Manual: verify F6 cycles focus between editor/sidebar/bottom panel
- [ ] Manual: verify Ctrl+PageDown/PageUp switches tabs in focused region
- [ ] Manual: verify progress bar renders with `▄` character
- [ ] Manual: verify left drawer opens on left side via plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm