### PR TITLE
feat: editor.byte_to_col / col_to_byte rune-offset helpers

### DIFF
--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -1258,6 +1258,24 @@ Require the `editor.read` permission.
 | `editor.file_path()`   | string                                                    | Absolute path of the active file.    |
 | `editor.file_name()`   | string                                                    | Filename only.                       |
 | `editor.language()`    | string                                                    | Detected language (e.g. `"go"`, `"lua"`). |
+| `editor.byte_to_col(text, byte)` | number                                          | Convert a 1-based **byte** offset in `text` to a 1-based **rune column**. |
+| `editor.col_to_byte(text, col)`  | number                                          | Convert a 1-based **rune column** in `text` to a 1-based **byte** offset. |
+
+> **Columns are runes, not bytes.** The editor — and every position in the
+> `editor.replace` and diagnostics APIs — uses 1-based **rune (visual) columns**.
+> But Lua string functions like `string.find` return **byte** offsets, and the
+> two diverge on any line containing multi-byte characters (an em-dash `—` is
+> 3 bytes but 1 column). Convert offsets you get from Lua before handing them
+> to the editor:
+>
+> ```lua
+> local s = string.find(line, "teh")            -- byte offset
+> local col = editor.byte_to_col(line, s)        -- rune column the editor expects
+> editor.set_cursor(lineNumber, col)
+> ```
+>
+> Skipping this makes squiggles and edits land in the wrong place once a line
+> has any non-ASCII text.
 
 ### Write Functions
 

--- a/internal/plugin/lua_editor.go
+++ b/internal/plugin/lua_editor.go
@@ -21,6 +21,8 @@ func setupEditorModule(L *lua.LState, p *Plugin) {
 			L.SetField(mod, "file_path", L.NewFunction(editorFilePath(p)))
 			L.SetField(mod, "file_name", L.NewFunction(editorFileName(p)))
 			L.SetField(mod, "language", L.NewFunction(editorLanguage(p)))
+			L.SetField(mod, "byte_to_col", L.NewFunction(editorByteToCol(p)))
+			L.SetField(mod, "col_to_byte", L.NewFunction(editorColToByte(p)))
 			L.SetField(mod, "register_context_menu", L.NewFunction(editorRegisterContextMenu(p)))
 		}
 
@@ -159,6 +161,66 @@ func editorLanguage(p *Plugin) lua.LGFunction {
 			return 2
 		}
 		L.Push(lua.LString(p.Editor.Language()))
+		return 1
+	}
+}
+
+// isUTF8Lead reports whether b is a UTF-8 lead byte (start of a rune), i.e.
+// not a 0x80..0xBF continuation byte.
+func isUTF8Lead(b byte) bool {
+	return b < 0x80 || b >= 0xC0
+}
+
+// editorByteToCol converts a 1-based byte offset into a 1-based rune column for
+// the given line text. It counts the UTF-8 lead bytes in text[1..b-1] and adds
+// one. The offset is clamped to [1, #text+1]. This is a pure helper (no editor
+// state) so plugins can map byte offsets from Lua string functions to the
+// rune/visual columns the editor APIs expect.
+func editorByteToCol(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		text := L.CheckString(1)
+		b := L.CheckInt(2)
+		if b < 1 {
+			b = 1
+		}
+		if b > len(text)+1 {
+			b = len(text) + 1
+		}
+		col := 1
+		for i := 0; i < b-1; i++ {
+			if isUTF8Lead(text[i]) {
+				col++
+			}
+		}
+		L.Push(lua.LNumber(col))
+		return 1
+	}
+}
+
+// editorColToByte converts a 1-based rune column into the 1-based byte offset
+// where that rune starts, for the given line text. It walks the string counting
+// lead bytes and clamps the column to [1, runeCount+1] (a column past the end
+// maps to #text+1). Inverse of editorByteToCol.
+func editorColToByte(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		text := L.CheckString(1)
+		c := L.CheckInt(2)
+		if c < 1 {
+			c = 1
+		}
+		runes := 0
+		for i := 0; i < len(text); i++ {
+			if isUTF8Lead(text[i]) {
+				runes++
+				if runes == c {
+					L.Push(lua.LNumber(i + 1))
+					return 1
+				}
+			}
+		}
+		// Column at or past the end: the (runeCount+1)-th rune starts past the
+		// last byte.
+		L.Push(lua.LNumber(len(text) + 1))
 		return 1
 	}
 }

