### PR TITLE
fix: widget focus highlights respect global focus

### DIFF
--- a/internal/plugin/panel_widget.go
+++ b/internal/plugin/panel_widget.go
@@ -79,6 +79,11 @@ func (pw *PluginPanelWidget) CursorPosition() (int, int, bool) {
 	return 0, 0, false
 }
 
-func (pw *PluginPanelWidget) Focusable() bool           { return true }
-func (pw *PluginPanelWidget) SetFocused(focused bool)    { pw.focused = focused }
-func (pw *PluginPanelWidget) IsFocused() bool            { return pw.focused }
+func (pw *PluginPanelWidget) Focusable() bool { return true }
+func (pw *PluginPanelWidget) SetFocused(focused bool) {
+	pw.focused = focused
+	if pw.state != nil && pw.state.focus != nil {
+		pw.state.focus.SetActive(focused)
+	}
+}
+func (pw *PluginPanelWidget) IsFocused() bool { return pw.focused }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -137,6 +137,14 @@ func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool
 
 func (g *EditorGroupWidget) Focusable() bool { return true }
 
+func (g *EditorGroupWidget) SetFocused(focused bool) {
+	if t := g.activeTab(); t != nil && t.Content != nil {
+		if setter, ok := t.Content.(interface{ SetFocused(bool) }); ok {
+			setter.SetFocused(focused)
+		}
+	}
+}
+
 func (g *EditorGroupWidget) activeTab() *editorTab {
 	if len(g.tabs) == 0 || g.active < 0 || g.active >= len(g.tabs) {
 		return nil
@@ -496,9 +504,19 @@ func (g *EditorGroupWidget) SetUseTabs(useTabs bool) {
 
 func (g *EditorGroupWidget) SwitchTab(idx int) {
 	if idx >= 0 && idx < len(g.tabs) {
+		if t := g.activeTab(); t != nil && t.Content != nil {
+			if setter, ok := t.Content.(interface{ SetFocused(bool) }); ok {
+				setter.SetFocused(false)
+			}
+		}
 		g.saveMultiState()
 		g.active = idx
 		g.syncTabs()
+		if t := g.activeTab(); t != nil && t.Content != nil {
+			if setter, ok := t.Content.(interface{ SetFocused(bool) }); ok {
+				setter.SetFocused(true)
+			}
+		}
 	}
 }
 
@@ -1325,7 +1343,14 @@ func (g *EditorGroupWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventIgnored
 	}
 	if t.Content != nil {
-		return t.Content.HandleEvent(ev)
+		result = t.Content.HandleEvent(ev)
+		if result != EventIgnored {
+			return result
+		}
+		if _, ok := ev.(*tcell.EventMouse); ok {
+			return EventConsumed
+		}
+		return EventIgnored
 	}
 	result = g.Editor.HandleEvent(ev)
 	g.saveMultiState()

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -310,18 +310,13 @@ func (r *Root) PopOverlay() {
 
 func (r *Root) SetFocus(w Widget) {
 	if r.Focused != nil {
-		if rk, ok := r.Focused.(RawKeyConsumer); ok {
-			if setter, ok2 := r.Focused.(interface{ SetFocused(bool) }); ok2 && rk.WantsRawKeys() {
-				setter.SetFocused(false)
-			}
+		if setter, ok := r.Focused.(interface{ SetFocused(bool) }); ok {
+			setter.SetFocused(false)
 		}
 	}
 	r.Focused = w
-	if rk, ok := w.(RawKeyConsumer); ok {
-		if setter, ok2 := w.(interface{ SetFocused(bool) }); ok2 {
-			_ = rk
-			setter.SetFocused(true)
-		}
+	if setter, ok := w.(interface{ SetFocused(bool) }); ok {
+		setter.SetFocused(true)
 	}
 }
 

--- a/internal/ui/tree_widget_adapter.go
+++ b/internal/ui/tree_widget_adapter.go
@@ -48,6 +48,10 @@ func (a *WidgetAdapter) Inner() widgets.Widget { return a.W }
 
 func (a *WidgetAdapter) Focusable() bool { return true }
 
+func (a *WidgetAdapter) SetFocused(focused bool) {
+	a.focus.SetActive(focused)
+}
+
 func (a *WidgetAdapter) Render(surface Surface) {
 	r := a.GetRect()
 	a.W.SetRect(Rect{X: r.X, Y: r.Y, W: r.W, H: r.H})

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -7,10 +7,18 @@ import (
 type FocusManager struct {
 	items   []FocusableWidget
 	focused int
+	active  bool
 }
 
 func NewFocusManager() *FocusManager {
 	return &FocusManager{focused: -1}
+}
+
+func (fm *FocusManager) SetActive(active bool) {
+	fm.active = active
+	if fm.focused >= 0 && fm.focused < len(fm.items) {
+		fm.items[fm.focused].SetFocused(active)
+	}
 }
 
 func (fm *FocusManager) Collect(w Widget) {
@@ -34,7 +42,9 @@ func (fm *FocusManager) Collect(w Widget) {
 				}
 			}
 		}
-		fm.items[fm.focused].SetFocused(true)
+		if fm.active {
+			fm.items[fm.focused].SetFocused(true)
+		}
 	}
 }
 
@@ -82,7 +92,7 @@ func (fm *FocusManager) setFocus(idx int) {
 		fm.items[fm.focused].SetFocused(false)
 	}
 	fm.focused = idx
-	if fm.focused >= 0 && fm.focused < len(fm.items) {
+	if fm.active && fm.focused >= 0 && fm.focused < len(fm.items) {
 		fm.items[fm.focused].SetFocused(true)
 	}
 }

--- a/internal/widgets/focus_test.go
+++ b/internal/widgets/focus_test.go
@@ -23,6 +23,7 @@ func TestFocusManagerCollect(t *testing.T) {
 	vs := NewVStackWidget(tree, label, NewHStackWidget(b1, b2))
 
 	fm := NewFocusManager()
+	fm.SetActive(true)
 	fm.Collect(vs)
 
 	if len(fm.items) != 3 {
@@ -50,6 +51,7 @@ func TestFocusManagerTabCycle(t *testing.T) {
 	vs := NewVStackWidget(tree, NewHStackWidget(b1, b2))
 
 	fm := NewFocusManager()
+	fm.SetActive(true)
 	fm.Collect(vs)
 
 	if fm.Focused() != Widget(tree) {
@@ -115,6 +117,7 @@ func TestFocusManagerKeyRouting(t *testing.T) {
 
 	hs := NewHStackWidget(b1, b2)
 	fm := NewFocusManager()
+	fm.SetActive(true)
 	fm.Collect(hs)
 
 	enterEv := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
@@ -165,6 +168,7 @@ func TestActiveBorderOnFocus(t *testing.T) {
 	box.Child = tree
 
 	fm := NewFocusManager()
+	fm.SetActive(true)
 	fm.Collect(box)
 
 	if !tree.IsFocused() {

--- a/internal/widgets/input_test.go
+++ b/internal/widgets/input_test.go
@@ -94,6 +94,7 @@ func TestInputClickFocus(t *testing.T) {
 
 	// Set up focus manager
 	fm := NewFocusManager()
+	fm.SetActive(true)
 	vs := NewVStackWidget(inp)
 	vs.SetRect(Rect{X: 5, Y: 10, W: 20, H: 3})
 	fm.Collect(vs)
@@ -156,6 +157,7 @@ func TestTabbedTabSwitchFocus(t *testing.T) {
 	})
 
 	fm := NewFocusManager()
+	fm.SetActive(true)
 
 	// Initial state: tab 0 active
 	surface := renderWidget(tabbed, 0, 0, 30, 20)
@@ -253,6 +255,7 @@ func TestTabbedClickInputViaFocusManager(t *testing.T) {
 	})
 
 	fm := NewFocusManager()
+	fm.SetActive(true)
 
 	// Wire OnChange like the adapter does
 	tabbed.OnChange = func(int) {


### PR DESCRIPTION
## Summary
- FocusManager now gates `SetFocused(true)` on an `active` flag so widget-level focus highlights only appear when the container has global focus
- Root.SetFocus calls `SetFocused(false/true)` on any widget (not just RawKeyConsumer), deactivating the old panel's FocusManager and activating the new one
- EditorGroup propagates focus to content tabs (plugin detail) and always consumes mouse clicks so clicking the editor area transfers focus from the sidebar
- WidgetAdapter and PluginPanelWidget wire `SetFocused` through to their FocusManagers

## Test plan
- [x] Unit tests updated — all pass
- [x] E2E tests pass
- [x] Verified with `--exec`: Docker sidebar Tree shows `[FOCUSED]` only when sidebar has global focus, not when editor is focused
- [x] Verified Install button in plugin detail tab responds to clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm