### PR TITLE
fix: widget click detection accounts for box model padding

### DIFF
--- a/internal/plugin/panel_widget.go
+++ b/internal/plugin/panel_widget.go
@@ -58,6 +58,12 @@ func (pw *PluginPanelWidget) HandleEvent(ev tcell.Event) widgets.EventResult {
 		}
 	}
 
+	if pw.state != nil && pw.state.root != nil {
+		if result := pw.state.root.HandleEvent(ev); result != widgets.EventIgnored {
+			return result
+		}
+	}
+
 	if pw.eventFunc != nil && pw.plugin.State != nil {
 		tbl := eventToLua(pw.plugin.State, ev)
 		if tbl != nil {

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -46,7 +46,7 @@ func createWidget(desc WidgetDesc, p *Plugin) widgets.Widget {
 	case WidgetLabel:
 		return createLabelWidget(desc, p)
 	case WidgetTitle:
-		return createTitleWidget(desc)
+		return createTitleWidget(desc, p)
 	case WidgetKeyValue:
 		return createKeyValueWidget(desc)
 	case WidgetTree:
@@ -94,6 +94,7 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 	case WidgetTitle:
 		if tw, ok := w.(*widgets.TitleWidget); ok {
 			tw.Config.Title = desc.Text
+			tw.Config.Badge = desc.Badge
 			applyBoxModel(&tw.Box, desc)
 		}
 	case WidgetKeyValue:
@@ -303,10 +304,24 @@ func createLabelWidget(desc WidgetDesc, p *Plugin) *widgets.LabelWidget {
 	return lw
 }
 
-func createTitleWidget(desc WidgetDesc) *widgets.TitleWidget {
-	tw := widgets.NewTitleWidget(widgets.TitleConfig{
-		Title: desc.Text,
-	})
+func createTitleWidget(desc WidgetDesc, p *Plugin) *widgets.TitleWidget {
+	config := widgets.TitleConfig{
+		Title:  desc.Text,
+		Badge:  desc.Badge,
+		Menu:   desc.Entries,
+		Icon:   desc.Icon,
+		Padded: desc.Padded,
+	}
+	if p.ShowContextMenu != nil && len(desc.Entries) > 0 {
+		config.OnMenu = func(entries []widgets.MenuEntry, screenX, screenY int) {
+			p.ShowContextMenu(entries, screenX, screenY, func(cmd string) {
+				if desc.OnMenu != nil {
+					desc.OnMenu(cmd)
+				}
+			})
+		}
+	}
+	tw := widgets.NewTitleWidget(config)
 	applyBoxModel(&tw.Box, desc)
 	return tw
 }
@@ -324,6 +339,7 @@ func createTreeWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
 		NodeMenu: desc.NodeMenu,
 	})
 	wireTreeCallbacks(tw, desc, p)
+	applyBoxModel(&tw.Box, desc)
 	return tw
 }
 
@@ -333,6 +349,7 @@ func createListWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
 		NodeMenu: desc.NodeMenu,
 	})
 	wireTreeCallbacks(tw, desc, p)
+	applyBoxModel(&tw.Box, desc)
 	return tw
 }
 
@@ -390,6 +407,7 @@ func createDropdownWidget(desc WidgetDesc, p *Plugin) *widgets.DropdownWidget {
 		Box:     &widgets.BoxModel{PaddingLeft: 1, PaddingRight: 1},
 	})
 	wireDropdownCallback(dd, desc, p)
+	applyBoxModel(&dd.Box, desc)
 	return dd
 }
 
@@ -446,6 +464,7 @@ func createButtonWidget(desc WidgetDesc, p *Plugin) *widgets.ButtonWidget {
 		Label: desc.Label,
 	})
 	wireButtonCallback(bw, desc, p)
+	applyBoxModel(&bw.Box, desc)
 	return bw
 }
 
@@ -461,6 +480,7 @@ func createInputWidget(desc WidgetDesc, p *Plugin) *widgets.InputWidget {
 		Prefix:      desc.Prefix,
 	})
 	wireInputCallbacks(iw, desc, p)
+	applyBoxModel(&iw.Box, desc)
 	return iw
 }
 

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -70,6 +70,8 @@ type WidgetDesc struct {
 	Text      string
 	TextStyle string
 	Badge     string
+	Icon      string
+	Padded    bool
 
 	MarginTop     int
 	MarginBottom  int

--- a/internal/widgets/title.go
+++ b/internal/widgets/title.go
@@ -7,6 +7,7 @@ import (
 
 type TitleConfig struct {
 	Title  string      `json:"title"`
+	Badge  string      `json:"badge,omitempty"`
 	Menu   []MenuEntry `json:"menu,omitempty"`
 	Icon   string      `json:"icon,omitempty"`
 	Padded bool        `json:"padded,omitempty"`
@@ -61,10 +62,27 @@ func (t *TitleWidget) Render(surface Surface) {
 		dw := t.dropdown.Width()
 		maxTextW = w - dw
 		r := t.GetRect()
-		t.dropdown.SetRect(Rect{X: r.X + w - dw, Y: r.Y, W: dw, H: 1})
+		ox := t.Box.MarginLeft + t.Box.PaddingLeft
+		oy := t.Box.MarginTop + t.Box.PaddingTop
+		if t.Box.BorderLeft {
+			ox++
+		}
+		if t.Box.BorderTop {
+			oy++
+		}
+		t.dropdown.SetRect(Rect{X: r.X + ox + w - dw, Y: r.Y + oy, W: dw, H: 1})
 		ddSurface := inner.Sub(Rect{X: w - dw, Y: 0, W: dw, H: 1})
 		t.dropdown.Render(ddSurface)
 	}
+	if t.Config.Badge != "" {
+		badgeRunes := []rune(t.Config.Badge)
+		bx := maxTextW - len(badgeRunes)
+		if bx > 0 {
+			inner.DrawText(bx, 0, t.Config.Badge, maxTextW, term.StyleMuted)
+			maxTextW = bx - 1
+		}
+	}
+
 	x := 0
 	for _, ch := range t.Config.Title {
 		if x >= maxTextW {

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -61,6 +61,8 @@ type TreeWidget struct {
 	focused   bool
 
 	scrollbar scrollbar
+	contentX  int
+	contentY  int
 	contentW  int
 }
 
@@ -199,6 +201,17 @@ func (t *TreeWidget) Render(surface Surface) {
 		return
 	}
 
+	ox := t.Box.MarginLeft + t.Box.PaddingLeft
+	oy := t.Box.MarginTop + t.Box.PaddingTop
+	if t.Box.BorderLeft {
+		ox++
+	}
+	if t.Box.BorderTop {
+		oy++
+	}
+	t.contentX = t.rect.X + ox
+	t.contentY = t.rect.Y + oy
+
 	if len(t.flatList) == 0 && t.Config.EmptyText != "" {
 		x := 1
 		for _, ch := range t.Config.EmptyText {
@@ -221,8 +234,8 @@ func (t *TreeWidget) Render(surface Surface) {
 
 	t.ensureVisible(h)
 
-	t.scrollbar.X = t.rect.X + w - 1
-	t.scrollbar.Y = t.rect.Y
+	t.scrollbar.X = t.contentX + w - 1
+	t.scrollbar.Y = t.contentY
 	t.scrollbar.Height = h
 	t.scrollbar.TotalItems = len(t.flatList)
 	t.scrollbar.TopItem = t.scrollTop
@@ -491,7 +504,7 @@ func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {
 		return EventConsumed
 	}
 
-	idx := t.scrollTop + (my - r.Y)
+	idx := t.scrollTop + (my - t.contentY)
 	if idx < 0 || idx >= len(t.flatList) {
 		return EventIgnored
 	}
@@ -509,14 +522,14 @@ func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {
 		t.selected = idx
 
 		menuW := t.menuIconWidth()
-		if menuW > 0 && mx >= t.rect.X+t.contentW-menuW {
+		if menuW > 0 && mx >= t.contentX+t.contentW-menuW {
 			if t.Config.OnMenu != nil {
 				t.Config.OnMenu(t.Config.NodeMenu, node, mx, my)
 			}
 			return EventConsumed
 		}
 
-		rightX := t.rect.X + t.contentW - 2 - t.menuIconWidth()
+		rightX := t.contentX + t.contentW - 2 - t.menuIconWidth()
 		for i := len(node.Actions) - 1; i >= 0; i-- {
 			action := node.Actions[i]
 			iconW := len([]rune(action.Icon))
@@ -561,7 +574,7 @@ func (t *TreeWidget) handleKey(ev *tcell.EventKey) EventResult {
 	case tcell.KeyEnter:
 		if ev.Modifiers()&tcell.ModShift != 0 {
 			if t.Config.OnMenu != nil && t.selected >= 0 && t.selected < len(t.flatList) {
-				t.Config.OnMenu(t.Config.NodeMenu, t.flatList[t.selected], t.rect.X, t.rect.Y+t.selected-t.scrollTop)
+				t.Config.OnMenu(t.Config.NodeMenu, t.flatList[t.selected], t.contentX, t.contentY+t.selected-t.scrollTop)
 			}
 			return EventConsumed
 		}


### PR DESCRIPTION
## Summary
- Tree widget click detection (`⋯` menu, scrollbar, row index) now uses inner content origin instead of outer rect, fixing off-by-one when `padding_left`/`padding_top` is applied
- Title widget dropdown rect accounts for box model offsets so the `⋮` button is clickable with padding
- Plugin panel widget falls back to VStack event dispatch for non-focusable widgets (e.g. title dropdown clicks)
- Wires `menu`, `on_menu`, `icon`, and `padded` fields from Lua `p:title({...})` through to the Go TitleWidget

## Test plan
- [x] `⋯` context menu on tree/list items works with `padding_left = 1`
- [x] Title `⋮` dropdown opens context menu in drawer panels
- [x] All existing tests pass (`make test`)
- [x] Verified via `--exec` debug harness screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm