### PR TITLE
docs: add Outline to LSP features, fix Nix command, credit contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,23 @@ yay -S ttt
 
 ### NixOS
 
-> **Note:** Always install from a tagged release. The `main` branch is unstable and may contain work-in-progress features.
+> **Note:** The flake tracks `main`. A future tagged release will ship a pinned flake; until then, install from `main`.
 
 Try it without installing:
 ```sh
-nix run github:eugenioenko/ttt/v0.3.5
+nix run github:eugenioenko/ttt
 ```
 
 Add to your `flake.nix` inputs:
 ```nix
 {
-  inputs.ttt.url = "github:eugenioenko/ttt/v0.3.5";
+  inputs.ttt.url = "github:eugenioenko/ttt";
 }
 ```
 
 Then add `inputs.ttt.packages.${system}.default` to your `environment.systemPackages` or home-manager packages.
+
+Thanks to [@pirate-boop](https://github.com/pirate-boop) for keeping the flake's `vendorHash` in sync.
 
 ### Go Install
 
@@ -276,6 +278,9 @@ To disable LSP entirely: `"lsp": { "enabled": false }` in settings.
 | Format Document (External) | Ctrl+L E | Format using an external formatter from settings |
 | Format Selection | *(command palette)* | Format the selected range via LSP |
 | Diagnostics | *(automatic)* | Error/warning squiggles inline, status bar summary, hover popup |
+| Outline | *(command palette)* | Symbol tree of the current file in the sidebar; navigate and jump to definitions. Uses LSP document symbols with a built-in fallback for Go and Markdown |
+
+The Outline panel was contributed by [@tenox7](https://github.com/tenox7).
 
 #### Auto-Completion
 

--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ To disable LSP entirely: `"lsp": { "enabled": false }` in settings.
 | Format Document (External) | Ctrl+L E | Format using an external formatter from settings |
 | Format Selection | *(command palette)* | Format the selected range via LSP |
 | Diagnostics | *(automatic)* | Error/warning squiggles inline, status bar summary, hover popup |
-| Outline | *(command palette)* | Symbol tree of the current file in the sidebar; navigate and jump to definitions. Uses LSP document symbols with a built-in fallback for Go and Markdown |
+| Outline\* | *(command palette)* | Symbol tree of the current file in the sidebar; navigate and jump to definitions. Uses LSP document symbols with a built-in fallback for Go and Markdown |
 
-The Outline panel was contributed by [@tenox7](https://github.com/tenox7).
+\* Thanks to [@tenox7](https://github.com/tenox7) for contributing the Outline feature.
 
 #### Auto-Completion
 


### PR DESCRIPTION
Small README polish + contributor credits.

## Changes

**NixOS section**
- Fixed the install command: it pointed at `github:eugenioenko/ttt/v0.3.5`, but that tag predates the flake (added just after v0.3.5) and has no `flake.nix` — so the command never worked. Now tracks `main`, which builds correctly.
- Updated the note accordingly (flake tracks `main`; a future tagged release will ship a pinned flake).
- Thanked @pirate-boop for the `vendorHash` fix (#336) that keeps the flake building.

**LSP → Supported Features**
- Added the **Outline** panel (symbol tree of the current file; LSP document symbols with a built-in Go/Markdown fallback).
- Credited @tenox7, who contributed the feature (#321).

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)