### PR TITLE
fix: syntax highlighting for markdown files

### DIFF
--- a/internal/core/highlight/highlighter.go
+++ b/internal/core/highlight/highlighter.go
@@ -104,9 +104,9 @@ func mapTokenType(t chroma.TokenType) term.Style {
 	case t == chroma.GenericEmph:
 		return term.StyleSyntaxString
 	case t == chroma.GenericInserted:
-		return term.StyleSuccess
+		return term.StyleDiffAdded
 	case t == chroma.GenericDeleted:
-		return term.StyleDanger
+		return term.StyleDiffDeleted
 	case t == chroma.Punctuation:
 		return term.StyleSyntaxPunctuation
 	default:

--- a/internal/core/highlight/highlighter.go
+++ b/internal/core/highlight/highlighter.go
@@ -97,6 +97,16 @@ func mapTokenType(t chroma.TokenType) term.Style {
 		return term.StyleSyntaxAttribute
 	case t == chroma.NameVariable || t.InSubCategory(chroma.NameVariable):
 		return term.StyleSyntaxVariable
+	case t == chroma.GenericHeading || t == chroma.GenericSubheading:
+		return term.StyleSyntaxKeyword
+	case t == chroma.GenericStrong:
+		return term.StyleSyntaxType
+	case t == chroma.GenericEmph:
+		return term.StyleSyntaxString
+	case t == chroma.GenericInserted:
+		return term.StyleSuccess
+	case t == chroma.GenericDeleted:
+		return term.StyleDanger
 	case t == chroma.Punctuation:
 		return term.StyleSyntaxPunctuation
 	default:

--- a/internal/core/highlight/highlighter_test.go
+++ b/internal/core/highlight/highlighter_test.go
@@ -71,6 +71,37 @@ func TestHighlightUnknownFile(t *testing.T) {
 	}
 }
 
+func assertSpanStyle(t *testing.T, h *Highlighter, line string, style term.Style) {
+	t.Helper()
+	for _, s := range h.HighlightLine(line) {
+		if s.Style == style {
+			return
+		}
+	}
+	t.Errorf("expected style %v in spans for %q", style, line)
+}
+
+func TestHighlightMarkdown(t *testing.T) {
+	h := New("README.md")
+	if h == nil {
+		t.Fatal("expected highlighter for .md files")
+	}
+	assertSpanStyle(t, h, "# Heading", term.StyleSyntaxKeyword)
+	assertSpanStyle(t, h, "## Subheading", term.StyleSyntaxKeyword)
+	assertSpanStyle(t, h, "some **bold** text", term.StyleSyntaxType)
+	assertSpanStyle(t, h, "some *italic* text", term.StyleSyntaxString)
+	assertSpanStyle(t, h, "inline `code` here", term.StyleSyntaxString)
+}
+
+func TestHighlightDiff(t *testing.T) {
+	h := New("changes.diff")
+	if h == nil {
+		t.Fatal("expected highlighter for .diff files")
+	}
+	assertSpanStyle(t, h, "+added line", term.StyleSuccess)
+	assertSpanStyle(t, h, "-removed line", term.StyleDanger)
+}
+
 func TestHighlightJSON(t *testing.T) {
 	h := New("config.json")
 	if h == nil {

--- a/internal/core/highlight/highlighter_test.go
+++ b/internal/core/highlight/highlighter_test.go
@@ -98,8 +98,8 @@ func TestHighlightDiff(t *testing.T) {
 	if h == nil {
 		t.Fatal("expected highlighter for .diff files")
 	}
-	assertSpanStyle(t, h, "+added line", term.StyleSuccess)
-	assertSpanStyle(t, h, "-removed line", term.StyleDanger)
+	assertSpanStyle(t, h, "+added line", term.StyleDiffAdded)
+	assertSpanStyle(t, h, "-removed line", term.StyleDiffDeleted)
 }
 
 func TestHighlightJSON(t *testing.T) {


### PR DESCRIPTION
## Problem

Opening a `.md` file shows no syntax highlighting even though chroma matches the markdown lexer.

## Root cause

Chroma's markdown lexer emits mostly `Generic*` token types — `GenericHeading` (`#`), `GenericSubheading` (`##`+), `GenericStrong` (`**bold**`), `GenericEmph` (`*italic*`). `mapTokenType()` in `internal/core/highlight/highlighter.go` only handled programming-language categories (Keyword, String, Comment, Name*, ...), so all Generic tokens fell through to `StyleDefault` and were dropped. Markdown files rendered almost entirely unstyled.

## Fix

Map Generic token types to existing theme styles:

| Token | Style |
|---|---|
| `GenericHeading` / `GenericSubheading` | `StyleSyntaxKeyword` |
| `GenericStrong` | `StyleSyntaxType` |
| `GenericEmph` | `StyleSyntaxString` |
| `GenericInserted` / `GenericDeleted` | `StyleDiffAdded` / `StyleDiffDeleted` |

The Inserted/Deleted mapping also gives `.diff`/`.patch` files +/- line coloring for free.

No new styles or theme changes needed — all mappings reuse existing `term.Style*` constants.

## Tests

Added `TestHighlightMarkdown` and `TestHighlightDiff` unit tests covering headings, bold, italic, inline code, and diff +/- lines.

## Known limitation (unchanged)

Fenced code blocks (```go) still render as plain text — highlighting is per-line and fences require multi-line lexer state. Separate, larger change.
