### PR TITLE
feat: plugin marketplace with detail tabs and monorepo support

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
 
 	"github.com/gdamore/tcell/v2"
 )
@@ -260,8 +261,8 @@ Docs: https://tttedit.dev
 	pluginsPanel := app.NewPluginsPanel(pluginManager)
 	editor.Sidebar.AddPanel("plugins", "Plugins", pluginsPanel.Adapter)
 	editor.PluginsPanel = pluginsPanel
-	pluginsPanel.OnInstall = func(repoURL string) {
-		editor.PluginInstallFromURL(repoURL)
+	pluginsPanel.OnInstall = func(repoURL, repoPath, name string) {
+		editor.PluginInstallFromURL(repoURL, repoPath, name)
 	}
 	pluginsPanel.OnUninstall = func(name string) {
 		editor.PluginUninstallByName(name)
@@ -279,14 +280,16 @@ Docs: https://tttedit.dev
 	pluginsPanel.OnUpdate = func(name string) {
 		editor.PluginUpdateByName(name)
 	}
+	pluginsPanel.OnOpenDetail = func(entry plugin.RemoteRegistryEntry) {
+		editor.OpenPluginDetail(entry)
+	}
+	pluginsPanel.OnDropdownMenu = func(entries []widgets.MenuEntry, screenX, screenY int) {
+		editor.ShowPluginDropdownMenu(entries, screenX, screenY)
+	}
 
 	go func() {
 		entries, err := plugin.FetchRemoteRegistry(plugin.DefaultRegistryURL)
-		if err != nil {
-			slog.Debug("fetch plugin registry", "error", err)
-			return
-		}
-		screen.PostEvent(tcell.NewEventInterrupt(&app.RemoteRegistryResult{Entries: entries}))
+		screen.PostEvent(tcell.NewEventInterrupt(&app.RemoteRegistryResult{Entries: entries, Err: err}))
 	}()
 
 	if len(pendingApprovals) > 0 {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,0 +1,66 @@
+[
+  {
+    "name": "cheat-sheet",
+    "author": "eugenioenko",
+    "description": "Fetch programming cheat sheets from cheat.sh and display them in an editor tab",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-cheat-sheet",
+    "version": "0.1.0",
+    "tags": ["reference", "cheatsheet", "documentation", "learning"]
+  },
+  {
+    "name": "color-picker",
+    "author": "eugenioenko",
+    "description": "Open a drawer with color swatches. Click a color to insert its hex value at the cursor",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-color-picker",
+    "version": "0.1.0",
+    "tags": ["color", "css", "design", "utility"]
+  },
+  {
+    "name": "docker-manager",
+    "author": "eugenioenko",
+    "description": "Manage Docker containers, images and volumes",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-docker-manager",
+    "version": "0.1.0",
+    "tags": ["docker", "containers", "devops", "infrastructure"]
+  },
+  {
+    "name": "go-test-runner",
+    "author": "eugenioenko",
+    "description": "Run Go tests and view results in a sidebar panel",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-go-test-runner",
+    "version": "0.1.0",
+    "tags": ["go", "testing", "runner", "golang"]
+  },
+  {
+    "name": "http-client",
+    "author": "eugenioenko",
+    "description": "Simple HTTP client for testing APIs",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-http-client",
+    "version": "0.1.0",
+    "tags": ["http", "api", "rest", "networking"]
+  },
+  {
+    "name": "markdown-preview",
+    "author": "eugenioenko",
+    "description": "Preview markdown files with styled rendering",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-markdown-preview",
+    "version": "0.1.0",
+    "tags": ["markdown", "preview", "documentation", "writing"]
+  },
+  {
+    "name": "notepad",
+    "author": "eugenioenko",
+    "description": "Persistent scratchpad for jotting down notes per workspace",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-notepad",
+    "version": "0.1.0",
+    "tags": ["notes", "scratchpad", "productivity", "utility"]
+  },
+  {
+    "name": "todo-scanner",
+    "author": "eugenioenko",
+    "description": "Scans workspace for TODO, FIXME, HACK, and NOTE comments",
+    "repo": "https://github.com/eugenioenko/ttt-plugin-todo-scanner",
+    "version": "0.1.0",
+    "tags": ["todo", "scanner", "productivity", "comments"]
+  }
+]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -82,6 +82,7 @@ type App struct {
 	PendingPluginApprovals  []*plugin.Plugin
 	PluginsPanel            *PluginsPanel
 	Output                  *ui.OutputWidget
+	pluginDetailWidgets     map[string]*pluginDetailState
 }
 
 func (a *App) KeyFor(cmd string) string {
@@ -392,6 +393,9 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		if a.PluginManager != nil {
 			a.PluginManager.DispatchEvent("file.close", path)
 		}
+	}
+	a.EditorGroup.OnContentTabClose = func(id string) {
+		a.cleanupPluginDetailTab(id)
 	}
 	if path := a.EditorGroup.ActiveFilePath(); path != "" {
 		if a.EditorGroup.Editor != nil && a.EditorGroup.Editor.Highlighter != nil {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -107,7 +107,7 @@ func (a *App) showPluginList() {
 func (a *App) pluginInstall() {
 	a.ShowInputDialogEx("Install Plugin", "Repository URL", "", "Install", func(repoURL string) {
 		go func() {
-			p, err := a.PluginManager.Install(repoURL)
+			p, err := a.PluginManager.Install(repoURL, "")
 			a.Screen.PostEvent(tcell.NewEventInterrupt(&pluginInstallResult{
 				plugin: p,
 				err:    err,
@@ -118,19 +118,29 @@ func (a *App) pluginInstall() {
 
 type pluginInstallResult struct {
 	plugin *plugin.Plugin
+	name   string
 	err    error
 }
 
 func (a *App) handlePluginInstallResult(result *pluginInstallResult) {
 	if result.err != nil {
+		a.resetPluginDetailButton(result.name)
 		a.ShowConfirmDialogEx("Install Failed", result.err.Error(), []string{"Close"}, []func(){
 			func() { a.DismissDialog() },
 		})
 		return
 	}
+	a.updatePluginDetailButtons()
 	a.PendingPluginApprovals = append(a.PendingPluginApprovals, result.plugin)
 	if len(a.PendingPluginApprovals) == 1 {
 		a.ShowPluginApprovalDialog(result.plugin)
+	}
+}
+
+func (a *App) resetPluginDetailButton(name string) {
+	if state, ok := a.pluginDetailWidgets[name]; ok {
+		state.installBtn.SetLabel("Install")
+		state.installBtn.Disabled = false
 	}
 }
 
@@ -167,6 +177,7 @@ func (a *App) doPluginUninstall(name string) {
 		slog.Error("plugin uninstall", "error", err)
 	}
 
+	a.resetPluginDetailButton(name)
 	if a.PluginsPanel != nil {
 		a.PluginsPanel.Refresh()
 	}
@@ -249,6 +260,7 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 	dialog.Buttons = []widgets.DialogButton{
 		{Label: "&Cancel", Handler: func() {
 			a.DismissDialog()
+			a.resetPluginDetailButton(p.Manifest.Name)
 			a.showNextPluginApproval()
 		}},
 		{Label: "&Allow", Handler: func() {
@@ -256,6 +268,7 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 			if err := a.PluginManager.ApproveAndLoad(p); err == nil {
 				a.WirePlugin(p)
 			}
+			a.updatePluginDetailButtons()
 			if a.PluginsPanel != nil {
 				a.PluginsPanel.Refresh()
 			}
@@ -264,6 +277,7 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 	}
 	dialog.OnDismiss = func() {
 		a.DismissDialog()
+		a.resetPluginDetailButton(p.Manifest.Name)
 		a.showNextPluginApproval()
 	}
 	dialog.Build()
@@ -401,7 +415,7 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 		a.DismissDialog()
 	}
 	p.OpenTab = func(id string, panel *plugin.PluginPanelWidget) {
-		a.EditorGroup.OpenPluginTab(id, panel)
+		a.EditorGroup.OpenPluginTab(id, id, panel)
 	}
 	p.CloseTab = func(id string) {
 		a.EditorGroup.ClosePluginTab(id)
@@ -558,13 +572,15 @@ func (a *App) pluginReloadAll() {
 
 type RemoteRegistryResult struct {
 	Entries []plugin.RemoteRegistryEntry
+	Err     error
 }
 
-func (a *App) PluginInstallFromURL(repoURL string) {
+func (a *App) PluginInstallFromURL(repoURL, repoPath, name string) {
 	go func() {
-		p, err := a.PluginManager.Install(repoURL)
+		p, err := a.PluginManager.Install(repoURL, repoPath)
 		a.Screen.PostEvent(tcell.NewEventInterrupt(&pluginInstallResult{
 			plugin: p,
+			name:   name,
 			err:    err,
 		}))
 	}()
@@ -593,9 +609,60 @@ func (a *App) PluginUpdateByName(name string) {
 }
 
 func (a *App) handleRemoteRegistryResult(result *RemoteRegistryResult) {
-	if a.PluginsPanel != nil {
-		a.PluginsPanel.SetAvailable(result.Entries)
+	if a.PluginsPanel == nil {
+		return
 	}
+	if result.Err != nil {
+		a.PluginsPanel.SearchTree.Config.EmptyText = "Could not load registry"
+		a.PluginsPanel.SearchTree.SetItems(nil)
+		return
+	}
+	a.PluginsPanel.SetAvailable(result.Entries)
+}
+
+func (a *App) ShowPluginDropdownMenu(entries []widgets.MenuEntry, x, y int) {
+	items := make([]ui.ContextMenuItem, len(entries))
+	for i, e := range entries {
+		items[i] = ui.ContextMenuItem{
+			Label:   e.Label,
+			Command: e.Command,
+			IsSep:   e.Separator,
+		}
+	}
+	menu := ui.NewContextMenuWidget(items, x, y)
+	menu.Borders = a.Borders
+	menu.OnExec = func(cmd string) {
+		a.Root.PopOverlay()
+		a.handlePluginDropdownCommand(cmd)
+	}
+	menu.OnDismiss = func() {
+		a.Root.PopOverlay()
+	}
+	a.Root.PushOverlay(ui.Overlay{Widget: menu, Modal: true})
+	a.Root.SetFocus(menu)
+}
+
+func (a *App) handlePluginDropdownCommand(cmd string) {
+	switch cmd {
+	case "updateAll":
+		names := a.PluginManager.InstalledPluginNames()
+		for _, name := range names {
+			a.PluginUpdateByName(name)
+		}
+	case "refresh":
+		a.PluginRefreshRegistry()
+	}
+}
+
+func (a *App) PluginRefreshRegistry() {
+	if a.PluginsPanel != nil {
+		a.PluginsPanel.SearchTree.Config.EmptyText = "Loading plugins..."
+		a.PluginsPanel.SearchTree.SetItems(nil)
+	}
+	go func() {
+		entries, err := plugin.FetchRemoteRegistry(plugin.DefaultRegistryURL)
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&RemoteRegistryResult{Entries: entries, Err: err}))
+	}()
 }
 
 func (a *App) showNextPluginApproval() {

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -312,6 +312,8 @@ func RunEventLoop(
 				app.handlePluginUpdateResult(v)
 			case *RemoteRegistryResult:
 				app.handleRemoteRegistryResult(v)
+			case *pluginReadmeResult:
+				app.handlePluginReadmeResult(v)
 			case *PrFetchResult:
 				if v.Err != nil {
 					app.StatusError("PR fetch failed: " + v.Err.Error())

--- a/internal/app/plugin_detail.go
+++ b/internal/app/plugin_detail.go
@@ -36,7 +36,7 @@ func (a *App) OpenPluginDetail(entry plugin.RemoteRegistryEntry) {
 
 	installBtn := widgets.NewButtonWidget(widgets.ButtonConfig{
 		Label: "Install",
-		Style: term.StyleSuccess,
+		Style: term.StyleDefault,
 		OnClick: func() {
 			if a.PluginsPanel != nil && a.PluginsPanel.OnInstall != nil {
 				a.PluginsPanel.OnInstall(entry.Repo, entry.Path, entry.Name)
@@ -89,14 +89,17 @@ func (a *App) OpenPluginDetail(entry plugin.RemoteRegistryEntry) {
 		headerWidgets = append(headerWidgets, tagsLabel)
 	}
 
-	divider := widgets.NewDividerWidget(widgets.DividerConfig{})
-	headerWidgets = append(headerWidgets, divider)
-
 	header := widgets.NewVStackWidget(headerWidgets...)
+	header.Box.PaddingLeft = 1
+	header.Box.PaddingRight = 1
+
+	divider := widgets.NewDividerWidget(widgets.DividerConfig{})
 
 	scroll := widgets.NewScrollViewWidget(md)
+	scroll.Box.PaddingLeft = 1
+	scroll.Box.PaddingRight = 1
 
-	content := widgets.NewVStackWidget(header, scroll)
+	content := widgets.NewVStackWidget(header, divider, scroll)
 	adapter := ui.NewWidgetAdapter(content)
 
 	a.EditorGroup.OpenPluginTab(tabID, entry.Name, adapter)

--- a/internal/app/plugin_detail.go
+++ b/internal/app/plugin_detail.go
@@ -1,0 +1,189 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/plugin"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+type pluginReadmeResult struct {
+	name    string
+	content string
+	err     error
+}
+
+type pluginDetailState struct {
+	markdown   *widgets.MarkdownWidget
+	installBtn *widgets.ButtonWidget
+}
+
+func (a *App) OpenPluginDetail(entry plugin.RemoteRegistryEntry) {
+	tabID := "plugin-detail:" + entry.Name
+
+	md := widgets.NewMarkdownWidget()
+	md.SetContent("Loading README...")
+
+	installed := a.isPluginInstalled(entry.Name)
+
+	installBtn := widgets.NewButtonWidget(widgets.ButtonConfig{
+		Label: "Install",
+		Style: term.StyleSuccess,
+		OnClick: func() {
+			if a.PluginsPanel != nil && a.PluginsPanel.OnInstall != nil {
+				a.PluginsPanel.OnInstall(entry.Repo, entry.Path, entry.Name)
+				if state, ok := a.pluginDetailWidgets[entry.Name]; ok {
+					state.installBtn.SetLabel("Installing...")
+					state.installBtn.Disabled = true
+				}
+			}
+		},
+	})
+
+	if installed {
+		installBtn.SetLabel("Installed")
+		installBtn.Disabled = true
+	}
+
+	a.pluginDetailWidgets[entry.Name] = &pluginDetailState{
+		markdown:   md,
+		installBtn: installBtn,
+	}
+
+	nameLabel := widgets.NewLabelWidget(widgets.LabelConfig{
+		Text:  entry.Name,
+		Style: term.StyleHoverBold,
+	})
+
+	headerRow := widgets.NewHStackWidget(nameLabel, installBtn)
+	headerRow.FixedHeight = 1
+
+	var metaParts []string
+	if entry.Version != "" {
+		metaParts = append(metaParts, "v"+entry.Version)
+	}
+	metaParts = append(metaParts, entry.Author)
+	metaLabel := widgets.NewLabelWidget(widgets.LabelConfig{
+		Text:  strings.Join(metaParts, " · "),
+		Style: term.StyleMuted,
+	})
+
+	descLabel := widgets.NewParagraphWidget(entry.Description)
+	descLabel.Style = term.StyleDefault
+
+	headerWidgets := []widgets.Widget{headerRow, metaLabel, descLabel}
+
+	if len(entry.Tags) > 0 {
+		tagsLabel := widgets.NewLabelWidget(widgets.LabelConfig{
+			Text:  strings.Join(entry.Tags, " · "),
+			Style: term.StyleMuted,
+		})
+		headerWidgets = append(headerWidgets, tagsLabel)
+	}
+
+	divider := widgets.NewDividerWidget(widgets.DividerConfig{})
+	headerWidgets = append(headerWidgets, divider)
+
+	header := widgets.NewVStackWidget(headerWidgets...)
+
+	scroll := widgets.NewScrollViewWidget(md)
+
+	content := widgets.NewVStackWidget(header, scroll)
+	adapter := ui.NewWidgetAdapter(content)
+
+	a.EditorGroup.OpenPluginTab(tabID, entry.Name, adapter)
+
+	go func() {
+		readme, err := fetchPluginReadme(entry.Repo, entry.Path)
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&pluginReadmeResult{
+			name:    entry.Name,
+			content: readme,
+			err:     err,
+		}))
+	}()
+}
+
+func (a *App) handlePluginReadmeResult(result *pluginReadmeResult) {
+	state, ok := a.pluginDetailWidgets[result.name]
+	if !ok {
+		return
+	}
+	if result.err != nil {
+		state.markdown.SetContent(fmt.Sprintf("Could not load README: %s", result.err))
+	} else {
+		state.markdown.SetContent(result.content)
+	}
+}
+
+func (a *App) updatePluginDetailButtons() {
+	for name, state := range a.pluginDetailWidgets {
+		if a.isPluginInstalled(name) {
+			state.installBtn.SetLabel("Installed")
+			state.installBtn.Disabled = true
+		}
+	}
+}
+
+func (a *App) cleanupPluginDetailTab(id string) {
+	const prefix = "plugin-detail:"
+	if name, ok := strings.CutPrefix(id, prefix); ok {
+		delete(a.pluginDetailWidgets, name)
+	}
+}
+
+func (a *App) isPluginInstalled(name string) bool {
+	for _, n := range a.PluginManager.InstalledPluginNames() {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchPluginReadme(repoURL, repoPath string) (string, error) {
+	rawURL := repoToRawReadme(repoURL, repoPath)
+	if rawURL == "" {
+		return "", fmt.Errorf("unsupported repository URL")
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch readme: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("readme returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read readme: %w", err)
+	}
+
+	return string(body), nil
+}
+
+func repoToRawReadme(repoURL, repoPath string) string {
+	repoURL = strings.TrimSuffix(repoURL, "/")
+	repoURL = strings.TrimSuffix(repoURL, ".git")
+
+	if path, ok := strings.CutPrefix(repoURL, "https://github.com/"); ok {
+		prefix := "https://raw.githubusercontent.com/" + path + "/main/"
+		if repoPath != "" {
+			return prefix + repoPath + "/README.md"
+		}
+		return prefix + "README.md"
+	}
+
+	return ""
+}

--- a/internal/app/plugins_panel.go
+++ b/internal/app/plugins_panel.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"strings"
+
 	"github.com/eugenioenko/ttt/internal/plugin"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -8,16 +10,22 @@ import (
 )
 
 type PluginsPanel struct {
-	Tree    *widgets.TreeWidget
-	Adapter *ui.WidgetAdapter
-	manager *plugin.Manager
+	SearchInput   *widgets.InputWidget
+	SearchTree    *widgets.TreeWidget
+	InstalledTree *widgets.TreeWidget
+	Dropdown      *widgets.DropdownWidget
+	Adapter       *ui.WidgetAdapter
+	manager       *plugin.Manager
 
-	OnInstall   func(repoURL string)
-	OnUninstall func(name string)
-	OnToggle    func(name string, enabled bool)
-	OnUpdate    func(name string)
+	OnInstall      func(repoURL, repoPath, name string)
+	OnUninstall    func(name string)
+	OnToggle       func(name string, enabled bool)
+	OnUpdate       func(name string)
+	OnOpenDetail   func(entry plugin.RemoteRegistryEntry)
+	OnDropdownMenu func(entries []widgets.MenuEntry, screenX, screenY int)
 
-	available []plugin.RemoteRegistryEntry
+	available   []plugin.RemoteRegistryEntry
+	searchQuery string
 }
 
 func NewPluginsPanel(mgr *plugin.Manager) *PluginsPanel {
@@ -25,7 +33,42 @@ func NewPluginsPanel(mgr *plugin.Manager) *PluginsPanel {
 		manager: mgr,
 	}
 
-	pp.Tree = widgets.NewTreeWidget(widgets.TreeConfig{
+	pp.SearchInput = widgets.NewInputWidget(widgets.InputConfig{
+		Placeholder: "Search plugins",
+		OnChange: func(text string) {
+			pp.searchQuery = strings.TrimSpace(text)
+			pp.refreshAvailable()
+		},
+	})
+
+	pp.SearchTree = widgets.NewTreeWidget(widgets.TreeConfig{
+		EmptyText: "Loading plugins...",
+		Indent:    1,
+		OnSelect: func(node *widgets.TreeNode) {
+			for _, entry := range pp.available {
+				if node.ID == "available."+entry.Name {
+					if pp.OnOpenDetail != nil {
+						pp.OnOpenDetail(entry)
+					}
+					return
+				}
+			}
+		},
+		OnCommand: func(cmd string, node *widgets.TreeNode) {
+			if cmd == "activate" {
+				for _, entry := range pp.available {
+					if node.ID == "available."+entry.Name {
+						if pp.OnInstall != nil {
+							pp.OnInstall(entry.Repo, entry.Path, entry.Name)
+						}
+						return
+					}
+				}
+			}
+		},
+	})
+
+	pp.InstalledTree = widgets.NewTreeWidget(widgets.TreeConfig{
 		EmptyText: "No plugins installed",
 		Indent:    1,
 		OnCommand: func(cmd string, node *widgets.TreeNode) {
@@ -33,30 +76,51 @@ func NewPluginsPanel(mgr *plugin.Manager) *PluginsPanel {
 		},
 	})
 
-	pp.Adapter = ui.NewWidgetAdapter(pp.Tree)
+	pp.Dropdown = widgets.NewDropdownWidget(widgets.DropdownConfig{
+		Entries: []widgets.MenuEntry{
+			{Label: "Update All", Command: "updateAll"},
+			{Label: "Refresh", Command: "refresh"},
+		},
+		OnMenu: func(entries []widgets.MenuEntry, screenX, screenY int) {
+			if pp.OnDropdownMenu != nil {
+				pp.OnDropdownMenu(entries, screenX, screenY)
+			}
+		},
+	})
+
+	titleLabel := widgets.NewLabelWidget(widgets.LabelConfig{
+		Text:  "Installed",
+		Style: term.StyleDefault,
+	})
+
+	titleLabel.Box.PaddingLeft = 1
+
+	divider := widgets.NewDividerWidget(widgets.DividerConfig{})
+
+	titleRow := widgets.NewHStackWidget(titleLabel, pp.Dropdown)
+	titleRow.FixedHeight = 1
+
+	divSearch := widgets.NewDividerWidget(widgets.DividerConfig{})
+	divInstalled := widgets.NewDividerWidget(widgets.DividerConfig{})
+
+	vstack := widgets.NewVStackWidget(
+		pp.SearchInput,
+		divSearch,
+		pp.SearchTree,
+		divInstalled,
+		titleRow,
+		divider,
+		pp.InstalledTree,
+	)
+
+	pp.Adapter = ui.NewWidgetAdapter(vstack)
 	pp.Refresh()
 	return pp
 }
 
 func (pp *PluginsPanel) handleCommand(cmd string, node *widgets.TreeNode) {
 	switch cmd {
-	case "activate":
-		if node.ID != "" && node.Expandable {
-			return
-		}
-		for _, entry := range pp.available {
-			if node.ID == "available."+entry.Name {
-				if pp.OnInstall != nil {
-					pp.OnInstall(entry.Repo)
-				}
-				return
-			}
-		}
-	case "uninstall":
-		if pp.OnUninstall != nil {
-			pp.OnUninstall(node.ID)
-		}
-	case "toggle":
+	case "activate", "toggle":
 		reg := pp.manager.Registry()
 		if reg == nil {
 			return
@@ -68,6 +132,10 @@ func (pp *PluginsPanel) handleCommand(cmd string, node *widgets.TreeNode) {
 		if pp.OnToggle != nil {
 			pp.OnToggle(node.ID, !entry.Enabled)
 		}
+	case "uninstall":
+		if pp.OnUninstall != nil {
+			pp.OnUninstall(node.ID)
+		}
 	case "update":
 		if pp.OnUpdate != nil {
 			pp.OnUpdate(node.ID)
@@ -76,17 +144,9 @@ func (pp *PluginsPanel) handleCommand(cmd string, node *widgets.TreeNode) {
 }
 
 func (pp *PluginsPanel) Refresh() {
-	var items []*widgets.TreeNode
-
-	installedSection := &widgets.TreeNode{
-		ID:         "_installed",
-		Label:      "INSTALLED",
-		Expandable: true,
-		Expanded:   true,
-	}
+	var installed []*widgets.TreeNode
 
 	reg := pp.manager.Registry()
-	plugins := pp.manager.Plugins()
 	names := pp.manager.InstalledPluginNames()
 
 	for _, name := range names {
@@ -120,45 +180,73 @@ func (pp *PluginsPanel) Refresh() {
 				{Icon: "×", Command: "uninstall"},
 			},
 		}
-		installedSection.Children = append(installedSection.Children, node)
+		installed = append(installed, node)
 	}
 
-	_ = plugins
-	items = append(items, installedSection)
+	pp.InstalledTree.SetItems(installed)
+	pp.refreshAvailable()
+}
 
-	if len(pp.available) > 0 {
-		availableSection := &widgets.TreeNode{
-			ID:         "_available",
-			Label:      "AVAILABLE",
-			Expandable: true,
-			Expanded:   true,
-		}
-
-		installed := make(map[string]bool)
-		for _, name := range names {
-			installed[name] = true
-		}
-
-		for _, entry := range pp.available {
-			if installed[entry.Name] {
-				continue
-			}
-			availableSection.Children = append(availableSection.Children, &widgets.TreeNode{
-				ID:    "available." + entry.Name,
-				Label: entry.Name,
-				Badge: entry.Description,
-			})
-		}
-
-		if len(availableSection.Children) > 0 {
-			items = append(items, availableSection)
-		}
+func (pp *PluginsPanel) refreshAvailable() {
+	if len(pp.available) == 0 {
+		pp.SearchTree.SetItems(nil)
+		return
 	}
 
-	pp.Tree.SetItems(items)
+	installedSet := make(map[string]bool)
+	for _, name := range pp.manager.InstalledPluginNames() {
+		installedSet[name] = true
+	}
+
+	var items []*widgets.TreeNode
+	for _, entry := range pp.available {
+		if installedSet[entry.Name] {
+			continue
+		}
+		if pp.searchQuery != "" && !matchesSearch(entry, pp.searchQuery) {
+			continue
+		}
+		items = append(items, &widgets.TreeNode{
+			ID:    "available." + entry.Name,
+			Label: entry.Name,
+			Badge: entry.Description,
+		})
+	}
+
+	pp.SearchTree.SetItems(items)
+}
+
+func matchesSearch(entry plugin.RemoteRegistryEntry, query string) bool {
+	query = strings.ToLower(query)
+	terms := strings.Fields(query)
+	for _, t := range terms {
+		if !termMatches(entry, t) {
+			return false
+		}
+	}
+	return true
+}
+
+func termMatches(entry plugin.RemoteRegistryEntry, t string) bool {
+	if strings.Contains(strings.ToLower(entry.Name), t) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(entry.Description), t) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(entry.Author), t) {
+		return true
+	}
+	for _, tag := range entry.Tags {
+		if strings.Contains(strings.ToLower(tag), t) {
+			return true
+		}
+	}
+	return false
 }
 
 func (pp *PluginsPanel) SetAvailable(entries []plugin.RemoteRegistryEntry) {
 	pp.available = entries
+	pp.SearchTree.Config.EmptyText = "Type to search plugins"
 	pp.Refresh()
 }

--- a/internal/app/plugins_panel.go
+++ b/internal/app/plugins_panel.go
@@ -44,22 +44,12 @@ func NewPluginsPanel(mgr *plugin.Manager) *PluginsPanel {
 	pp.SearchTree = widgets.NewTreeWidget(widgets.TreeConfig{
 		EmptyText: "Loading plugins...",
 		Indent:    1,
-		OnSelect: func(node *widgets.TreeNode) {
-			for _, entry := range pp.available {
-				if node.ID == "available."+entry.Name {
-					if pp.OnOpenDetail != nil {
-						pp.OnOpenDetail(entry)
-					}
-					return
-				}
-			}
-		},
 		OnCommand: func(cmd string, node *widgets.TreeNode) {
 			if cmd == "activate" {
 				for _, entry := range pp.available {
 					if node.ID == "available."+entry.Name {
-						if pp.OnInstall != nil {
-							pp.OnInstall(entry.Repo, entry.Path, entry.Name)
+						if pp.OnOpenDetail != nil {
+							pp.OnOpenDetail(entry)
 						}
 						return
 					}

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -215,9 +215,10 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		Problems:          problems,
 		References:        references,
 		Output:            output,
-		DocVersions:       make(map[string]int),
-		AllDiagnostics:    make(map[string][]ui.Diagnostic),
-		LspNotified:       make(map[string]bool),
+		DocVersions:         make(map[string]int),
+		AllDiagnostics:      make(map[string][]ui.Diagnostic),
+		LspNotified:         make(map[string]bool),
+		pluginDetailWidgets: make(map[string]*pluginDetailState),
 	}
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -87,6 +87,9 @@ func (m *Manager) LoadAll() []*Plugin {
 				continue
 			}
 
+			p.Repo = regEntry.Repo
+			p.RepoPath = regEntry.Path
+
 			if !regEntry.Enabled {
 				continue
 			}
@@ -152,6 +155,7 @@ func (m *Manager) ApproveAndLoad(p *Plugin) error {
 	m.registry.AddOrUpdate(
 		p.Manifest.Name,
 		p.Repo,
+		p.RepoPath,
 		p.Manifest.Version,
 		p.Manifest.Permissions,
 	)
@@ -231,10 +235,15 @@ func (m *Manager) DispatchEvent(name string, args ...interface{}) {
 	}
 }
 
-func (m *Manager) Install(repoURL string) (*Plugin, error) {
+func (m *Manager) Install(repoURL, repoPath string) (*Plugin, error) {
 	if !strings.HasPrefix(repoURL, "https://") {
 		return nil, fmt.Errorf("only https:// URLs are allowed for plugin install")
 	}
+
+	if repoPath != "" {
+		return m.installFromSubdir(repoURL, repoPath)
+	}
+
 	name := filepath.Base(repoURL)
 	name = strings.TrimSuffix(name, ".git")
 	if name == "" || name == "." {
@@ -263,6 +272,75 @@ func (m *Manager) Install(repoURL string) (*Plugin, error) {
 		Repo:     repoURL,
 		Manifest: manifest,
 	}, nil
+}
+
+func (m *Manager) installFromSubdir(repoURL, repoPath string) (*Plugin, error) {
+	tmpDir, err := os.MkdirTemp("", "ttt-plugin-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cmd := exec.Command("git", "clone", "--depth", "1", repoURL, tmpDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("git clone failed: %s: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	srcDir := filepath.Join(tmpDir, repoPath)
+	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("path %q not found in repository", repoPath)
+	}
+
+	manifest, err := LoadManifest(srcDir)
+	if err != nil {
+		return nil, fmt.Errorf("invalid plugin: %w", err)
+	}
+
+	targetDir := filepath.Join(m.pluginsDir, manifest.Name)
+	if _, err := os.Stat(targetDir); err == nil {
+		return nil, fmt.Errorf("plugin %q already exists", manifest.Name)
+	}
+
+	if err := copyDir(srcDir, targetDir); err != nil {
+		os.RemoveAll(targetDir)
+		return nil, fmt.Errorf("copy plugin: %w", err)
+	}
+
+	return &Plugin{
+		Name:     manifest.Name,
+		Dir:      targetDir,
+		Repo:     repoURL,
+		RepoPath: repoPath,
+		Manifest: manifest,
+	}, nil
+}
+
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		srcPath := filepath.Join(src, e.Name())
+		dstPath := filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			data, err := os.ReadFile(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(dstPath, data, 0644); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (m *Manager) Uninstall(name string) error {
@@ -306,6 +384,12 @@ func (m *Manager) Update(name string) (*Plugin, bool, error) {
 		return nil, false, fmt.Errorf("plugin %q not found", name)
 	}
 
+	regEntry := m.registry.Find(name)
+
+	if regEntry != nil && regEntry.Path != "" {
+		return m.updateFromSubdir(name, dir, regEntry)
+	}
+
 	cmd := exec.Command("git", "-C", dir, "pull")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, false, fmt.Errorf("git pull failed: %s: %s", err, strings.TrimSpace(string(out)))
@@ -316,7 +400,6 @@ func (m *Manager) Update(name string) (*Plugin, bool, error) {
 		return nil, false, fmt.Errorf("invalid manifest after update: %w", err)
 	}
 
-	regEntry := m.registry.Find(name)
 	if regEntry == nil {
 		p := &Plugin{Name: newManifest.Name, Dir: dir, Manifest: newManifest}
 		return p, true, nil
@@ -334,6 +417,66 @@ func (m *Manager) Update(name string) (*Plugin, bool, error) {
 		regEntry.Enabled = false
 		m.registry.Save()
 		p := &Plugin{Name: newManifest.Name, Dir: dir, Manifest: newManifest}
+		return p, true, nil
+	}
+
+	for _, p := range m.plugins {
+		if p.Name == name {
+			p.Destroy()
+			p.Manifest = newManifest
+			p.Granted = regEntry.Permissions
+			if err := p.Init(); err != nil {
+				return nil, false, err
+			}
+			m.collectRegistrations(p)
+			regEntry.Version = newManifest.Version
+			m.registry.Save()
+			return p, false, nil
+		}
+	}
+
+	return nil, false, nil
+}
+
+func (m *Manager) updateFromSubdir(name, dir string, regEntry *RegistryEntry) (*Plugin, bool, error) {
+	if regEntry.Repo == "" {
+		return nil, false, fmt.Errorf("plugin %q has no repository URL", name)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "ttt-plugin-update-*")
+	if err != nil {
+		return nil, false, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cmd := exec.Command("git", "clone", "--depth", "1", regEntry.Repo, tmpDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, false, fmt.Errorf("git clone failed: %s: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	srcDir := filepath.Join(tmpDir, regEntry.Path)
+	newManifest, err := LoadManifest(srcDir)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid manifest after update: %w", err)
+	}
+
+	os.RemoveAll(dir)
+	if err := copyDir(srcDir, dir); err != nil {
+		return nil, false, fmt.Errorf("copy plugin: %w", err)
+	}
+
+	diff := DiffPermissions(regEntry.Permissions, newManifest.Permissions)
+	if !diff.IsEmpty() {
+		for i, p := range m.plugins {
+			if p.Name == name {
+				p.Destroy()
+				m.plugins = append(m.plugins[:i], m.plugins[i+1:]...)
+				break
+			}
+		}
+		regEntry.Enabled = false
+		m.registry.Save()
+		p := &Plugin{Name: newManifest.Name, Dir: dir, Repo: regEntry.Repo, RepoPath: regEntry.Path, Manifest: newManifest}
 		return p, true, nil
 	}
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -38,6 +38,7 @@ type Plugin struct {
 	Name     string
 	Dir      string
 	Repo     string
+	RepoPath string
 	Manifest Manifest
 	Granted  PermissionSet
 	Enabled  bool

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -9,6 +9,7 @@ import (
 type RegistryEntry struct {
 	Name        string        `json:"name"`
 	Repo        string        `json:"repo,omitempty"`
+	Path        string        `json:"path,omitempty"`
 	Version     string        `json:"version"`
 	Enabled     bool          `json:"enabled"`
 	Permissions PermissionSet `json:"permissions"`
@@ -76,10 +77,11 @@ func (r *Registry) Remove(name string) {
 	}
 }
 
-func (r *Registry) AddOrUpdate(name, repo, version string, perms PermissionSet) {
+func (r *Registry) AddOrUpdate(name, repo, path, version string, perms PermissionSet) {
 	entry := r.Find(name)
 	if entry != nil {
 		entry.Repo = repo
+		entry.Path = path
 		entry.Version = version
 		entry.Permissions = perms
 		entry.Enabled = true
@@ -88,6 +90,7 @@ func (r *Registry) AddOrUpdate(name, repo, version string, perms PermissionSet) 
 	r.Entries = append(r.Entries, RegistryEntry{
 		Name:        name,
 		Repo:        repo,
+		Path:        path,
 		Version:     version,
 		Enabled:     true,
 		Permissions: perms,

--- a/internal/plugin/registry_remote.go
+++ b/internal/plugin/registry_remote.go
@@ -8,13 +8,16 @@ import (
 	"time"
 )
 
-const DefaultRegistryURL = "https://raw.githubusercontent.com/eugenioenko/ttt-plugins/main/registry.json"
+const DefaultRegistryURL = "https://raw.githubusercontent.com/eugenioenko/ttt/main/community-plugins.json"
 
 type RemoteRegistryEntry struct {
-	Name        string `json:"name"`
-	Repo        string `json:"repo"`
-	Description string `json:"description"`
-	Author      string `json:"author"`
+	Name        string   `json:"name"`
+	Repo        string   `json:"repo"`
+	Description string   `json:"description"`
+	Author      string   `json:"author"`
+	Version     string   `json:"version,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Path        string   `json:"path,omitempty"`
 }
 
 func FetchRemoteRegistry(url string) ([]RemoteRegistryEntry, error) {

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -20,7 +20,7 @@ func TestLoadRegistryMissing(t *testing.T) {
 func TestRegistryRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("test", "github.com/test/test", "1.0.0", PermissionSet{PanelSidebar: true})
+	r.AddOrUpdate("test", "github.com/test/test", "", "1.0.0", PermissionSet{PanelSidebar: true})
 
 	if err := r.Save(); err != nil {
 		t.Fatalf("save error: %v", err)
@@ -44,8 +44,8 @@ func TestRegistryRoundTrip(t *testing.T) {
 func TestRegistryFind(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("alpha", "", "1.0", PermissionSet{})
-	r.AddOrUpdate("beta", "", "2.0", PermissionSet{})
+	r.AddOrUpdate("alpha", "", "", "1.0", PermissionSet{})
+	r.AddOrUpdate("beta", "", "", "2.0", PermissionSet{})
 
 	if r.Find("alpha") == nil {
 		t.Error("expected to find alpha")
@@ -58,7 +58,7 @@ func TestRegistryFind(t *testing.T) {
 func TestRegistrySetEnabled(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("test", "", "1.0", PermissionSet{})
+	r.AddOrUpdate("test", "", "", "1.0", PermissionSet{})
 
 	r.SetEnabled("test", false)
 	entry := r.Find("test")
@@ -70,7 +70,7 @@ func TestRegistrySetEnabled(t *testing.T) {
 func TestRegistryUpdatePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("test", "", "1.0", PermissionSet{})
+	r.AddOrUpdate("test", "", "", "1.0", PermissionSet{})
 
 	r.UpdatePermissions("test", PermissionSet{Commands: true})
 	entry := r.Find("test")

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -23,7 +23,7 @@ func TestManagerInstallRejectsNonHTTPS(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, err := m.Install(tt.url)
+		_, err := m.Install(tt.url, "")
 		if tt.blocked && err == nil {
 			t.Errorf("expected %q to be blocked", tt.url)
 		}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -44,6 +44,7 @@ type Diagnostic struct {
 
 type editorTab struct {
 	FilePath    string
+	Title       string
 	Buf         *buffer.Buffer
 	Cur         *cursor.Cursor
 	Vp          *view.Viewport
@@ -84,6 +85,7 @@ type EditorGroupWidget struct {
 	OnFileOpen             func(path, lang, text string)
 	OnFileChange           func(path, lang, text string)
 	OnFileClose            func(path, lang string)
+	OnContentTabClose      func(id string)
 	OnError                func(msg string)
 	OnNotify               func(msg string)
 	pendingNotify          []string
@@ -300,10 +302,11 @@ func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, ne
 	g.SwitchTab(len(g.tabs) - 1)
 }
 
-func (g *EditorGroupWidget) OpenPluginTab(id string, content Widget) {
+func (g *EditorGroupWidget) OpenPluginTab(id, title string, content Widget) {
 	for i, t := range g.tabs {
 		if t.FilePath == id {
 			t.Content = content
+			t.Title = title
 			g.tabs[i] = t
 			g.SwitchTab(i)
 			return
@@ -311,6 +314,7 @@ func (g *EditorGroupWidget) OpenPluginTab(id string, content Widget) {
 	}
 	g.tabs = append(g.tabs, editorTab{
 		FilePath: id,
+		Title:    title,
 		Content:  content,
 		Pinned:   true,
 	})
@@ -320,6 +324,9 @@ func (g *EditorGroupWidget) OpenPluginTab(id string, content Widget) {
 func (g *EditorGroupWidget) ClosePluginTab(id string) {
 	for i, t := range g.tabs {
 		if t.FilePath == id {
+			if t.Content != nil && g.OnContentTabClose != nil {
+				g.OnContentTabClose(t.FilePath)
+			}
 			g.tabs = append(g.tabs[:i], g.tabs[i+1:]...)
 			if len(g.tabs) == 0 {
 				g.tabs = []editorTab{{
@@ -521,6 +528,9 @@ func (g *EditorGroupWidget) CloseTab() {
 	if g.OnFileClose != nil && closing.Highlighter != nil && !closing.Virtual {
 		g.OnFileClose(closing.FilePath, closing.Highlighter.Language())
 	}
+	if closing.Content != nil && g.OnContentTabClose != nil {
+		g.OnContentTabClose(closing.FilePath)
+	}
 	g.tabs = append(g.tabs[:g.active], g.tabs[g.active+1:]...)
 	if len(g.tabs) == 0 {
 		g.tabs = []editorTab{{
@@ -544,6 +554,13 @@ func (g *EditorGroupWidget) CloseOtherTabs() {
 	if t == nil || len(g.tabs) <= 1 {
 		return
 	}
+	if g.OnContentTabClose != nil {
+		for i, tab := range g.tabs {
+			if i != g.active && tab.Content != nil {
+				g.OnContentTabClose(tab.FilePath)
+			}
+		}
+	}
 	g.tabs = []editorTab{*t}
 	g.active = 0
 	g.syncTabs()
@@ -561,6 +578,10 @@ func (g *EditorGroupWidget) CloseOtherSaved() {
 		}
 		if g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty {
 			kept = append(kept, g.tabs[i])
+			continue
+		}
+		if g.tabs[i].Content != nil && g.OnContentTabClose != nil {
+			g.OnContentTabClose(g.tabs[i].FilePath)
 		}
 	}
 	g.tabs = kept
@@ -1206,8 +1227,12 @@ func (g *EditorGroupWidget) syncTabs() {
 		if len(g.tabs) == 1 && ts.Virtual && ts.Buf != nil && !ts.Buf.Dirty && len(ts.Buf.Lines) <= 1 && (len(ts.Buf.Lines) == 0 || ts.Buf.Lines[0] == "") {
 			closable = false
 		}
+		name := ts.FilePath
+		if ts.Title != "" {
+			name = ts.Title
+		}
 		uiTabs = append(uiTabs, Tab{
-			Name:     ts.FilePath,
+			Name:     name,
 			Active:   i == g.active,
 			Dirty:    dirty,
 			Closable: closable,

--- a/internal/widgets/button.go
+++ b/internal/widgets/button.go
@@ -21,6 +21,7 @@ type ButtonConfig struct {
 type ButtonWidget struct {
 	BaseWidget
 	Config      ButtonConfig
+	Disabled    bool
 	label       string
 	accelIndex  int
 	accelRune   rune
@@ -48,6 +49,12 @@ func NewButtonWidget(config ButtonConfig) *ButtonWidget {
 	return b
 }
 
+func (b *ButtonWidget) SetLabel(label string) {
+	b.label = label
+	b.accelIndex = -1
+	b.accelRune = 0
+}
+
 func (b *ButtonWidget) Height() int { return 1 + b.BoxOverheadH() }
 func (b *ButtonWidget) Width() int {
 	w := len([]rune(b.label)) + b.BoxOverheadW()
@@ -63,7 +70,9 @@ func (b *ButtonWidget) Render(surface Surface) {
 	if style == 0 {
 		style = term.StyleButton
 	}
-	if b.focused {
+	if b.Disabled {
+		style = term.StyleMuted
+	} else if b.focused {
 		style = term.StyleButtonFocused
 	}
 
@@ -125,6 +134,9 @@ func (b *ButtonWidget) HandleEvent(ev tcell.Event) EventResult {
 }
 
 func (b *ButtonWidget) trigger() {
+	if b.Disabled {
+		return
+	}
 	if b.Config.OnClick != nil {
 		b.Config.OnClick()
 	}

--- a/internal/widgets/markdown.go
+++ b/internal/widgets/markdown.go
@@ -1,0 +1,142 @@
+package widgets
+
+import (
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/markdown"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
+)
+
+type MarkdownWidget struct {
+	BaseWidget
+	lines     []markdown.Line
+	wrapWidth int
+	wrapped   []markdown.Line
+}
+
+func NewMarkdownWidget() *MarkdownWidget {
+	return &MarkdownWidget{}
+}
+
+func (m *MarkdownWidget) SetContent(text string) {
+	m.lines = markdown.Render(text)
+	m.wrapWidth = 0
+	m.wrapped = nil
+}
+
+func (m *MarkdownWidget) Height() int { return 0 }
+func (m *MarkdownWidget) Width() int  { return 0 }
+
+func (m *MarkdownWidget) ScrollSize() (int, int) {
+	r := m.GetRect()
+	w := r.W
+	if w <= 0 {
+		w = 80
+	}
+	m.rewrap(w)
+	return w, len(m.wrapped)
+}
+
+func (m *MarkdownWidget) rewrap(width int) {
+	if width == m.wrapWidth && m.wrapped != nil {
+		return
+	}
+	m.wrapWidth = width
+	m.wrapped = nil
+	for _, line := range m.lines {
+		text := line.Text()
+		if text == "" {
+			m.wrapped = append(m.wrapped, markdown.Line{
+				Spans: []markdown.Span{{Text: "", Style: term.StyleDefault}},
+			})
+			continue
+		}
+		if strings.HasPrefix(text, "---") {
+			m.wrapped = append(m.wrapped, line)
+			continue
+		}
+		if len([]rune(text)) <= width {
+			m.wrapped = append(m.wrapped, line)
+			continue
+		}
+		m.wrapped = append(m.wrapped, wrapMarkdownLine(line, width)...)
+	}
+}
+
+func wrapMarkdownLine(line markdown.Line, width int) []markdown.Line {
+	styles := flattenMarkdownStyles(line)
+	runes := []rune(line.Text())
+	var result []markdown.Line
+	for len(runes) > 0 {
+		end := width
+		if end > len(runes) {
+			end = len(runes)
+		}
+		if end < len(runes) {
+			bp := -1
+			for j := end - 1; j > 0; j-- {
+				if runes[j] == ' ' {
+					bp = j
+					break
+				}
+			}
+			if bp > 0 {
+				end = bp + 1
+			}
+		}
+		var spans []markdown.Span
+		pos := 0
+		chunk := runes[:end]
+		chunkStyles := styles[:end]
+		for pos < len(chunk) {
+			st := chunkStyles[pos]
+			start := pos
+			for pos < len(chunk) && chunkStyles[pos] == st {
+				pos++
+			}
+			spans = append(spans, markdown.Span{Text: string(chunk[start:pos]), Style: st})
+		}
+		result = append(result, markdown.Line{Spans: spans})
+		runes = runes[end:]
+		styles = styles[end:]
+	}
+	return result
+}
+
+func flattenMarkdownStyles(line markdown.Line) []term.Style {
+	var styles []term.Style
+	for _, span := range line.Spans {
+		for range []rune(span.Text) {
+			styles = append(styles, span.Style)
+		}
+	}
+	return styles
+}
+
+func (m *MarkdownWidget) Render(surface Surface) {
+	w, h := surface.Size()
+	if w <= 0 || h <= 0 {
+		return
+	}
+
+	m.rewrap(w)
+
+	for y := 0; y < h && y < len(m.wrapped); y++ {
+		line := m.wrapped[y]
+		x := 0
+		for _, span := range line.Spans {
+			for _, ch := range span.Text {
+				if x >= w {
+					break
+				}
+				surface.SetCell(x, y, term.Cell{Ch: ch, Style: span.Style})
+				x++
+			}
+		}
+	}
+}
+
+func (m *MarkdownWidget) HandleEvent(ev tcell.Event) EventResult {
+	return EventIgnored
+}


### PR DESCRIPTION
## Summary
- Add plugin marketplace sidebar panel with search, detail tabs, install/uninstall flow
- Plugin detail tab with header (name, version, author, tags), full-width divider, and scrollable README fetched from GitHub
- Monorepo/subdirectory support: plugins can specify a `path` field for subdirectory install via clone-and-copy
- Install state tracking with button transitions (Install → Installing... → Installed)
- Loading/error states for registry fetch, dropdown menu wiring (Update All, Refresh)
- Memory cleanup for detail widget state on tab close
- Click/Enter on search results opens detail tab (not install)

## Test plan
- [ ] Plugin panel loads and displays registry entries
- [ ] Search filters plugins by name, description, tags
- [ ] Click/Enter on plugin opens detail tab with header and README
- [ ] Install button installs plugin, transitions to "Installed"
- [ ] Monorepo plugins (with path) install correctly
- [ ] Dropdown menu: Refresh re-fetches registry, Update All works
- [ ] Closing detail tab cleans up widget state
- [ ] Registry fetch error shows "Could not load registry"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm