### PR TITLE
fix: make LSP signature help integration test reliable

### DIFF
--- a/tests/integration/lsp-autocomplete-trigger.test.js
+++ b/tests/integration/lsp-autocomplete-trigger.test.js
@@ -81,7 +81,7 @@ describe("lsp autocomplete trigger characters", () => {
 
     // Move to line 2 and type 'consol' — should trigger completion
     tui.press("ctrl+g");
-    tui.waitStable();
+    tui.waitStable(1000);
     tui.type("2");
     tui.press("enter");
     tui.waitStable();
@@ -110,26 +110,29 @@ describe("lsp autocomplete trigger characters", () => {
     cpSync(LSP_DIR, dir, { recursive: true });
 
     const testFile = resolve(dir, "sighelp.js");
-    writeFileSync(testFile, "// sig\nconsole.log\n", "utf8");
+    writeFileSync(testFile, "console.log\n", "utf8");
     const configFile = resolve(LSP_DIR, "settings.json");
 
     tui.start("--config", configFile, testFile);
     tui.waitFor("console.log");
     waitForLogAfter("lsp initialized", 0);
+    tui.waitStable(2000);
 
-    // Move to end of line 2 (after "console.log")
-    tui.press("ctrl+g");
-    tui.waitStable();
-    tui.type("2");
-    tui.press("enter");
-    tui.waitStable();
+    // Cursor starts on line 1 — move to end of "console.log"
     tui.press("end");
+    tui.waitStable();
 
-    const mark = logSize();
-
-    // Type '(' — should trigger signature help
-    tui.type("(");
-    const log = waitForLogAfter("lsp signature help response.*label=", mark, 20000);
+    // Type '(' — should trigger signature help.
+    // Retry if the LSP server isn't ready yet (returns null).
+    let log = "";
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const mark = logSize();
+      tui.type("(");
+      log = waitForLogAfter("lsp signature help response.*label=", mark, 5000);
+      if (/lsp signature help response.*label=/.test(log)) break;
+      tui.press("backspace");
+      tui.waitStable(1000);
+    }
     expect(log).toMatch(/lsp signature help response.*label=/);
 
     tui.press("escape");
@@ -152,7 +155,7 @@ describe("lsp autocomplete trigger characters", () => {
     waitForLogAfter("lsp initialized", 0);
 
     tui.press("ctrl+g");
-    tui.waitStable();
+    tui.waitStable(1000);
     tui.type("2");
     tui.press("enter");
     tui.waitStable();


### PR DESCRIPTION
## Summary
- Added retry loop (up to 3 attempts) to the signature help test — types `(`, waits 5s for LSP response, backspaces and retries if the server returns null
- Increased `waitStable` delays after `ctrl+g` (Go to Line) from 100ms to 1000ms in the completion tests
- Simplified signature help test file to skip unnecessary Go to Line navigation
- Root cause: typescript-language-server occasionally returns null for signature help when it hasn't finished indexing, even after reporting "initialized"

## Test plan
- [x] Signature help test passes 20/20 locally (was 7/10 before fix)
- [x] All 3 LSP tests pass together 3/3 runs
- [x] Retry kicks in when needed (observed 11s run where retry succeeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm