### PR TITLE
feat: add spell checking via aspell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ The codebase follows a strict layered architecture: **core → view → render �
 
 - **`internal/workspace/`** — Multi-folder workspace management. `Folder` and `Workspace` types track one or more project roots, with `IsRepo` git-detection, `FolderForFile` lookup (longest-prefix match), and JSON-based workspace file loading/saving (`.ttt` files). The editor falls back to `cwd` when no folders are explicitly provided.
 
+- **`internal/spell/`** — Spell checking via the `aspell` binary (ispell pipe protocol). Prose filetypes only (`ModeForLanguage` maps highlighter language → aspell filter mode; code files are skipped). Misspellings render as curly underlines through the same `UlStyle` cell channel as LSP diagnostics (diagnostics take precedence). Async flow mirrors the git gutter: `ScheduleSpellCheck` (debounced, `spell.debounce`) → `RequestSpellCheck` (generation counter, line copy, goroutine) → `SpellResult` via `EventInterrupt`. Corrections apply as a single-undo `BatchCommand` after verifying the span is not stale. Off by default (`spell.enabled`); toggled from the Options menu. Suggestions surface via `spell.suggest` (autocomplete popup) and the editor right-click menu.
+
 - **`cmd/ttt/main.go`** — Entry point with event loop. Wires all components together, handles key dispatch, viewport scrolling, and redraw. Accepts a `--workspace <file>` flag to open a saved workspace, or folder/file paths as positional arguments.
 
 ### Design Principles
@@ -174,6 +176,7 @@ cat /tmp/state.json   # see full widget tree, focus, selection, panels
 
 Supported commands:
 - `click X Y` — simulate mouse click at coordinates
+- `rclick X Y` — simulate right click at coordinates
 - `hover X Y` — simulate mouse hover (move) at coordinates
 - `key COMBO` — simulate key press (e.g. `key ctrl+p`, `key enter`, `key ctrl+k x`)
 - `type TEXT` — type a string of text

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ cp bin/ttt ~/.local/bin/
 - **Auto-completion** — LSP-powered completions with live filtering, debounce, and auto-import support
 - **Signature help** — parameter hints shown automatically on `(` and `,`
 - **Diagnostics** — inline curly underline squiggles, problems panel, hover popup, and status bar counts
+- **Spell checking** — prose files (markdown, HTML, XML, TeX, plain text) checked via [aspell](http://aspell.net) with curly-underline squiggles; corrections from the right-click menu or command palette, personal dictionary support; toggle in the Options menu (off by default, requires `aspell` in PATH)
 - **Document formatting** — format document, format selection, and format-on-save via LSP (command palette)
 - **Git blame** — inline blame info for the current line shown in the status bar (author, relative time, summary)
 - **Line numbers** with current-line highlighting

--- a/config/settings.json
+++ b/config/settings.json
@@ -36,5 +36,8 @@
   },
   "markdown": {
     "wrapWidth": 80
+  },
+  "spell": {
+    "debounce": 500
   }
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -78,6 +78,9 @@ type App struct {
 	Watcher                *watcher.Watcher
 	GitGutterGen           int
 	GitGutterTimer         *time.Timer
+	SpellGen               int
+	SpellTimer             *time.Timer
+	spellErrShown          bool
 	Version                string
 	PluginManager          *plugin.Manager
 	PendingPluginApprovals []*plugin.Plugin
@@ -436,6 +439,7 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		a.ScheduleAutocomplete()
 		a.CheckSignatureHelpTrigger()
 		a.ScheduleGitGutter()
+		a.ScheduleSpellCheck()
 		if a.PluginManager != nil {
 			a.PluginManager.DispatchEvent("editor.change", path)
 		}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -19,6 +19,7 @@ func RegisterCommands(app *App) {
 	registerPRCommands(app)
 	registerHelpCommands(app)
 	registerOptionsCommands(app)
+	registerSpellCommands(app)
 	registerSettingsCommands(app)
 	registerPluginCommands(app)
 	registerDebugCommands(app)

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/spell"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/widgets"
@@ -58,6 +59,22 @@ func (a *App) ToggleGitGutter() {
 	} else if a.EditorGroup.Editor != nil {
 		a.EditorGroup.Editor.LineChanges = nil
 	}
+}
+
+func (a *App) ToggleSpellCheck() {
+	enabled := !a.Settings.Spell.IsEnabled()
+	a.Settings.Spell.Enabled = &enabled
+	config.SaveSettings(*a.Settings)
+	if !enabled {
+		a.EditorGroup.ClearAllMisspellings()
+		return
+	}
+	if !spell.Available() {
+		a.StatusWarn("aspell not found in PATH — install aspell to enable spell check")
+		return
+	}
+	a.spellErrShown = false
+	a.RequestSpellCheck()
 }
 
 func (a *App) SetGutterStyle(style string) {
@@ -147,6 +164,11 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		gitGutterChecked = ui.MenuChecked
 	}
 
+	spellChecked := ui.MenuUnchecked
+	if a.Settings.Spell.IsEnabled() {
+		spellChecked = ui.MenuChecked
+	}
+
 	syntaxChecked := ui.MenuUnchecked
 	if a.Settings.Editor.IsSyntaxHighlightEnabled() {
 		syntaxChecked = ui.MenuChecked
@@ -159,6 +181,7 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		{Label: "Bracket Colors", Command: "options.toggleBracketColors", Checked: bracketColorChecked},
 		{Label: "LSP Code Assist", Command: "options.toggleLSP", Checked: lspChecked},
 		{Label: "Git Gutter", Command: "options.toggleGitGutter", Checked: gitGutterChecked},
+		{Label: "Spell Check", Command: "options.toggleSpellCheck", Checked: spellChecked},
 		ui.MenuSep(),
 		{Label: "Gutter Style", Command: "options.gutterStyle"},
 		{Label: "Border Style", Command: "options.borderStyle"},
@@ -207,6 +230,12 @@ func registerOptionsCommands(app *App) {
 		ID: "options.toggleGitGutter", Title: "Toggle Git Gutter",
 		Keywords: []string{"preferences", "settings", "editor", "view", "git"},
 		Handler:  app.ToggleGitGutter,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.toggleSpellCheck", Title: "Toggle Spell Check",
+		Keywords: []string{"preferences", "settings", "editor", "spelling", "aspell", "typo"},
+		Handler:  app.ToggleSpellCheck,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/debug_dump.go
+++ b/internal/app/debug_dump.go
@@ -21,6 +21,7 @@ type DebugState struct {
 	ActiveTab   int              `json:"active_tab"`
 	Overlay     *DebugOverlay    `json:"overlay"`
 	Selection   DebugSelection   `json:"selection"`
+	Misspelled  []DebugSpell     `json:"misspelled,omitempty"`
 	Output      []string         `json:"output"`
 	WidgetTree  *DebugWidgetNode `json:"widget_tree"`
 }
@@ -66,6 +67,12 @@ type DebugSelection struct {
 type DebugPos struct {
 	Line int `json:"line"`
 	Col  int `json:"col"`
+}
+
+type DebugSpell struct {
+	Line int    `json:"line"`
+	Col  int    `json:"col"`
+	Word string `json:"word"`
 }
 
 type DebugWidgetNode struct {
@@ -133,6 +140,12 @@ func (a *App) BuildDebugState() *DebugState {
 			Active: true,
 			Start:  &DebugPos{Line: sl, Col: sc},
 			End:    &DebugPos{Line: el, Col: ec},
+		}
+	}
+
+	if a.EditorGroup.Editor != nil {
+		for _, m := range a.EditorGroup.Editor.Misspellings {
+			state.Misspelled = append(state.Misspelled, DebugSpell{Line: m.Line, Col: m.Col, Word: m.Word})
 		}
 	}
 

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -101,6 +101,7 @@ func RunEventLoop(
 		if filePath != lastGutterFile {
 			lastGutterFile = filePath
 			app.RequestGitGutterForActiveFile()
+			app.RequestSpellCheck()
 		}
 
 		if filePath != lastCursorFile || line != lastCursorLine || col != lastCursorCol {
@@ -235,6 +236,10 @@ func RunEventLoop(
 				}
 			case *GitGutterTrigger:
 				app.RequestGitGutterForActiveFile()
+			case *SpellResult:
+				app.HandleSpellResult(v)
+			case *SpellTrigger:
+				app.RequestSpellCheck()
 			case *AutocompleteTrigger:
 				triggerChar := app.charBeforeCursor()
 				isTrigger := triggerChar != "" && (len(app.CompletionTriggers) == 0 || app.isCompletionTrigger(triggerChar))

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -29,6 +29,8 @@ func RunExecScript(a *App, script string) {
 		switch action {
 		case "click":
 			execClick(a, args)
+		case "rclick":
+			execRightClick(a, args)
 		case "hover":
 			execHover(a, args)
 		case "drag":
@@ -90,6 +92,28 @@ func execClick(a *App, args string) {
 	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button1, tcell.ModNone))
 	time.Sleep(50 * time.Millisecond)
 	// Release
+	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+}
+
+func execRightClick(a *App, args string) {
+	parts := strings.Fields(args)
+	if len(parts) < 2 {
+		slog.Error("exec_script: rclick requires X Y", "args", args)
+		return
+	}
+	x, err := strconv.Atoi(parts[0])
+	if err != nil {
+		slog.Error("exec_script: invalid rclick X", "value", parts[0], "error", err)
+		return
+	}
+	y, err := strconv.Atoi(parts[1])
+	if err != nil {
+		slog.Error("exec_script: invalid rclick Y", "value", parts[1], "error", err)
+		return
+	}
+
+	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button2, tcell.ModNone))
+	time.Sleep(50 * time.Millisecond)
 	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
 }
 

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/ui"
 
@@ -135,12 +138,15 @@ func resolveShortcuts(reg *command.Registry, items []ui.ContextMenuItem) []ui.Co
 }
 
 func openContextMenu(app *App, items []ui.ContextMenuItem, x, y int) {
-	reg := app.Reg
-	menu := ui.NewContextMenuWidget(resolveShortcuts(reg, items), x, y)
+	openContextMenuWith(app, items, x, y, func(cmd string) { app.Reg.Execute(cmd) })
+}
+
+func openContextMenuWith(app *App, items []ui.ContextMenuItem, x, y int, exec func(cmd string)) {
+	menu := ui.NewContextMenuWidget(resolveShortcuts(app.Reg, items), x, y)
 	menu.Borders = app.Borders
 	menu.OnExec = func(cmd string) {
 		app.Root.PopOverlay()
-		reg.Execute(cmd)
+		exec(cmd)
 	}
 	menu.OnDismiss = func() {
 		app.Root.PopOverlay()
@@ -231,6 +237,52 @@ func handleRightClick(app *App, mx, my int) {
 	if app.EditorGroup.ActiveDiffWidget() != nil {
 		openContextMenu(app, diffContextMenu, mx, my)
 	} else {
-		openContextMenu(app, editorContextMenu, mx, my)
+		openEditorContextMenu(app, mx, my)
 	}
+}
+
+const maxSpellMenuSuggestions = 5
+
+// openEditorContextMenu opens the editor context menu, prepending correction
+// items when the click landed on a misspelled word.
+func openEditorContextMenu(app *App, mx, my int) {
+	var fix *ui.SpellSpan
+	if editor := app.EditorGroup.Editor; editor != nil {
+		if line, col, ok := editor.MouseToBufferPos(mx, my); ok {
+			fix = editor.MisspellingAt(line, col)
+		}
+	}
+	if fix == nil {
+		openContextMenu(app, editorContextMenu, mx, my)
+		return
+	}
+
+	span := *fix
+	var items []ui.ContextMenuItem
+	for i, s := range span.Suggestions {
+		if i >= maxSpellMenuSuggestions {
+			break
+		}
+		items = append(items, ui.ContextMenuItem{
+			Label:   "Correct to \"" + s + "\"",
+			Command: "spell.apply." + strconv.Itoa(i),
+		})
+	}
+	items = append(items,
+		ui.ContextMenuItem{Label: "Add \"" + span.Word + "\" to Dictionary", Command: "spell.add"},
+		ui.MenuSep())
+	items = append(items, editorContextMenu...)
+
+	openContextMenuWith(app, items, mx, my, func(cmd string) {
+		switch {
+		case strings.HasPrefix(cmd, "spell.apply."):
+			if i, err := strconv.Atoi(strings.TrimPrefix(cmd, "spell.apply.")); err == nil && i < len(span.Suggestions) {
+				app.ApplySpellFix(span, span.Suggestions[i])
+			}
+		case cmd == "spell.add":
+			app.AddSpellWord(span.Word)
+		default:
+			app.Reg.Execute(cmd)
+		}
+	})
 }

--- a/internal/app/spellcheck.go
+++ b/internal/app/spellcheck.go
@@ -1,0 +1,212 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/core/undo"
+	"github.com/eugenioenko/ttt/internal/spell"
+	"github.com/eugenioenko/ttt/internal/ui"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// SpellResult carries the async result of an aspell run.
+type SpellResult struct {
+	Gen   int
+	Path  string
+	Spans []ui.SpellSpan
+	Err   string
+}
+
+// SpellTrigger is posted as an EventInterrupt to request a spell check on the
+// main thread after a debounce delay.
+type SpellTrigger struct{}
+
+// ScheduleSpellCheck debounces spell checking during typing.
+func (a *App) ScheduleSpellCheck() {
+	if !a.Settings.Spell.IsEnabled() {
+		return
+	}
+	if a.SpellTimer != nil {
+		a.SpellTimer.Stop()
+	}
+	debounce := time.Duration(a.Settings.Spell.Debounce) * time.Millisecond
+	a.SpellTimer = time.AfterFunc(debounce, func() {
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&SpellTrigger{}))
+	})
+}
+
+// RequestSpellCheck triggers an async aspell run over the active file. The
+// result is posted as a SpellResult via EventInterrupt.
+func (a *App) RequestSpellCheck() {
+	if !a.Settings.Spell.IsEnabled() || !spell.Available() {
+		return
+	}
+	path := a.EditorGroup.ActiveFilePath()
+	buf := a.EditorGroup.ActiveBuffer()
+	if path == "" || buf == nil || a.EditorGroup.IsActiveVirtual() {
+		return
+	}
+	lang := ""
+	if a.EditorGroup.Editor.Highlighter != nil {
+		lang = a.EditorGroup.Editor.Highlighter.Language()
+	}
+	mode, ok := spell.ModeForLanguage(lang)
+	if !ok {
+		a.EditorGroup.SetMisspellings(path, nil)
+		return
+	}
+
+	a.SpellGen++
+	gen := a.SpellGen
+	linesCopy := make([]string, len(buf.Lines))
+	copy(linesCopy, buf.Lines)
+	dict := a.Settings.Spell.Lang
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		found, err := spell.Check(ctx, linesCopy, dict, mode)
+		if err != nil {
+			a.Screen.PostEvent(tcell.NewEventInterrupt(&SpellResult{Gen: gen, Path: path, Err: err.Error()}))
+			return
+		}
+		spans := make([]ui.SpellSpan, len(found))
+		for i, m := range found {
+			spans[i] = ui.SpellSpan{
+				Line:        m.Line,
+				Col:         m.Col,
+				Len:         len([]rune(m.Word)),
+				Word:        m.Word,
+				Suggestions: m.Suggestions,
+			}
+		}
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&SpellResult{Gen: gen, Path: path, Spans: spans}))
+	}()
+}
+
+// HandleSpellResult applies an async spell result on the main thread.
+func (a *App) HandleSpellResult(v *SpellResult) {
+	if v.Err != "" {
+		if !a.spellErrShown {
+			a.spellErrShown = true
+			a.StatusError("Spell check: " + v.Err)
+		}
+		return
+	}
+	if v.Gen == a.SpellGen {
+		a.EditorGroup.SetMisspellings(v.Path, v.Spans)
+	}
+}
+
+func (a *App) spellAtCursor() *ui.SpellSpan {
+	if !a.EditorGroup.IsEditorActive() {
+		return nil
+	}
+	editor := a.EditorGroup.Editor
+	return editor.MisspellingAt(editor.Cursor.Line, editor.Cursor.Col)
+}
+
+// SpellSuggest shows correction suggestions for the misspelled word at the
+// cursor in an autocomplete popup.
+func (a *App) SpellSuggest() {
+	m := a.spellAtCursor()
+	if m == nil {
+		a.StatusNotify("No misspelling at cursor")
+		return
+	}
+	if len(m.Suggestions) == 0 {
+		a.StatusNotify("No suggestions for \"" + m.Word + "\"")
+		return
+	}
+	items := make([]ui.CompletionItem, len(m.Suggestions))
+	for i, s := range m.Suggestions {
+		items[i] = ui.CompletionItem{Label: s, InsertText: s}
+	}
+	fix := *m
+	// Not routed through ShowAutocomplete: prefix filtering would drop
+	// corrections that don't share a prefix with the misspelled word.
+	a.CompletionItems = nil
+	ac := ui.NewAutocompleteWidget(items, 0, 0)
+	ac.OnSelect = func(item ui.CompletionItem) {
+		a.DismissAutocomplete()
+		a.ApplySpellFix(fix, item.InsertText)
+	}
+	ac.OnDismiss = func() {
+		a.DismissAutocomplete()
+	}
+	a.EditorGroup.Autocomplete = ac
+}
+
+// ApplySpellFix replaces a misspelled word with the chosen correction as a
+// single undoable edit. Spans can go stale between the async check and the
+// user acting on one, so the word is verified in place first.
+func (a *App) ApplySpellFix(m ui.SpellSpan, replacement string) {
+	if !a.EditorGroup.IsEditorActive() {
+		return
+	}
+	editor := a.EditorGroup.Editor
+	if m.Line >= len(editor.Buf.Lines) {
+		return
+	}
+	runes := []rune(editor.Buf.Lines[m.Line])
+	if m.Col+m.Len > len(runes) || string(runes[m.Col:m.Col+m.Len]) != m.Word {
+		a.RequestSpellCheck()
+		return
+	}
+	if editor.Undo != nil {
+		editor.Undo.BreakGroup()
+	}
+	editor.ExecCommand(&undo.BatchCommand{Commands: []undo.EditCommand{
+		&undo.DeleteSelectionCommand{
+			StartLine: m.Line, StartCol: m.Col,
+			EndLine: m.Line, EndCol: m.Col + m.Len,
+		},
+		&undo.PasteCommand{
+			Line: m.Line, Col: m.Col,
+			Text: replacement, Suffix: string(runes[m.Col+m.Len:]),
+		},
+	}})
+	editor.Cursor.Line = m.Line
+	editor.Cursor.Col = m.Col + len([]rune(replacement))
+	editor.FlushOnChange()
+	a.RequestSpellCheck()
+}
+
+// SpellAddWord adds the misspelled word at the cursor to the personal
+// aspell dictionary.
+func (a *App) SpellAddWord() {
+	m := a.spellAtCursor()
+	if m == nil {
+		a.StatusNotify("No misspelling at cursor")
+		return
+	}
+	a.AddSpellWord(m.Word)
+}
+
+func (a *App) AddSpellWord(word string) {
+	if err := spell.AddToDictionary(a.Settings.Spell.Lang, word); err != nil {
+		a.StatusError("Failed to add \"" + word + "\" to dictionary: " + err.Error())
+		return
+	}
+	a.StatusNotify("Added \"" + word + "\" to dictionary")
+	a.RequestSpellCheck()
+}
+
+func registerSpellCommands(app *App) {
+	reg := app.Reg
+
+	reg.Register(command.Command{
+		ID: "spell.suggest", Title: "Spell: Suggest Corrections",
+		Keywords: []string{"spelling", "typo", "aspell", "fix"},
+		Handler:  app.SpellSuggest,
+	})
+
+	reg.Register(command.Command{
+		ID: "spell.addWord", Title: "Spell: Add Word to Dictionary",
+		Keywords: []string{"spelling", "personal", "aspell", "ignore"},
+		Handler:  app.SpellAddWord,
+	})
+}

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -83,6 +83,7 @@ func BuildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	applyDiagStyle(&m, term.StyleDiagWarning, theme.Editor.Diagnostics.Warning)
 	applyDiagStyle(&m, term.StyleDiagInfo, theme.Editor.Diagnostics.Info)
 	applyDiagStyle(&m, term.StyleDiagHint, theme.Editor.Diagnostics.Hint)
