### PR TITLE
test: cover ttt.plugin_dir; fix debug-plugin Dir

### DIFF
--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -106,14 +106,16 @@ func (a *App) debugRunPlugin() {
 
 	path := a.EditorGroup.ActiveFilePath()
 	name := "debug-plugin"
+	dir := "."
 	if path != "" {
 		parts := strings.Split(path, "/")
 		name = strings.TrimSuffix(parts[len(parts)-1], ".lua")
+		dir = filepath.Dir(path)
 	}
 
 	p := &plugin.Plugin{
 		Name:    name,
-		Dir:     ".",
+		Dir:     dir,
 		Enabled: true,
 		Manifest: plugin.Manifest{
 			Name:  name,

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -263,3 +263,22 @@ func TestSandboxRegisterBottomWithoutPermission(t *testing.T) {
 		t.Error("bottom title should not be set without permission")
 	}
 }
+
+func TestPluginDirExposed(t *testing.T) {
+	p := &Plugin{Name: "test", Dir: "/some/plugin/dir"}
+	p.State = NewSandbox()
+	defer p.State.Close()
+	setupTTTModule(p.State, p)
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		result = ttt.plugin_dir()
+	`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := p.State.GetGlobal("result").String()
+	if got != "/some/plugin/dir" {
+		t.Errorf("expected /some/plugin/dir, got %q", got)
+	}
+}


### PR DESCRIPTION
Completes #329 — this commit was pushed to that branch minutes after it merged, so it never landed:

- Unit test for the `ttt.plugin_dir()` Lua binding
- "Debug: Run Current File as Plugin" sets `Dir` to the current file's directory instead of `"."`, so `plugin_dir()` behaves identically across all three plugin load paths (installed, `--plugin`, debug command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)