### PR TITLE
feat: ttt.notify(message, level) plugin status-bar toasts

### DIFF
--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -257,6 +257,25 @@ ttt.show_info("Shortcuts", {
 })
 ```
 
+### `ttt.notify(message[, level])`
+
+Show a transient message in the status bar.
+
+| Parameter | Type   | Required | Description                                                       |
+|-----------|--------|----------|-------------------------------------------------------------------|
+| `message` | string | yes      | The text to show.                                                 |
+| `level`   | string | no       | `"info"` (default), `"warn"`, or `"error"` — controls the colour. |
+
+```lua
+ttt.notify("Formatted 3 files")
+ttt.notify("aspell not found in PATH", "warn")
+ttt.notify("Could not reach the server", "error")
+```
+
+Use `notify` for lightweight, non-blocking feedback (a linter's "binary missing"
+hint, "added to dictionary", and so on). For anything the user must respond to,
+use [`ttt.confirm`](#ttt-confirm) or [`ttt.show_info`](#ttt-show_info) instead.
+
 ### `ttt.open_drawer(config)`
 
 Open a drawer panel anchored to the left or right side of the editor. Requires `panel.drawer` permission.
@@ -1810,7 +1829,7 @@ local id = crypto.uuid()               -- "550e8400-e29b-41d4-a716-446655440000"
 
 | Module         | Description                    |
 |----------------|--------------------------------|
-| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown`, `screenshot`, `debug`, `click`, `drag`, `quit` |
+| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `notify`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown`, `screenshot`, `debug`, `click`, `drag`, `quit` |
 | `ttt.json`     | JSON encode/decode             |
 | `ttt.editor`   | Editor buffer read/write       |
 | `ttt.fs`       | Filesystem access              |

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -365,6 +365,16 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 			a.EditorGroup.GoToLine(line)
 		}
 	}
+	p.Notify = func(message, level string) {
+		switch level {
+		case "warn":
+			a.StatusWarn(message)
+		case "error":
+			a.StatusError(message)
+		default:
+			a.StatusNotify(message)
+		}
+	}
 	p.PostAsync = func(result *plugin.PluginAsyncResult) {
 		a.Screen.PostEvent(tcell.NewEventInterrupt(result))
 	}

--- a/internal/plugin/lua_notify_test.go
+++ b/internal/plugin/lua_notify_test.go
@@ -1,0 +1,44 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func TestNotifyLevels(t *testing.T) {
+	cases := []struct {
+		name      string
+		lua       string
+		wantMsg   string
+		wantLevel string
+	}{
+		{"default", `require("ttt").notify("hi")`, "hi", "info"},
+		{"info", `require("ttt").notify("hi", "info")`, "hi", "info"},
+		{"warn", `require("ttt").notify("careful", "warn")`, "careful", "warn"},
+		{"error", `require("ttt").notify("boom", "error")`, "boom", "error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, cleanup := newTestPluginBase(PermissionSet{})
+			defer cleanup()
+
+			var gotMsg, gotLevel string
+			var called bool
+			p.Notify = func(message, level string) {
+				gotMsg = message
+				gotLevel = level
+				called = true
+			}
+
+			if err := p.State.DoString(tc.lua); err != nil {
+				t.Fatalf("error: %v", err)
+			}
+			if !called {
+				t.Fatal("expected Notify to be called")
+			}
+			if gotMsg != tc.wantMsg || gotLevel != tc.wantLevel {
+				t.Errorf("got msg=%q level=%q, want msg=%q level=%q", gotMsg, gotLevel, tc.wantMsg, tc.wantLevel)
+			}
+		})
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -80,6 +80,7 @@ type Plugin struct {
 	DebugDumpToFile    func(path string) error
 	QuitApp            func()
 	OpenFile           func(path string, line int)
+	Notify             func(message, level string)
 	PublishDiagnostics func(path string, items []DiagnosticItem)
 	ClearDiagnostics   func(path string)
 
@@ -236,6 +237,7 @@ func (p *Plugin) Destroy() {
 	p.ScreenshotToFile = nil
 	p.DebugDumpToFile = nil
 	p.QuitApp = nil
+	p.Notify = nil
 	p.PublishDiagnostics = nil
 	p.ClearDiagnostics = nil
 	p.EditorContextProvider = nil

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -249,6 +249,15 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "notify", L.NewFunction(func(L *lua.LState) int {
+			msg := L.CheckString(1)
+			level := L.OptString(2, "info")
+			if p.Notify != nil {
+				p.Notify(msg, level)
+			}
+			return 0
+		}))
+
 		L.SetField(mod, "show_info", L.NewFunction(func(L *lua.LState) int {
 			title := L.CheckString(1)
 			tbl := L.CheckTable(2)


### PR DESCRIPTION
Implements #344: expose status-bar toasts to Lua plugins.

## API

```lua
local ttt = require("ttt")
ttt.notify("Done")               -- info (default)
ttt.notify("Careful", "warn")    -- warning
ttt.notify("Failed", "error")    -- error
```

## Changes

- Added `Notify func(message, level string)` capability field to `Plugin` (nilled in `Destroy()`).
- Wired it in `App.WirePlugin` to dispatch to the existing `StatusNotify`/`StatusWarn`/`StatusError` methods based on level (defaults to info).
- Registered `ttt.notify` in `setupTTTModule` (no new permission — benign).
- Unit test covering default, info, warn, and error levels.

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)