### PR TITLE
fix: tab-bar overflow — dead close-×, chevron overlap, and over-scroll (#354)

### DIFF
--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -35,6 +35,7 @@ type TabBarWidget struct {
 	OnNextTab        func()
 	OnDoubleClick    func()
 	tabSpans         []tabSpan
+	renderArrowW     int // arrow-gutter width from the last Render; HandleEvent reuses it for hit tests
 	hasOverflowLeft  bool
 	hasOverflowRight bool
 	totalTabWidth    int
@@ -103,6 +104,7 @@ func (t *TabBarWidget) Render(surface Surface) {
 		arrowW = 3 // " ◀ " or " ▶ "
 	}
 	innerLeft := arrowW
+	t.renderArrowW = arrowW
 	innerRight := w - arrowW
 	if t.MoreButton != nil && w >= 5 {
 		innerRight = w - 4 - arrowW
@@ -258,10 +260,13 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventConsumed
 	}
 
-	arrowW := 0
-	if t.hasOverflowLeft || t.hasOverflowRight {
-		arrowW = 3
-	}
+	// Single source of truth: reuse the exact arrow-gutter width the last Render
+	// used, instead of recomputing it from the overflow flags. The two diverge in
+	// the window where tabs overflow the inner zone (the ⋮ MoreButton steals 4
+	// cols) but not the full width: Render reserves no gutter (arrowW 0) while a
+	// recompute here would assume 3 — shifting every close-X hit test by 3 cells
+	// and making the button dead until the tab set grows/shrinks. (issue #354)
+	arrowW := t.renderArrowW
 
 	if btn&tcell.Button2 != 0 && t.OnTabRightClick != nil {
 		localX := mx - r.X - arrowW + t.ScrollOffset

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -309,16 +309,21 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventConsumed
 	}
 
-	// Handle overflow arrow clicks — switch to prev/next tab
-	if t.hasOverflowLeft && mx >= r.X && mx < r.X+arrowW {
-		if t.OnPrevTab != nil {
+	// Clicks in the reserved ◀/▶ arrow columns are consumed here so they never
+	// fall through to the empty-space double-click handler (which would spawn a
+	// tab — the "jump to the other side" bug when clicking a hidden chevron).
+	// Scroll only when there is something hidden in that direction; the overflow
+	// flag is set only when the active tab isn't already at that end, so it can't
+	// wrap.
+	if arrowW > 0 && mx >= r.X && mx < r.X+arrowW {
+		if t.hasOverflowLeft && t.OnPrevTab != nil {
 			t.OnPrevTab()
 		}
 		return EventConsumed
 	}
 	rightZoneStart := r.X + t.renderInnerRight
-	if t.hasOverflowRight && mx >= rightZoneStart && mx < rightZoneStart+arrowW {
-		if t.OnNextTab != nil {
+	if arrowW > 0 && mx >= rightZoneStart && mx < rightZoneStart+arrowW {
+		if t.hasOverflowRight && t.OnNextTab != nil {
 			t.OnNextTab()
 		}
 		return EventConsumed

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -35,7 +35,8 @@ type TabBarWidget struct {
 	OnNextTab        func()
 	OnDoubleClick    func()
 	tabSpans         []tabSpan
-	renderArrowW     int // arrow-gutter width from the last Render; HandleEvent reuses it for hit tests
+	renderArrowW     int // arrow-gutter width from the last Render, reused by HandleEvent
+	renderInnerRight int // right edge of the tab zone from the last Render, reused by HandleEvent
 	hasOverflowLeft  bool
 	hasOverflowRight bool
 	totalTabWidth    int
@@ -97,18 +98,21 @@ func (t *TabBarWidget) Render(surface Surface) {
 
 	t.totalTabWidth = pos
 
-	// Determine if tabs overflow the available width
-	hasOverflow := pos > w
+	// Overflow is measured against the space left after the ⋮ MoreButton, so the
+	// arrow gutter is reserved before tabs can overlap the chevron. (issue #354)
+	moreW := 0
+	if t.MoreButton != nil && w >= 5 {
+		moreW = 4
+	}
+	hasOverflow := pos > w-moreW
 	arrowW := 0
 	if hasOverflow {
 		arrowW = 3 // " ◀ " or " ▶ "
 	}
 	innerLeft := arrowW
 	t.renderArrowW = arrowW
-	innerRight := w - arrowW
-	if t.MoreButton != nil && w >= 5 {
-		innerRight = w - 4 - arrowW
-	}
+	innerRight := w - moreW - arrowW
+	t.renderInnerRight = innerRight
 	innerW := innerRight - innerLeft
 	if innerW < 1 {
 		innerW = 1
@@ -123,6 +127,11 @@ func (t *TabBarWidget) Render(surface Surface) {
 		if s.start < t.ScrollOffset {
 			t.ScrollOffset = s.start
 		}
+	}
+	// Never scroll past the last tab, so closing tabs can't strand the view on
+	// the final tab with empty space to its right.
+	if maxScroll := pos - innerW; t.ScrollOffset > maxScroll {
+		t.ScrollOffset = maxScroll
 	}
 	if t.ScrollOffset < 0 {
 		t.ScrollOffset = 0
@@ -260,12 +269,7 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventConsumed
 	}
 
-	// Single source of truth: reuse the exact arrow-gutter width the last Render
-	// used, instead of recomputing it from the overflow flags. The two diverge in
-	// the window where tabs overflow the inner zone (the ⋮ MoreButton steals 4
-	// cols) but not the full width: Render reserves no gutter (arrowW 0) while a
-	// recompute here would assume 3 — shifting every close-X hit test by 3 cells
-	// and making the button dead until the tab set grows/shrinks. (issue #354)
+	// Reuse Render's gutter width so click hit-tests line up with the screen.
 	arrowW := t.renderArrowW
 
 	if btn&tcell.Button2 != 0 && t.OnTabRightClick != nil {
@@ -312,10 +316,7 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		return EventConsumed
 	}
-	rightZoneStart := r.X + r.W - arrowW
-	if t.MoreButton != nil && r.W >= 5 {
-		rightZoneStart = r.X + r.W - 4 - arrowW
-	}
+	rightZoneStart := r.X + t.renderInnerRight
 	if t.hasOverflowRight && mx >= rightZoneStart && mx < rightZoneStart+arrowW {
 		if t.OnNextTab != nil {
 			t.OnNextTab()

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
-	"github.com/eugenioenko/ttt/internal/term"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v2"
 )
 
 func TestTabBarRender(t *testing.T) {
@@ -86,6 +88,62 @@ func TestTabBarOverflowScrollLeft(t *testing.T) {
 	// Left arrow " ◀ " — chevron is at col 1
 	if grid[1][1].Ch != '◀' {
 		t.Fatalf("expected left arrow at row 1 col 1, got '%c'", grid[1][1].Ch)
+	}
+}
+
+// TestTabBarCloseHitInMoreButtonWindow guards issue #354: when the tabs overflow
+// the inner zone (the ⋮ MoreButton reserves 4 cols) but NOT the full widget width,
+// Render reserves no arrow gutter (arrowW 0). HandleEvent used to recompute arrowW
+// from the overflow flags and land on 3, shifting every close-X hit test by 3 cells
+// so clicking the active tab's × did nothing. The click must reuse Render's arrowW.
+func TestTabBarCloseHitInMoreButtonWindow(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.MoreButton = NewMoreButtonWidget()
+	tb.SetTabs([]Tab{
+		{Name: "main.go", Active: true, Closable: true},
+		{Name: "buffer.go"},
+		{Name: "cursor.go"},
+	})
+
+	// Measure total tab width, then size the bar to exactly that width. With the
+	// MoreButton stealing 4 cols this puts us in the divergent window: tabs fit the
+	// full width (arrowW 0) but overflow the inner zone (hasOverflowRight true).
+	tb.SetRect(Rect{X: 0, Y: 0, W: 200, H: 3})
+	probe := makeGrid(200, 3)
+	tb.Render(NewRenderSurface(probe, Rect{X: 0, Y: 0, W: 200, H: 3}))
+	w := tb.totalTabWidth
+
+	tb.SetRect(Rect{X: 0, Y: 0, W: w, H: 3})
+	grid := makeGrid(w, 3)
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: w, H: 3}))
+
+	if tb.renderArrowW != 0 {
+		t.Fatalf("test setup: expected no arrow gutter, got renderArrowW=%d", tb.renderArrowW)
+	}
+	if !tb.hasOverflowRight {
+		t.Fatal("test setup: expected right overflow inside the MoreButton window")
+	}
+
+	// Find the rendered close × of the active tab (row 1, StyleActiveTab).
+	closeX := -1
+	for x := 0; x < w; x++ {
+		if grid[1][x].Ch == 'x' && grid[1][x].Style == term.StyleActiveTab {
+			closeX = x
+		}
+	}
+	if closeX < 0 {
+		t.Fatal("test setup: could not find rendered close × for active tab")
+	}
+
+	closed := -1
+	tb.OnTabClose = func(i int) { closed = i }
+
+	// A real click is mouse-down then mouse-up at the same cell.
+	tb.HandleEvent(tcell.NewEventMouse(closeX, 1, tcell.Button1, 0))
+	tb.HandleEvent(tcell.NewEventMouse(closeX, 1, tcell.ButtonNone, 0))
+
+	if closed != 0 {
+		t.Fatalf("clicking the visible close × should close tab 0, got closed=%d", closed)
 	}
 }
 

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -91,12 +91,11 @@ func TestTabBarOverflowScrollLeft(t *testing.T) {
 	}
 }
 
-// TestTabBarCloseHitInMoreButtonWindow guards issue #354: when the tabs overflow
-// the inner zone (the ⋮ MoreButton reserves 4 cols) but NOT the full widget width,
-// Render reserves no arrow gutter (arrowW 0). HandleEvent used to recompute arrowW
-// from the overflow flags and land on 3, shifting every close-X hit test by 3 cells
-// so clicking the active tab's × did nothing. The click must reuse Render's arrowW.
-func TestTabBarCloseHitInMoreButtonWindow(t *testing.T) {
+// renderInMoreButtonWindow sizes the bar to exactly the total tab width with a
+// MoreButton present, so tabs overflow the inner zone but not the full width —
+// the #354 window. Returns the rendered grid and the bar width.
+func renderInMoreButtonWindow(t *testing.T) (*TabBarWidget, [][]term.Cell, int) {
+	t.Helper()
 	tb := NewTabBarWidget()
 	tb.MoreButton = NewMoreButtonWidget()
 	tb.SetTabs([]Tab{
@@ -105,9 +104,6 @@ func TestTabBarCloseHitInMoreButtonWindow(t *testing.T) {
 		{Name: "cursor.go"},
 	})
 
-	// Measure total tab width, then size the bar to exactly that width. With the
-	// MoreButton stealing 4 cols this puts us in the divergent window: tabs fit the
-	// full width (arrowW 0) but overflow the inner zone (hasOverflowRight true).
 	tb.SetRect(Rect{X: 0, Y: 0, W: 200, H: 3})
 	probe := makeGrid(200, 3)
 	tb.Render(NewRenderSurface(probe, Rect{X: 0, Y: 0, W: 200, H: 3}))
@@ -116,12 +112,16 @@ func TestTabBarCloseHitInMoreButtonWindow(t *testing.T) {
 	tb.SetRect(Rect{X: 0, Y: 0, W: w, H: 3})
 	grid := makeGrid(w, 3)
 	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: w, H: 3}))
+	return tb, grid, w
+}
 
-	if tb.renderArrowW != 0 {
-		t.Fatalf("test setup: expected no arrow gutter, got renderArrowW=%d", tb.renderArrowW)
-	}
-	if !tb.hasOverflowRight {
-		t.Fatal("test setup: expected right overflow inside the MoreButton window")
+// TestTabBarCloseHitInMoreButtonWindow guards issue #354: clicking the active
+// tab's rendered × in the MoreButton window must close it (was a dead click).
+func TestTabBarCloseHitInMoreButtonWindow(t *testing.T) {
+	tb, grid, w := renderInMoreButtonWindow(t)
+
+	if tb.renderArrowW == 0 {
+		t.Fatal("expected the arrow gutter to be reserved once the strip overflows the inner zone")
 	}
 
 	// Find the rendered close × of the active tab (row 1, StyleActiveTab).
@@ -144,6 +144,54 @@ func TestTabBarCloseHitInMoreButtonWindow(t *testing.T) {
 
 	if closed != 0 {
 		t.Fatalf("clicking the visible close × should close tab 0, got closed=%d", closed)
+	}
+}
+
+// TestTabBarChevronNotDrawnOverTab: when a chevron shows, its gutter must be
+// reserved so tabs never render on top of it.
+func TestTabBarChevronNotDrawnOverTab(t *testing.T) {
+	tb, grid, _ := renderInMoreButtonWindow(t)
+
+	if (tb.hasOverflowLeft || tb.hasOverflowRight) && tb.renderArrowW == 0 {
+		t.Fatal("chevron shown without a reserved gutter — tabs will overlap it")
+	}
+	if tb.hasOverflowLeft && grid[1][1].Ch != '◀' {
+		t.Fatalf("left chevron cell overwritten by a tab, got '%c'", grid[1][1].Ch)
+	}
+}
+
+// TestTabBarNoOverScrollAfterClose: closing tabs must not leave the strip scrolled
+// past the last tab (only the final tab visible with empty space to its right).
+func TestTabBarNoOverScrollAfterClose(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.MoreButton = NewMoreButtonWidget()
+
+	many := make([]Tab, 20)
+	for i := range many {
+		many[i] = Tab{Name: "untitled-" + string(rune('a'+i)) + ".go"}
+	}
+	many[19].Active = true
+	tb.SetTabs(many)
+	tb.SetRect(Rect{X: 0, Y: 0, W: 40, H: 3})
+	tb.Render(NewRenderSurface(makeGrid(40, 3), Rect{X: 0, Y: 0, W: 40, H: 3}))
+	if tb.ScrollOffset == 0 {
+		t.Fatal("test setup: expected a non-zero scroll offset with 20 tabs at width 40")
+	}
+
+	// Close down to three tabs, first active (like closing everything to the right).
+	tb.SetTabs([]Tab{
+		{Name: "untitled-a.go", Active: true},
+		{Name: "untitled-b.go"},
+		{Name: "untitled-c.go"},
+	})
+	tb.SetRect(Rect{X: 0, Y: 0, W: 40, H: 3})
+	tb.Render(NewRenderSurface(makeGrid(40, 3), Rect{X: 0, Y: 0, W: 40, H: 3}))
+
+	if tb.ScrollOffset != 0 {
+		t.Fatalf("offset should snap back to 0 once the tabs fit, got %d", tb.ScrollOffset)
+	}
+	if tb.hasOverflowLeft {
+		t.Fatal("no left overflow expected once the tabs fit")
 	}
 }
 

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/term"
@@ -192,6 +193,48 @@ func TestTabBarNoOverScrollAfterClose(t *testing.T) {
 	}
 	if tb.hasOverflowLeft {
 		t.Fatal("no left overflow expected once the tabs fit")
+	}
+}
+
+// TestTabBarGutterClickDoesNotSpawnTab: at the first tab the ◀ is hidden but its
+// gutter is still reserved. Double-clicking that empty gutter must be a no-op —
+// it must NOT fall through to the empty-space double-click handler and spawn a
+// tab (which looked like "jumping to the other side").
+func TestTabBarGutterClickDoesNotSpawnTab(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.MoreButton = NewMoreButtonWidget()
+
+	const n = 8
+	tabs := make([]Tab, n)
+	for i := range tabs {
+		tabs[i] = Tab{Name: fmt.Sprintf("untitled-%d.go", i+1), Active: i == 0, Closable: i == 0}
+	}
+	tb.SetTabs(tabs)
+
+	doubleClicks, prevTabs := 0, 0
+	tb.OnDoubleClick = func() { doubleClicks++ }
+	tb.OnPrevTab = func() { prevTabs++ }
+
+	r := Rect{X: 0, Y: 0, W: 40, H: 3}
+	tb.SetRect(r)
+	tb.Render(NewRenderSurface(makeGrid(40, 3), r))
+	if tb.hasOverflowLeft || tb.renderArrowW == 0 {
+		t.Fatalf("test setup: want hidden ◀ with reserved gutter, got ovL=%v arrowW=%d",
+			tb.hasOverflowLeft, tb.renderArrowW)
+	}
+
+	// Two clicks on the empty left gutter (where ◀ would be), fast enough to be a
+	// double-click.
+	for i := 0; i < 2; i++ {
+		tb.HandleEvent(tcell.NewEventMouse(r.X+1, 1, tcell.Button1, 0))
+		tb.HandleEvent(tcell.NewEventMouse(r.X+1, 1, tcell.ButtonNone, 0))
+	}
+
+	if doubleClicks != 0 {
+		t.Fatalf("gutter double-click spawned a tab (OnDoubleClick fired %d times)", doubleClicks)
+	}
+	if prevTabs != 0 {
+		t.Fatalf("gutter click on a hidden ◀ scrolled (OnPrevTab fired %d times)", prevTabs)
 	}
 }
 

--- a/tests/functional/tab-close-click.test.js
+++ b/tests/functional/tab-close-click.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+
+afterEach(() => {
+  tui.kill();
+});
+
+describe("tab close button hit test (#354)", () => {
+  it("closes the active tab when its × is clicked in the MoreButton overflow window", () => {
+    tui.start();
+    // At 83 cols the tab strip overflows the inner zone (the ⋮ MoreButton
+    // reserves 4 cols) but NOT the full width — the window where Render draws
+    // no overflow-arrow gutter. The click handler used to assume a 3-col gutter
+    // anyway, shifting the close-X hit test by 3 cells so the × was a dead
+    // click. This puts the active tab's × at row 2, col 75.
+    tui.setSize(83, 24);
+
+    tui.press("ctrl+n");
+    tui.press("ctrl+n");
+    tui.press("ctrl+n");
+    tui.waitStable();
+    const before = tui.snapshot();
+
+    tui.click(75, 2);
+    tui.waitStable();
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run();
+
+    // Sanity: the × really is under the click (guards against geometry drift
+    // silently turning this into a no-op that always passes).
+    expect(snapshots[before].split("\n")[2][75]).toBe("x");
+    expect(snapshots[before]).toContain("untitled-4");
+
+    // The click must close the active tab.
+    expect(snapshots[after]).not.toContain("untitled-4");
+  });
+});

--- a/tests/functional/tab-close-click.test.js
+++ b/tests/functional/tab-close-click.test.js
@@ -8,11 +8,8 @@ afterEach(() => {
 describe("tab close button hit test (#354)", () => {
   it("closes the active tab when its × is clicked in the MoreButton overflow window", () => {
     tui.start();
-    // At 83 cols the tab strip overflows the inner zone (the ⋮ MoreButton
-    // reserves 4 cols) but NOT the full width — the window where Render draws
-    // no overflow-arrow gutter. The click handler used to assume a 3-col gutter
-    // anyway, shifting the close-X hit test by 3 cells so the × was a dead
-    // click. This puts the active tab's × at row 2, col 75.
+    // At 83 cols the strip lands in the #354 overflow window; the active tab's
+    // close × renders at row 2, col 72.
     tui.setSize(83, 24);
 
     tui.press("ctrl+n");
@@ -21,18 +18,36 @@ describe("tab close button hit test (#354)", () => {
     tui.waitStable();
     const before = tui.snapshot();
 
-    tui.click(75, 2);
+    tui.click(72, 2);
     tui.waitStable();
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
 
-    // Sanity: the × really is under the click (guards against geometry drift
-    // silently turning this into a no-op that always passes).
-    expect(snapshots[before].split("\n")[2][75]).toBe("x");
+    // Sanity: the × really is under the click (guard against geometry drift).
+    expect(snapshots[before].split("\n")[2][72]).toBe("x");
     expect(snapshots[before]).toContain("untitled-4");
 
     // The click must close the active tab.
     expect(snapshots[after]).not.toContain("untitled-4");
+  });
+
+  it("does not over-scroll the strip after closing many tabs", () => {
+    tui.start();
+    tui.setSize(150, 30);
+
+    for (let i = 0; i < 20; i++) tui.press("ctrl+n");
+    tui.waitStable();
+    for (let i = 0; i < 11; i++) tui.press("ctrl+w");
+    tui.waitStable();
+
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Before the fix the strip was stranded on the last tab (one label visible);
+    // it should now show several tabs.
+    const tabRow = snapshots[s].split("\n")[2];
+    const visible = (tabRow.match(/untitled-\d+/g) || []).length;
+    expect(visible).toBeGreaterThan(1);
   });
 });

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -26,11 +26,22 @@ let size = "120x40";
 export function start(...startArgs) {
   commands = [];
   snapCount = 0;
+  size = "120x40";
   tmpDir = mkdtempSync(join(tmpdir(), "ttt-bb-"));
   args = [];
   for (const a of startArgs) {
     args.push(a);
   }
+}
+
+// Override the terminal size for this run (default 120x40). Reset by start().
+export function setSize(w, h) {
+  size = `${w}x${h}`;
+}
+
+// Simulate a mouse click at screen coordinates (col x, row y).
+export function click(x, y) {
+  commands.push(`click ${x} ${y}`);
 }
 
 export function type(text) {


### PR DESCRIPTION
Fixes #354 and two closely-related tab-bar overflow bugs found while verifying it. All three come from the render and the click/scroll logic computing the overflow layout in slightly different ways.

## 1. Dead close-× click (#354)

Render reserved the 3-col `◀`/`▶` gutter only when tabs exceeded the **full** width (`pos > w`), but the click handler decided from the overflow flags, which measure against the **inner** width (`w - 4`, since the `⋮` MoreButton reserves 4 cols). In the window `w-4 < pos ≤ w` the two disagreed by 3 cells, so clicking the visible × did nothing. Opening/closing a tab moved width across that boundary — the "comes and goes" symptom.

## 2. Chevron rendered on top of the tabs

Same root cause: because overflow was measured against the full width, in that window the gutter was 0-width while the `◀` still drew — landing on the first tab's border. Overflow is now measured against the space left after the MoreButton, so the gutter is always reserved before a chevron shows.

## 3. Over-scroll after closing tabs

There was no upper clamp on the scroll offset. Closing tabs from the right shrank the strip but left the offset pointing past the end, stranding the view on the last tab with empty space to its right and the earlier ~10 tabs hidden behind a dead `◀`. Added a max-scroll clamp.

## Cleanup

Render now stores `arrowW` and the inner-right edge; the click handler reuses them instead of re-deriving the MoreButton math — removing the duplicated computations that caused the divergence in the first place (single source of truth, per CLAUDE.md).

## Tests

Reproduced all three deterministically with `--exec` (sweeping width / spawning+closing tabs). Guards added at two levels, each confirmed to fail before the fix:

- **Unit** — close-× click in the overflow window, chevron-gutter reservation, no over-scroll after closing.
- **Functional (black-box)** — drives the real binary: clicks the rendered × in the overflow window, and closes 11 of 20 tabs and asserts the strip isn't stranded. Adds `tui.setSize()` / `tui.click()`.


## 4. Clicking a hidden chevron spawned a tab ("jump to the other side")

Reaching the first tab hides the `◀` but keeps its 3-col gutter reserved. Clicking that empty gutter fell through to the empty-space **double-click** handler, so a double-click there spawned a new tab — which landed at the far right and became active, looking exactly like the strip wrapped to the other end. Clicks in the reserved `◀`/`▶` columns are now consumed (scroll when the chevron is shown, no-op otherwise) so they never reach the double-click handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
