### PR TITLE
feat: add ttt.plugin_dir() API for plugin-local storage

### DIFF
--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -423,6 +423,11 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "plugin_dir", L.NewFunction(func(L *lua.LState) int {
+			L.Push(lua.LString(p.Dir))
+			return 1
+		}))
+
 		L.SetField(mod, "on_install", L.NewFunction(func(L *lua.LState) int {
 			fn := L.CheckFunction(1)
 			p.InstallFunc = fn


### PR DESCRIPTION
## Summary
- Adds `ttt.plugin_dir()` Lua API that returns the plugin's install directory
- Enables plugins to persist state (cached data, last-used PR number, settings) relative to their own folder

## Test plan
- [x] `ttt.plugin_dir()` returns the correct path for installed plugins
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GG9dYw2AG18ro5c2dkPtm