### PR TITLE
test: add 10 new functional tests covering untested features

### DIFF
--- a/tests/functional/close-tabs.test.js
+++ b/tests/functional/close-tabs.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("close tabs commands", () => {
+  it("should close all saved tabs, keeping dirty ones", () => {
+    dir = createTempDir();
+    const fileA = createTempFile(dir, "a.txt", "content-a");
+    const fileB = createTempFile(dir, "b.txt", "content-b");
+    const fileC = createTempFile(dir, "c.txt", "content-c");
+
+    tui.start(fileA, fileB, fileC);
+    tui.waitFor("c.txt");
+
+    // Switch to b.txt (second tab) and make it dirty
+    tui.press("alt+,");
+    tui.waitFor("content-b");
+    tui.type("dirty");
+    tui.waitStable();
+
+    tui.exec("View: Close All Saved Tabs");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // b.txt should remain because it has unsaved changes
+    expect(snapshots[s0]).toContain("b.txt");
+    // a.txt and c.txt were saved, so they should be closed
+    expect(snapshots[s0]).not.toContain("a.txt");
+    expect(snapshots[s0]).not.toContain("c.txt");
+  });
+
+  it("should close other tabs, keeping only the active one", () => {
+    dir = createTempDir();
+    const fileA = createTempFile(dir, "a.txt", "content-a");
+    const fileB = createTempFile(dir, "b.txt", "content-b");
+    const fileC = createTempFile(dir, "c.txt", "content-c");
+
+    tui.start(fileA, fileB, fileC);
+    tui.waitFor("c.txt");
+
+    // Switch to b.txt
+    tui.press("alt+,");
+    tui.waitFor("content-b");
+
+    tui.exec("View: Close Other Tabs");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Only b.txt should remain
+    expect(snapshots[s0]).toContain("b.txt");
+    expect(snapshots[s0]).not.toContain("a.txt");
+    expect(snapshots[s0]).not.toContain("c.txt");
+  });
+
+  it("should close all tabs and show untitled buffer when none are dirty", () => {
+    dir = createTempDir();
+    const fileA = createTempFile(dir, "a.txt", "content-a");
+    const fileB = createTempFile(dir, "b.txt", "content-b");
+
+    tui.start(fileA, fileB);
+    tui.waitFor("b.txt");
+
+    tui.exec("View: Close All Tabs");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // All tabs closed, editor should create a new untitled buffer
+    expect(snapshots[s0]).toContain("untitled");
+    expect(snapshots[s0]).not.toContain("a.txt");
+    expect(snapshots[s0]).not.toContain("b.txt");
+  });
+
+  it("should show confirmation dialog when closing all tabs with dirty file", () => {
+    dir = createTempDir();
+    const fileA = createTempFile(dir, "a.txt", "content-a");
+
+    tui.start(fileA);
+    tui.waitFor("content-a");
+
+    // Make the file dirty
+    tui.type("dirty");
+    tui.waitStable();
+
+    tui.exec("View: Close All Tabs");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // A confirmation dialog should appear for the unsaved file
+    expect(snapshots[s0]).toMatch(/Save|Discard|Cancel/);
+  });
+});

--- a/tests/functional/delete-line.test.js
+++ b/tests/functional/delete-line.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("delete line", () => {
+  it("should delete first line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "del1.txt", "AAA\nBBB\nCCC");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("BBB\nCCC\n");
+  });
+
+  it("should delete middle line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "del2.txt", "AAA\nBBB\nCCC");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.press("arrow_down");
+    tui.waitStable();
+
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nCCC\n");
+  });
+
+  it("should delete last line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "del3.txt", "AAA\nBBB\nCCC");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.press("arrow_down");
+    tui.waitStable();
+    tui.press("arrow_down");
+    tui.waitStable();
+
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nBBB\n");
+  });
+
+  it("should delete only line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "del4.txt", "ONLY");
+
+    tui.start(file);
+    tui.waitFor("ONLY");
+
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("");
+  });
+
+  it("should delete multiple lines in sequence", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "del5.txt", "AAA\nBBB\nCCC\nDDD");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("DDD\n");
+  });
+
+  it("should undo delete line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "del6.txt", "AAA\nBBB");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.pressChord("ctrl+k", "k");
+    tui.waitStable();
+
+    tui.press("ctrl+z");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nBBB\n");
+  });
+});

--- a/tests/functional/explorer.test.js
+++ b/tests/functional/explorer.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("explorer", () => {
+  it("should show files in directory", () => {
+    dir = createTempDir();
+    createTempFile(dir, "alpha.txt", "alpha content");
+    createTempFile(dir, "beta.txt", "beta content");
+    createTempFile(dir, "gamma.txt", "gamma content");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("alpha.txt");
+    expect(snapshots[s0]).toContain("beta.txt");
+    expect(snapshots[s0]).toContain("gamma.txt");
+  });
+
+  it("should open file from explorer", () => {
+    dir = createTempDir();
+    createTempFile(dir, "test.txt", "HELLO WORLD");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.press("ctrl+0");
+    tui.waitStable();
+
+    // Navigate down to the file and open it
+    tui.press("arrow_down");
+    tui.press("arrow_down");
+    tui.press("arrow_down");
+    tui.press("enter");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("HELLO WORLD");
+  });
+
+  it("should show subdirectories", () => {
+    dir = createTempDir();
+    mkdirSync(join(dir, "subdir"), { recursive: true });
+    writeFileSync(join(dir, "subdir", "inner.txt"), "inner content");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("subdir");
+  });
+
+  it("should expand subdirectory to show contents", () => {
+    dir = createTempDir();
+    mkdirSync(join(dir, "subdir"), { recursive: true });
+    writeFileSync(join(dir, "subdir", "inner.txt"), "inner content");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.press("ctrl+0");
+    tui.waitStable();
+
+    // Navigate to subdir and expand it
+    tui.press("arrow_down");
+    tui.press("arrow_down");
+    tui.press("enter");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("inner.txt");
+  });
+
+  it("should create new file from explorer", () => {
+    dir = createTempDir();
+    createTempFile(dir, "existing.txt", "existing content");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.press("ctrl+0");
+    tui.waitStable();
+
+    tui.exec("Explorer: New File");
+    tui.waitStable();
+
+    tui.type("newfile.txt");
+    tui.press("enter");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("newfile.txt");
+  });
+});

--- a/tests/functional/find-navigation.test.js
+++ b/tests/functional/find-navigation.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+  dir = null;
+});
+
+describe("find navigation (F3 / Shift+F3)", () => {
+  it("F3 cycles through matches", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "cycle.txt",
+      "cat here\ndog there\ncat again\nbird\ncat end"
+    );
+
+    tui.start(file);
+    tui.waitFor("cat here");
+
+    tui.press("ctrl+f");
+    tui.waitStable();
+
+    tui.type("cat");
+    tui.waitStable();
+
+    // Initial match is on line 1
+    const s0 = tui.snapshot();
+
+    // F3 moves to next match (line 3)
+    tui.press("f3");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+
+    // F3 moves to next match (line 5)
+    tui.press("f3");
+    tui.waitStable();
+
+    const s2 = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("1/3");
+    expect(snapshots[s0]).toContain("Ln 1");
+    expect(snapshots[s1]).toContain("Ln 3");
+    expect(snapshots[s2]).toContain("Ln 5");
+  });
+
+  it("Shift+F3 goes to previous match", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "prev.txt",
+      "cat here\ndog there\ncat again\nbird\ncat end"
+    );
+
+    tui.start(file);
+    tui.waitFor("cat here");
+
+    tui.press("ctrl+f");
+    tui.waitStable();
+
+    tui.type("cat");
+    tui.waitStable();
+
+    // Start at match 1 on line 1
+    const s0 = tui.snapshot();
+
+    // F3 advances to match 2 on line 3
+    tui.press("f3");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+
+    // Shift+F3 goes back to match 1 on line 1
+    tui.press("shift+f3");
+    tui.waitStable();
+
+    const s2 = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Ln 1");
+    expect(snapshots[s1]).toContain("Ln 3");
+    expect(snapshots[s2]).toContain("Ln 1");
+  });
+
+  it("F3 wraps around from last match to first", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "wrap.txt",
+      "cat start\ndog middle\ncat end"
+    );
+
+    tui.start(file);
+    tui.waitFor("cat start");
+
+    tui.press("ctrl+f");
+    tui.waitStable();
+
+    tui.type("cat");
+    tui.waitStable();
+
+    // Start at match 1 on line 1
+    const s0 = tui.snapshot();
+
+    // F3 advances to match 2 on line 3
+    tui.press("f3");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+
+    // F3 wraps around back to match 1 on line 1
+    tui.press("f3");
+    tui.waitStable();
+
+    const s2 = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("1/2");
+    expect(snapshots[s0]).toContain("Ln 1");
+    expect(snapshots[s1]).toContain("Ln 3");
+    expect(snapshots[s2]).toContain("Ln 1");
+  });
+
+  it("find with no matches shows zero count", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "nomatch.txt",
+      "cat here\ndog there\nbird end"
+    );
+
+    tui.start(file);
+    tui.waitFor("cat here");
+
+    tui.press("ctrl+f");
+    tui.waitStable();
+
+    tui.type("zzzzz");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("0/0");
+  });
+});

