### PR TITLE
fix: Cyrillic cursor drift (#281)

### DIFF
--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -1270,8 +1270,9 @@ func leadingWhitespace(s string) string {
 
 func bufColToVisualCol(line string, bufCol, tabW int) int {
 	visCol := 0
-	for i, ch := range line {
-		if i >= bufCol {
+	ri := 0
+	for _, ch := range line {
+		if ri >= bufCol {
 			break
 		}
 		if ch == '\t' {
@@ -1279,25 +1280,28 @@ func bufColToVisualCol(line string, bufCol, tabW int) int {
 		} else {
 			visCol++
 		}
+		ri++
 	}
 	return visCol
 }
 
 func visualColToBufCol(line string, targetVisCol, tabW int) int {
 	visCol := 0
-	for i, ch := range line {
+	ri := 0
+	for _, ch := range line {
 		if visCol >= targetVisCol {
-			return i
+			return ri
 		}
 		if ch == '\t' {
 			nextStop := ((visCol / tabW) + 1) * tabW
 			if targetVisCol < nextStop {
-				return i
+				return ri
 			}
 			visCol = nextStop
 		} else {
 			visCol++
 		}
+		ri++
 	}
 	return len([]rune(line))
 }

--- a/internal/ui/tab_indent_test.go
+++ b/internal/ui/tab_indent_test.go
@@ -20,6 +20,10 @@ func TestBufColToVisualCol(t *testing.T) {
 		{"tab after text", "ab\tc", 3, 4, 4},
 		{"empty line", "", 0, 4, 0},
 		{"at end of line", "abc", 3, 4, 3},
+		{"cyrillic full", "Привет", 6, 4, 6},
+		{"cyrillic partial", "Привет", 3, 4, 3},
+		{"cyrillic with tab", "\tПривет", 4, 4, 7},
+		{"mixed ascii cyrillic", "hiПривет", 5, 4, 5},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,6 +50,9 @@ func TestVisualColToBufCol(t *testing.T) {
 		{"click past line end", "abc", 10, 4, 3},
 		{"two tabs click between", "\t\thello", 5, 4, 1},
 		{"spaces", "    abc", 4, 4, 4},
+		{"cyrillic click", "Привет", 3, 4, 3},
+		{"cyrillic click end", "Привет", 6, 4, 6},
+		{"cyrillic click past", "Привет", 10, 4, 6},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix `bufColToVisualCol` and `visualColToBufCol` to use rune index instead of Go's range loop byte index, which caused cursor drift on multi-byte UTF-8 text (Cyrillic, CJK, etc.)
- Add 7 unit tests covering Cyrillic strings, mixed ASCII/Cyrillic, and Cyrillic with tabs

## Test plan
- [x] Unit tests fail on broken code (TDD red step confirmed)
- [x] Unit tests pass after fix (TDD green step confirmed)
- [x] Full test suite passes (`make test`)
- [x] Build succeeds (`make build`)

Fixes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm