### PR TITLE
feat: plugin manifest api version field

### DIFF
--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -35,6 +35,7 @@ Every plugin requires a `plugin.ttt.json` manifest file at the root of its direc
   "version": "1.0.0",
   "author": "Your Name",
   "entry": "init.lua",
+  "api": 1,
   "permissions": {
     "panel.sidebar": true
   }
@@ -48,6 +49,7 @@ Every plugin requires a `plugin.ttt.json` manifest file at the root of its direc
 | `version`     | string | no       | Semver version string.                              |
 | `author`      | string | no       | Plugin author name.                                 |
 | `entry`       | string | yes      | Path to the Lua entry point, relative to the plugin directory. |
+| `api`         | number | no       | Plugin API version the plugin targets. Defaults to `1` when omitted. The editor refuses to load plugins that target a newer API than it supports. |
 | `permissions` | object | no       | Object declaring required permissions (see [Permissions Reference](#permissions-reference)). |
 
 ### Minimal Example

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -7,12 +7,17 @@ import (
 	"path/filepath"
 )
 
+// SupportedAPIVersion is the plugin API version this editor implements.
+// Manifests without an "api" field are assumed to target version 1.
+const SupportedAPIVersion = 1
+
 type Manifest struct {
 	Name        string        `json:"name"`
 	Description string        `json:"description"`
 	Version     string        `json:"version"`
 	Author      string        `json:"author"`
 	Entry       string        `json:"entry"`
+	API         int           `json:"api,omitempty"`
 	Permissions PermissionSet `json:"permissions"`
 }
 
@@ -33,6 +38,13 @@ func LoadManifest(dir string) (Manifest, error) {
 	}
 	if m.Entry == "" {
 		return Manifest{}, fmt.Errorf("manifest missing required field: entry")
+	}
+	if m.API == 0 {
+		m.API = 1
+	}
+	if m.API < 1 || m.API > SupportedAPIVersion {
+		return Manifest{}, fmt.Errorf("plugin %q requires plugin API v%d; this version of ttt supports v%d",
+			m.Name, m.API, SupportedAPIVersion)
 	}
 
 	return m, nil

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -68,3 +68,53 @@ func TestLoadManifestMissingFile(t *testing.T) {
 		t.Fatal("expected error for missing file")
 	}
 }
+
+func TestLoadManifestAPIVersionDefaultsToOne(t *testing.T) {
+	dir := t.TempDir()
+	data := `{"name": "test", "entry": "init.lua"}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.API != 1 {
+		t.Errorf("expected missing api to default to 1, got %d", m.API)
+	}
+}
+
+func TestLoadManifestAPIVersionSupported(t *testing.T) {
+	dir := t.TempDir()
+	data := `{"name": "test", "entry": "init.lua", "api": 1}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.API != 1 {
+		t.Errorf("expected api 1, got %d", m.API)
+	}
+}
+
+func TestLoadManifestAPIVersionTooNew(t *testing.T) {
+	dir := t.TempDir()
+	data := `{"name": "test", "entry": "init.lua", "api": 2}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	_, err := LoadManifest(dir)
+	if err == nil {
+		t.Fatal("expected error for unsupported api version")
+	}
+}
+
+func TestLoadManifestAPIVersionInvalid(t *testing.T) {
+	dir := t.TempDir()
+	data := `{"name": "test", "entry": "init.lua", "api": -1}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	_, err := LoadManifest(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid api version")
+	}
+}

--- a/pre-release.md
+++ b/pre-release.md
@@ -1,0 +1,78 @@
+# Pre-Release Worklist — Plugin System
+
+What the plugin system needs before v1.0.0 so third-party developers can build real
+functionality. Sourced from the full API audit and QA sweep (PR #324). Work these
+**one at a time** — each item is its own branch/PR.
+
+## Critical — API contract, must land before 1.0
+
+These are manifest/API format decisions. Everything else can be *added* compatibly
+later; these can't be *changed* compatibly later.
+
+- [ ] **1. Manifest API version** — DECIDED: doing it.
+  Add optional `"api": 1` to `plugin.ttt.json`. A missing field is assumed to be v1,
+  so existing plugins keep working unchanged. Loader refuses (with a clear OUTPUT
+  error) to load plugins declaring an API newer than the editor supports. Update the
+  manifest docs and, afterwards, the plugins in the ttt-plugins repo to declare it.
+
+- [ ] **2. Per-plugin persistent storage (`ttt.storage`)**
+  Sanctioned KV storage (JSON values) persisted per plugin, outside the workspace.
+  Today plugins have nowhere to put state: notepad wrote `.ttt-notepad.json` into the
+  workspace (it ended up committed to this repo), and `ttt.settings` writes into the
+  user's settings.json. Consider a workspace-scoped variant (`storage.workspace`).
+
+- [ ] **3. Timers (`ttt.set_interval` / `ttt.set_timeout`)**
+  No way to run periodic work today — docker-manager needs a manual Refresh button
+  because of this. Must be main-loop-safe (dispatch through the PostAsync path like
+  the other async APIs). Include `clear_interval`/`clear_timeout`, and clean up
+  timers on plugin destroy/reload.
+
+- [ ] **4. Streaming, cancellable exec (`sys.spawn`)**
+  `exec_async` buffers all output until exit — test runners, build watchers, and log
+  tails can't stream and can't be cancelled. `sys.spawn(binary, args, {on_line,
+  on_exit}) -> handle` with `handle:kill()` and `handle:write()` (stdin). Kill
+  processes on plugin destroy/reload. go-test-runner is the in-house proof case.
+
+- [ ] **5. Network domain scoping in the manifest**
+  `"network.http": true` is all-hosts-or-nothing and the approval dialog can't be
+  reasoned about. Support `"network.http": ["api.github.com"]` (keep `true` as
+  all-hosts for compatibility), matching the per-binary `system.exec` design.
+  Enforce in the network API; show domains in the approval dialog.
+
+## High value — makes plugins first-class, strong candidates before 1.0
+
+- [ ] **6. Editor integration points**
+  - `ttt.diagnostics.publish(path, items)` — plugins as linters, feeding the existing
+    squiggles/problems pipeline
+  - Status bar segments (git-blame style) registered by plugins
+  - Gutter marks / line decorations (coverage, bookmarks, review comments)
+  - `editor.save()`, access to non-active buffers, read-only text tabs
+- [ ] **7. More events**
+  `tab.change` (active file switched), `workspace.change`, `theme.change`,
+  `selection.change`, app shutdown hook. Each is a one-line DispatchEvent at an
+  existing site.
+- [ ] **8. Small API/UI gaps** (each trivial)
+  - `ttt.prompt(title, placeholder, cb)` — input dialog (only confirm/show_info exist)
+  - `ttt.notify(message)` — status bar toast (StatusNotify exists internally)
+  - Expose `p:checkbox` and `p:select` (widgets exist in Go, not exposed to Lua)
+  - Tree node `badge_style` / `icon_style` parseable from Lua (Go fields exist)
+
+## Nice to have — post-1.0, as the ecosystem demands
+
+- [ ] **9. "Plugins: Create New Plugin" scaffold command** — manifest + init.lua in
+  the local plugins dir, opens the entry file
+- [ ] **10. Registry version pinning** — install/update to tags instead of `git pull`
+  whatever main is
+- [ ] **11. Plugin testing recipe docs** — the `--plugin` + `--exec` harness works
+  today (it found 6 widget bugs in the QA sweep); needs a docs-web page showing the
+  pattern
+- [ ] **12. Render-time watchdog** — plugin render runs on the UI thread; log a
+  warning when a plugin's render exceeds a budget (the 10-error auto-disable catches
+  crashes, not slowness)
+
+## Working agreement
+
+- One item at a time, one PR per item, review between items.
+- Items 1–5 gate the 1.0 release; 6–8 are judgment calls; 9–12 explicitly don't block.
+- After item 1 lands, update the plugins in the ttt-plugins repo to declare `"api": 1`.
+- This file is a working document — delete it before the release.


### PR DESCRIPTION
First item from `pre-release.md` (plugin API worklist).

Manifests may declare `"api": 1` — the plugin API version they target. Semantics:

- **Missing field = v1** — every existing plugin keeps working unchanged
- The editor refuses to load plugins declaring an API **newer** than `SupportedAPIVersion`, with a clear error (`plugin "x" requires plugin API v2; this version of ttt supports v1`) instead of failing undefined mid-execution
- Invalid values (`< 1`) are rejected

Docs: manifest example + field table updated in the plugin authoring guide.

Follow-up (separate PR in ttt-plugins): declare `"api": 1` in every community plugin manifest.

## Test plan
- [x] unit: default-to-1, explicit 1, too-new rejected, invalid rejected
- [x] `go test ./...` green locally
- [x] docs-web builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)