+	applyDiagStyle(&m, term.StyleSpellError, theme.Editor.SpellError)
 
 	applyBracketColors(&m, theme.Editor.BracketColors, theme.Terminal)
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -103,6 +103,22 @@ func DefaultEditorSettings() EditorSettings {
 	}
 }
 
+type SpellSettings struct {
+	Enabled  *bool  `json:"enabled,omitempty"`
+	Lang     string `json:"lang,omitempty"`
+	Debounce int    `json:"debounce"`
+}
+
+func (s SpellSettings) IsEnabled() bool {
+	return s.Enabled != nil && *s.Enabled
+}
+
+func DefaultSpellSettings() SpellSettings {
+	return SpellSettings{
+		Debounce: 500,
+	}
+}
+
 type SearchSettings struct {
 	Debounce int `json:"debounce"`
 }
@@ -155,6 +171,7 @@ type Settings struct {
 	Autocomplete AutocompleteSettings `json:"autocomplete,omitzero"`
 	Plugins      PluginSettings       `json:"plugins,omitzero"`
 	Markdown     MarkdownSettings     `json:"markdown,omitzero"`
+	Spell        SpellSettings        `json:"spell,omitzero"`
 	Formatters   map[string]string    `json:"formatters,omitempty"`
 }
 
@@ -168,6 +185,7 @@ func DefaultSettings() Settings {
 		LSP:          DefaultLSPSettings(),
 		Autocomplete: DefaultAutocompleteSettings(),
 		Markdown:     DefaultMarkdownSettings(),
+		Spell:        DefaultSpellSettings(),
 	}
 }
 

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -71,6 +71,7 @@ type EditorStyles struct {
 	BracketMatch  StyleDef         `json:"bracketMatch"`
 	BracketColors []string         `json:"bracketColors,omitempty"`
 	Diagnostics   DiagnosticStyles `json:"diagnostics"`
+	SpellError    StyleDef         `json:"spellError"`
 }
 
 type DiffStyles struct {
@@ -310,6 +311,7 @@ func (t *ThemeConfig) ResolveColors() {
 	fillFg(&t.Editor.Diagnostics.Warning, t.Warning.Fg)
 	fillFg(&t.Editor.Diagnostics.Info, t.Default.Fg)
 	fillFg(&t.Editor.Diagnostics.Hint, t.Default.Fg)
+	fillFg(&t.Editor.SpellError, t.Warning.Fg)
 	if !t.Hover.Bold.Bold {
 		t.Hover.Bold.Bold = true
 	}

--- a/internal/spell/aspell.go
+++ b/internal/spell/aspell.go
@@ -1,0 +1,162 @@
+// Package spell provides spell checking by piping text through aspell's
+// ispell-compatible pipe protocol.
+package spell
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Misspelling is one misspelled word found by aspell.
+type Misspelling struct {
+	Line        int // 0-based buffer line
+	Col         int // rune column of the word start
+	Word        string
+	Suggestions []string
+}
+
+const maxSuggestions = 10
+
+var (
+	lookOnce sync.Once
+	binPath  string
+)
+
+// Available reports whether the aspell binary is present in PATH.
+func Available() bool {
+	lookOnce.Do(func() { binPath, _ = exec.LookPath("aspell") })
+	return binPath != ""
+}
+
+// ModeForLanguage maps a highlighter language name to an aspell filter mode.
+// ok is false for languages that should not be spell checked (code files).
+// An empty language (file with no highlighter) is checked as plain text.
+func ModeForLanguage(lang string) (mode string, ok bool) {
+	switch lang {
+	case "", "plaintext", "reStructuredText", "Org Mode":
+		return "", true
+	case "markdown":
+		return "markdown", true
+	case "HTML":
+		return "html", true
+	case "XML":
+		return "sgml", true
+	case "TeX":
+		return "tex", true
+	}
+	return "", false
+}
+
+// Check pipes lines through aspell and returns the misspellings found.
+// lang is an aspell dictionary code like "en_US"; empty follows locale settings.
+func Check(ctx context.Context, lines []string, lang, mode string) ([]Misspelling, error) {
+	args := []string{"pipe", "--encoding=utf-8"}
+	if mode != "" {
+		args = append(args, "--mode="+mode)
+	}
+	if lang != "" {
+		args = append(args, "--lang="+lang)
+	}
+	cmd := exec.CommandContext(ctx, "aspell", args...)
+	var in strings.Builder
+	in.WriteString("!\n") // terse mode: no output for correct words
+	for _, line := range lines {
+		in.WriteString("^") // data-line prefix so aspell never parses line content as a command
+		in.WriteString(line)
+		in.WriteString("\n")
+	}
+	cmd.Stdin = strings.NewReader(in.String())
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			msg, _, _ := strings.Cut(strings.TrimSpace(string(exitErr.Stderr)), "\n")
+			return nil, errors.New(msg)
+		}
+		return nil, err
+	}
+	return parsePipeOutput(out), nil
+}
+
+// parsePipeOutput parses ispell -a output: a version banner, then results per
+// input line terminated by a blank line. Reported offsets are rune positions
+// in the sent line, shifted by one for the ^ prefix.
+func parsePipeOutput(out []byte) []Misspelling {
+	var found []Misspelling
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	line := 0
+	first := true
+	for sc.Scan() {
+		text := sc.Text()
+		if first {
+			first = false
+			if strings.HasPrefix(text, "@(#)") {
+				continue
+			}
+		}
+		if text == "" {
+			line++
+			continue
+		}
+		if m, ok := parseResult(text); ok {
+			m.Line = line
+			found = append(found, m)
+		}
+	}
+	return found
+}
+
+// parseResult parses "& word count offset: sug1, sug2" and "# word offset".
+func parseResult(s string) (Misspelling, bool) {
+	if len(s) < 3 || (s[0] != '&' && s[0] != '#') {
+		return Misspelling{}, false
+	}
+	body := s[2:]
+	var sugs []string
+	if s[0] == '&' {
+		head, rest, ok := strings.Cut(body, ": ")
+		if !ok {
+			return Misspelling{}, false
+		}
+		body = head
+		sugs = strings.Split(rest, ", ")
+		if len(sugs) > maxSuggestions {
+			sugs = sugs[:maxSuggestions]
+		}
+	}
+	fields := strings.Fields(body)
+	wordEnd := len(fields) - 1 // "# word offset"
+	if s[0] == '&' {
+		wordEnd = len(fields) - 2 // "& word count offset"
+	}
+	if wordEnd < 1 {
+		return Misspelling{}, false
+	}
+	offset, err := strconv.Atoi(fields[len(fields)-1])
+	if err != nil || offset < 1 {
+		return Misspelling{}, false
+	}
+	return Misspelling{
+		Col:         offset - 1,
+		Word:        strings.Join(fields[:wordEnd], " "),
+		Suggestions: sugs,
+	}, true
+}
+
+// AddToDictionary adds word to the user's personal aspell dictionary.
+func AddToDictionary(lang, word string) error {
+	args := []string{"pipe", "--encoding=utf-8"}
+	if lang != "" {
+		args = append(args, "--lang="+lang)
+	}
+	cmd := exec.Command("aspell", args...)
+	cmd.Stdin = strings.NewReader("*" + word + "\n#\n")
+	return cmd.Run()
+}

--- a/internal/spell/aspell_test.go
+++ b/internal/spell/aspell_test.go
@@ -1,0 +1,97 @@
+package spell
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestParsePipeOutput(t *testing.T) {
+	out := []byte(`@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.8.2)
+& helllo 3 1: hello, hell, he'll
+& tesst 2 23: tests, test
+
+# xqzt 8
+
+& wrld 2 12: weld, world
+`)
+	got := parsePipeOutput(out)
+	want := []Misspelling{
+		{Line: 0, Col: 0, Word: "helllo", Suggestions: []string{"hello", "hell", "he'll"}},
+		{Line: 0, Col: 22, Word: "tesst", Suggestions: []string{"tests", "test"}},
+		{Line: 1, Col: 7, Word: "xqzt"},
+		{Line: 2, Col: 11, Word: "wrld", Suggestions: []string{"weld", "world"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestParsePipeOutputBlankLinesOnly(t *testing.T) {
+	out := []byte("@(#) banner\n\n\n\n")
+	if got := parsePipeOutput(out); len(got) != 0 {
+		t.Errorf("expected no misspellings, got %+v", got)
+	}
+}
+
+func TestParseResultMalformed(t *testing.T) {
+	for _, s := range []string{"", "&", "& word", "& word 3", "# word", "& word 3 x: a", "* ok", "& w 1 0: a"} {
+		if m, ok := parseResult(s); ok {
+			t.Errorf("parseResult(%q) unexpectedly ok: %+v", s, m)
+		}
+	}
+}
+
+func TestParseResultSuggestionCap(t *testing.T) {
+	m, ok := parseResult("& word 12 5: a, b, c, d, e, f, g, h, i, j, k, l")
+	if !ok || len(m.Suggestions) != maxSuggestions {
+		t.Errorf("expected %d suggestions, got %+v ok=%v", maxSuggestions, m, ok)
+	}
+}
+
+func TestModeForLanguage(t *testing.T) {
+	cases := []struct {
+		lang string
+		mode string
+		ok   bool
+	}{
+		{"", "", true},
+		{"plaintext", "", true},
+		{"markdown", "markdown", true},
+		{"HTML", "html", true},
+		{"XML", "sgml", true},
+		{"TeX", "tex", true},
+		{"Go", "", false},
+		{"Python", "", false},
+	}
+	for _, c := range cases {
+		mode, ok := ModeForLanguage(c.lang)
+		if mode != c.mode || ok != c.ok {
+			t.Errorf("ModeForLanguage(%q) = %q,%v want %q,%v", c.lang, mode, ok, c.mode, c.ok)
+		}
+	}
+}
+
+func TestCheckRealAspell(t *testing.T) {
+	if !Available() {
+		t.Skip("aspell not installed")
+	}
+	lines := []string{"helllo world", "", "a naïve tesst"}
+	got, err := Check(context.Background(), lines, "en_US", "")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	byWord := map[string]Misspelling{}
+	for _, m := range got {
+		byWord[m.Word] = m
+	}
+	if m, ok := byWord["helllo"]; !ok || m.Line != 0 || m.Col != 0 || len(m.Suggestions) == 0 {
+		t.Errorf("helllo: %+v ok=%v", m, ok)
+	}
+	if m, ok := byWord["tesst"]; !ok || m.Line != 2 || m.Col != 8 {
+		t.Errorf("tesst: want line 2 col 8 (rune offset after naïve), got %+v ok=%v", m, ok)
+	}
+	if _, ok := byWord["world"]; ok {
+		t.Error("world flagged as misspelled")
+	}
+}

--- a/internal/term/screen.go
+++ b/internal/term/screen.go
@@ -45,6 +45,7 @@ const (
 	StyleDiagWarning
 	StyleDiagInfo
 	StyleDiagHint
+	StyleSpellError
 	StyleInput
 	StyleInputPlaceholder
 	StyleInputAction

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -42,24 +42,34 @@ type Diagnostic struct {
 	Source    string
 }
 
+// SpellSpan marks a misspelled word in the buffer, with rune-based columns.
+type SpellSpan struct {
+	Line        int
+	Col         int
+	Len         int
+	Word        string
+	Suggestions []string
+}
+
 type editorTab struct {
-	FilePath    string
-	Title       string
-	Buf         *buffer.Buffer
-	Cur         *cursor.Cursor
-	Vp          *view.Viewport
-	Undo        *undo.UndoStack
-	Sel         *selection.Selection
-	Multi       *multicursor.MultiCursor
-	Highlighter *highlight.Highlighter
-	Diagnostics []Diagnostic
-	Folds       *fold.State
-	TabSize     int
-	UseTabs     bool
-	Content     Widget
-	Pinned      bool
-	Virtual     bool
-	LineChanges []diff.LineChangeKind
+	FilePath     string
+	Title        string
+	Buf          *buffer.Buffer
+	Cur          *cursor.Cursor
+	Vp           *view.Viewport
+	Undo         *undo.UndoStack
+	Sel          *selection.Selection
+	Multi        *multicursor.MultiCursor
+	Highlighter  *highlight.Highlighter
+	Diagnostics  []Diagnostic
+	Misspellings []SpellSpan
+	Folds        *fold.State
+	TabSize      int
+	UseTabs      bool
+	Content      Widget
+	Pinned       bool
+	Virtual      bool
+	LineChanges  []diff.LineChangeKind
 }
 
 type EditorGroupWidget struct {
@@ -924,6 +934,29 @@ func (g *EditorGroupWidget) SetDiagnostics(path string, diags []Diagnostic) {
 	}
 }
 
+func (g *EditorGroupWidget) SetMisspellings(path string, spans []SpellSpan) {
+	for i := range g.tabs {
+		if g.tabs[i].FilePath == path {
+			g.tabs[i].Misspellings = spans
+			if i == g.active {
+				g.Editor.Misspellings = spans
+				g.Editor.buildSpellIndex()
+			}
+			return
+		}
+	}
+}
+
+func (g *EditorGroupWidget) ClearAllMisspellings() {
+	for i := range g.tabs {
+		g.tabs[i].Misspellings = nil
+	}
+	if g.Editor != nil {
+		g.Editor.Misspellings = nil
+		g.Editor.spellByLine = nil
+	}
+}
+
 // SetLineChanges updates the git gutter indicators for the tab with the given path.
 func (g *EditorGroupWidget) SetLineChanges(path string, changes []diff.LineChangeKind) {
 	for i := range g.tabs {
@@ -1236,9 +1269,11 @@ func (g *EditorGroupWidget) syncTabs() {
 		g.Editor.Multi = t.Multi
 		g.Editor.Highlighter = t.Highlighter
 		g.Editor.Diagnostics = t.Diagnostics
+		g.Editor.Misspellings = t.Misspellings
 		g.Editor.Folds = t.Folds
 		g.Editor.LineChanges = t.LineChanges
 		g.Editor.buildDiagIndex()
+		g.Editor.buildSpellIndex()
 		g.Editor.InvalidateBracketColors()
 		if t.TabSize > 0 {
 			g.Editor.TabSize = t.TabSize

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -50,6 +50,7 @@ type EditorPaneWidget struct {
 	scrollbar               Scrollbar
 	hscrollbar              HScrollbar
 	Diagnostics             []Diagnostic
+	Misspellings            []SpellSpan
 	Folds                   *fold.State
 	OnChange                func()
 	bufferDirty             bool
@@ -62,6 +63,7 @@ type EditorPaneWidget struct {
 	cachedVisibleLines      []int
 	searchByLine            map[int][]int
 	diagByLine              map[int][]int
+	spellByLine             map[int][]int
 	LineChanges             []diff.LineChangeKind
 	bracketColorCache       bracketColorMap
 	bracketColorDirty       bool
@@ -153,6 +155,13 @@ func (e *EditorPaneWidget) buildDiagIndex() {
 		for line := d.StartLine; line <= d.EndLine; line++ {
 			e.diagByLine[line] = append(e.diagByLine[line], i)
 		}
+	}
+}
+
+func (e *EditorPaneWidget) buildSpellIndex() {
+	e.spellByLine = make(map[int][]int, len(e.Misspellings))
+	for i, m := range e.Misspellings {
+		e.spellByLine[m.Line] = append(e.spellByLine[m.Line], i)
 	}
 }
 
@@ -453,6 +462,9 @@ func (e *EditorPaneWidget) Render(surface Surface) {
 					}
 				}
 				ulStyle := e.diagStyleAt(lineIdx, colIdx)
+				if ulStyle == 0 && e.MisspellingAt(lineIdx, colIdx) != nil {
+					ulStyle = term.StyleSpellError
+				}
 				surface.SetCell(gutterW+x, y, term.Cell{Ch: ch, Style: style, BgStyle: bgStyle, UlStyle: ulStyle})
 			}
 		} else {
@@ -541,6 +553,27 @@ func (e *EditorPaneWidget) DiagnosticAt(line, col int) *Diagnostic {
 		return d
 	}
 	return nil
+}
+
+func (e *EditorPaneWidget) MisspellingAt(line, col int) *SpellSpan {
+	for _, i := range e.spellByLine[line] {
+		m := &e.Misspellings[i]
+		if col >= m.Col && col < m.Col+m.Len {
+			return m
+		}
+	}
+	return nil
+}
+
+// MouseToBufferPos converts screen coordinates to a buffer position,
+// accounting for the gutter, scrolling and word wrap.
+func (e *EditorPaneWidget) MouseToBufferPos(mx, my int) (line, col int, ok bool) {
+	r := e.GetRect()
+	if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
+		return 0, 0, false
+	}
+	line, col = e.mouseToPos(r, mx, my)
+	return line, col, true
 }
 
 func (e *EditorPaneWidget) diagStyleAt(line, col int) term.Style {

--- a/tests/e2e/spellcheck_test.go
+++ b/tests/e2e/spellcheck_test.go
@@ -1,0 +1,160 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/app"
+	"github.com/eugenioenko/ttt/internal/spell"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/ui"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func setupSpellTest(t *testing.T, name, content string) *testHarness {
+	t.Helper()
+	if !spell.Available() {
+		t.Skip("aspell not installed")
+	}
+	h := newTestHarness(t, 100, 24)
+	enabled := true
+	h.app.Settings.Spell.Enabled = &enabled
+	h.app.Settings.Spell.Lang = "en_US"
+	f := filepath.Join(h.dir, name)
+	os.WriteFile(f, []byte(content), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+	return h
+}
+
+// runSpellCheck triggers an async spell check and pumps the posted result
+// through the same handler the event loop uses.
+func runSpellCheck(h *testHarness) {
+	h.t.Helper()
+	h.app.RequestSpellCheck()
+	watchdog := time.AfterFunc(10*time.Second, func() {
+		h.screen.PostEvent(tcell.NewEventInterrupt(nil))
+	})
+	defer watchdog.Stop()
+	for {
+		ev := h.screen.PollEvent()
+		iev, ok := ev.(*tcell.EventInterrupt)
+		if !ok {
+			continue
+		}
+		res, ok := iev.Data().(*app.SpellResult)
+		if !ok {
+			h.t.Fatal("timed out waiting for SpellResult")
+		}
+		if res.Err != "" {
+			h.t.Fatalf("spell check failed: %s", res.Err)
+		}
+		h.app.HandleSpellResult(res)
+		h.redraw()
+		return
+	}
+}
+
+func TestSpellCheckMarksMisspellings(t *testing.T) {
+	h := setupSpellTest(t, "typo.md", "# My Documnet\n\nThis is a smiple test.\n")
+	defer h.stop()
+
+	runSpellCheck(h)
+
+	editor := h.app.EditorGroup.Editor
+	if len(editor.Misspellings) != 2 {
+		t.Fatalf("expected 2 misspellings, got %+v", editor.Misspellings)
+	}
+	m := editor.MisspellingAt(0, 7)
+	if m == nil || m.Word != "Documnet" || m.Col != 5 {
+		t.Fatalf("MisspellingAt(0,7) = %+v, want Documnet at col 5", m)
+	}
+	if editor.MisspellingAt(0, 3) != nil {
+		t.Error("MisspellingAt(0,3) matched outside the word")
+	}
+	if len(m.Suggestions) == 0 {
+		t.Error("expected suggestions for Documnet")
+	}
+
+	// The misspelled cells carry the spell underline; correct cells do not.
+	cells := make([][]term.Cell, h.app.Root.Height)
+	for y := range cells {
+		cells[y] = make([]term.Cell, h.app.Root.Width)
+	}
+	h.app.Root.Render(cells)
+	r := editor.GetRect()
+	gw := editor.GutterWidth()
+	row := cells[r.Y]
+	if got := row[r.X+gw+5].UlStyle; got != term.StyleSpellError {
+		t.Errorf("cell in Documnet: UlStyle = %v, want StyleSpellError", got)
+	}
+	if got := row[r.X+gw+2].UlStyle; got != 0 {
+		t.Errorf("cell in 'My': UlStyle = %v, want 0", got)
+	}
+}
+
+func TestSpellSuggestAppliesCorrection(t *testing.T) {
+	h := setupSpellTest(t, "typo.md", "a smiple test\n")
+	defer h.stop()
+
+	runSpellCheck(h)
+
+	editor := h.app.EditorGroup.Editor
+	editor.Cursor.Line, editor.Cursor.Col = 0, 3
+	h.exec("spell.suggest")
+	if h.app.EditorGroup.Autocomplete == nil {
+		t.Fatal("expected suggestion popup")
+	}
+
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+	if h.app.EditorGroup.Autocomplete != nil {
+		t.Error("expected popup dismissed after accept")
+	}
+	line := editor.Buf.Lines[0]
+	if strings.Contains(line, "smiple") {
+		t.Errorf("expected smiple replaced, got %q", line)
+	}
+	if !strings.HasPrefix(line, "a ") || !strings.HasSuffix(line, " test") {
+		t.Errorf("replacement damaged surrounding text: %q", line)
+	}
+
+	h.exec("editor.undo")
+	if got := editor.Buf.Lines[0]; got != "a smiple test" {
+		t.Errorf("undo did not restore original line: %q", got)
+	}
+}
+
+func TestSpellCheckSkipsCodeFiles(t *testing.T) {
+	h := setupSpellTest(t, "main.go", "package main // a smiple typo\n")
+	defer h.stop()
+
+	// Code filetypes resolve to no aspell mode: the request completes
+	// synchronously with no goroutine and clears any stale spans.
+	h.app.EditorGroup.Editor.Misspellings = []ui.SpellSpan{{Line: 0, Col: 0, Len: 1, Word: "x"}}
+	h.app.RequestSpellCheck()
+	if got := h.app.EditorGroup.Editor.Misspellings; len(got) != 0 {
+		t.Errorf("expected no misspellings for Go file, got %+v", got)
+	}
+}
+
+func TestToggleSpellCheckClearsSpans(t *testing.T) {
+	h := setupSpellTest(t, "typo.md", "a smiple test\n")
+	defer h.stop()
+
+	runSpellCheck(h)
+	if len(h.app.EditorGroup.Editor.Misspellings) == 0 {
+		t.Fatal("expected misspellings before toggle")
+	}
+
+	h.exec("options.toggleSpellCheck")
+	if h.app.Settings.Spell.IsEnabled() {
+		t.Error("expected spell check disabled after toggle")
+	}
+	if got := h.app.EditorGroup.Editor.Misspellings; len(got) != 0 {
+		t.Errorf("expected spans cleared after disable, got %+v", got)
+	}
+}

--- a/tests/functional/spell-check.test.js
+++ b/tests/functional/spell-check.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function aspellAvailable() {
+  try {
+    execSync("which aspell", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!aspellAvailable())("spell check", () => {
+  it("suggests and applies a correction for a misspelled word", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "doc.md", "a smiple test\n");
+
+    tui.start(file);
+    tui.waitFor("a smiple test");
+    tui.exec("Toggle Spell Check");
+    tui.wait(1000);
+
+    tui.press("arrow_right");
+    tui.press("arrow_right");
+    tui.press("arrow_right");
+    tui.exec("Spell: Suggest Corrections");
+    tui.waitStable();
+    const sPopup = tui.snapshot();
+
+    tui.press("enter");
+    tui.waitStable();
+    const sFixed = tui.snapshot();
+
+    const { snapshots } = tui.run();
+
+    expect(snapshots[sPopup]).toContain("simple");
+    expect(snapshots[sFixed]).toContain("a simple test");
+    expect(snapshots[sFixed]).not.toContain("smiple");
+  });
+
+  it("reports no misspelling on a correct word", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "doc.md", "a simple test\n");
+
+    tui.start(file);
+    tui.waitFor("a simple test");
+    tui.exec("Toggle Spell Check");
+    tui.wait(1000);
+
+    tui.exec("Spell: Suggest Corrections");
+    tui.waitStable();
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("No misspelling at cursor");
+  });
+});


### PR DESCRIPTION
Adds native spell checking backed by `aspell`, modeled on micro's aspell plugin but integrated with ttt's existing diagnostics infrastructure.

## What it does

- Checks **prose filetypes only** — markdown, HTML, XML, TeX, reStructuredText, Org, plain text (files with no lexer, e.g. `COMMIT_EDITMSG`). Code files are skipped. Aspell filter modes (`--mode=markdown` etc.) keep code spans and URLs inside markdown out of the results.
- Misspelled words get **curly underlines** via the same `UlStyle` cell channel as LSP diagnostics. Diagnostics take precedence when both hit a cell. New theme style `editor.spellError` (defaults to the warning color).
- **Right-click a misspelled word** → up to 5 `Correct to "…"` items plus `Add "…" to Dictionary` prepended to the editor context menu.
- **Command palette**: `Spell: Suggest Corrections` (autocomplete popup at the cursor), `Spell: Add Word to Dictionary` (aspell personal dictionary), `Toggle Spell Check`.
- **Options menu** gets a Spell Check toggle with live apply (no restart). Off by default; requires `aspell` in PATH (warns when missing, inert otherwise).
- Settings: `spell.enabled`, `spell.lang` (aspell dictionary code, empty = locale), `spell.debounce` (default 500ms).

## How it works

- `internal/spell` — small aspell client speaking the ispell pipe protocol: terse mode, `^`-prefixed data lines, parses `&`/`#` result lines. Offsets are rune positions (verified with multibyte text), matching the editor's rune-based column convention.
- Async flow mirrors the git gutter: `ScheduleSpellCheck` (debounced on change) → `RequestSpellCheck` (generation counter + buffer-line copy + goroutine) → `SpellResult` posted via `EventInterrupt`. Re-checks on edit, file open, and tab switch; results are stored per tab and restored on switch, like diagnostics.
- Corrections apply as a **single-undo** `BatchCommand` (delete + paste), and the span is re-verified against the buffer first so a stale result can never mangle text — if the word moved, it just re-checks.
- Errors from aspell (e.g. missing dictionary for `spell.lang`) surface once in the status bar instead of spamming on every keystroke.

## Also included

- `rclick X Y` command in the `--exec` debug harness (needed to test the context-menu path; generally useful).
- Debug state dump now includes the active editor's misspellings.
- Regenerated reference `config/settings.json` (new `spell` section).

## Testing

- **Unit** (`internal/spell`): protocol parser (banner, blank-line tracking, `&`/`#`, suggestion cap, malformed lines), mode mapping, plus a real-aspell round-trip with multibyte offsets (skips when aspell is absent).
- **E2E** (`tests/e2e/spellcheck_test.go`): async check marks spans and sets `UlStyle` on the right cells (and not on correct words), suggest→Enter applies a correction and a single undo restores it, code files are skipped and stale spans cleared, toggle-off clears spans. All skip when aspell is missing.
- **Functional** (`tests/functional/spell-check.test.js`): toggle → suggest → accept flow and the no-misspelling notice, gated on aspell presence.
- Verified live via the debug harness: right-click menu with corrections, click-to-apply, settings persistence across runs.

## Known limitations

- Spell checking is whole-file per check (like micro's plugin); fine at typical prose sizes, guarded by a 15s timeout.
- A spell underline and an LSP diagnostic on the same cell can't stack — diagnostics win.
- Suggestions come from a completed check, so a word typed &lt;debounce ago may not offer corrections yet.
