### PR TITLE
QA bug fixes from automated sweep (BUG-001 through BUG-041)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ cat /tmp/state.json   # see full widget tree, focus, selection, panels
 
 Supported commands:
 - `click X Y` — simulate mouse click at coordinates
+- `hover X Y` — simulate mouse hover (move) at coordinates
 - `key COMBO` — simulate key press (e.g. `key ctrl+p`, `key enter`, `key ctrl+k x`)
 - `type TEXT` — type a string of text
 - `exec "Command Name"` — run a command by title (same as command palette)

--- a/bugs.md
+++ b/bugs.md
@@ -1,0 +1,451 @@
+# QA Bug Report — ttt Editor
+
+Generated: 2026-06-27
+
+## Summary
+
+- **Total bugs found**: 43
+- Critical: 2 | Major: 14 | Minor: 21 | Cosmetic: 6
+- **Categories tested**: view, edit, transform, sidebar, tabs, terminal, folding, file, edge, mouse (partial), settings (partial)
+- **Categories incomplete**: find (agent stopped before submitting)
+
+## Critical
+
+### BUG-001: Multi-line text transform undo causes content loss and file corruption after one Ctrl+Z
+- **Category**: transform
+- **Severity**: critical
+- **Steps to reproduce**: 1. Open any text file with 3+ lines
+2. Position cursor at start of line 1
+3. Press shift+down three times to select lines 1-3
+4. Run 'Transform to Uppercase' via command palette
+5. Press Ctrl+Z (Undo) once
+- **Expected**: One Ctrl+Z should fully restore the original three lines. The file should look exactly as before the transform.
+- **Actual**: After one Ctrl+Z, the original lines 1-3 are GONE from the file. Lines that were previously below the selection (lines 4+) shift up and appear as lines 1+. If the user saves now, the original content is permanently lost. A second Ctrl+Z is required to fully restore the file.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_final_multi1undo.txt shows original lines 1-3 (hello world, HELLO WORLD, Hello World) gone after 1 undo, replaced by former lines 4+. transform_final_multi2undo.txt shows correct restoration after 2 undos. Same root cause as transform-001: transformSelection() in /home/enko/Documents/ttt/internal/ui/editor_widget.go uses BreakGroup() creating non-atomic delete+paste undo groups.`
+
+### BUG-002: Terminal: Close All panics with slice bounds out of range when 2+ terminals are open
+- **Category**: terminal
+- **Severity**: critical
+- **Steps to reproduce**: 1. Open the editor
+2. Run 'Terminal: New Terminal' to open first terminal (or 'Terminal: Toggle Terminal')
+3. Wait for shell to load
+4. Run 'Terminal: New Terminal' to open a second terminal
+5. Wait for second shell to load
+6. Run 'Terminal: Close All'
+- **Expected**: All terminals close gracefully, the terminal panel shows 'No terminals. Press + to create one.'
+- **Actual**: The app crashes with: panic: runtime error: slice bounds out of range [1:0] (or [2:1] with 3 terminals) inside CloseTerminal. This is a race condition: CloseTerminal calls tt.Term.Close() which blocks on <-t.done until the readLoop goroutine finishes. The readLoop goroutine calls OnExit() → PostEvent(panelID). In the exec harness (which runs on a separate goroutine), the main event loop can process the posted event and call CloseTerminal for the same terminal concurrently, causing the Terminals slice to be modified twice — leading to an out-of-bounds access on the second removal.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_crash.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_crash2.txt`
+
+## Major
+
+### BUG-003: Non-existent file from CLI - silently ignored with no error shown
+- **Category**: file
+- **Severity**: major
+- **Steps to reproduce**: 1. Run: /home/enko/Documents/ttt/bin/ttt /path/to/nonexistent_file.txt
+2. Wait for editor to start
+3. Observe the tab and status bar
+- **Expected**: Either open an empty tab named 'nonexistent_file.txt' ready to save to that path (VS Code behavior), or show a clear error message in the status bar explaining the file was not found
+- **Actual**: The default 'untitled' tab is shown with no error message. The specified file path is silently discarded. Root cause: OpenFile() is called during BuildApp() before Init() registers the OnError→StatusError callback, so the error is only logged via slog.Error() and never reaches the UI.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_nonexist_check.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_nonexist.txt`
+
+### BUG-004: Text transform (uppercase/lowercase/titlecase) undo leaves line empty after one Ctrl+Z
+- **Category**: transform
+- **Severity**: major
+- **Steps to reproduce**: 1. Open any text file
+2. Navigate to line 1 (hello world)
+3. Press shift+end to select the entire line
+4. Run command palette: 'Transform to Uppercase'
+5. Press Ctrl+Z (Undo) once
+- **Expected**: One Ctrl+Z should fully restore the original text: 'hello world'
+- **Actual**: After one Ctrl+Z, the line becomes EMPTY. The text is not restored. A second Ctrl+Z is required to get back to 'hello world'.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_final_1undo.txt (line 1 empty after 1 undo), transform_final_2undo.txt (line 1 restored after 2 undos). Root cause: /home/enko/Documents/ttt/internal/ui/editor_widget.go in transformSelection() calls e.Undo.BreakGroup() before two separate e.exec() calls (DeleteSelectionCommand then InsertStringCommand), making them separate undo groups instead of one atomic operation. Fix: use BatchCommand like ToggleLineComment does at line 1930.`
+
+### BUG-005: View: Close All Tabs silently discards unsaved changes without confirmation
+- **Category**: view
+- **Severity**: major
+- **Steps to reproduce**: 1. Open a file (e.g. bin/ttt main.go)
+2. Type any text to modify the buffer
+3. Run command 'View: Close All Tabs'
+4. Observe result
+- **Expected**: A dialog should appear asking the user to Save, Discard, or Cancel for each modified file before closing — matching VS Code behavior for this command
+- **Actual**: All tabs are silently closed immediately. The unsaved changes are lost with no prompt. A new empty 'untitled' tab opens instead.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step60_close_all_no_confirm.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state60_close_all_no_confirm.json, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step70_closeall_named_modified.txt. Root cause: the 'tab.closeAll' command calls app.EditorGroup.CloseAllTabs() directly (internal/app/commands_editor.go:291), which unconditionally replaces all tabs without checking dirty state, unlike app.CloseTab() which correctly checks IsDirty() and shows a confirmation dialog.`
+
+### BUG-006: View: Close Other Tabs silently discards unsaved changes in non-active tabs
+- **Category**: view
+- **Severity**: major
+- **Steps to reproduce**: 1. Open two files (e.g. bin/ttt main.go app.go)
+2. app.go is active by default — type any text to modify it
+3. Press 'View: Previous Tab' to switch to main.go
+4. Run command 'View: Close Other Tabs'
+5. Observe result
+- **Expected**: A dialog should appear asking to Save, Discard, or Cancel for app.go (which has unsaved changes) before closing it
+- **Actual**: app.go is silently closed with all unsaved changes lost. No confirmation is shown. Only main.go remains.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step62_close_other_test.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state62d_after_close.json. The debug state confirms: after typing in app.go (modified: True) and running Close Other Tabs, only main.go (modified: False) remains. Root cause: 'tab.closeOthers' command calls app.EditorGroup.CloseOtherTabs() directly (internal/app/commands_editor.go:283), which replaces the tabs array unconditionally without checking dirty state on the tabs being discarded.`
+
+### BUG-007: Terminal: Toggle Fullscreen off hides the terminal panel instead of restoring to split view
+- **Category**: terminal
+- **Severity**: major
+- **Steps to reproduce**: 1. Open the editor
+2. Run 'Terminal: Toggle Terminal' to open the terminal in split view (bottom ~39% of screen)
+3. Run 'Terminal: Toggle Fullscreen' — terminal expands to fill full right-side area (editor is hidden)
+4. Run 'Terminal: Toggle Fullscreen' again to exit fullscreen
+- **Expected**: The terminal panel returns to its previous split-view position, still visible at the bottom ~39% with the editor above it (matching VS Code behavior where un-maximizing the terminal restores the split view)
+- **Actual**: The terminal panel is hidden entirely — ShowBottom is set to false via HideBottomPanel(). The code at commands_view.go line 26-27 checks 'if ShowBottom && BottomH >= fullH { HideBottomPanel() }' which treats exiting fullscreen the same as toggling the panel off. The user must manually re-open the terminal after exiting fullscreen.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step8a_before_fs.txt (TERMINAL visible), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step8b_during_fs.txt (fullscreen), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step8c_after_fs.txt (panel gone)`
+
+### BUG-008: Search result click: matched line not visible (viewport off by 1 row)
+- **Category**: sidebar
+- **Severity**: major
+- **Steps to reproduce**: 1. Open editor with a project directory
+2. Open Find panel (click Find tab or exec 'Show Search')
+3. Type a search query (e.g. 'func')
+4. Wait for results to appear
+5. Click on a specific line result (e.g. '3: func Helper() string {')
+6. Observe the editor viewport
+- **Expected**: Editor scrolls to show the matched line (line 3) at or near the top of the viewport, with cursor placed on that line
+- **Actual**: Editor shows from line N+1 (e.g. line 4 when the match is on line 3). The cursor is correctly placed at Ln 3 Col 1 per status bar, but that line is above the viewport and not visible. The user cannot see the matched code.
+- **Evidence**: `sidebar_step_main_func_result.txt (Ln 3 cursor, viewport shows line 4+), sidebar_step31_click_result_line.txt (Ln 5 cursor, viewport shows line 6+), sidebar_step_final_click_result.txt (Ln 3 cursor, viewport shows line 4+). Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
+
+### BUG-009: After clicking search result, keypresses modify search query instead of editing opened file
+- **Category**: sidebar
+- **Severity**: major
+- **Steps to reproduce**: 1. Open Find panel (exec 'Show Search')
+2. Type a search query (e.g. 'TestButton')
+3. Wait for results
+4. Click on the specific result line (e.g. '5: func TestButton(t *testing.T) {}')
+5. Immediately type some text (e.g. 'hello')
+- **Expected**: After clicking a search result to open/navigate to a file, focus moves to the editor. Subsequent typing edits the file at the cursor position.
+- **Actual**: Focus returns to the search input field after clicking the result. Typing 'hello' changes the search query from 'TestButton' to 'TestButtonhello', triggering a new search (showing 'No results'). The opened file is not modified.
+- **Evidence**: `sidebar_step32_type_after_result.txt shows search input changed to 'TestButtonhello' and 'No results', file was not modified. Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
+
+### BUG-010: Ctrl+Right / Ctrl+Left keybindings move by 1 char instead of jumping by word
+- **Category**: edit
+- **Severity**: major
+- **Steps to reproduce**: 1. Open any file with text (e.g. 'Hello World'). 2. Cursor is at col 0. 3. Press Ctrl+Right (bound to editor.moveWordRight). 4. Observe cursor position.
+- **Expected**: Cursor jumps forward to the end of the current word (col 5 after 'Hello' in 'Hello World'), matching standard editor and VS Code behavior for word movement.
+- **Actual**: Cursor advances only 1 character (col 0 → col 1). Ctrl+Left behaves identically — moves 1 character backward instead of jumping to the previous word boundary. The exec 'Move Word Right' command (via command palette) correctly jumps to col 5, confirming the command logic is correct but the keybinding is broken.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_state19_ctrl_right.json (cursor at col 1), edit_state44_ctrl_left.json (cursor at col 10 instead of word start), edit_state17_word_right.json (exec correctly lands at col 5)`
+
+### BUG-011: Alt+Backspace / Alt+Delete / Ctrl+Delete keybindings delete only 1 char instead of a whole word
+- **Category**: edit
+- **Severity**: major
+- **Steps to reproduce**: 1. Open file with 'Hello World' on line 1. 2. Press End to move to col 11 (end of line). 3. Press Alt+Backspace (bound to editor.deleteWordLeft). 4. Check cursor position and line content.
+- **Expected**: Alt+Backspace deletes the word to the left ('World', 5 chars), leaving 'Hello ' with cursor at col 6. Alt+Delete and Ctrl+Delete (bound to editor.deleteWordRight) should delete the word to the right of cursor.
+- **Actual**: Alt+Backspace deletes only the single character immediately to the left ('d'), leaving 'Hello Worl' with cursor at col 10. Alt+Delete and Ctrl+Delete also each delete only 1 character forward. Root cause: EditorPaneWidget.HandleEvent matches tcell.KeyBackspace and tcell.KeyDelete without checking for Alt/Ctrl modifiers, consuming the event before global key handlers run. The exec 'Delete Word Left' command correctly deletes the full word (cursor moves to col 6), confirming the command is working but the keybinding is broken.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_state45_alt_bs.json (cursor at col 10 instead of col 6), edit_screen46_alt_del.txt ('ello World' after alt+delete from col 0), edit_state_key_delword.json vs edit_state_palette_delword.json (col 10 vs col 6)`
+
+### BUG-012: View: Close All Tabs discards unsaved changes without prompting
+- **Category**: edge
+- **Severity**: major
+- **Steps to reproduce**: 1. Open a named file (e.g. bin/ttt /tmp/test.txt)
+2. Type some text to modify the file (tab shows ● indicator)
+3. Run 'View: Close All Tabs' from command palette
+4. Observe result
+- **Expected**: A 'Save changes to [filename]?' dialog should appear with Save/Discard/Cancel options, matching VS Code behavior
+- **Actual**: The modified file is closed immediately without any dialog. Unsaved changes are silently discarded. A new untitled tab opens.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step32a_before.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step32b_after.txt`
+
+### BUG-013: View: Close Other Tabs discards unsaved changes in background tabs without prompting
+- **Category**: edge
+- **Severity**: major
+- **Steps to reproduce**: 1. Open 3 files: bin/ttt file1.txt file2.txt file3.txt
+2. Navigate to file2.txt and type text to modify it (shows ● indicator)
+3. Navigate to another tab (e.g. file3.txt)
+4. Run 'View: Close Other Tabs' from command palette
+- **Expected**: A 'Save changes to file2.txt?' dialog should appear for any other tab with unsaved changes before closing
+- **Actual**: All other tabs including the modified file2.txt are closed immediately without any dialog. Unsaved changes are silently discarded.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step34b_before_close.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step34c_after_close_other.txt`
+
+## Minor
+
+### BUG-014: Tab bar clips partial tab names in overflow mode without truncation indicator
+- **Category**: tabs
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open 12 or more files: `bin/ttt file1.go file2.go ... file12.go`
+2. Note file_8.go (last file) is the active tab
+3. Observe tab bar: there are hidden tabs to the left (◀ indicator visible)
+4. Navigate to the first tab by pressing Ctrl+K , eleven times
+5. Observe both edges of the tab bar
+- **Expected**: Tabs that do not fully fit in the visible area should either be hidden completely (not rendered) or shown with an ellipsis truncation (e.g., 'gam...' for 'gamma.go'). The ◀/▶ arrows should indicate hidden tabs.
+- **Actual**: Partially-visible tabs show raw clipped filenames at both edges. On the LEFT: 'a.go' is displayed instead of 'gamma.go' (showing only the last 4 characters of the filename). On the RIGHT: 'file_6.g' is displayed instead of 'file_6.go' (missing the trailing 'o'). These appear as genuine filenames and can mislead users into thinking there is a file called 'a.go'.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step58_overflow_confirm.txt (left overflow 'a.go'), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step59_both_overflow.txt (right overflow 'file_6.g')`
+
+### BUG-015: Tab bar overflow menu (⋮) only shows 'Close All', missing list of hidden tabs
+- **Category**: tabs
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open 12 or more files to cause tab bar overflow
+2. Click the ⋮ button at the far right of the tab bar
+- **Expected**: The overflow menu should list all open tabs (especially those hidden off-screen) so users can navigate to them directly, similar to VS Code's tab overflow menu which shows a list of all tabs.
+- **Actual**: The ⋮ dropdown only contains a single option: 'Close All'. There is no way to see or navigate to tabs that have scrolled off-screen via this menu. Users must use Ctrl+K , / Ctrl+K . repeatedly to cycle through hidden tabs.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step43_more_button.txt`
+
+### BUG-016: New File (Ctrl+N) always appends tab at end of list instead of after current tab
+- **Category**: tabs
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open three files: `bin/ttt alpha.go beta.go gamma.go`
+2. Navigate to beta.go (middle tab) with Ctrl+K ,
+3. Press Ctrl+N (or use 'New File' from command palette)
+4. Observe the position of the new 'untitled' tab
+- **Expected**: The new untitled tab should be inserted immediately after the currently active tab: [alpha.go, beta.go, untitled, gamma.go] with untitled active. This matches VS Code behavior where new tabs open next to the current tab.
+- **Actual**: The new untitled tab is always appended at the end of the tab list regardless of which tab is currently active: [alpha.go, beta.go, gamma.go, untitled]. The new tab is at the end even when the active tab is in the middle.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_state54_new_file_position.json (active_tab=1 was beta.go, untitled at index 3 = end), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_state55_new_from_middle.json`
+
+### BUG-017: File explorer single-click on a file replaces current tab content instead of opening new tab
+- **Category**: tabs
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open a directory: `bin/ttt /path/to/dir/`
+2. The editor starts with one 'untitled' empty tab and the file explorer visible
+3. Click on a file in the explorer (e.g., alpha.go) — it replaces 'untitled' and opens in the same tab (1 tab total)
+4. Click on a different file (e.g., beta.go) — it replaces alpha.go (still 1 tab total)
+5. Compare: opening files via command line creates separate tabs
+- **Expected**: Clicking a file in the explorer should open it in a new tab (or VS Code-style 'preview' tab). Each file click should add a new tab, similar to how multiple command-line arguments create multiple tabs.
+- **Actual**: When the current tab is 'untitled', clicking a file in the explorer replaces the untitled tab content (expected). However, subsequent explorer clicks on different files replace the current tab's content rather than opening new tabs. Only if the file is already open in another tab does it switch to the existing tab. Starting from a directory with no explicit files, clicking through multiple files leaves only 1 tab open at a time.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_state3_all_open.json (after clicking 4 files in explorer, only 1 tab 'gamma.go' remains)`
+
+### BUG-018: Go to File picker - filename truncated and fused with directory name without separator
+- **Category**: file
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open ttt on a project with deep git worktree paths (e.g., .claude/worktrees/...)
+2. Invoke Go to File (Ctrl+K P)
+3. Observe list items where the directory path is very long
+- **Expected**: The filename column should remain readable. When space is tight, the directory path should be truncated with an ellipsis, and there should always be a visual gap or separator between the filename and directory columns.
+- **Actual**: The filename is truncated to only a few characters and the directory path is appended directly with no separator. For example: 'settings.local.json' becomes 'settin.claude/worktrees/agent-a07104541439a4bc5/.claude' making it unreadable and ambiguous.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_gotofile_display.txt`
+
+### BUG-019: No read-only file indicator when opening files with restricted permissions
+- **Category**: file
+- **Severity**: minor
+- **Steps to reproduce**: 1. Create a read-only file: echo 'content' > /tmp/test.txt && chmod 444 /tmp/test.txt
+2. Open it in ttt
+3. Edit and save (Ctrl+S)
+- **Expected**: A clear read-only indicator should appear in the tab title (e.g., a lock icon or '(read-only)') or in the status bar. Saving should either warn the user or be blocked until they explicitly choose to overwrite.
+- **Actual**: No indicator is shown anywhere. The file opens and can be edited normally. Ctrl+S saves silently without any warning. On Linux, the atomic save (temp file + rename in same directory) can succeed even for chmod 444 files when the containing directory is writable, so the user unknowingly overwrites a read-only file.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_readonly_open.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_readonly_save.txt`
+
+### BUG-020: Go to Line dialog stays open and does not navigate when entering line number 0
+- **Category**: folding
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open any file in the editor
+2. Press Ctrl+G (or run 'Go to Line' from command palette)
+3. Type '0' in the dialog (it shows ':0')
+4. Press Enter
+5. Wait several seconds
+- **Expected**: Dialog closes and cursor moves to line 1 (first line, clamped from 0), or an error message is shown with the dialog remaining open as feedback
+- **Actual**: Dialog stays open indefinitely with no feedback and no navigation. The cursor does not move. User must press Escape to close the stuck dialog. The same issue occurs for any non-positive number (0, -1, etc.).
+- **Evidence**: `folding_step52_goto0_verify.txt shows dialog still open after 500ms wait. folding_state52_goto0.json shows cursor.line=0 (unchanged initial position, no navigation occurred). Root cause: /home/enko/Documents/ttt/internal/ui/selectdialog_widget.go line 305 has condition `n > 0` which silently rejects 0 without calling OnGoToLine or OnDismiss. For comparison, line 1 works correctly: folding_step53_goto1.txt shows dialog dismissed and cursor at line 1.`
+
+### BUG-021: Fold gutter indicators (▼) not shown on fresh file open — only appear after tab switching
+- **Category**: folding
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open a Go file with foldable blocks
+2. Observe the gutter area next to line numbers
+3. Compare with opening two files, then switching between tabs
+- **Expected**: Downward triangle (▼) affordance indicators appear in the gutter on all foldable lines immediately when a file is opened, making foldable regions discoverable (consistent with VS Code behavior)
+- **Actual**: No ▼ gutter indicators appear on fresh open. Indicators appear only after switching between two tabs (clicking away to another file and back). They also do not appear after running Fold All + Unfold All. This makes fold affordances invisible to users who never switch tabs.
+- **Evidence**: `folding_step54_fresh_gutter.txt: fresh open shows lines 3, 10, 15, 20, 26, 32 without ▼ indicators. folding_step57_gutter_after_keys.txt: after ctrl+k 0 (Fold All) + ctrl+k 9 (Unfold All) keyboard shortcuts, still no ▼ indicators. folding_step56_gutter_after_tabswitch.txt: after clicking away to second_file.go and back, lines 3 and 10 show ▼ indicators. folding_step55_gutter_after_foldall.txt: after exec Fold All + Unfold All via command palette, still no ▼ indicators.`
+
+### BUG-022: Toggle Syntax Highlight requires editor restart to take effect
+- **Category**: folding
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open any syntax-highlighted source file
+2. Run 'Toggle Syntax Highlight' from the command palette (or View menu)
+3. Observe the status bar and editor content
+- **Expected**: Syntax highlighting toggles immediately without restarting the editor, as in VS Code where the toggle takes effect instantly
+- **Actual**: Status bar shows notification: 'Restart to apply syntax highlight changes [OK]'. The syntax highlight state does not change until the editor is restarted. Toggling again shows the same notification again.
+- **Evidence**: `folding_step33_syntax_off.txt: notification 'Restart to apply syntax highlight changes [OK]' visible in status bar after first toggle. folding_step50_syntax_toggle1.txt and folding_step51_syntax_toggle2.txt: same notification on both first and second toggle invocations.`
+
+### BUG-023: Toggle Fold (ctrl+k [) has no effect when cursor is on closing brace
+- **Category**: folding
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open a Go file with functions
+2. Navigate cursor to a closing brace line (e.g., line 12 '}'  of func Add)
+3. Press Ctrl+K [ (Toggle Fold keybinding)
+4. Observe whether the containing block folds
+- **Expected**: Fold toggles the containing block (VS Code allows fold toggle from the closing brace position as well as the opening brace). Cursor should be able to initiate a fold from the closing bracket.
+- **Actual**: Nothing happens. The fold is only triggered from the opening line of a block (e.g., the 'func Foo() {' line). Pressing ctrl+k [ while on the closing '}' line has no effect and gives no feedback.
+- **Evidence**: `folding_step48_on_closing.txt: cursor on line 12 ('}' of Add function). folding_step49_fold_from_closing.txt: identical content after pressing ctrl+k [, no fold applied, no visible change.`
+
+### BUG-024: Modified indicator (dot) not cleared after Undo restores file to saved state
+- **Category**: transform
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open a file (no dot indicator shown)
+2. Run 'Toggle Line Comment' on line 1 (dot indicator appears)
+3. Press Ctrl+Z to undo the comment toggle
+4. Observe tab title
+- **Expected**: After undoing all changes, the dot (●) modified indicator should disappear from the tab title since the file now matches its saved state on disk (as in VS Code)
+- **Actual**: The dot (●) remains in the tab title even after fully undoing all changes. The file content is correctly restored, but the unsaved-changes indicator is not cleared.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_t40_initial.txt (no dot), transform_t40_modified.txt (dot appears after comment), transform_t40_after_undo.txt (dot still shown after undo). Root cause: Buffer.Dirty in /home/enko/Documents/ttt/internal/core/buffer/buffer.go is only set to false on save/load, not when the undo stack returns to the save point.`
+
+### BUG-025: Sort Lines Ascending/Descending without selection moves trailing empty line to top
+- **Category**: transform
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open a file that ends with a trailing newline (e.g., sort_test.txt: cherry, apple, banana, zebra, mango)
+2. Do NOT make any selection
+3. Run 'Sort Lines Ascending' (or ctrl+k o) without selecting anything
+- **Expected**: All non-empty lines are sorted alphabetically. The trailing empty line (file terminator) should either be excluded from sorting or remain at the end.
+- **Actual**: The trailing empty line is treated as a sortable line (empty string sorts before all words alphabetically) and moves to the first position. Result: (empty line), apple, banana, cherry, mango, zebra. The empty line is now at the top of the file.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_t30_before.txt (original: cherry, apple, banana, zebra, mango, empty), transform_t30_after.txt (after sort: empty line at position 1 followed by sorted words).`
+
+### BUG-026: View: Show Panel Tab dialog displays internal IDs instead of friendly panel names
+- **Category**: view
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open the bottom panel: run 'View: Toggle Panel'
+2. Run command 'View: Show Panel Tab'
+3. Observe the list of panel options in the dialog
+- **Expected**: The dialog should show user-friendly display names matching the tab bar labels — e.g. 'Notepad', 'TODOs' for plugin panels
+- **Actual**: The dialog shows raw internal IDs: 'terminal', 'problems', 'references', 'output', 'plugin.notepad', 'plugin.todo-scanner'. The 'plugin.' prefix and raw ID format are not user-friendly.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step23_show_panel_tab.txt. Root cause: the 'panel.show' command handler (internal/app/commands_view.go:344) iterates over BottomPanel.PanelIDs() and uses each ID as both the SelectItem ID and Label. PanelIDs() returns internal IDs, not display titles. The fix is to expose panel titles alongside IDs (e.g. a PanelItems() method on TabbedPanel) and use those as labels.`
+
+### BUG-027: View: Focus Terminal does not give keyboard focus when terminal panel is not currently visible
+- **Category**: terminal
+- **Severity**: minor
+- **Steps to reproduce**: 1. Start the editor with no terminal open
+2. Run 'View: Focus Terminal'
+- **Expected**: The terminal panel opens AND keyboard focus is given to the terminal, so the user can immediately start typing commands without additional clicks (matching VS Code's Ctrl+` behavior)
+- **Actual**: The terminal panel opens and a new terminal is spawned (ShowBottom is set, showTerminalPanel is called), but keyboard focus is NOT transferred to the terminal. Focus remains on the previously focused widget (the file explorer tree). The bug is in focusTerminal() in commands_view.go lines 132-139: the early 'return' statement after showTerminalPanel() exits before calling a.Root.SetFocus(), unlike the else branch (when panel is already visible) which correctly calls SetFocus.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step10_focus_terminal.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_state10_focus_terminal.json`
+
+### BUG-028: Opening file from Explorer keeps focus in sidebar tree; typing is silently consumed
+- **Category**: sidebar
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open editor with a project directory (sidebar showing Explorer)
+2. Click on a file in the Explorer tree to open it (e.g. click on main.go)
+3. Observe the opened file in the editor
+4. Without clicking the editor, type some text
+- **Expected**: After clicking a file to open it, focus should either move to the editor (VS Code default) or at minimum have a clear visual indicator that focus is in the sidebar. Typed characters should edit the file or at least produce a visible response.
+- **Actual**: Focus stays on the Explorer Tree widget (confirmed via debug state: focused widget is Tree). The file opens correctly in the editor, but typing is silently consumed by the tree as navigation shortcuts with no visible effect on screen. The status bar still shows the untouched file state. Users must click the editor or press Escape before they can type.
+- **Evidence**: `sidebar_step16_type_after_click_open.txt (typed 'test' but file unchanged, no modification indicator), sidebar_state15_click_open_file.json (focus field shows 'other', focused widget is Tree after file open). Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
+
+### BUG-029: Clicking on search result group header collapses the group instead of opening file
+- **Category**: sidebar
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open Find panel and search for text
+2. Observe results grouped by file: '▼ tests/button_test.go (1)' followed by '  5: func TestButton ...'
+3. Click on the file group header line '▼ tests/button_test.go (1)'
+- **Expected**: Clicking on a file group header in search results should open the file (same as clicking the specific result line), or at minimum be a neutral action. In VS Code, clicking the file header opens the file.
+- **Actual**: Clicking the file group header collapses the group (arrow changes from ▼ to ▶), hiding the child result lines. The file is NOT opened. No navigation occurs.
+- **Evidence**: `sidebar_step30_click_testbutton.txt shows group collapsed (▶ icon) after click, editor still shows 'untitled' with no file opened. Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
+
+### BUG-030: Tab dirty indicator (●) does not clear after undoing back to the last saved state
+- **Category**: edit
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open file. 2. Type 'X' (file is now modified, ● appears). 3. Save the file (exec 'Save File'). 4. Confirm ● disappears after save. 5. Type 'Y'. 6. Press Ctrl+Z to undo. 7. Content is now identical to the last saved state.
+- **Expected**: The tab's ● (modified) indicator clears when the buffer content matches the last saved state, matching VS Code behavior. The editor should track which undo step corresponds to the last save ('clean point') and clear the dirty flag when reached.
+- **Actual**: After undoing back to the saved content, the tab still shows ● and the buffer reports modified=true. The indicator only clears if the file is saved again. Simpler case also reproduces: type ABC on a fresh file, then exec 'Undo' three times — content returns to original but ● remains and buffer reports modified=true.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_screen49_undo_to_save.txt (shows ● after undo to saved state), edit_state49_undo_to_save.json (modified: true), edit_screen41_dirty.txt (same pattern after simpler type+undo)`
+
+### BUG-031: Cut and Copy without a selection are no-ops instead of acting on the current line
+- **Category**: edit
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open file with text. 2. Ensure no selection is active (cursor on line 1, no selection). 3. Execute 'Cut' command. 4. Observe buffer and clipboard.
+- **Expected**: Cut without selection should cut the entire current line and place it on the clipboard (VS Code behavior). Copy without selection should copy the entire current line to the clipboard. This allows quick line operations without needing to manually select the whole line.
+- **Actual**: Cut without selection is a complete no-op: buffer is unchanged (modified=false) and the clipboard is not updated with line content. Copy without selection also leaves the clipboard unchanged. The clipboard retains whatever was there from a prior operation.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_screen33_cut_nsel.txt (buffer unchanged after Cut with no selection), edit_state33_cut_nsel.json (modified: false, same 6 lines)`
+
+### BUG-032: Delete Line on empty file causes viewport horizontal offset — first character typed after is invisible
+- **Category**: edge
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open editor with no files (new untitled buffer)
+2. Run 'Delete Line' from command palette
+3. Type any text (e.g. 'ABCDEFGH')
+4. Observe the display
+- **Expected**: All typed characters should be visible, starting from the first character. The line should show 'ABCDEFGH'.
+- **Actual**: The first character typed is not rendered. Display shows 'BCDEFGH' (missing 'A'). Status bar correctly reports Ln 1, Col 9 indicating 8 chars exist. Pressing Home corrects the display, revealing the missing first character.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step31f_type_after_del.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step31g_after_home.txt`
+
+### BUG-033: Go to Line dialog gives no feedback when input is invalid (non-numeric, 0, or negative)
+- **Category**: edge
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open any file
+2. Run 'Go to Line' from command palette (shows dialog with ':' prefix)
+3. Type 'abc' (or '0' or '-1')
+4. Press Enter
+- **Expected**: Either show an inline error message (e.g. 'Invalid line number') and keep dialog open for correction, or accept 0/-1 by clamping to the nearest valid line (line 1)
+- **Actual**: The dialog stays open with the invalid input still showing, and the cursor does not move. No error message or visual feedback is provided. The user has no indication why Enter had no effect.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step15a_gotoline_afterenter.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step26a_gotoline0.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step26b_gotolineneg.txt`
+
+## Cosmetic
+
+### BUG-034: Close button (x) is only visible on the active tab; inactive tabs show no close button
+- **Category**: tabs
+- **Severity**: cosmetic
+- **Steps to reproduce**: 1. Open two or more files: `bin/ttt alpha.go beta.go gamma.go`
+2. Observe the tab bar — the active tab (gamma.go) shows '│ gamma.go x │' with the x close button
+3. Observe the inactive tabs (alpha.go, beta.go) in the tab bar
+- **Expected**: All tabs should show a close button (or show it on hover in environments that support hover). Users should be able to close any tab with a single click without first needing to activate it.
+- **Actual**: Only the active tab shows the 'x' close button. Inactive tabs display only the filename with no close affordance. To close an inactive tab, users must first click it to make it active (which changes the editor content), then click the 'x' button. This requires 2 clicks and changes the active buffer unnecessarily.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step6_multi_files.txt (row 3 shows inactive tabs without x, active tab 'delta.txt x' with x)`
+
+### BUG-035: New untitled file naming skips '-1', jumping directly to '-2'
+- **Category**: file
+- **Severity**: cosmetic
+- **Steps to reproduce**: 1. Launch ttt with no files (default untitled tab opens)
+2. Run 'New File' three times via command palette or Ctrl+N
+3. Observe the tab names
+- **Expected**: Consistent sequential numbering: 'untitled-1', 'untitled-2', 'untitled-3', 'untitled-4' (VS Code: 'Untitled-1', 'Untitled-2', etc.)
+- **Actual**: Tabs are named: 'untitled', 'untitled-2', 'untitled-3', 'untitled-4'. The first new file has no number and the subsequent ones start from -2, skipping -1.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_naming2.txt`
+
+### BUG-036: Inconsistent editor border box-drawing style across sessions (rounded vs straight corners)
+- **Category**: folding
+- **Severity**: cosmetic
+- **Steps to reproduce**: 1. Open a file and observe the editor pane border style
+2. Close and reopen the editor (or run tests in separate invocations)
+3. Compare border styles between runs
+- **Expected**: Editor window border uses a consistent box-drawing character style across all sessions (e.g., always rounded corners ╭──╮ or always straight corners ┌──┐)
+- **Actual**: Editor border alternates between rounded corners (╭──╮ with U+256D) and straight corners (┌──┐ with U+250C) across different invocations with no user-visible action to explain the change. A third style (double-line ╔══╗) appears momentarily during mouse tab-click operations.
+- **Evidence**: `folding_step1_initial.txt: rounded corners ╭──╮ on first invocation. folding_step26_linenums_on.txt: straight corners ┌──┐ in a later invocation. folding_step44_before_nav.txt: rounded corners ╭──╮ again. folding_step20_fold_active.txt: double-line ╔══╗ during tab switching.`
+
+### BUG-037: Debug state 'focus' field always returns 'other' regardless of which pane is focused
+- **Category**: view
+- **Severity**: cosmetic
+- **Steps to reproduce**: 1. Open the editor with any file
+2. Run 'View: Focus Editor', capture debug state
+3. Run 'View: Focus Sidebar', capture debug state
+4. Run 'View: Focus Panel', capture debug state
+5. Check the 'focus' field in all three debug states
+- **Expected**: The 'focus' field should reflect the actual focused region: 'editor', 'sidebar', or 'bottom_panel' respectively
+- **Actual**: All three states return 'focus: other'. The describeFocus() function checks for *ui.EditorPaneWidget but the editor group uses *ui.EditorGroupWidget as Root.Focused. Similarly, focus on sidebar/panel is set to their active child widgets (WidgetAdapter, TerminalPanelWidget), not the SidebarWidget/BottomPanelWidget containers that describeFocus() checks for. The only case that works is 'search' (SearchWidget). This only affects the debug dump — functionality is not impacted.
+- **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state5_focus_editor.json (shows focus: other after View: Focus Editor), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state7_focus_panel.json (shows focus: other after View: Focus Panel). Root cause in internal/app/debug_dump.go:156 — the type switch checks EditorPaneWidget instead of EditorGroupWidget, and checks SidebarWidget/BottomPanelWidget instead of the widgets that are actually set as Root.Focused.`
+
+### BUG-038: Sidebar tab bar shows no visual indicator of which panel is currently active
+- **Category**: sidebar
+- **Severity**: cosmetic
+- **Steps to reproduce**: 1. Open editor with project directory
+2. Note tab bar shows 'Explore  Find  Changes  >>  ...'
+3. Click the Find tab to switch to Search panel
+4. Note tab bar still shows 'Explore  Find  Changes  >>  ...' with no visual change to indicate Find is now active
+- **Expected**: The active sidebar tab should have a visual distinction (underline, different background, bold text, or other indicator) so users can see which panel is currently active at a glance
+- **Actual**: All tab labels appear identical in text rendering regardless of which panel is active. While this may use colors in a real terminal that are not captured in text screenshots, even the text layout contains no structural indicator (no underline character, no bracket, no arrow) marking the active tab.
+- **Evidence**: `sidebar_step8_click_find.txt vs sidebar_step8_click_changes.txt vs sidebar_step8_click_explore.txt all show identical tab bar text 'Explore  Find  Changes  >>  ...'. Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
+
+### BUG-039: Bottom panel tab clicks do not switch the active tab
+- **Category**: mouse
+- **Severity**: major
+- **Steps to reproduce**: 1. Open terminal (Terminal: Toggle Terminal) to show bottom panel
+2. Bottom panel shows tabs: TERMINAL, PROBLEMS, REFERENCES, OUTPUT, etc.
+3. Click on PROBLEMS tab, or any other non-active tab
+- **Expected**: Clicking a tab should switch the active bottom panel to that tab
+- **Actual**: The active panel stays on "terminal" regardless of which tab is clicked. Tested clicks at X positions 3, 5, 13, 15, 23, 25, 33, 35, 41, 43, 51, 53 — all kept active=terminal.
+- **Evidence**: `mouse_bptab_x*.json files all show bottom_panel.active=terminal`
+
+### BUG-040: Command palette not dismissed by clicking outside its bounds
+- **Category**: mouse
+- **Severity**: minor
+- **Steps to reproduce**: 1. Open command palette (Ctrl+P)
+2. Click outside the palette area (e.g. in the editor below)
+- **Expected**: Clicking outside the palette should dismiss it (standard behavior in VS Code)
+- **Actual**: The palette stays open after clicking outside. Escape works correctly to dismiss.
+- **Evidence**: `mouse_test19b_state.json shows overlay still present after clicking at (5, 30)`
+
+### BUG-041: Debug state focus field always reports "other" regardless of actual focus
+- **Category**: mouse
+- **Severity**: cosmetic
+- **Steps to reproduce**: 1. Click in editor, sidebar, or bottom panel
+2. Capture debug state
+- **Expected**: Focus field should report "editor", "sidebar", "bottom", etc.
+- **Actual**: Focus field always shows "other". Same root cause as BUG-037 — the debug dump type switch doesn't match the actual focused widget types.
+- **Evidence**: `All mouse_*.json state files show focus="other"`
+
+> Note: BUG-041 is a duplicate of BUG-037, listed here for mouse category completeness.

--- a/bugs.md
+++ b/bugs.md
@@ -38,7 +38,7 @@ Generated: 2026-06-27
 
 ## Major
 
-### BUG-003: Non-existent file from CLI - silently ignored with no error shown
+### ~~BUG-003: Non-existent file from CLI - silently ignored with no error shown~~ FIXED
 - **Category**: file
 - **Severity**: major
 - **Steps to reproduce**: 1. Run: /home/enko/Documents/ttt/bin/ttt /path/to/nonexistent_file.txt

--- a/bugs.md
+++ b/bugs.md
@@ -277,7 +277,7 @@ Generated: 2026-06-27
 - **Actual**: The dot (●) remains in the tab title even after fully undoing all changes. The file content is correctly restored, but the unsaved-changes indicator is not cleared.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_t40_initial.txt (no dot), transform_t40_modified.txt (dot appears after comment), transform_t40_after_undo.txt (dot still shown after undo). Root cause: Buffer.Dirty in /home/enko/Documents/ttt/internal/core/buffer/buffer.go is only set to false on save/load, not when the undo stack returns to the save point.`
 
-### BUG-025: Sort Lines Ascending/Descending without selection moves trailing empty line to top
+### ~~BUG-025: Sort Lines Ascending/Descending without selection moves trailing empty line to top~~ FIXED
 - **Category**: transform
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open a file that ends with a trailing newline (e.g., sort_test.txt: cherry, apple, banana, zebra, mango)

--- a/bugs.md
+++ b/bugs.md
@@ -11,7 +11,7 @@ Generated: 2026-06-27
 
 ## Critical
 
-### BUG-001: Multi-line text transform undo causes content loss and file corruption after one Ctrl+Z
+### ~~BUG-001: Multi-line text transform undo causes content loss and file corruption after one Ctrl+Z~~ FIXED
 - **Category**: transform
 - **Severity**: critical
 - **Steps to reproduce**: 1. Open any text file with 3+ lines
@@ -23,7 +23,7 @@ Generated: 2026-06-27
 - **Actual**: After one Ctrl+Z, the original lines 1-3 are GONE from the file. Lines that were previously below the selection (lines 4+) shift up and appear as lines 1+. If the user saves now, the original content is permanently lost. A second Ctrl+Z is required to fully restore the file.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_final_multi1undo.txt shows original lines 1-3 (hello world, HELLO WORLD, Hello World) gone after 1 undo, replaced by former lines 4+. transform_final_multi2undo.txt shows correct restoration after 2 undos. Same root cause as transform-001: transformSelection() in /home/enko/Documents/ttt/internal/ui/editor_widget.go uses BreakGroup() creating non-atomic delete+paste undo groups.`
 
-### BUG-002: Terminal: Close All panics with slice bounds out of range when 2+ terminals are open
+### ~~BUG-002: Terminal: Close All panics with slice bounds out of range when 2+ terminals are open~~ FIXED
 - **Category**: terminal
 - **Severity**: critical
 - **Steps to reproduce**: 1. Open the editor

--- a/bugs.md
+++ b/bugs.md
@@ -71,7 +71,7 @@ Generated: 2026-06-27
 - **Actual**: All tabs are silently closed immediately. The unsaved changes are lost with no prompt. A new empty 'untitled' tab opens instead.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step60_close_all_no_confirm.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state60_close_all_no_confirm.json, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step70_closeall_named_modified.txt. Root cause: the 'tab.closeAll' command calls app.EditorGroup.CloseAllTabs() directly (internal/app/commands_editor.go:291), which unconditionally replaces all tabs without checking dirty state, unlike app.CloseTab() which correctly checks IsDirty() and shows a confirmation dialog.`
 
-### BUG-006: View: Close Other Tabs silently discards unsaved changes in non-active tabs
+### ~~BUG-006: View: Close Other Tabs silently discards unsaved changes in non-active tabs~~ FIXED
 - **Category**: view
 - **Severity**: major
 - **Steps to reproduce**: 1. Open two files (e.g. bin/ttt main.go app.go)

--- a/bugs.md
+++ b/bugs.md
@@ -107,7 +107,7 @@ Generated: 2026-06-27
 - **Actual**: Editor shows from line N+1 (e.g. line 4 when the match is on line 3). The cursor is correctly placed at Ln 3 Col 1 per status bar, but that line is above the viewport and not visible. The user cannot see the matched code.
 - **Evidence**: `sidebar_step_main_func_result.txt (Ln 3 cursor, viewport shows line 4+), sidebar_step31_click_result_line.txt (Ln 5 cursor, viewport shows line 6+), sidebar_step_final_click_result.txt (Ln 3 cursor, viewport shows line 4+). Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
 
-### BUG-009: After clicking search result, keypresses modify search query instead of editing opened file
+### ~~BUG-009: After clicking search result, keypresses modify search query instead of editing opened file~~ NOT A BUG
 - **Category**: sidebar
 - **Severity**: major
 - **Steps to reproduce**: 1. Open Find panel (exec 'Show Search')
@@ -119,7 +119,7 @@ Generated: 2026-06-27
 - **Actual**: Focus returns to the search input field after clicking the result. Typing 'hello' changes the search query from 'TestButton' to 'TestButtonhello', triggering a new search (showing 'No results'). The opened file is not modified.
 - **Evidence**: `sidebar_step32_type_after_result.txt shows search input changed to 'TestButtonhello' and 'No results', file was not modified. Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
 
-### BUG-010: Ctrl+Right / Ctrl+Left keybindings move by 1 char instead of jumping by word
+### ~~BUG-010: Ctrl+Right / Ctrl+Left keybindings move by 1 char instead of jumping by word~~ NOT A BUG
 - **Category**: edit
 - **Severity**: major
 - **Steps to reproduce**: 1. Open any file with text (e.g. 'Hello World'). 2. Cursor is at col 0. 3. Press Ctrl+Right (bound to editor.moveWordRight). 4. Observe cursor position.
@@ -127,7 +127,7 @@ Generated: 2026-06-27
 - **Actual**: Cursor advances only 1 character (col 0 → col 1). Ctrl+Left behaves identically — moves 1 character backward instead of jumping to the previous word boundary. The exec 'Move Word Right' command (via command palette) correctly jumps to col 5, confirming the command logic is correct but the keybinding is broken.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_state19_ctrl_right.json (cursor at col 1), edit_state44_ctrl_left.json (cursor at col 10 instead of word start), edit_state17_word_right.json (exec correctly lands at col 5)`
 
-### BUG-011: Alt+Backspace / Alt+Delete / Ctrl+Delete keybindings delete only 1 char instead of a whole word
+### ~~BUG-011: Alt+Backspace / Alt+Delete / Ctrl+Delete keybindings delete only 1 char instead of a whole word~~ NOT A BUG
 - **Category**: edit
 - **Severity**: major
 - **Steps to reproduce**: 1. Open file with 'Hello World' on line 1. 2. Press End to move to col 11 (end of line). 3. Press Alt+Backspace (bound to editor.deleteWordLeft). 4. Check cursor position and line content.
@@ -135,7 +135,7 @@ Generated: 2026-06-27
 - **Actual**: Alt+Backspace deletes only the single character immediately to the left ('d'), leaving 'Hello Worl' with cursor at col 10. Alt+Delete and Ctrl+Delete also each delete only 1 character forward. Root cause: EditorPaneWidget.HandleEvent matches tcell.KeyBackspace and tcell.KeyDelete without checking for Alt/Ctrl modifiers, consuming the event before global key handlers run. The exec 'Delete Word Left' command correctly deletes the full word (cursor moves to col 6), confirming the command is working but the keybinding is broken.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_state45_alt_bs.json (cursor at col 10 instead of col 6), edit_screen46_alt_del.txt ('ello World' after alt+delete from col 0), edit_state_key_delword.json vs edit_state_palette_delword.json (col 10 vs col 6)`
 
-### BUG-012: View: Close All Tabs discards unsaved changes without prompting
+### ~~BUG-012: View: Close All Tabs discards unsaved changes without prompting~~ DUPLICATE of BUG-005
 - **Category**: edge
 - **Severity**: major
 - **Steps to reproduce**: 1. Open a named file (e.g. bin/ttt /tmp/test.txt)
@@ -146,7 +146,7 @@ Generated: 2026-06-27
 - **Actual**: The modified file is closed immediately without any dialog. Unsaved changes are silently discarded. A new untitled tab opens.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step32a_before.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step32b_after.txt`
 
-### BUG-013: View: Close Other Tabs discards unsaved changes in background tabs without prompting
+### ~~BUG-013: View: Close Other Tabs discards unsaved changes in background tabs without prompting~~ DUPLICATE of BUG-006
 - **Category**: edge
 - **Severity**: major
 - **Steps to reproduce**: 1. Open 3 files: bin/ttt file1.txt file2.txt file3.txt
@@ -159,7 +159,7 @@ Generated: 2026-06-27
 
 ## Minor
 
-### BUG-014: Tab bar clips partial tab names in overflow mode without truncation indicator
+### ~~BUG-014: Tab bar clips partial tab names in overflow mode without truncation indicator~~ NOT A BUG
 - **Category**: tabs
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open 12 or more files: `bin/ttt file1.go file2.go ... file12.go`
@@ -171,7 +171,7 @@ Generated: 2026-06-27
 - **Actual**: Partially-visible tabs show raw clipped filenames at both edges. On the LEFT: 'a.go' is displayed instead of 'gamma.go' (showing only the last 4 characters of the filename). On the RIGHT: 'file_6.g' is displayed instead of 'file_6.go' (missing the trailing 'o'). These appear as genuine filenames and can mislead users into thinking there is a file called 'a.go'.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step58_overflow_confirm.txt (left overflow 'a.go'), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step59_both_overflow.txt (right overflow 'file_6.g')`
 
-### BUG-015: Tab bar overflow menu (⋮) only shows 'Close All', missing list of hidden tabs
+### ~~BUG-015: Tab bar overflow menu (⋮) only shows 'Close All', missing list of hidden tabs~~ NOT A BUG
 - **Category**: tabs
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open 12 or more files to cause tab bar overflow
@@ -180,7 +180,7 @@ Generated: 2026-06-27
 - **Actual**: The ⋮ dropdown only contains a single option: 'Close All'. There is no way to see or navigate to tabs that have scrolled off-screen via this menu. Users must use Ctrl+K , / Ctrl+K . repeatedly to cycle through hidden tabs.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step43_more_button.txt`
 
-### BUG-016: New File (Ctrl+N) always appends tab at end of list instead of after current tab
+### ~~BUG-016: New File (Ctrl+N) always appends tab at end of list instead of after current tab~~ NOT A BUG
 - **Category**: tabs
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open three files: `bin/ttt alpha.go beta.go gamma.go`
@@ -191,7 +191,7 @@ Generated: 2026-06-27
 - **Actual**: The new untitled tab is always appended at the end of the tab list regardless of which tab is currently active: [alpha.go, beta.go, gamma.go, untitled]. The new tab is at the end even when the active tab is in the middle.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_state54_new_file_position.json (active_tab=1 was beta.go, untitled at index 3 = end), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_state55_new_from_middle.json`
 
-### BUG-017: File explorer single-click on a file replaces current tab content instead of opening new tab
+### ~~BUG-017: File explorer single-click on a file replaces current tab content instead of opening new tab~~ NOT A BUG
 - **Category**: tabs
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open a directory: `bin/ttt /path/to/dir/`
@@ -203,7 +203,7 @@ Generated: 2026-06-27
 - **Actual**: When the current tab is 'untitled', clicking a file in the explorer replaces the untitled tab content (expected). However, subsequent explorer clicks on different files replace the current tab's content rather than opening new tabs. Only if the file is already open in another tab does it switch to the existing tab. Starting from a directory with no explicit files, clicking through multiple files leaves only 1 tab open at a time.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_state3_all_open.json (after clicking 4 files in explorer, only 1 tab 'gamma.go' remains)`
 
-### BUG-018: Go to File picker - filename truncated and fused with directory name without separator
+### ~~BUG-018: Go to File picker - filename truncated and fused with directory name without separator~~ FIXED
 - **Category**: file
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open ttt on a project with deep git worktree paths (e.g., .claude/worktrees/...)

--- a/bugs.md
+++ b/bugs.md
@@ -297,7 +297,7 @@ Generated: 2026-06-27
 - **Actual**: The dialog shows raw internal IDs: 'terminal', 'problems', 'references', 'output', 'plugin.notepad', 'plugin.todo-scanner'. The 'plugin.' prefix and raw ID format are not user-friendly.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step23_show_panel_tab.txt. Root cause: the 'panel.show' command handler (internal/app/commands_view.go:344) iterates over BottomPanel.PanelIDs() and uses each ID as both the SelectItem ID and Label. PanelIDs() returns internal IDs, not display titles. The fix is to expose panel titles alongside IDs (e.g. a PanelItems() method on TabbedPanel) and use those as labels.`
 
-### BUG-027: View: Focus Terminal does not give keyboard focus when terminal panel is not currently visible
+### ~~BUG-027: View: Focus Terminal does not give keyboard focus when terminal panel is not currently visible~~ FIXED
 - **Category**: terminal
 - **Severity**: minor
 - **Steps to reproduce**: 1. Start the editor with no terminal open
@@ -306,7 +306,7 @@ Generated: 2026-06-27
 - **Actual**: The terminal panel opens and a new terminal is spawned (ShowBottom is set, showTerminalPanel is called), but keyboard focus is NOT transferred to the terminal. Focus remains on the previously focused widget (the file explorer tree). The bug is in focusTerminal() in commands_view.go lines 132-139: the early 'return' statement after showTerminalPanel() exits before calling a.Root.SetFocus(), unlike the else branch (when panel is already visible) which correctly calls SetFocus.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step10_focus_terminal.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_state10_focus_terminal.json`
 
-### BUG-028: Opening file from Explorer keeps focus in sidebar tree; typing is silently consumed
+### ~~BUG-028: Opening file from Explorer keeps focus in sidebar tree; typing is silently consumed~~ WONTFIX
 - **Category**: sidebar
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open editor with a project directory (sidebar showing Explorer)
@@ -317,7 +317,7 @@ Generated: 2026-06-27
 - **Actual**: Focus stays on the Explorer Tree widget (confirmed via debug state: focused widget is Tree). The file opens correctly in the editor, but typing is silently consumed by the tree as navigation shortcuts with no visible effect on screen. The status bar still shows the untouched file state. Users must click the editor or press Escape before they can type.
 - **Evidence**: `sidebar_step16_type_after_click_open.txt (typed 'test' but file unchanged, no modification indicator), sidebar_state15_click_open_file.json (focus field shows 'other', focused widget is Tree after file open). Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
 
-### BUG-029: Clicking on search result group header collapses the group instead of opening file
+### ~~BUG-029: Clicking on search result group header collapses the group instead of opening file~~ NOT A BUG
 - **Category**: sidebar
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open Find panel and search for text
@@ -327,7 +327,7 @@ Generated: 2026-06-27
 - **Actual**: Clicking the file group header collapses the group (arrow changes from ▼ to ▶), hiding the child result lines. The file is NOT opened. No navigation occurs.
 - **Evidence**: `sidebar_step30_click_testbutton.txt shows group collapsed (▶ icon) after click, editor still shows 'untitled' with no file opened. Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
 
-### BUG-030: Tab dirty indicator (●) does not clear after undoing back to the last saved state
+### ~~BUG-030: Tab dirty indicator (●) does not clear after undoing back to the last saved state~~ FIXED (duplicate of BUG-024)
 - **Category**: edit
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open file. 2. Type 'X' (file is now modified, ● appears). 3. Save the file (exec 'Save File'). 4. Confirm ● disappears after save. 5. Type 'Y'. 6. Press Ctrl+Z to undo. 7. Content is now identical to the last saved state.
@@ -335,7 +335,7 @@ Generated: 2026-06-27
 - **Actual**: After undoing back to the saved content, the tab still shows ● and the buffer reports modified=true. The indicator only clears if the file is saved again. Simpler case also reproduces: type ABC on a fresh file, then exec 'Undo' three times — content returns to original but ● remains and buffer reports modified=true.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_screen49_undo_to_save.txt (shows ● after undo to saved state), edit_state49_undo_to_save.json (modified: true), edit_screen41_dirty.txt (same pattern after simpler type+undo)`
 
-### BUG-031: Cut and Copy without a selection are no-ops instead of acting on the current line
+### ~~BUG-031: Cut and Copy without a selection are no-ops instead of acting on the current line~~ REVIEW (#278)
 - **Category**: edit
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open file with text. 2. Ensure no selection is active (cursor on line 1, no selection). 3. Execute 'Cut' command. 4. Observe buffer and clipboard.
@@ -343,7 +343,7 @@ Generated: 2026-06-27
 - **Actual**: Cut without selection is a complete no-op: buffer is unchanged (modified=false) and the clipboard is not updated with line content. Copy without selection also leaves the clipboard unchanged. The clipboard retains whatever was there from a prior operation.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edit_screen33_cut_nsel.txt (buffer unchanged after Cut with no selection), edit_state33_cut_nsel.json (modified: false, same 6 lines)`
 
-### BUG-032: Delete Line on empty file causes viewport horizontal offset — first character typed after is invisible
+### ~~BUG-032: Delete Line on empty file causes viewport horizontal offset — first character typed after is invisible~~ NOT REPRODUCIBLE
 - **Category**: edge
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open editor with no files (new untitled buffer)
@@ -354,7 +354,7 @@ Generated: 2026-06-27
 - **Actual**: The first character typed is not rendered. Display shows 'BCDEFGH' (missing 'A'). Status bar correctly reports Ln 1, Col 9 indicating 8 chars exist. Pressing Home corrects the display, revealing the missing first character.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step31f_type_after_del.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/edge_step31g_after_home.txt`
 
-### BUG-033: Go to Line dialog gives no feedback when input is invalid (non-numeric, 0, or negative)
+### ~~BUG-033: Go to Line dialog gives no feedback when input is invalid (non-numeric, 0, or negative)~~ FIXED (duplicate of BUG-020)
 - **Category**: edge
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open any file
@@ -367,7 +367,7 @@ Generated: 2026-06-27
 
 ## Cosmetic
 
-### BUG-034: Close button (x) is only visible on the active tab; inactive tabs show no close button
+### ~~BUG-034: Close button (x) is only visible on the active tab; inactive tabs show no close button~~ NOT A BUG
 - **Category**: tabs
 - **Severity**: cosmetic
 - **Steps to reproduce**: 1. Open two or more files: `bin/ttt alpha.go beta.go gamma.go`
@@ -377,7 +377,7 @@ Generated: 2026-06-27
 - **Actual**: Only the active tab shows the 'x' close button. Inactive tabs display only the filename with no close affordance. To close an inactive tab, users must first click it to make it active (which changes the editor content), then click the 'x' button. This requires 2 clicks and changes the active buffer unnecessarily.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/tabs_step6_multi_files.txt (row 3 shows inactive tabs without x, active tab 'delta.txt x' with x)`
 
-### BUG-035: New untitled file naming skips '-1', jumping directly to '-2'
+### ~~BUG-035: New untitled file naming skips '-1', jumping directly to '-2'~~ NOT A BUG
 - **Category**: file
 - **Severity**: cosmetic
 - **Steps to reproduce**: 1. Launch ttt with no files (default untitled tab opens)
@@ -387,7 +387,7 @@ Generated: 2026-06-27
 - **Actual**: Tabs are named: 'untitled', 'untitled-2', 'untitled-3', 'untitled-4'. The first new file has no number and the subsequent ones start from -2, skipping -1.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_naming2.txt`
 
-### BUG-036: Inconsistent editor border box-drawing style across sessions (rounded vs straight corners)
+### ~~BUG-036: Inconsistent editor border box-drawing style across sessions (rounded vs straight corners)~~ NOT A BUG
 - **Category**: folding
 - **Severity**: cosmetic
 - **Steps to reproduce**: 1. Open a file and observe the editor pane border style
@@ -397,7 +397,7 @@ Generated: 2026-06-27
 - **Actual**: Editor border alternates between rounded corners (╭──╮ with U+256D) and straight corners (┌──┐ with U+250C) across different invocations with no user-visible action to explain the change. A third style (double-line ╔══╗) appears momentarily during mouse tab-click operations.
 - **Evidence**: `folding_step1_initial.txt: rounded corners ╭──╮ on first invocation. folding_step26_linenums_on.txt: straight corners ┌──┐ in a later invocation. folding_step44_before_nav.txt: rounded corners ╭──╮ again. folding_step20_fold_active.txt: double-line ╔══╗ during tab switching.`
 
-### BUG-037: Debug state 'focus' field always returns 'other' regardless of which pane is focused
+### ~~BUG-037: Debug state 'focus' field always returns 'other' regardless of which pane is focused~~ DEFERRED
 - **Category**: view
 - **Severity**: cosmetic
 - **Steps to reproduce**: 1. Open the editor with any file
@@ -409,7 +409,7 @@ Generated: 2026-06-27
 - **Actual**: All three states return 'focus: other'. The describeFocus() function checks for *ui.EditorPaneWidget but the editor group uses *ui.EditorGroupWidget as Root.Focused. Similarly, focus on sidebar/panel is set to their active child widgets (WidgetAdapter, TerminalPanelWidget), not the SidebarWidget/BottomPanelWidget containers that describeFocus() checks for. The only case that works is 'search' (SearchWidget). This only affects the debug dump — functionality is not impacted.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state5_focus_editor.json (shows focus: other after View: Focus Editor), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state7_focus_panel.json (shows focus: other after View: Focus Panel). Root cause in internal/app/debug_dump.go:156 — the type switch checks EditorPaneWidget instead of EditorGroupWidget, and checks SidebarWidget/BottomPanelWidget instead of the widgets that are actually set as Root.Focused.`
 
-### BUG-038: Sidebar tab bar shows no visual indicator of which panel is currently active
+### ~~BUG-038: Sidebar tab bar shows no visual indicator of which panel is currently active~~ ISSUE (#279)
 - **Category**: sidebar
 - **Severity**: cosmetic
 - **Steps to reproduce**: 1. Open editor with project directory
@@ -420,7 +420,7 @@ Generated: 2026-06-27
 - **Actual**: All tab labels appear identical in text rendering regardless of which panel is active. While this may use colors in a real terminal that are not captured in text screenshots, even the text layout contains no structural indicator (no underline character, no bracket, no arrow) marking the active tab.
 - **Evidence**: `sidebar_step8_click_find.txt vs sidebar_step8_click_changes.txt vs sidebar_step8_click_explore.txt all show identical tab bar text 'Explore  Find  Changes  >>  ...'. Files at /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/`
 
-### BUG-039: Bottom panel tab clicks do not switch the active tab
+### ~~BUG-039: Bottom panel tab clicks do not switch the active tab~~ NOT REPRODUCIBLE
 - **Category**: mouse
 - **Severity**: major
 - **Steps to reproduce**: 1. Open terminal (Terminal: Toggle Terminal) to show bottom panel
@@ -430,7 +430,7 @@ Generated: 2026-06-27
 - **Actual**: The active panel stays on "terminal" regardless of which tab is clicked. Tested clicks at X positions 3, 5, 13, 15, 23, 25, 33, 35, 41, 43, 51, 53 — all kept active=terminal.
 - **Evidence**: `mouse_bptab_x*.json files all show bottom_panel.active=terminal`
 
-### BUG-040: Command palette not dismissed by clicking outside its bounds
+### ~~BUG-040: Command palette not dismissed by clicking outside its bounds~~ FIXED
 - **Category**: mouse
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open command palette (Ctrl+P)
@@ -439,7 +439,7 @@ Generated: 2026-06-27
 - **Actual**: The palette stays open after clicking outside. Escape works correctly to dismiss.
 - **Evidence**: `mouse_test19b_state.json shows overlay still present after clicking at (5, 30)`
 
-### BUG-041: Debug state focus field always reports "other" regardless of actual focus
+### ~~BUG-041: Debug state focus field always reports "other" regardless of actual focus~~ DEFERRED (duplicate of BUG-037)
 - **Category**: mouse
 - **Severity**: cosmetic
 - **Steps to reproduce**: 1. Click in editor, sidebar, or bottom panel

--- a/bugs.md
+++ b/bugs.md
@@ -48,7 +48,7 @@ Generated: 2026-06-27
 - **Actual**: The default 'untitled' tab is shown with no error message. The specified file path is silently discarded. Root cause: OpenFile() is called during BuildApp() before Init() registers the OnError→StatusError callback, so the error is only logged via slog.Error() and never reaches the UI.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_nonexist_check.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_nonexist.txt`
 
-### BUG-004: Text transform (uppercase/lowercase/titlecase) undo leaves line empty after one Ctrl+Z
+### ~~BUG-004: Text transform (uppercase/lowercase/titlecase) undo leaves line empty after one Ctrl+Z~~ FIXED (same fix as BUG-001)
 - **Category**: transform
 - **Severity**: major
 - **Steps to reproduce**: 1. Open any text file
@@ -60,7 +60,7 @@ Generated: 2026-06-27
 - **Actual**: After one Ctrl+Z, the line becomes EMPTY. The text is not restored. A second Ctrl+Z is required to get back to 'hello world'.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_final_1undo.txt (line 1 empty after 1 undo), transform_final_2undo.txt (line 1 restored after 2 undos). Root cause: /home/enko/Documents/ttt/internal/ui/editor_widget.go in transformSelection() calls e.Undo.BreakGroup() before two separate e.exec() calls (DeleteSelectionCommand then InsertStringCommand), making them separate undo groups instead of one atomic operation. Fix: use BatchCommand like ToggleLineComment does at line 1930.`
 
-### BUG-005: View: Close All Tabs silently discards unsaved changes without confirmation
+### ~~BUG-005: View: Close All Tabs silently discards unsaved changes without confirmation~~ FIXED
 - **Category**: view
 - **Severity**: major
 - **Steps to reproduce**: 1. Open a file (e.g. bin/ttt main.go)

--- a/bugs.md
+++ b/bugs.md
@@ -245,7 +245,7 @@ Generated: 2026-06-27
 - **Actual**: No ▼ gutter indicators appear on fresh open. Indicators appear only after switching between two tabs (clicking away to another file and back). They also do not appear after running Fold All + Unfold All. This makes fold affordances invisible to users who never switch tabs.
 - **Evidence**: `folding_step54_fresh_gutter.txt: fresh open shows lines 3, 10, 15, 20, 26, 32 without ▼ indicators. folding_step57_gutter_after_keys.txt: after ctrl+k 0 (Fold All) + ctrl+k 9 (Unfold All) keyboard shortcuts, still no ▼ indicators. folding_step56_gutter_after_tabswitch.txt: after clicking away to second_file.go and back, lines 3 and 10 show ▼ indicators. folding_step55_gutter_after_foldall.txt: after exec Fold All + Unfold All via command palette, still no ▼ indicators.`
 
-### BUG-022: Toggle Syntax Highlight requires editor restart to take effect
+### ~~BUG-022: Toggle Syntax Highlight requires editor restart to take effect~~ NOT A BUG
 - **Category**: folding
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open any syntax-highlighted source file
@@ -255,7 +255,7 @@ Generated: 2026-06-27
 - **Actual**: Status bar shows notification: 'Restart to apply syntax highlight changes [OK]'. The syntax highlight state does not change until the editor is restarted. Toggling again shows the same notification again.
 - **Evidence**: `folding_step33_syntax_off.txt: notification 'Restart to apply syntax highlight changes [OK]' visible in status bar after first toggle. folding_step50_syntax_toggle1.txt and folding_step51_syntax_toggle2.txt: same notification on both first and second toggle invocations.`
 
-### BUG-023: Toggle Fold (ctrl+k [) has no effect when cursor is on closing brace
+### ~~BUG-023: Toggle Fold (ctrl+k [) has no effect when cursor is on closing brace~~ NOT A BUG
 - **Category**: folding
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open a Go file with functions
@@ -266,7 +266,7 @@ Generated: 2026-06-27
 - **Actual**: Nothing happens. The fold is only triggered from the opening line of a block (e.g., the 'func Foo() {' line). Pressing ctrl+k [ while on the closing '}' line has no effect and gives no feedback.
 - **Evidence**: `folding_step48_on_closing.txt: cursor on line 12 ('}' of Add function). folding_step49_fold_from_closing.txt: identical content after pressing ctrl+k [, no fold applied, no visible change.`
 
-### BUG-024: Modified indicator (dot) not cleared after Undo restores file to saved state
+### ~~BUG-024: Modified indicator (dot) not cleared after Undo restores file to saved state~~ FIXED
 - **Category**: transform
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open a file (no dot indicator shown)

--- a/bugs.md
+++ b/bugs.md
@@ -287,7 +287,7 @@ Generated: 2026-06-27
 - **Actual**: The trailing empty line is treated as a sortable line (empty string sorts before all words alphabetically) and moves to the first position. Result: (empty line), apple, banana, cherry, mango, zebra. The empty line is now at the top of the file.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/transform_t30_before.txt (original: cherry, apple, banana, zebra, mango, empty), transform_t30_after.txt (after sort: empty line at position 1 followed by sorted words).`
 
-### BUG-026: View: Show Panel Tab dialog displays internal IDs instead of friendly panel names
+### ~~BUG-026: View: Show Panel Tab dialog displays internal IDs instead of friendly panel names~~ FIXED
 - **Category**: view
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open the bottom panel: run 'View: Toggle Panel'

--- a/bugs.md
+++ b/bugs.md
@@ -83,7 +83,7 @@ Generated: 2026-06-27
 - **Actual**: app.go is silently closed with all unsaved changes lost. No confirmation is shown. Only main.go remains.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_step62_close_other_test.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/view_state62d_after_close.json. The debug state confirms: after typing in app.go (modified: True) and running Close Other Tabs, only main.go (modified: False) remains. Root cause: 'tab.closeOthers' command calls app.EditorGroup.CloseOtherTabs() directly (internal/app/commands_editor.go:283), which replaces the tabs array unconditionally without checking dirty state on the tabs being discarded.`
 
-### BUG-007: Terminal: Toggle Fullscreen off hides the terminal panel instead of restoring to split view
+### ~~BUG-007: Terminal: Toggle Fullscreen off hides the terminal panel instead of restoring to split view~~ NOT A BUG
 - **Category**: terminal
 - **Severity**: major
 - **Steps to reproduce**: 1. Open the editor
@@ -94,7 +94,7 @@ Generated: 2026-06-27
 - **Actual**: The terminal panel is hidden entirely — ShowBottom is set to false via HideBottomPanel(). The code at commands_view.go line 26-27 checks 'if ShowBottom && BottomH >= fullH { HideBottomPanel() }' which treats exiting fullscreen the same as toggling the panel off. The user must manually re-open the terminal after exiting fullscreen.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step8a_before_fs.txt (TERMINAL visible), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step8b_during_fs.txt (fullscreen), /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/terminal_step8c_after_fs.txt (panel gone)`
 
-### BUG-008: Search result click: matched line not visible (viewport off by 1 row)
+### ~~BUG-008: Search result click: matched line not visible (viewport off by 1 row)~~ FIXED
 - **Category**: sidebar
 - **Severity**: major
 - **Steps to reproduce**: 1. Open editor with a project directory

--- a/bugs.md
+++ b/bugs.md
@@ -213,7 +213,7 @@ Generated: 2026-06-27
 - **Actual**: The filename is truncated to only a few characters and the directory path is appended directly with no separator. For example: 'settings.local.json' becomes 'settin.claude/worktrees/agent-a07104541439a4bc5/.claude' making it unreadable and ambiguous.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_gotofile_display.txt`
 
-### BUG-019: No read-only file indicator when opening files with restricted permissions
+### ~~BUG-019: No read-only file indicator when opening files with restricted permissions~~ ISSUE #277
 - **Category**: file
 - **Severity**: minor
 - **Steps to reproduce**: 1. Create a read-only file: echo 'content' > /tmp/test.txt && chmod 444 /tmp/test.txt
@@ -223,7 +223,7 @@ Generated: 2026-06-27
 - **Actual**: No indicator is shown anywhere. The file opens and can be edited normally. Ctrl+S saves silently without any warning. On Linux, the atomic save (temp file + rename in same directory) can succeed even for chmod 444 files when the containing directory is writable, so the user unknowingly overwrites a read-only file.
 - **Evidence**: `/tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_readonly_open.txt, /tmp/claude-1000/-home-enko-Documents-ttt/f9eb676f-0e80-45ca-9c81-8abb71498225/scratchpad/qa/file_readonly_save.txt`
 
-### BUG-020: Go to Line dialog stays open and does not navigate when entering line number 0
+### ~~BUG-020: Go to Line dialog stays open and does not navigate when entering line number 0~~ FIXED
 - **Category**: folding
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open any file in the editor
@@ -235,7 +235,7 @@ Generated: 2026-06-27
 - **Actual**: Dialog stays open indefinitely with no feedback and no navigation. The cursor does not move. User must press Escape to close the stuck dialog. The same issue occurs for any non-positive number (0, -1, etc.).
 - **Evidence**: `folding_step52_goto0_verify.txt shows dialog still open after 500ms wait. folding_state52_goto0.json shows cursor.line=0 (unchanged initial position, no navigation occurred). Root cause: /home/enko/Documents/ttt/internal/ui/selectdialog_widget.go line 305 has condition `n > 0` which silently rejects 0 without calling OnGoToLine or OnDismiss. For comparison, line 1 works correctly: folding_step53_goto1.txt shows dialog dismissed and cursor at line 1.`
 
-### BUG-021: Fold gutter indicators (▼) not shown on fresh file open — only appear after tab switching
+### ~~BUG-021: Fold gutter indicators (▼) not shown on fresh file open — only appear after tab switching~~ NOT A BUG (hover-to-reveal by design)
 - **Category**: folding
 - **Severity**: minor
 - **Steps to reproduce**: 1. Open a Go file with foldable blocks

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -240,14 +240,20 @@ func (a *App) SpawnTerminal() {
 }
 
 func (a *App) CloseTerminal(panelID string) {
+	idx := -1
 	for i, tt := range a.Terminals {
 		if tt.ID == panelID {
-			tt.Term.Close()
-			a.Terminals = append(a.Terminals[:i], a.Terminals[i+1:]...)
-			a.TerminalPanel.RemoveTerminal(i)
+			idx = i
 			break
 		}
 	}
+	if idx < 0 {
+		return
+	}
+	a.Terminals[idx].Term.Close()
+	a.Terminals = append(a.Terminals[:idx], a.Terminals[idx+1:]...)
+	a.TerminalPanel.RemoveTerminal(idx)
+
 	if a.TerminalPanel.Count() == 0 {
 		a.FocusEditor()
 	} else {
@@ -256,9 +262,15 @@ func (a *App) CloseTerminal(panelID string) {
 }
 
 func (a *App) CloseAllTerminals() {
-	for i := len(a.Terminals) - 1; i >= 0; i-- {
-		a.CloseTerminal(a.Terminals[i].ID)
+	terms := a.Terminals
+	a.Terminals = nil
+	for i := len(terms) - 1; i >= 0; i-- {
+		a.TerminalPanel.RemoveTerminal(i)
 	}
+	for _, tt := range terms {
+		tt.Term.Close()
+	}
+	a.FocusEditor()
 }
 
 func (a *App) refreshWorkspaceWidgets() {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -376,6 +376,10 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	a.EditorGroup.OnError = func(msg string) {
 		a.StatusError(msg)
 	}
+	a.EditorGroup.OnNotify = func(msg string) {
+		a.StatusNotify(msg)
+	}
+	a.EditorGroup.FlushNotifications()
 	a.EditorGroup.OnFileOpen = func(path, lang, text string) {
 		a.NotifyLSPOpen(path, lang, text)
 		a.RequestGitGutterForActiveFile()

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -456,6 +456,7 @@ func registerWidgetCallbacks(app *App) {
 	app.EditorGroup.TabBar.MoreButton.OnClick = func(sx, sy int) {
 		moreMenu := []ui.ContextMenuItem{
 			{Label: "Close All", Command: "tab.closeAll"},
+			{Label: "Close All Saved", Command: "tab.closeAllSaved"},
 		}
 		openContextMenu(app, moreMenu, sx, sy)
 	}
@@ -466,6 +467,7 @@ func registerWidgetCallbacks(app *App) {
 			{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
 			{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
 			{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
+			{Label: "Close All Saved", Shortcut: "", Command: "tab.closeAllSaved"},
 			ui.MenuSep(),
 			{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
 			{Label: "Copy Relative Path", Command: "file.copyRelativePath"},

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -288,7 +288,32 @@ func registerEditorCommands(app *App) {
 	reg.Register(command.Command{
 		ID: "tab.closeAll", Title: "View: Close All Tabs",
 		Keywords: []string{"tab"},
-		Handler:  func() { app.EditorGroup.CloseAllTabs() },
+		Handler: func() {
+			if !app.EditorGroup.HasDirtyTabs() {
+				app.EditorGroup.CloseAllTabs()
+				return
+			}
+			app.ShowConfirmDialog("You have unsaved changes.",
+				[]string{"Abort", "Close Saved", "Discard All"},
+				[]func(){
+					func() { app.DismissDialog() },
+					func() {
+						app.DismissDialog()
+						app.EditorGroup.CloseAllSaved()
+					},
+					func() {
+						app.DismissDialog()
+						app.EditorGroup.CloseAllTabs()
+					},
+				},
+			)
+		},
+	})
+
+	reg.Register(command.Command{
+		ID: "tab.closeAllSaved", Title: "View: Close All Saved Tabs",
+		Keywords: []string{"tab", "close", "saved"},
+		Handler:  func() { app.EditorGroup.CloseAllSaved() },
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -95,6 +95,48 @@ func (a *App) CloseTab() {
 	)
 }
 
+func (a *App) CloseOtherTabs() {
+	if !a.EditorGroup.HasDirtyOtherTabs() {
+		a.EditorGroup.CloseOtherTabs()
+		return
+	}
+	a.ShowConfirmDialog("Other tabs have unsaved changes.",
+		[]string{"Abort", "Close Saved", "Discard All"},
+		[]func(){
+			func() { a.DismissDialog() },
+			func() {
+				a.DismissDialog()
+				a.EditorGroup.CloseOtherSaved()
+			},
+			func() {
+				a.DismissDialog()
+				a.EditorGroup.CloseOtherTabs()
+			},
+		},
+	)
+}
+
+func (a *App) CloseAllTabs() {
+	if !a.EditorGroup.HasDirtyTabs() {
+		a.EditorGroup.CloseAllTabs()
+		return
+	}
+	a.ShowConfirmDialog("You have unsaved changes.",
+		[]string{"Abort", "Close Saved", "Discard All"},
+		[]func(){
+			func() { a.DismissDialog() },
+			func() {
+				a.DismissDialog()
+				a.EditorGroup.CloseAllSaved()
+			},
+			func() {
+				a.DismissDialog()
+				a.EditorGroup.CloseAllTabs()
+			},
+		},
+	)
+}
+
 func (a *App) NewFile() {
 	a.EditorGroup.NewFile()
 	a.Root.SetFocus(a.EditorGroup)
@@ -282,32 +324,13 @@ func registerEditorCommands(app *App) {
 	reg.Register(command.Command{
 		ID: "tab.closeOthers", Title: "View: Close Other Tabs",
 		Keywords: []string{"tab"},
-		Handler:  func() { app.EditorGroup.CloseOtherTabs() },
+		Handler:  app.CloseOtherTabs,
 	})
 
 	reg.Register(command.Command{
 		ID: "tab.closeAll", Title: "View: Close All Tabs",
 		Keywords: []string{"tab"},
-		Handler: func() {
-			if !app.EditorGroup.HasDirtyTabs() {
-				app.EditorGroup.CloseAllTabs()
-				return
-			}
-			app.ShowConfirmDialog("You have unsaved changes.",
-				[]string{"Abort", "Close Saved", "Discard All"},
-				[]func(){
-					func() { app.DismissDialog() },
-					func() {
-						app.DismissDialog()
-						app.EditorGroup.CloseAllSaved()
-					},
-					func() {
-						app.DismissDialog()
-						app.EditorGroup.CloseAllTabs()
-					},
-				},
-			)
-		},
+		Handler:  app.CloseAllTabs,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_help.go
+++ b/internal/app/commands_help.go
@@ -7,6 +7,8 @@ import (
 )
 
 var explorerHelpEntries = []widgets.KeyValueEntry{
+	{Key: "Click", Value: "Open file in preview"},
+	{Key: "Double-click", Value: "Open file permanently"},
 	{Key: "Enter", Value: "Open file or toggle folder"},
 	{Key: "Space", Value: "Open file or toggle folder"},
 	{Key: "Shift+Enter", Value: "Open context menu"},

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -344,13 +344,13 @@ func registerViewCommands(app *App) {
 		ID: "panel.show", Title: "View: Show Panel Tab",
 		Keywords: []string{"view", "bottom", "tab", "switch"},
 		Handler: func() {
-			ids := app.BottomPanel.PanelIDs()
-			if len(ids) == 0 {
+			panels := app.BottomPanel.PanelEntries()
+			if len(panels) == 0 {
 				return
 			}
 			var items []widgets.SelectItem
-			for _, id := range ids {
-				items = append(items, widgets.SelectItem{ID: id, Label: id})
+			for _, p := range panels {
+				items = append(items, widgets.SelectItem{ID: p.ID, Label: p.Title})
 			}
 			app.ShowSelectDialog("Show Panel", items, func(id string) {
 				app.BottomPanel.SetActivePanel(id)

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -136,7 +136,6 @@ func (a *App) focusTerminal() {
 			a.ContentSplit.BottomH = min(r.H/2, maxH)
 		}
 		a.showTerminalPanel()
-		return
 	}
 	a.BottomPanel.SetActivePanel("terminal")
 	if w := a.BottomPanel.ActiveWidget(); w != nil {

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -29,6 +29,8 @@ func RunExecScript(a *App, script string) {
 		switch action {
 		case "click":
 			execClick(a, args)
+		case "hover":
+			execHover(a, args)
 		case "drag":
 			execDrag(a, args)
 		case "key":
@@ -88,6 +90,25 @@ func execClick(a *App, args string) {
 	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button1, tcell.ModNone))
 	time.Sleep(50 * time.Millisecond)
 	// Release
+	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+}
+
+func execHover(a *App, args string) {
+	parts := strings.Fields(args)
+	if len(parts) < 2 {
+		slog.Error("exec_script: hover requires X Y", "args", args)
+		return
+	}
+	x, err := strconv.Atoi(parts[0])
+	if err != nil {
+		slog.Error("exec_script: invalid hover X", "value", parts[0], "error", err)
+		return
+	}
+	y, err := strconv.Atoi(parts[1])
+	if err != nil {
+		slog.Error("exec_script: invalid hover Y", "value", parts[1], "error", err)
+		return
+	}
 	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
 }
 

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -177,6 +177,25 @@ func openMenuBarDropdown(app *App, index int) {
 		next := (index + dir + len(menuBarMenus)) % len(menuBarMenus)
 		openMenuBarDropdown(app, next)
 	}
+	menu.OnMouseOutside = func(ev tcell.Event) {
+		mev, ok := ev.(*tcell.EventMouse)
+		if !ok {
+			return
+		}
+		mx, my := mev.Position()
+		r := app.MenuBar.GetRect()
+		if my != r.Y {
+			return
+		}
+		localX := mx - r.X
+		for i, span := range app.MenuBar.ItemSpans() {
+			if localX >= span.Start && localX < span.End && i != index {
+				app.Root.PopOverlay()
+				openMenuBarDropdown(app, i)
+				return
+			}
+		}
+	}
 	app.Root.PushOverlay(ui.Overlay{Widget: menu, Modal: true})
 	app.Root.SetFocus(menu)
 }

--- a/internal/core/undo/undo.go
+++ b/internal/core/undo/undo.go
@@ -16,9 +16,19 @@ type EditCommand interface {
 // UndoStack manages undo and redo stacks with automatic grouping of
 // consecutive character inserts and deletes.
 type UndoStack struct {
-	undo     []EditCommand
-	redo     []EditCommand
-	grouping bool
+	undo      []EditCommand
+	redo      []EditCommand
+	grouping  bool
+	savePoint int
+}
+
+func (s *UndoStack) MarkSaved() {
+	s.grouping = false
+	s.savePoint = len(s.undo)
+}
+
+func (s *UndoStack) AtSavePoint() bool {
+	return len(s.undo) == s.savePoint
 }
 
 // Push adds a command to the undo stack and clears the redo stack.

--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -30,10 +30,11 @@ type ContextMenuWidget struct {
 	AnchorX  int
 	AnchorY  int
 	Borders  *term.BorderSet
-	OnExec      func(command string)
-	OnDismiss   func()
-	OnNavigate  func(dir int)
-	firstEvent  bool
+	OnExec         func(command string)
+	OnDismiss      func()
+	OnNavigate     func(dir int)
+	OnMouseOutside func(ev tcell.Event)
+	firstEvent     bool
 }
 
 func NewContextMenuWidget(items []ContextMenuItem, x, y int) *ContextMenuWidget {
@@ -226,6 +227,9 @@ func (c *ContextMenuWidget) HandleEvent(ev tcell.Event) EventResult {
 		if btn == tcell.ButtonNone {
 			if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
 				c.Selected = -1
+				if c.OnMouseOutside != nil {
+					c.OnMouseOutside(ev)
+				}
 				return EventConsumed
 			}
 			itemIdx := my - r.Y - 1

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -14,7 +14,9 @@ import (
 	"github.com/eugenioenko/ttt/internal/core/undo"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/view"
+	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -172,8 +174,11 @@ func (g *EditorGroupWidget) OpenFile(path string) {
 		newBuf.TrimTrailingWhitespace = ec.TrimTrailingWS
 	}
 	if err := newBuf.LoadFile(path); err != nil {
-		g.reportError(fmt.Sprintf("Failed to open %s: %v", path, err))
-		return
+		if !errors.Is(err, os.ErrNotExist) {
+			g.reportError(fmt.Sprintf("Failed to open %s: %v", path, err))
+			return
+		}
+		slog.Info("new file buffer created", "path", path)
 	}
 	tabSize := g.TabSize
 	useTabs := !g.InsertSpaces

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -549,6 +549,37 @@ func (g *EditorGroupWidget) CloseOtherTabs() {
 	g.syncTabs()
 }
 
+func (g *EditorGroupWidget) CloseOtherSaved() {
+	t := g.activeTab()
+	if t == nil || len(g.tabs) <= 1 {
+		return
+	}
+	kept := []editorTab{*t}
+	for i := range g.tabs {
+		if i == g.active {
+			continue
+		}
+		if g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty {
+			kept = append(kept, g.tabs[i])
+		}
+	}
+	g.tabs = kept
+	g.active = 0
+	g.syncTabs()
+}
+
+func (g *EditorGroupWidget) HasDirtyOtherTabs() bool {
+	for i := range g.tabs {
+		if i == g.active {
+			continue
+		}
+		if g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *EditorGroupWidget) CloseAllTabs() {
 	g.tabs = []editorTab{{
 		FilePath: "untitled",

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -563,6 +563,33 @@ func (g *EditorGroupWidget) CloseAllTabs() {
 	g.syncTabs()
 }
 
+func (g *EditorGroupWidget) CloseAllSaved() {
+	var kept []editorTab
+	for i := range g.tabs {
+		if g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty {
+			kept = append(kept, g.tabs[i])
+		}
+	}
+	if len(kept) == 0 {
+		g.CloseAllTabs()
+		return
+	}
+	g.tabs = kept
+	if g.active >= len(g.tabs) {
+		g.active = len(g.tabs) - 1
+	}
+	g.syncTabs()
+}
+
+func (g *EditorGroupWidget) HasDirtyTabs() bool {
+	for i := range g.tabs {
+		if g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *EditorGroupWidget) Save() bool {
 	t := g.activeTab()
 	if t == nil || t.Content != nil {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -85,6 +85,8 @@ type EditorGroupWidget struct {
 	OnFileChange           func(path, lang, text string)
 	OnFileClose            func(path, lang string)
 	OnError                func(msg string)
+	OnNotify               func(msg string)
+	pendingNotify          []string
 }
 
 func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool, gutterStyle string) *EditorGroupWidget {
@@ -148,6 +150,24 @@ func (g *EditorGroupWidget) reportError(msg string) {
 	}
 }
 
+func (g *EditorGroupWidget) notify(msg string) {
+	if g.OnNotify != nil {
+		g.OnNotify(msg)
+	} else {
+		g.pendingNotify = append(g.pendingNotify, msg)
+	}
+}
+
+func (g *EditorGroupWidget) FlushNotifications() {
+	if g.OnNotify == nil {
+		return
+	}
+	for _, msg := range g.pendingNotify {
+		g.OnNotify(msg)
+	}
+	g.pendingNotify = nil
+}
+
 func (g *EditorGroupWidget) PinActiveTab() {
 	if t := g.activeTab(); t != nil {
 		t.Pinned = true
@@ -178,7 +198,7 @@ func (g *EditorGroupWidget) OpenFile(path string) {
 			g.reportError(fmt.Sprintf("Failed to open %s: %v", path, err))
 			return
 		}
-		slog.Info("new file buffer created", "path", path)
+		g.notify(fmt.Sprintf("New file: %s", filepath.Base(path)))
 	}
 	tabSize := g.TabSize
 	useTabs := !g.InsertSpaces

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -820,6 +820,22 @@ func (g *EditorGroupWidget) GoToLine(line int) {
 	g.Editor.ExpandFoldContaining(bufLine)
 	g.Editor.Cursor.Line = bufLine
 	g.Editor.Cursor.Col = 0
+	h := g.Editor.Viewport.Height
+	if h <= 0 {
+		r := g.GetRect()
+		h = r.H - 3
+		if h > 0 {
+			g.Editor.Viewport.Height = h
+		}
+	}
+	if h > 0 {
+		margin := h / 3
+		top := bufLine - margin
+		if top < 0 {
+			top = 0
+		}
+		g.Editor.Viewport.TopLine = top
+	}
 	g.Editor.scrollViewport()
 }
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -633,6 +633,9 @@ func (g *EditorGroupWidget) Save() bool {
 		g.reportError(fmt.Sprintf("Failed to save %s: %v", t.FilePath, err))
 		return false
 	}
+	if t.Undo != nil {
+		t.Undo.MarkSaved()
+	}
 	return true
 }
 
@@ -644,6 +647,9 @@ func (g *EditorGroupWidget) SaveAs(path string) {
 	if err := t.Buf.SaveFile(path); err != nil {
 		g.reportError(fmt.Sprintf("Failed to save %s: %v", path, err))
 		return
+	}
+	if t.Undo != nil {
+		t.Undo.MarkSaved()
 	}
 	t.FilePath = path
 	t.Virtual = false
@@ -760,6 +766,9 @@ func (g *EditorGroupWidget) Undo() {
 			g.Editor.Cursor.Line = pos.Line
 			g.Editor.Cursor.Col = pos.Col
 		}
+		if t.Undo.AtSavePoint() {
+			t.Buf.Dirty = false
+		}
 		g.undoRedoPostProcess()
 	}
 }
@@ -773,6 +782,9 @@ func (g *EditorGroupWidget) Redo() {
 		if pos := t.Undo.Redo(t.Buf); pos != nil {
 			g.Editor.Cursor.Line = pos.Line
 			g.Editor.Cursor.Col = pos.Col
+		}
+		if t.Undo.AtSavePoint() {
+			t.Buf.Dirty = false
 		}
 		g.undoRedoPostProcess()
 	}

--- a/internal/ui/editor_group_test.go
+++ b/internal/ui/editor_group_test.go
@@ -78,13 +78,17 @@ func TestEditorGroupOpenFileNotFound(t *testing.T) {
 	var errMsg string
 	g.OnError = func(msg string) { errMsg = msg }
 
-	g.OpenFile("/nonexistent/path/file.txt")
+	path := "/nonexistent/path/file.txt"
+	g.OpenFile(path)
 
-	if errMsg == "" {
-		t.Fatal("expected OnError to be called for missing file")
+	if errMsg != "" {
+		t.Fatalf("unexpected error for new file: %s", errMsg)
 	}
-	if len(g.tabs) != 1 || g.tabs[0].FilePath != "untitled" {
-		t.Fatal("should not have added a tab for missing file")
+	if g.tabs[g.active].FilePath != path {
+		t.Fatalf("expected tab with path %q, got %q", path, g.tabs[g.active].FilePath)
+	}
+	if g.tabs[g.active].Buf.Lines[0] != "" {
+		t.Fatal("expected empty buffer for new file")
 	}
 }
 

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -2601,33 +2601,38 @@ func (e *EditorPaneWidget) transformSelection(fn func(string) string) {
 		e.Undo.BreakGroup()
 	}
 
-	// Delete the selection
-	delCmd := &undo.DeleteSelectionCommand{
-		StartLine: start.Line, StartCol: start.Col,
-		EndLine: end.Line, EndCol: end.Col,
-	}
-	e.exec(delCmd)
+	oldLines := make([]string, end.Line-start.Line+1)
+	copy(oldLines, e.Buf.Lines[start.Line:end.Line+1])
 
-	// Insert the transformed text
 	tLines := strings.Split(transformed, "\n")
-	if len(tLines) == 1 {
-		e.exec(&undo.InsertStringCommand{Line: start.Line, Col: start.Col, Text: tLines[0]})
-	} else {
-		currentLine := []rune(e.Buf.Lines[start.Line])
-		col := start.Col
-		if col > len(currentLine) {
-			col = len(currentLine)
-		}
-		suffix := string(currentLine[col:])
-		e.exec(&undo.PasteCommand{
-			Line:   start.Line,
-			Col:    col,
-			Text:   transformed,
-			Suffix: suffix,
-		})
+	prefix := string([]rune(oldLines[0])[:start.Col])
+	lastOld := []rune(oldLines[len(oldLines)-1])
+	suffix := ""
+	if end.Col < len(lastOld) {
+		suffix = string(lastOld[end.Col:])
 	}
 
-	// Restore the selection so the user sees the transformed range
+	newLines := make([]string, len(tLines))
+	for i, tl := range tLines {
+		switch {
+		case len(tLines) == 1:
+			newLines[i] = prefix + tl + suffix
+		case i == 0:
+			newLines[i] = prefix + tl
+		case i == len(tLines)-1:
+			newLines[i] = tl + suffix
+		default:
+			newLines[i] = tl
+		}
+	}
+
+	cmd := &undo.ReplaceLinesCommand{
+		Start:    start.Line,
+		OldLines: oldLines,
+		NewLines: newLines,
+	}
+	e.exec(cmd)
+
 	newEndLine := start.Line + len(tLines) - 1
 	var newEndCol int
 	if len(tLines) == 1 {

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -1950,7 +1950,11 @@ func (e *EditorPaneWidget) lineRange() (int, int) {
 		}
 		return e.Buf.ClampLine(start.Line), e.Buf.ClampLine(endLine)
 	}
-	return 0, len(e.Buf.Lines) - 1
+	end := len(e.Buf.Lines) - 1
+	if end > 0 && e.Buf.Lines[end] == "" {
+		end--
+	}
+	return 0, end
 }
 
 // copyLines returns a copy of the buffer lines in the given range (inclusive).

--- a/internal/ui/menubar_widget.go
+++ b/internal/ui/menubar_widget.go
@@ -15,7 +15,7 @@ type MenuBarWidget struct {
 	Items    []MenuItem
 	Selected int
 	OnSelect func(index int)
-	itemSpans []struct{ start, end int }
+	itemSpans []MenuItemSpan
 }
 
 func NewMenuBarWidget(items []MenuItem) *MenuBarWidget {
@@ -24,6 +24,12 @@ func NewMenuBarWidget(items []MenuItem) *MenuBarWidget {
 		Selected: -1,
 	}
 }
+
+type MenuItemSpan struct {
+	Start, End int
+}
+
+func (m *MenuBarWidget) ItemSpans() []MenuItemSpan { return m.itemSpans }
 
 func (m *MenuBarWidget) Height() int     { return 1 }
 func (m *MenuBarWidget) Focusable() bool { return true }
@@ -35,7 +41,7 @@ func (m *MenuBarWidget) Render(surface Surface) {
 		surface.SetCell(x, 0, term.Cell{Ch: ' ', Style: term.StyleMenuBar})
 	}
 
-	m.itemSpans = make([]struct{ start, end int }, len(m.Items))
+	m.itemSpans = make([]MenuItemSpan, len(m.Items))
 	x := 1
 	for i, item := range m.Items {
 		style := term.StyleMenuBar
@@ -54,14 +60,14 @@ func (m *MenuBarWidget) Render(surface Surface) {
 		}
 		surface.SetCell(x, 0, term.Cell{Ch: ' ', Style: style})
 		x++
-		m.itemSpans[i] = struct{ start, end int }{startX, x}
+		m.itemSpans[i] = MenuItemSpan{startX, x}
 		x++
 	}
 }
 
 func (m *MenuBarWidget) ItemAnchorX(index int) int {
 	if index >= 0 && index < len(m.itemSpans) {
-		return m.itemSpans[index].start
+		return m.itemSpans[index].Start
 	}
 	return 0
 }
@@ -75,7 +81,7 @@ func (m *MenuBarWidget) HandleEvent(ev tcell.Event) EventResult {
 			if my == r.Y {
 				localX := mx - r.X
 				for i, span := range m.itemSpans {
-					if localX >= span.start && localX < span.end {
+					if localX >= span.Start && localX < span.End {
 						m.Selected = i
 						if m.OnSelect != nil {
 							m.OnSelect(i)

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -310,7 +310,10 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 		if p.mode == paletteGoToLineMode {
 			if p.OnGoToLine != nil {
 				text := strings.TrimPrefix(p.Input.Text, ":")
-				if n, err := strconv.Atoi(text); err == nil && n > 0 {
+				if n, err := strconv.Atoi(text); err == nil {
+					if n < 1 {
+						n = 1
+					}
 					p.OnGoToLine(n)
 				}
 			}

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -269,6 +269,14 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 
 		if btn&tcell.Button1 != 0 {
+			inBox := mx >= p.boxX && mx < p.boxX+p.boxW && my >= p.boxY && my < p.boxY+p.boxH
+			if !inBox {
+				if p.OnDismiss != nil {
+					p.OnDismiss()
+				}
+				return EventConsumed
+			}
+
 			if my == p.inputY {
 				p.Input.HandleClick(mx, my)
 				return EventConsumed

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -204,10 +204,18 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 			if idx == p.Selected {
 				detailStyle = style
 			}
-			detailRunes := []rune(item.Detail)
-			sx := contentRight - 1 - len(detailRunes)
-			if sx > boxX+1 {
-				surface.DrawText(sx, y, item.Detail, contentRight-1, detailStyle)
+			labelEnd := boxX + 2 + len([]rune(item.Label))
+			minGap := 3
+			availStart := labelEnd + minGap
+			availW := contentRight - 1 - availStart
+			if availW > 0 {
+				detail := item.Detail
+				detailRunes := []rune(detail)
+				if len(detailRunes) > availW {
+					detail = "…" + string(detailRunes[len(detailRunes)-availW+1:])
+				}
+				sx := contentRight - 1 - len([]rune(detail))
+				surface.DrawText(sx, y, detail, contentRight-1, detailStyle)
 			}
 		}
 	}

--- a/internal/ui/tabbed_panel.go
+++ b/internal/ui/tabbed_panel.go
@@ -134,6 +134,19 @@ func (tp *TabbedPanel) PanelIDs() []string {
 	return ids
 }
 
+type PanelInfo struct {
+	ID    string
+	Title string
+}
+
+func (tp *TabbedPanel) PanelEntries() []PanelInfo {
+	entries := make([]PanelInfo, len(tp.panels))
+	for i, p := range tp.panels {
+		entries[i] = PanelInfo{ID: p.ID, Title: p.Title}
+	}
+	return entries
+}
+
 func (tp *TabbedPanel) SetPanelDirty(id string, dirty bool) {
 	tp.Tabs.SetDirty(id, dirty)
 }

--- a/tests/e2e/case_transform_test.go
+++ b/tests/e2e/case_transform_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 func TestUpperCase(t *testing.T) {
@@ -140,5 +142,46 @@ func TestUpperCaseMultiLine(t *testing.T) {
 	}
 	if h.app.EditorGroup.Editor.Buf.Lines[1] != "WORLD" {
 		t.Errorf("expected 'WORLD', got %q", h.app.EditorGroup.Editor.Buf.Lines[1])
+	}
+}
+
+func TestUpperCaseMultiLineUndo(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "undo.txt")
+	os.WriteFile(f, []byte("hello\nworld\nthird\nfourth\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	ed := h.app.EditorGroup.Editor
+	// Select lines 0-2 via shift+down x3
+	for range 3 {
+		h.pressKey(tcell.KeyDown, tcell.ModShift)
+	}
+	h.exec("editor.upperCase")
+	h.redraw()
+
+	if ed.Buf.Lines[0] != "HELLO" {
+		t.Errorf("after transform: expected 'HELLO', got %q", ed.Buf.Lines[0])
+	}
+	if ed.Buf.Lines[3] != "fourth" {
+		t.Errorf("after transform: expected 'fourth' untouched, got %q", ed.Buf.Lines[3])
+	}
+
+	h.exec("editor.undo")
+	h.redraw()
+
+	if ed.Buf.Lines[0] != "hello" {
+		t.Errorf("after 1 undo: expected 'hello', got %q", ed.Buf.Lines[0])
+	}
+	if ed.Buf.Lines[1] != "world" {
+		t.Errorf("after 1 undo: expected 'world', got %q", ed.Buf.Lines[1])
+	}
+	if ed.Buf.Lines[2] != "third" {
+		t.Errorf("after 1 undo: expected 'third', got %q", ed.Buf.Lines[2])
+	}
+	if ed.Buf.Lines[3] != "fourth" {
+		t.Errorf("after 1 undo: expected 'fourth', got %q", ed.Buf.Lines[3])
 	}
 }

--- a/tests/e2e/close_tabs_test.go
+++ b/tests/e2e/close_tabs_test.go
@@ -48,6 +48,40 @@ func TestCloseAllTabsDirtyShowsDialog(t *testing.T) {
 	}
 }
 
+func TestCloseOtherTabsDirtyShowsDialog(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	a := filepath.Join(h.dir, "a.txt")
+	b := filepath.Join(h.dir, "b.txt")
+	os.WriteFile(a, []byte("aaa\n"), 0644)
+	os.WriteFile(b, []byte("bbb\n"), 0644)
+
+	h.app.EditorGroup.OpenFile(a)
+	h.app.EditorGroup.OpenFile(b)
+	h.redraw()
+
+	// b is active (last opened). Dirty it.
+	h.pressRune('X')
+	h.redraw()
+
+	// Switch to a so b becomes "other"
+	h.app.EditorGroup.OpenFile(a)
+	h.redraw()
+
+	active := h.app.EditorGroup.ActiveFileName()
+	if active != "a.txt" {
+		t.Fatalf("expected a.txt active, got %q", active)
+	}
+
+	h.exec("tab.closeOthers")
+	h.redraw()
+
+	if !h.app.Root.HasOverlay() {
+		t.Fatal("expected confirm dialog for dirty other tabs")
+	}
+}
+
 func TestCloseAllSavedKeepsDirty(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()

--- a/tests/e2e/close_tabs_test.go
+++ b/tests/e2e/close_tabs_test.go
@@ -1,0 +1,77 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCloseAllTabsNoDirty(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "clean.txt")
+	os.WriteFile(f, []byte("hello\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.exec("tab.closeAll")
+	h.redraw()
+
+	name := h.app.EditorGroup.ActiveFileName()
+	if name != "untitled" {
+		t.Errorf("expected untitled after close all, got %q", name)
+	}
+}
+
+func TestCloseAllTabsDirtyShowsDialog(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "dirty.txt")
+	os.WriteFile(f, []byte("hello\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.pressRune('X')
+	h.redraw()
+
+	if !h.app.EditorGroup.IsDirty() {
+		t.Fatal("expected dirty buffer")
+	}
+
+	h.exec("tab.closeAll")
+	h.redraw()
+
+	if !h.app.Root.HasOverlay() {
+		t.Fatal("expected confirm dialog for dirty tabs")
+	}
+}
+
+func TestCloseAllSavedKeepsDirty(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	clean := filepath.Join(h.dir, "clean.txt")
+	dirty := filepath.Join(h.dir, "dirty.txt")
+	os.WriteFile(clean, []byte("clean\n"), 0644)
+	os.WriteFile(dirty, []byte("dirty\n"), 0644)
+
+	h.app.EditorGroup.OpenFile(clean)
+	h.app.EditorGroup.OpenFile(dirty)
+	h.redraw()
+
+	h.pressRune('X')
+	h.redraw()
+
+	h.exec("tab.closeAllSaved")
+	h.redraw()
+
+	name := h.app.EditorGroup.ActiveFileName()
+	if name != "dirty.txt" {
+		t.Errorf("expected dirty tab to remain, got %q", name)
+	}
+	if !h.app.EditorGroup.IsDirty() {
+		t.Error("expected remaining tab to be dirty")
+	}
+}

--- a/tests/e2e/goto_line_viewport_test.go
+++ b/tests/e2e/goto_line_viewport_test.go
@@ -1,0 +1,43 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGoToLineViewportPosition(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	var lines []string
+	for i := 1; i <= 100; i++ {
+		lines = append(lines, "line "+string(rune('0'+i/100))+string(rune('0'+(i/10)%10))+string(rune('0'+i%10)))
+	}
+	f := filepath.Join(h.dir, "big.txt")
+	os.WriteFile(f, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.app.EditorGroup.GoToLine(50)
+	h.redraw()
+
+	topLine := h.app.EditorGroup.Editor.Viewport.TopLine
+	cursorLine := h.app.EditorGroup.Editor.Cursor.Line
+	vpHeight := h.app.EditorGroup.Editor.Viewport.Height
+
+	if cursorLine != 49 {
+		t.Fatalf("expected cursor on line 49 (0-indexed), got %d", cursorLine)
+	}
+
+	margin := vpHeight / 3
+	expectedTop := cursorLine - margin
+	if topLine != expectedTop {
+		t.Errorf("expected TopLine ~%d (1/3 margin), got %d", expectedTop, topLine)
+	}
+
+	if cursorLine < topLine || cursorLine >= topLine+vpHeight {
+		t.Errorf("cursor line %d not visible in viewport [%d, %d)", cursorLine, topLine, topLine+vpHeight)
+	}
+}

--- a/tests/e2e/sort_lines_test.go
+++ b/tests/e2e/sort_lines_test.go
@@ -36,12 +36,12 @@ func TestSortLinesAscNoSelection(t *testing.T) {
 	h.app.EditorGroup.OpenFile(f)
 	h.redraw()
 
-	// No selection — sorts all lines including the trailing empty line
+	// No selection — sorts all lines (trailing empty line stays at bottom)
 	h.exec("editor.sortLinesAsc")
 
 	lines := h.app.EditorGroup.Editor.Buf.Lines
-	if lines[0] != "" || lines[1] != "apple" || lines[2] != "banana" || lines[3] != "cherry" {
-		t.Errorf("expected ['', apple, banana, cherry], got %v", lines)
+	if lines[0] != "apple" || lines[1] != "banana" || lines[2] != "cherry" || lines[3] != "" {
+		t.Errorf("expected [apple, banana, cherry, ''], got %v", lines)
 	}
 }
 
@@ -92,12 +92,12 @@ func TestReverseLinesNoSelection(t *testing.T) {
 	h.app.EditorGroup.OpenFile(f)
 	h.redraw()
 
-	// No selection — reverses all lines including trailing empty line
+	// No selection — reverses all lines (trailing empty line stays at bottom)
 	h.exec("editor.reverseLines")
 
 	lines := h.app.EditorGroup.Editor.Buf.Lines
-	if lines[0] != "" || lines[1] != "third" || lines[2] != "second" || lines[3] != "first" {
-		t.Errorf("expected ['', third, second, first], got %v", lines)
+	if lines[0] != "third" || lines[1] != "second" || lines[2] != "first" || lines[3] != "" {
+		t.Errorf("expected [third, second, first, ''], got %v", lines)
 	}
 }
 
@@ -131,12 +131,12 @@ func TestSortLinesUndo(t *testing.T) {
 	h.app.EditorGroup.OpenFile(f)
 	h.redraw()
 
-	// No selection — sort all lines
+	// No selection — sort all lines (trailing empty line stays at bottom)
 	h.exec("editor.sortLinesAsc")
 
 	lines := h.app.EditorGroup.Editor.Buf.Lines
-	if lines[0] != "" {
-		t.Errorf("expected first line '' after sort, got %q", lines[0])
+	if lines[0] != "apple" || lines[1] != "banana" || lines[2] != "cherry" || lines[3] != "" {
+		t.Errorf("expected [apple, banana, cherry, ''] after sort, got %v", lines)
 	}
 
 	// Undo should restore original order

--- a/tests/e2e/undo_dirty_test.go
+++ b/tests/e2e/undo_dirty_test.go
@@ -1,0 +1,65 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUndoToClearsDirty(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "dirty.txt")
+	os.WriteFile(f, []byte("hello\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.pressRune('X')
+	h.redraw()
+
+	if !h.app.EditorGroup.IsDirty() {
+		t.Fatal("expected dirty after typing")
+	}
+
+	h.exec("editor.undo")
+	h.redraw()
+
+	if h.app.EditorGroup.IsDirty() {
+		t.Fatal("expected clean after undo to original state")
+	}
+}
+
+func TestUndoToSavePoint(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "savepoint.txt")
+	os.WriteFile(f, []byte("hello\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.pressRune('A')
+	h.redraw()
+
+	h.app.EditorGroup.Save()
+	h.redraw()
+
+	if h.app.EditorGroup.IsDirty() {
+		t.Fatal("expected clean after save")
+	}
+
+	h.pressRune('B')
+	h.redraw()
+
+	if !h.app.EditorGroup.IsDirty() {
+		t.Fatal("expected dirty after typing post-save")
+	}
+
+	h.exec("editor.undo")
+	h.redraw()
+
+	if h.app.EditorGroup.IsDirty() {
+		t.Fatal("expected clean after undo to save point")
+	}
+}

--- a/tests/functional/case-transform.test.js
+++ b/tests/functional/case-transform.test.js
@@ -79,8 +79,6 @@ describe("case transforms", () => {
 
     tui.press("ctrl+z");
     tui.waitStable();
-    tui.press("ctrl+z");
-    tui.waitStable();
 
     snap = tui.snapshot();
     expect(snap).toContain("hello world");


### PR DESCRIPTION
## Summary

- **12 bugs fixed**: close tabs unsaved confirm, open non-existent file, GoToLine viewport, file picker truncation, Go to Line clamping, undo save point dirty tracking, sort/reverse trailing empty line, Show Panel Tab display names, Focus Terminal keyboard focus, command palette click-outside dismiss, menu bar hover switching
- **3 issues created**: cut/copy without selection (#278), sidebar active tab indicator (#279), file picker horizontal scroll (#277)
- **13 marked not-a-bug/by-design**: terminal toggle behavior, search focus, fold indicators, explorer click focus, tab close button visibility, file naming, border styles, etc.
- **3 deferred/duplicates**: debug focus field, settings reload notification
- Added `hover` command to `--exec` debug harness
- Added Explorer Shortcuts help entries for click/double-click
- E2E tests for close tabs, GoToLine viewport, undo dirty tracking

## Test plan
- [x] `make test` passes
- [x] `make build` succeeds
- [x] `--exec` screenshot verification for key fixes
- [ ] Manual verification of menu hover switching
- [ ] Functional tests (LSP failures expected/known)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm