### PR TITLE
docs: plugin testing guide + API doc gap fixes

### DIFF
--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
             { label: 'Keybindings', link: '/guides/keybindings/' },
             { label: 'Plugins', link: '/guides/plugins/' },
             { label: 'Plugin Authoring', link: '/guides/plugin-authoring/' },
+            { label: 'Testing Plugins', link: '/guides/plugin-testing/' },
           ],
         },
         {

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -419,6 +419,18 @@ local lines = ttt.markdown("# Hello\nSome **bold** text")
 -- lines[2] = { {text = "Some ", style = "default"}, {text = "bold", style = "bold"}, ... }
 ```
 
+### Debug helpers
+
+These drive and capture the editor for automated testing (see [Testing Plugins](/guides/plugin-testing/)). They are the Lua equivalents of the `--exec` script commands. No permission required.
+
+| Function | Description |
+|----------|-------------|
+| `ttt.screenshot(path)` | Write the current screen (plain text) to a file. |
+| `ttt.debug(path)` | Write the editor's full state as JSON to a file (cursor, panels, widget tree, OUTPUT log). |
+| `ttt.click(x, y)` | Simulate a mouse click at screen coordinates. |
+| `ttt.drag(x1, y1, x2, y2)` | Simulate a mouse drag between two points. |
+| `ttt.quit()` | Exit the editor. |
+
 ### `ttt.json` Module
 
 The `ttt.json` module provides JSON encoding and decoding. No permission required.
@@ -1771,7 +1783,7 @@ Plugins run in a sandboxed Lua 5.1 environment. Only safe standard library modul
 | Function     | Returns | Description |
 |--------------|---------|-------------|
 | `os.time()`  | number  | Current Unix timestamp (seconds since epoch). |
-| `os.clock()` | number  | CPU time elapsed since the editor started (seconds, fractional). |
+| `os.clock()` | number  | Seconds elapsed since the editor started (wall-clock, fractional). |
 | `os.date([format])` | string | Format current time. Supports `%Y`, `%m`, `%d`, `%H`, `%M`, `%S`, `%c`, `%A`, `%a`, `%B`, `%b`, `%p`, `%I`, `%Z`, `%%`. Default format is `%c`. |
 
 ```lua
@@ -1798,7 +1810,7 @@ local id = crypto.uuid()               -- "550e8400-e29b-41d4-a716-446655440000"
 
 | Module         | Description                    |
 |----------------|--------------------------------|
-| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown` |
+| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown`, `screenshot`, `debug`, `click`, `drag`, `quit` |
 | `ttt.json`     | JSON encode/decode             |
 | `ttt.editor`   | Editor buffer read/write       |
 | `ttt.fs`       | Filesystem access              |

--- a/docs-web/src/content/docs/guides/plugin-testing.md
+++ b/docs-web/src/content/docs/guides/plugin-testing.md
@@ -1,0 +1,126 @@
+---
+title: Testing Plugins
+description: Drive plugins headlessly with --plugin and --exec to test them like a browser end-to-end harness.
+---
+
+TTT ships a scripted-interaction harness that lets you load a plugin, click and type through it, and read back both the rendered screen and the editor's internal state — all headless, in a single command, no real terminal required. It's the fastest way to develop and regression-test a plugin, and it's how the built-in plugins are tested.
+
+## The two flags
+
+- **`--plugin FILE`** loads a single Lua file as a plugin on startup, granted **all permissions** (no approval dialog). Use it to iterate on a plugin without installing it. `ttt.plugin_dir()` resolves to the file's directory.
+- **`--exec "commands"`** runs a semicolon-separated script after startup, then the editor exits. Combine with `--size WxH` for deterministic layout.
+
+```sh
+bin/ttt --size 100x30 --plugin ./my-plugin/init.lua README.md \
+  --exec "wait 300; panel plugin.init; wait 100; screenshot /tmp/out.txt; quit"
+```
+
+The plugin's name (used for its panel id, `plugin.<name>`) is the Lua file's basename without `.lua` — so `init.lua` registers as `plugin.init`.
+
+## `--exec` commands
+
+| Command | Description |
+|---------|-------------|
+| `wait MS` | Pause (let timers, async callbacks, and renders settle) |
+| `panel ID` | Open a bottom-panel tab by id (e.g. `panel output`, `panel plugin.init`) |
+| `key COMBO` | Press a key or chord (`key enter`, `key ctrl+k p`, `key tab`) |
+| `type TEXT` | Type a string |
+| `click X Y` | Click at screen coordinates |
+| `hover X Y` | Move the mouse to coordinates |
+| `drag X1 Y1 X2 Y2` | Drag between two points |
+| `exec "Command Name"` | Run a command by its palette title |
+| `screenshot PATH` | Write the current screen (plain text) to a file |
+| `debug PATH` | Write the editor's full state as JSON to a file |
+| `quit` | Exit |
+
+## Reading results: screen vs. state
+
+The harness gives you two windows into the editor, and the gap between them is where bugs hide.
+
+**`screenshot`** is what the user sees — the rendered grid as text. Grep it for labels, widget content, dialog text.
+
+**`debug`** is what actually happened — a JSON dump of cursor, selection, active tab, open panels, the widget tree, and the **OUTPUT log** (everything the plugin logged with `ttt.log`). This is your assertion channel: have your plugin `ttt.log` what it did, then read it back.
+
+```sh
+bin/ttt --size 100x30 --plugin ./init.lua file.txt \
+  --exec "wait 300; panel plugin.init; key tab; key enter; wait 100; debug /tmp/state.json; quit"
+```
+
+```sh
+# Pull the plugin's log lines out of the dump
+python3 -c "import json; print([l for l in json.load(open('/tmp/state.json'))['output']])"
+```
+
+A common pattern: the screenshot shows the panel *looks* unchanged, but the OUTPUT log shows a callback fired with the wrong data — that mismatch is the bug. (This is exactly how the widget system's scrollview mouse-routing bugs were found: clicks visually did nothing, but the debug dump proved events never reached the widgets.)
+
+## Isolate from your real config
+
+By default the editor reads and writes your real `~/.config/ttt` — settings toggles, installed plugins, keybindings. When scripting, set **`TTT_CONFIG_DIR`** to a throwaway directory so tests can't mutate your actual configuration and don't pick up your installed plugins:
+
+```sh
+TTT_CONFIG_DIR=/tmp/ttt-test bin/ttt --plugin ./init.lua --exec "..."
+```
+
+Always do this in any automated test — a scripted run of a settings-toggling command will otherwise persist into your real config.
+
+## Testing a scoped plugin (with a manifest)
+
+`--plugin` grants all permissions, so it can't exercise permission scoping. To test a plugin the way it will really run — with its manifest permissions — install it into an isolated config dir and pre-approve it in the registry:
+
+```sh
+CFG=/tmp/ttt-test
+mkdir -p "$CFG/plugins"
+cp -r ./my-plugin "$CFG/plugins/"
+# pre-approve so it loads enabled without the permission dialog
+cat > "$CFG/plugins.ttt.json" <<'JSON'
+[{"name":"my-plugin","version":"","enabled":true,"permissions":{"network.http":["cheat.sh"]}}]
+JSON
+
+TTT_CONFIG_DIR="$CFG" bin/ttt --size 100x30 somefile.txt \
+  --exec "wait 400; panel output; wait 100; screenshot /tmp/out.txt; quit"
+```
+
+The `permissions` block in the registry entry must match the plugin's manifest, or the editor will re-prompt for approval.
+
+## Example: assert an interval timer fires
+
+```lua
+-- timers.lua
+local ttt = require("ttt")
+local ticks = 0
+ttt.set_interval(100, function()
+  ticks = ticks + 1
+  ttt.log("info", "tick " .. ticks)
+end)
+```
+
+```sh
+bin/ttt --size 100x30 --plugin ./timers.lua file.txt \
+  --exec "wait 550; panel output; wait 100; screenshot /tmp/out.txt; quit"
+grep -c "tick" /tmp/out.txt   # ~5 ticks in 550ms
+```
+
+## Wiring it into a test runner
+
+The functional test suite (`tests/functional/`) wraps this harness in a small JS helper (`tui.js`) that accumulates commands and runs them in one batch, then asserts on the returned screenshots. The pattern:
+
+```js
+tui.start("--plugin", pluginFile, file);
+tui.waitFor("ready");
+tui.wait(550);
+tui.panel("output");
+const s = tui.snapshot();
+const { snapshots } = tui.run();
+expect(snapshots[s]).toContain("tick 3");
+```
+
+`tui.js` sets `TTT_CONFIG_DIR` to a per-test temp directory automatically, so tests are isolated by default. See existing tests like `plugin-timers.test.js` for a complete example.
+
+## Lua debug helpers
+
+The same capture functions are available from Lua, so a plugin can screenshot or dump state from inside a callback:
+
+- `ttt.screenshot(path)` — write the screen to a file
+- `ttt.debug(path)` — write the state dump to a file
+- `ttt.click(x, y)` / `ttt.drag(x1, y1, x2, y2)` — simulate input
+- `ttt.quit()` — exit the editor

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -91,6 +91,7 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 		if lw, ok := w.(*widgets.LabelWidget); ok {
 			lw.Config.Text = desc.Text
 			lw.Config.Badge = desc.Badge
+			lw.FixedWidth = desc.FixedWidth
 			if desc.TextStyle != "" {
 				lw.Config.Style = resolveStyleName(desc.TextStyle)
 			}

--- a/internal/plugin/widget_builder_test.go
+++ b/internal/plugin/widget_builder_test.go
@@ -191,3 +191,21 @@ func TestContainersApplyBoxModel(t *testing.T) {
 		t.Errorf("scrollview box model not applied on update: %+v", sv2.Box)
 	}
 }
+
+func TestReconcileUpdatesLabelWidth(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	ws.Reconcile([]WidgetDesc{{Kind: WidgetLabel, Key: "label:0", Text: "hi", FixedWidth: 10}}, p)
+	lw := ws.items[0].(*widgets.LabelWidget)
+	if lw.FixedWidth != 10 {
+		t.Fatalf("expected initial width 10, got %d", lw.FixedWidth)
+	}
+
+	ws.Reconcile([]WidgetDesc{{Kind: WidgetLabel, Key: "label:0", Text: "hi", FixedWidth: 20}}, p)
+	lw2 := ws.items[0].(*widgets.LabelWidget)
+	if lw2.FixedWidth != 20 {
+		t.Errorf("expected width updated to 20 on reconcile, got %d", lw2.FixedWidth)
+	}
+}

--- a/pre-release.md
+++ b/pre-release.md
@@ -67,9 +67,10 @@ later; these can't be *changed* compatibly later.
   the local plugins dir, opens the entry file
 - [ ] **10. Registry version pinning** — install/update to tags instead of `git pull`
   whatever main is
-- [ ] **11. Plugin testing recipe docs** — the `--plugin` + `--exec` harness works
-  today (it found 6 widget bugs in the QA sweep); needs a docs-web page showing the
-  pattern
+- [x] **11. Plugin testing recipe docs** — DONE. New `guides/plugin-testing.md`:
+  `--plugin`/`--exec` harness, screenshot-vs-debug assertion pattern, `TTT_CONFIG_DIR`
+  isolation, testing scoped plugins via a pre-approved registry, timer example, and
+  `tui.js` wiring. Sidebar entry added.
 - [ ] **12. Render-time watchdog** — plugin render runs on the UI thread; log a
   warning when a plugin's render exceeds a budget (the 10-error auto-disable catches
   crashes, not slowness)


### PR DESCRIPTION
Worklist item 11 (plugin testing docs) plus a full doc-consistency audit of the plugin API against the code.

## New: Testing Plugins guide
`guides/plugin-testing.md` — how to drive a plugin headlessly:
- `--plugin` (load a file with all permissions) + `--exec` (scripted commands) with the full command table
- The **screenshot vs. debug** assertion pattern (rendered screen vs. internal state / OUTPUT log) — the technique that found the widget-system bugs in the QA sweep
- `TTT_CONFIG_DIR` isolation so tests never touch your real config
- Testing a **scoped** plugin (manifest permissions) via a pre-approved registry entry
- Timer assertion example + the `tui.js` functional-test wiring

## Doc-gap audit fixes
An audit of docs-web against `internal/plugin/` surfaced four gaps:
1. ~~`network.http` documented as bool-only~~ — already fixed in #332 (host-allowlist section present).
2. **Five `ttt.*` debug helpers undocumented** (`screenshot`, `debug`, `click`, `drag`, `quit`) — now a "Debug helpers" section + core-module list.
3. **`os.clock()`** described as CPU time; it's wall-clock (`sandbox.go`) — corrected.
4. **`p:label` `width` not updated on reconcile** — this was a real code bug (`updateWidget` omitted `FixedWidth`), fixed + test, matching the title/input reconcile fixes.

Everything else (manifest, all widget fields, editor/fs/system/net/events/json/settings modules, styles, other permissions) audited consistent.

## Tests
- `TestReconcileUpdatesLabelWidth` for the label fix
- `go test ./...` green, functional 189, docs-web builds (20 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)