--- a/tests/functional/home-end-keys.test.js
+++ b/tests/functional/home-end-keys.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("home and end keys", () => {
+  it("should jump to end of line with End key", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "end.txt", "hello world");
+
+    tui.start(file);
+    tui.waitFor("hello world");
+
+    tui.press("end");
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("hello worldX\n");
+  });
+
+  it("should jump to start of line with Home key", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "home.txt", "hello world");
+
+    tui.start(file);
+    tui.waitFor("hello world");
+
+    tui.press("end");
+    tui.press("home");
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("Xhello world\n");
+  });
+
+  it("should work with Home/End on second line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "line2.txt", "first\nsecond line");
+
+    tui.start(file);
+    tui.waitFor("second line");
+
+    tui.press("arrow_down");
+    tui.press("end");
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("first\nsecond lineX\n");
+  });
+
+  it("should handle Home on indented line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "indent.txt", "    indented");
+
+    tui.start(file);
+    tui.waitFor("indented");
+
+    tui.press("end");
+    tui.press("home");
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    // Smart home goes to first non-whitespace; plain home goes to column 0
+    const smartHome = "    Xindented\n";
+    const plainHome = "X    indented\n";
+    expect([smartHome, plainHome]).toContain(content);
+  });
+
+  it("should handle End then type on empty line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "empty.txt", "hello\n\nworld");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("arrow_down");
+    tui.press("end");
+    tui.type("MIDDLE");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("hello\nMIDDLE\nworld\n");
+  });
+});

--- a/tests/functional/insert-line.test.js
+++ b/tests/functional/insert-line.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("insert line", () => {
+  it("should insert line below with ctrl+enter", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "below.txt", "AAA\nBBB\nCCC");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.press("ctrl+enter");
+    tui.type("NEW");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nNEW\nBBB\nCCC\n");
+  });
+
+  it("should insert line above via command palette", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "above.txt", "AAA\nBBB\nCCC");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.press("arrow_down");
+    tui.waitStable();
+
+    tui.exec("Insert Line Above");
+    tui.waitStable();
+    tui.type("NEW");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nNEW\nBBB\nCCC\n");
+  });
+
+  it("should insert line below on last line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "last.txt", "AAA\nBBB\nCCC");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.press("arrow_down");
+    tui.press("arrow_down");
+    tui.waitStable();
+
+    tui.press("ctrl+enter");
+    tui.type("END");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nBBB\nCCC\nEND\n");
+  });
+
+  it("should insert empty line below indented line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "indent.txt", "  indented\nnormal");
+
+    tui.start(file);
+    tui.waitFor("indented");
+
+    tui.press("ctrl+enter");
+    tui.type("x");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("  indented\nx\nnormal\n");
+  });
+
+  it("should undo insert line below", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "undo.txt", "AAA\nBBB\nCCC");
+
+    tui.start(file);
+    tui.waitFor("AAA");
+
+    tui.press("ctrl+enter");
+    tui.type("NEW");
+    tui.waitStable();
+
+    tui.press("ctrl+z");
+    tui.press("ctrl+z");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("AAA\nBBB\nCCC\n");
+  });
+});

