### PR TITLE
feat: rename Problems panel to Diagnostics; route plugin diagnostics into it

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 
 The bottom panel (Ctrl+K B to toggle) contains the **Terminal**, **Problems**, and **References** tabs.
 
-- **Problems tab** — lists all LSP diagnostics (errors, warnings) grouped by file; click to jump to location
+- **Diagnostics tab** — lists all LSP diagnostics (errors, warnings) grouped by file; click to jump to location
 - **References tab** — shows results from Find All References; click to jump to location
 - **Terminal tab** — integrated terminal emulator (see below)
 
@@ -291,7 +291,7 @@ Completions trigger automatically as you type with a configurable debounce (defa
 The LSP server publishes diagnostics (errors, warnings, hints) which are displayed as:
 
 - **Inline squiggles** — curly underlines on the affected range, colored by severity
-- **Problems panel** — a tab in the bottom panel listing all diagnostics grouped by file
+- **Diagnostics panel** — a tab in the bottom panel listing all diagnostics grouped by file
 - **Hover popup** — hover over a squiggle to see the diagnostic message
 - **Status bar** — error/warning counts shown in the status bar
 

--- a/docs-web/src/content/docs/guides/lsp.md
+++ b/docs-web/src/content/docs/guides/lsp.md
@@ -296,7 +296,7 @@ Completions trigger automatically as you type with a configurable debounce (defa
 The LSP server publishes diagnostics (errors, warnings, hints) which are displayed as:
 
 - **Inline squiggles** on the affected range, colored by severity
-- **Problems panel** in the bottom panel listing all diagnostics grouped by file
+- **Diagnostics panel** in the bottom panel listing all diagnostics grouped by file
 - **Hover popup** over a squiggle to see the diagnostic message
 - **Status bar** error/warning counts
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,7 +66,6 @@ type App struct {
 	LastHoverCol           int
 	Problems               *ui.ProblemsWidget
 	References             *ui.ReferencesWidget
-	AllDiagnostics         map[string][]ui.Diagnostic
 	Keybindings            []config.KeyBinding
 	LspNotified            map[string]bool
 	Explorer               *NavigationPanel
@@ -289,7 +288,7 @@ func (a *App) refreshWorkspaceWidgets() {
 
 func (a *App) refreshProblems() {
 	var items []ui.ProblemItem
-	for path, diags := range a.AllDiagnostics {
+	for path, diags := range a.EditorGroup.DiagnosticsByPath() {
 		for _, d := range diags {
 			items = append(items, ui.ProblemItem{
 				File:     path,

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -322,13 +322,9 @@ func RunEventLoop(
 					app.ApplyTextEdits(v.Edits)
 				}
 			case *DiagnosticsResult:
+				// SetDiagnostics routes through the "lsp" source and fires
+				// OnDiagnosticsChanged, which rebuilds the Diagnostics panel.
 				app.EditorGroup.SetDiagnostics(v.Path, v.Diagnostics)
-				if len(v.Diagnostics) == 0 {
-					delete(app.AllDiagnostics, v.Path)
-				} else {
-					app.AllDiagnostics[v.Path] = v.Diagnostics
-				}
-				app.refreshProblems()
 			case *FileChangedResult:
 				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -144,7 +144,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	output := ui.NewOutputWidget()
 	bottomPanel := ui.NewBottomPanelWidget(borders)
 	bottomPanel.AddPanel("terminal", "Terminal", terminalPanel)
-	bottomPanel.AddPanel("problems", "Problems", problems)
+	bottomPanel.AddPanel("problems", "Diagnostics", problems)
 	bottomPanel.AddPanel("references", "References", references)
 	bottomPanel.AddPanel("output", "Output", output)
 
@@ -197,7 +197,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	root := ui.NewRoot(rootBox)
 	root.SetFocus(editorGroup)
 
-	return &App{
+	app := &App{
 		Root:                root,
 		EditorGroup:         editorGroup,
 		Sidebar:             sidebar,
@@ -220,8 +220,11 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		References:          references,
 		Output:              output,
 		DocVersions:         make(map[string]int),
-		AllDiagnostics:      make(map[string][]ui.Diagnostic),
 		LspNotified:         make(map[string]bool),
 		pluginDetailWidgets: make(map[string]*pluginDetailState),
 	}
+	// Rebuild the Diagnostics panel whenever any source (LSP or a plugin)
+	// changes its diagnostics.
+	app.EditorGroup.OnDiagnosticsChanged = app.refreshProblems
+	return app
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -94,6 +94,9 @@ type EditorGroupWidget struct {
 	// diagSources holds diagnostics keyed by source ("lsp", "plugin:<name>")
 	// then by file path. Merged per-path into each tab's Diagnostics.
 	diagSources map[string]map[string][]Diagnostic
+	// OnDiagnosticsChanged fires whenever any source's diagnostics change, so
+	// the Diagnostics panel can rebuild from DiagnosticsByPath().
+	OnDiagnosticsChanged func()
 }
 
 func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool, gutterStyle string) *EditorGroupWidget {
@@ -956,6 +959,21 @@ func (g *EditorGroupWidget) SetDiagnosticsSource(source, path string, diags []Di
 		byPath[path] = diags
 	}
 	g.recomputeDiagnostics(path)
+	if g.OnDiagnosticsChanged != nil {
+		g.OnDiagnosticsChanged()
+	}
+}
+
+// DiagnosticsByPath returns every diagnostic across all sources, merged by
+// file path — used to populate the Diagnostics panel.
+func (g *EditorGroupWidget) DiagnosticsByPath() map[string][]Diagnostic {
+	merged := make(map[string][]Diagnostic)
+	for _, byPath := range g.diagSources {
+		for path, diags := range byPath {
+			merged[path] = append(merged[path], diags...)
+		}
+	}
+	return merged
 }
 
 // ClearDiagnosticsSource removes all diagnostics published by source and
@@ -972,6 +990,9 @@ func (g *EditorGroupWidget) ClearDiagnosticsSource(source string) {
 	delete(g.diagSources, source)
 	for _, path := range paths {
 		g.recomputeDiagnostics(path)
+	}
+	if g.OnDiagnosticsChanged != nil {
+		g.OnDiagnosticsChanged()
 	}
 }
 


### PR DESCRIPTION
Closes #345. Also renames the panel per discussion.

## Rename: Problems → Diagnostics
The bottom-panel tab is renamed from **Problems** to **Diagnostics** — the technically correct term: it's the LSP spec name, it matches what the code and the `ttt.diagnostics` plugin API already call things, and it's accurate for all severities (a `hint`/`info` isn't a "problem"). The internal panel **ID stays `problems`**, so nothing that references it by id breaks. README + LSP guide references updated to match.

## #345: plugin diagnostics in the panel
Previously the panel was fed from `app.AllDiagnostics`, which only the LSP path populated — so plugin-published diagnostics (via `ttt.diagnostics`) rendered as squiggles but never appeared in the panel.

`EditorGroup.diagSources` already stores **both** LSP and plugin diagnostics per source/path (workspace-wide), so it becomes the single source of truth:
- New `EditorGroup.DiagnosticsByPath()` merges all sources.
- New `OnDiagnosticsChanged` callback (wired to `refreshProblems`) rebuilds the panel whenever **any** source changes — LSP publish, plugin publish/clear, or plugin teardown (disable/reload/uninstall).
- The redundant `app.AllDiagnostics` map is removed; the eventloop's LSP handler just calls `SetDiagnostics` and the panel updates itself.

## Verified
`--exec` with the mock spell-check plugin: the tab reads **Diagnostics** and lists the plugin's entries:
```
W spelltest.txt:1 Did you mean 'the'?
W spelltest.txt:2 Did you mean 'receive'?
...
```
Build, `internal/app` + `internal/ui` tests, `gofmt`, and `go vet` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)