### PR TITLE
feat: plugin timers (set_timeout / set_interval)

### DIFF
--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -348,6 +348,39 @@ local ok, err = fs.write(state_file, json.encode(state))
 
 Note: the plugin directory is a git clone that `Plugins: Update` pulls into, and it is deleted on uninstall — keep only regenerable state there.
 
+### `ttt.set_timeout(ms, callback)` / `ttt.set_interval(ms, callback)`
+
+Schedule a callback to run later on the editor's main loop. `set_timeout` fires once after `ms` milliseconds; `set_interval` fires every `ms` milliseconds until cleared. Both return a numeric timer id. No permission required.
+
+Callbacks run on the main thread (the same place render and event handlers run), so they can safely touch plugin state and call any `ttt` API — no need for `panel:redraw()` juggling as with raw goroutines. Because they share the UI thread, `set_interval` enforces a minimum interval of 50ms.
+
+```lua
+local ttt = require("ttt")
+
+-- Refresh a data panel every 5 seconds
+local timer = ttt.set_interval(5000, function()
+  refresh_data()
+  panel:redraw()
+end)
+
+-- Run something once, shortly after load
+ttt.set_timeout(200, function()
+  ttt.log("plugin warmed up")
+end)
+```
+
+### `ttt.clear_timeout(id)` / `ttt.clear_interval(id)`
+
+Cancel a pending timeout or a running interval by its id. The two are interchangeable (a single timer registry backs both). Cancelling an unknown or already-fired id is a no-op.
+
+```lua
+local id = ttt.set_interval(1000, poll)
+-- later...
+ttt.clear_interval(id)
+```
+
+All of a plugin's timers are automatically stopped when the plugin is disabled, reloaded, or uninstalled — you don't need to clear them on shutdown.
+
 ### `ttt.on_install(callback)`
 
 Register a function that runs once when the plugin is installed (from the Plugins panel or **Plugins: Install from URL**). Use this for one-time setup like writing default settings. No permission required to register the hook; whatever the callback does is still permission-checked.
@@ -1752,7 +1785,7 @@ local id = crypto.uuid()               -- "550e8400-e29b-41d4-a716-446655440000"
 
 | Module         | Description                    |
 |----------------|--------------------------------|
-| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `on_install`, `on_uninstall`, `markdown` |
+| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown` |
 | `ttt.json`     | JSON encode/decode             |
 | `ttt.editor`   | Editor buffer read/write       |
 | `ttt.fs`       | Filesystem access              |

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -92,6 +92,9 @@ type Plugin struct {
 	pendingDrawer *pendingDrawerCall
 	LastError     error
 	errorCount    int
+
+	timers      map[int]func()
+	nextTimerID int
 }
 
 type pendingDrawerCall struct {
@@ -197,6 +200,7 @@ func (p *Plugin) SafePostAsync(result *PluginAsyncResult) {
 func (p *Plugin) Destroy() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.stopTimersLocked()
 	if p.State != nil {
 		p.State.Close()
 		p.State = nil

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -428,6 +428,29 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 1
 		}))
 
+		L.SetField(mod, "set_timeout", L.NewFunction(func(L *lua.LState) int {
+			ms := L.CheckInt(1)
+			fn := L.CheckFunction(2)
+			id := p.SetTimeout(ms, func() { p.CallLuaFunc(fn) })
+			L.Push(lua.LNumber(id))
+			return 1
+		}))
+
+		L.SetField(mod, "set_interval", L.NewFunction(func(L *lua.LState) int {
+			ms := L.CheckInt(1)
+			fn := L.CheckFunction(2)
+			id := p.SetInterval(ms, func() { p.CallLuaFunc(fn) })
+			L.Push(lua.LNumber(id))
+			return 1
+		}))
+
+		clearTimer := L.NewFunction(func(L *lua.LState) int {
+			p.ClearTimer(L.CheckInt(1))
+			return 0
+		})
+		L.SetField(mod, "clear_timeout", clearTimer)
+		L.SetField(mod, "clear_interval", clearTimer)
+
 		L.SetField(mod, "on_install", L.NewFunction(func(L *lua.LState) int {
 			fn := L.CheckFunction(1)
 			p.InstallFunc = fn

--- a/internal/plugin/timers.go
+++ b/internal/plugin/timers.go
@@ -1,0 +1,94 @@
+package plugin
+
+import (
+	"sync"
+	"time"
+)
+
+// MinTimerIntervalMs floors ttt.set_interval — callbacks run on the main
+// loop, so faster intervals would starve the UI.
+const MinTimerIntervalMs = 50
+
+// SetTimeout schedules fn once on the main loop after ms milliseconds.
+func (p *Plugin) SetTimeout(ms int, fn func()) int {
+	if ms < 0 {
+		ms = 0
+	}
+	id := p.registerTimer(nil)
+	t := time.AfterFunc(time.Duration(ms)*time.Millisecond, func() {
+		p.SafePostAsync(&PluginAsyncResult{Plugin: p, Callback: func() {
+			p.ClearTimer(id)
+			fn()
+		}})
+	})
+	p.setTimerCancel(id, func() { t.Stop() })
+	return id
+}
+
+// SetInterval schedules fn on the main loop every ms milliseconds until cleared.
+func (p *Plugin) SetInterval(ms int, fn func()) int {
+	if ms < MinTimerIntervalMs {
+		ms = MinTimerIntervalMs
+	}
+	stop := make(chan struct{})
+	var once sync.Once
+	id := p.registerTimer(func() { once.Do(func() { close(stop) }) })
+	ticker := time.NewTicker(time.Duration(ms) * time.Millisecond)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				p.SafePostAsync(&PluginAsyncResult{Plugin: p, Callback: fn})
+			}
+		}
+	}()
+	return id
+}
+
+// ClearTimer cancels the timer with the given id; unknown ids are a no-op.
+func (p *Plugin) ClearTimer(id int) {
+	p.mu.Lock()
+	cancel := p.timers[id]
+	delete(p.timers, id)
+	p.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (p *Plugin) registerTimer(cancel func()) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.timers == nil {
+		p.timers = make(map[int]func())
+	}
+	p.nextTimerID++
+	id := p.nextTimerID
+	p.timers[id] = cancel
+	return id
+}
+
+func (p *Plugin) setTimerCancel(id int, cancel func()) {
+	p.mu.Lock()
+	_, active := p.timers[id]
+	if active {
+		p.timers[id] = cancel
+	}
+	p.mu.Unlock()
+	if !active {
+		cancel()
+	}
+}
+
+// stopTimersLocked cancels all timers; caller must hold p.mu.
+func (p *Plugin) stopTimersLocked() {
+	for _, cancel := range p.timers {
+		if cancel != nil {
+			cancel()
+		}
+	}
+	p.timers = nil
+}

--- a/internal/plugin/timers_test.go
+++ b/internal/plugin/timers_test.go
@@ -1,0 +1,160 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// timerHarness simulates the main loop: posted async results are executed
+// in order on the test goroutine.
+type timerHarness struct {
+	p       *Plugin
+	results chan *PluginAsyncResult
+}
+
+func newTimerHarness(t *testing.T) *timerHarness {
+	t.Helper()
+	h := &timerHarness{results: make(chan *PluginAsyncResult, 64)}
+	p := &Plugin{Name: "timer-test"}
+	p.State = NewSandbox()
+	t.Cleanup(func() {
+		if p.State != nil {
+			p.State.Close()
+		}
+	})
+	p.PostAsync = func(r *PluginAsyncResult) { h.results <- r }
+	setupTTTModule(p.State, p)
+	h.p = p
+	return h
+}
+
+// runOne waits for one posted callback and executes it, like the event loop.
+func (h *timerHarness) runOne(t *testing.T, timeout time.Duration) bool {
+	t.Helper()
+	select {
+	case r := <-h.results:
+		if r.Callback != nil {
+			r.Callback()
+		}
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (h *timerHarness) luaGlobal(name string) lua.LValue {
+	return h.p.State.GetGlobal(name)
+}
+
+func TestSetTimeoutFiresOnce(t *testing.T) {
+	h := newTimerHarness(t)
+	err := h.p.State.DoString(`
+		local ttt = require("ttt")
+		fired = 0
+		ttt.set_timeout(10, function() fired = fired + 1 end)
+	`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !h.runOne(t, 2*time.Second) {
+		t.Fatal("timeout callback never posted")
+	}
+	if got := h.luaGlobal("fired").String(); got != "1" {
+		t.Errorf("expected fired=1, got %s", got)
+	}
+	if h.runOne(t, 150*time.Millisecond) {
+		t.Error("set_timeout fired more than once")
+	}
+}
+
+func TestSetIntervalRepeatsUntilCleared(t *testing.T) {
+	h := newTimerHarness(t)
+	err := h.p.State.DoString(`
+		local ttt = require("ttt")
+		ticks = 0
+		timer_id = ttt.set_interval(10, function() ticks = ticks + 1 end)
+	`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if !h.runOne(t, 2*time.Second) {
+			t.Fatalf("interval tick %d never posted", i+1)
+		}
+	}
+	if got := h.luaGlobal("ticks").String(); got != "2" {
+		t.Errorf("expected ticks=2, got %s", got)
+	}
+
+	if err := h.p.State.DoString(`require("ttt").clear_interval(timer_id)`); err != nil {
+		t.Fatalf("clear_interval: %v", err)
+	}
+	// Drain anything posted before the clear took effect, then expect silence.
+	for h.runOne(t, 120*time.Millisecond) {
+	}
+	if h.runOne(t, 150*time.Millisecond) {
+		t.Error("interval still ticking after clear_interval")
+	}
+}
+
+func TestClearTimeoutCancels(t *testing.T) {
+	h := newTimerHarness(t)
+	err := h.p.State.DoString(`
+		local ttt = require("ttt")
+		fired = 0
+		local id = ttt.set_timeout(50, function() fired = fired + 1 end)
+		ttt.clear_timeout(id)
+	`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.runOne(t, 200*time.Millisecond) {
+		t.Error("cleared timeout still fired")
+	}
+	if got := h.luaGlobal("fired").String(); got != "0" {
+		t.Errorf("expected fired=0, got %s", got)
+	}
+}
+
+func TestDestroyStopsTimers(t *testing.T) {
+	h := newTimerHarness(t)
+	err := h.p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.set_interval(10, function() end)
+		ttt.set_timeout(30, function() end)
+	`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	h.p.Destroy()
+
+	// PostAsync is nilled by Destroy; nothing should arrive.
+	if h.runOne(t, 150*time.Millisecond) {
+		t.Error("timer posted after Destroy")
+	}
+	if h.p.timers != nil {
+		t.Error("expected timers map cleared on Destroy")
+	}
+}
+
+func TestTimerIDsAreDistinct(t *testing.T) {
+	h := newTimerHarness(t)
+	err := h.p.State.DoString(`
+		local ttt = require("ttt")
+		a = ttt.set_timeout(1000, function() end)
+		b = ttt.set_interval(1000, function() end)
+		c = ttt.set_timeout(1000, function() end)
+	`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	a, b, c := h.luaGlobal("a").String(), h.luaGlobal("b").String(), h.luaGlobal("c").String()
+	if a == b || b == c || a == c {
+		t.Errorf("expected distinct ids, got %s %s %s", a, b, c)
+	}
+}

--- a/pre-release.md
+++ b/pre-release.md
@@ -24,11 +24,11 @@ later; these can't be *changed* compatibly later.
   state via `fs.write` requires the broad fs.write permission, and the plugin dir is
   a git clone (update conflicts) that's deleted on uninstall.
 
-- [ ] **3. Timers (`ttt.set_interval` / `ttt.set_timeout`)**
-  No way to run periodic work today — docker-manager needs a manual Refresh button
-  because of this. Must be main-loop-safe (dispatch through the PostAsync path like
-  the other async APIs). Include `clear_interval`/`clear_timeout`, and clean up
-  timers on plugin destroy/reload.
+- [x] **3. Timers (`ttt.set_interval` / `ttt.set_timeout`)** — DONE (PR pending).
+  `set_timeout`/`set_interval` return ids; `clear_timeout`/`clear_interval` cancel
+  (interchangeable). Callbacks dispatch through the PostAsync main-loop path, so they
+  can touch state safely. `set_interval` floored at 50ms. All timers stopped on
+  Destroy (disable/reload/uninstall). Unit + functional tests, docs-web section.
 
 - [ ] **4. Streaming, cancellable exec (`sys.spawn`)**
   `exec_async` buffers all output until exit — test runners, build watchers, and log

--- a/tests/functional/plugin-timers.test.js
+++ b/tests/functional/plugin-timers.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("plugin timers", () => {
+  it("interval ticks repeatedly and timeout fires once through the event loop", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello timers\n");
+    const pluginFile = join(dir, "timers.lua");
+    writeFileSync(
+      pluginFile,
+      `local ttt = require("ttt")
+local ticks = 0
+ttt.set_interval(100, function()
+  ticks = ticks + 1
+  ttt.log("info", "tick " .. ticks)
+end)
+ttt.set_timeout(150, function()
+  ttt.log("info", "timeout-once")
+end)
+local cancelled = ttt.set_timeout(100, function()
+  ttt.log("error", "cancelled-timer-fired")
+end)
+ttt.clear_timeout(cancelled)
+`
+    );
+
+    tui.start("--plugin", pluginFile, file);
+    tui.waitFor("hello timers");
+    tui.wait(550);
+    tui.panel("output");
+    tui.wait(150);
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // At least 3 interval ticks in ~700ms
+    expect(snapshots[s0]).toContain("tick 3");
+    // Timeout fired exactly once
+    expect(snapshots[s0]).toContain("timeout-once");
+    // Cleared timer never fired
+    expect(snapshots[s0]).not.toContain("cancelled-timer-fired");
+  });
+});

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -66,6 +66,10 @@ export function exec(command) {
   commands.push(`exec "${command}"`);
 }
 
+export function panel(id) {
+  commands.push(`panel ${id}`);
+}
+
 export function wait(ms = 200) {
   commands.push(`wait ${ms}`);
 }


### PR DESCRIPTION
Item 3 from `pre-release.md` (plugin API worklist). Plugins had no way to run periodic work — docker-manager needs a manual Refresh button because of this.

## API

- `ttt.set_timeout(ms, fn) -> id` — fire `fn` once after `ms`
- `ttt.set_interval(ms, fn) -> id` — fire `fn` every `ms` (floored at 50ms)
- `ttt.clear_timeout(id)` / `ttt.clear_interval(id)` — cancel; interchangeable; unknown id is a no-op

Callbacks dispatch through the existing `PostAsync` main-loop path (same as `exec_async`/`net.*_async`), so they run on the UI thread — plugins can touch state and call any `ttt` API directly, no goroutine-safety dance. A plugin's timers are all stopped on `Destroy` (disable, reload, uninstall), so plugins don't need shutdown cleanup.

## Tests
- Unit (`internal/plugin/timers_test.go`): timeout-fires-once, interval-repeats-until-cleared, clear-cancels, Destroy-stops-all, distinct ids — via a harness that drains the async queue like the event loop. `-race` clean.
- Functional (`plugin-timers.test.js`): drives the real binary with a `--plugin`, reads interval ticks + one-shot timeout + a cleared timer out of the OUTPUT panel. Adds a `panel(id)` tui helper.
- Docs: Timers section in the plugin authoring guide; module list updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)