--- a/tests/functional/options-toggle.test.js
+++ b/tests/functional/options-toggle.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("options toggle", () => {
+  it("should toggle line numbers on and off", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "lines.txt",
+      "first line\nsecond line\nthird line\nfourth line\nfifth line\n"
+    );
+
+    tui.start(file);
+    tui.waitFor("first line");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    tui.exec("Toggle Line Numbers");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+
+    // Toggle back to restore original state
+    tui.exec("Toggle Line Numbers");
+    tui.waitStable();
+
+    const s2 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // The toggle should change something
+    expect(snapshots[s0]).not.toBe(snapshots[s1]);
+
+    // One snapshot should have gutter line numbers (e.g., "  1  first"),
+    // the other should not. The gutter pattern is digits followed by
+    // two spaces then the line content.
+    const gutterPattern = /\d\s{2}first line/;
+    const hasGutter0 = gutterPattern.test(snapshots[s0]);
+    const hasGutter1 = gutterPattern.test(snapshots[s1]);
+    expect(hasGutter0).not.toBe(hasGutter1);
+
+    // Toggling back should restore the original state
+    expect(snapshots[s2]).toBe(snapshots[s0]);
+  });
+
+  it("should toggle syntax highlight without crashing", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "test.go",
+      'package main\n\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("hello")\n}\n'
+    );
+
+    tui.start(file);
+    tui.waitFor("package main");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    tui.exec("Toggle Syntax Highlight");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+
+    // Toggle back to restore
+    tui.exec("Toggle Syntax Highlight");
+    tui.waitStable();
+
+    const s2 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Both snapshots should still contain the file content
+    expect(snapshots[s0]).toContain("package main");
+    expect(snapshots[s1]).toContain("package main");
+    expect(snapshots[s2]).toContain("package main");
+  });
+
+  it("should toggle bracket pair colorization without crashing", () => {
+    dir = createTempDir();
+    const file = createTempFile(
+      dir,
+      "brackets.go",
+      "package main\n\nfunc main() {\n\tif (true) {\n\t\tx := ((1 + 2) * 3)\n\t}\n}\n"
+    );
+
+    tui.start(file);
+    tui.waitFor("package main");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    tui.exec("Toggle Bracket Pair Colorization");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+
+    // Toggle back to restore
+    tui.exec("Toggle Bracket Pair Colorization");
+    tui.waitStable();
+
+    const s2 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Editor should remain functional and show content in all states
+    expect(snapshots[s0]).toContain("package main");
+    expect(snapshots[s1]).toContain("package main");
+    expect(snapshots[s2]).toContain("package main");
+  });
+});

--- a/tests/functional/quick-open.test.js
+++ b/tests/functional/quick-open.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("quick open (Go to File)", () => {
+  it("should open quick open dialog with ctrl+k p", () => {
+    dir = createTempDir();
+    createTempFile(dir, "alpha.txt", "alpha content");
+    createTempFile(dir, "beta.txt", "beta content");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.pressChord("ctrl+k", "p");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("alpha.txt");
+    expect(snapshots[s0]).toContain("beta.txt");
+  });
+
+  it("should filter files by typing", () => {
+    dir = createTempDir();
+    createTempFile(dir, "apple.txt", "apple content");
+    createTempFile(dir, "banana.txt", "banana content");
+    createTempFile(dir, "cherry.txt", "cherry content");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.pressChord("ctrl+k", "p");
+    tui.waitStable();
+
+    tui.type("ban");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("banana");
+  });
+
+  it("should open the selected file on enter", () => {
+    dir = createTempDir();
+    createTempFile(dir, "target.txt", "TARGET CONTENT");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.pressChord("ctrl+k", "p");
+    tui.waitStable();
+
+    tui.type("target");
+    tui.waitStable();
+
+    tui.press("enter");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("TARGET CONTENT");
+  });
+
+  it("should dismiss quick open with escape", () => {
+    dir = createTempDir();
+    createTempFile(dir, "file.txt", "file content");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.pressChord("ctrl+k", "p");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    tui.press("escape");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Dialog should be visible in the first snapshot
+    expect(snapshots[s0]).toContain("file.txt");
+    // After escape, the overlay should be gone
+    expect(snapshots[s1]).not.toContain("Go to File");
+  });
+});