--- a/internal/plugin/lua_editor_offsets_test.go
+++ b/internal/plugin/lua_editor_offsets_test.go
@@ -1,0 +1,130 @@
+package plugin
+
+import (
+	"strconv"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// runOffsetLua evaluates a Lua snippet against a plugin with editor.read granted
+// and returns the numeric global "result".
+func runOffsetLua(t *testing.T, script string) int {
+	t.Helper()
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorRead: true}, mock)
+	defer cleanup()
+	if err := p.State.DoString(script); err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+	return int(lua.LVAsNumber(p.State.GetGlobal("result")))
+}
+
+// TestEditorByteToColMultibyte verifies byte offsets around a multi-byte char
+// (em-dash) map to the correct rune columns. Line: "pane — adn".
+// Bytes:  p(1) a(2) n(3) e(4) space(5) — (6,7,8) space(9) a(10) d(11) n(12)
+// Runes:  p(1) a(2) n(3) e(4) space(5) —(6)      space(7) a(8) d(9) n(10)
+func TestEditorByteToColMultibyte(t *testing.T) {
+	// "adn" starts at byte 10, which is rune column 8.
+	if col := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.byte_to_col("pane \226\128\148 adn", 10)
+	`); col != 8 {
+		t.Errorf("expected col 8 for byte 10, got %d", col)
+	}
+
+	// The em-dash itself starts at byte 6, rune column 6.
+	if col := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.byte_to_col("pane \226\128\148 adn", 6)
+	`); col != 6 {
+		t.Errorf("expected col 6 for byte 6, got %d", col)
+	}
+}
+
+func TestEditorColToByteMultibyte(t *testing.T) {
+	// Rune column 8 ("adn") starts at byte 10.
+	if b := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.col_to_byte("pane \226\128\148 adn", 8)
+	`); b != 10 {
+		t.Errorf("expected byte 10 for col 8, got %d", b)
+	}
+
+	// The space after the em-dash is rune column 7, byte 9.
+	if b := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.col_to_byte("pane \226\128\148 adn", 7)
+	`); b != 9 {
+		t.Errorf("expected byte 9 for col 7, got %d", b)
+	}
+}
+
+func TestEditorOffsetASCII(t *testing.T) {
+	// ASCII-only: byte == col for every position, both directions.
+	for _, pos := range []int{1, 3, 6} {
+		if col := runOffsetLua(t, `
+			local editor = require("ttt.editor")
+			_G.result = editor.byte_to_col("hello", `+strconv.Itoa(pos)+`)
+		`); col != pos {
+			t.Errorf("byte_to_col ascii byte %d: expected %d, got %d", pos, pos, col)
+		}
+		if b := runOffsetLua(t, `
+			local editor = require("ttt.editor")
+			_G.result = editor.col_to_byte("hello", `+strconv.Itoa(pos)+`)
+		`); b != pos {
+			t.Errorf("col_to_byte ascii col %d: expected %d, got %d", pos, pos, b)
+		}
+	}
+}
+
+func TestEditorOffsetEdges(t *testing.T) {
+	// byte_to_col: offset past the end clamps to runeCount+1.
+	// "pane — adn" has 10 runes; #text is 12 bytes; byte 13 -> col 11.
+	if col := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.byte_to_col("pane \226\128\148 adn", 13)
+	`); col != 11 {
+		t.Errorf("expected col 11 for end offset, got %d", col)
+	}
+
+	// col_to_byte: column past the end clamps to #text+1 (13).
+	if b := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.col_to_byte("pane \226\128\148 adn", 11)
+	`); b != 13 {
+		t.Errorf("expected byte 13 for end col, got %d", b)
+	}
+
+	// Below-range inputs clamp to 1.
+	if col := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.byte_to_col("hello", 0)
+	`); col != 1 {
+		t.Errorf("expected col 1 for byte 0, got %d", col)
+	}
+	if b := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.col_to_byte("hello", 0)
+	`); b != 1 {
+		t.Errorf("expected byte 1 for col 0, got %d", b)
+	}
+}
+
+func TestEditorOffsetRoundTrip(t *testing.T) {
+	// For a rune-start byte (what Lua string functions return),
+	// col_to_byte(byte_to_col(b)) == b. Byte 10 starts "adn".
+	if b := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.col_to_byte("pane \226\128\148 adn", editor.byte_to_col("pane \226\128\148 adn", 10))
+	`); b != 10 {
+		t.Errorf("round-trip byte 10: expected 10, got %d", b)
+	}
+	// The em-dash lead byte (byte 6) also round-trips.
+	if b := runOffsetLua(t, `
+		local editor = require("ttt.editor")
+		_G.result = editor.col_to_byte("pane \226\128\148 adn", editor.byte_to_col("pane \226\128\148 adn", 6))
+	`); b != 6 {
+		t.Errorf("round-trip byte 6: expected 6, got %d", b)
+	}
+}


### PR DESCRIPTION
Adds two pure string helpers to the `ttt.editor` Lua module so plugins can convert between byte offsets (what Lua `string.find` and friends return) and the 1-based rune/visual columns the editor and `ttt.diagnostics` / `editor.replace` APIs expect. This closes the multibyte footgun where a squiggle or edit drifts after a multi-byte character (e.g. an em-dash).

## API
```lua
local col  = editor.byte_to_col(text, byte_offset)  -- 1-based byte -> 1-based rune column
local byte = editor.col_to_byte(text, col)          -- inverse
```

Both operate on a line's text passed in directly (no editor state — deterministic, staleness-free), are 1-based, and clamp out-of-range inputs. Registered under the `editor.read` permission gate.

- `byte_to_col(text, b)`: number of UTF-8 lead bytes in `text[1..b-1]` plus 1; `b` clamped to `[1, #text+1]`.
- `col_to_byte(text, c)`: 1-based byte offset where the c-th rune starts; `c` clamped so a column past the end maps to `#text+1`.

## Tests
`internal/plugin/lua_editor_offsets_test.go` covers a multibyte line (`"pane — adn"`, em-dash = 3 bytes), an ASCII-only case (byte == col), edge/clamp cases, and lead-byte round-trip.

Verified: `make build`, `go test ./internal/plugin/`, `gofmt -l` (clean), `go vet ./internal/plugin/`.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)