--- a/tests/functional/select-word.test.js
+++ b/tests/functional/select-word.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir, readFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("word-level cursor movement and selection", () => {
+  it("should move word right", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "moveright.txt", "hello world foo");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("home");
+    tui.waitStable();
+
+    tui.press("ctrl+right");
+    tui.waitStable();
+
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("helloX world foo\n");
+  });
+
+  it("should move word left", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "moveleft.txt", "hello world");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("end");
+    tui.waitStable();
+
+    tui.press("ctrl+left");
+    tui.waitStable();
+
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("hello Xworld\n");
+  });
+
+  it("should select word right and delete", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "selright.txt", "hello world foo");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("home");
+    tui.waitStable();
+
+    tui.press("ctrl+right");
+    tui.waitStable();
+
+    tui.exec("Select Word Right");
+    tui.exec("Select Word Right");
+    tui.waitStable();
+
+    tui.press("backspace");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("hello foo\n");
+  });
+
+  it("should select word right and replace", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "selreplace.txt", "hello world");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("home");
+    tui.waitStable();
+
+    tui.exec("Select Word Right");
+    tui.waitStable();
+
+    tui.type("HI");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("HI world\n");
+  });
+
+  it("should move word right across multiple words", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "multiword.txt", "one two three");
+
+    tui.start(file);
+    tui.waitFor("one");
+
+    tui.press("home");
+    tui.waitStable();
+
+    tui.press("ctrl+right");
+    tui.press("ctrl+right");
+    tui.press("ctrl+right");
+    tui.waitStable();
+
+    tui.type("X");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.run();
+
+    const content = readFile(file);
+    expect(content).toBe("one twoX three\n");
+  });
+});

--- a/tests/functional/undo-dirty-flag.test.js
+++ b/tests/functional/undo-dirty-flag.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("undo/redo dirty flag tracking", () => {
+  it("should show dirty indicator after typing", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "clean.txt", "hello");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    const s0 = tui.snapshot();
+
+    tui.type("x");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).not.toContain("●");
+    expect(snapshots[s1]).toContain("●");
+  });
+
+  it("should clear dirty indicator after undo", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.type("x");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    tui.press("ctrl+z");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("●");
+    expect(snapshots[s1]).not.toContain("●");
+  });
+
+  it("should re-set dirty indicator after redo", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.type("x");
+    tui.waitStable();
+
+    tui.press("ctrl+z");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    tui.press("ctrl+y");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).not.toContain("●");
+    expect(snapshots[s1]).toContain("●");
+  });
+
+  it("should clear dirty indicator after save", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.type("x");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("●");
+    expect(snapshots[s1]).not.toContain("●");
+  });
+
+  it("should clear dirty indicator when undoing back to save point", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.press("end");
+    tui.type("abc");
+    tui.waitStable();
+
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    tui.type("xyz");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    // Undo "xyz" — back to the saved state "helloabc"
+    tui.press("ctrl+z");
+    tui.waitStable();
+
+    const s1 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("●");
+    expect(snapshots[s1]).not.toContain("●");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **46 new test cases** across **10 new functional test files** using the `--exec` debug harness
- Covers features that previously had no functional test coverage: insert/delete line, word movement, explorer navigation, tab management, options toggles, quick open, dirty flag tracking, Home/End keys, and find match navigation
- All tests pass locally; pre-existing fold test failures on main are unrelated

## New test files

| File | Tests | What it covers |
|---|---|---|
| `insert-line.test.js` | 5 | Insert Line Below (Ctrl+Enter), Insert Line Above, undo |
| `delete-line.test.js` | 6 | Delete first/middle/last/only line, sequential, undo |
| `select-word.test.js` | 5 | Ctrl+Right/Left word movement, word selection + delete/replace |
| `explorer.test.js` | 5 | File listing, open from explorer, subdirectories, create file |
| `close-tabs.test.js` | 4 | Close All Saved, Close Others, Close All (clean/dirty) |
| `options-toggle.test.js` | 3 | Toggle Line Numbers, Syntax Highlight, Bracket Colors |
| `quick-open.test.js` | 4 | Go to File dialog: open, filter, select, dismiss |
| `undo-dirty-flag.test.js` | 5 | Dirty indicator tracks undo/redo/save state correctly |
| `home-end-keys.test.js` | 5 | Home/End navigation, indented lines, empty lines |
| `find-navigation.test.js` | 4 | F3/Shift+F3 match cycling, wrap around, zero matches |

## Test plan

- [x] All 46 new tests pass locally
- [x] All 39 pre-existing functional tests still pass
- [ ] CI functional-tests job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm