### PR TITLE
feat: left-truncation option for tree/list widgets (#359)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,8 @@ Lua plugins render UI in sidebar panels, bottom-panel tabs, drawers, and editor 
 |---|---|---|
 | `p:label(text)` or `p:label({...})` | `text`, `style`, `badge`, `width`, borders | Static text line. `style` is a named style (see below). `border`/`border_top`/`border_bottom`/`border_left`/`border_right` draw borders. Supports box model. |
 | `p:title(text)` or `p:title({...})` | `text`, `badge`, `menu`, `on_menu(command)`, `icon`, `padded` | Bold section heading with optional right-aligned badge and dropdown menu. `menu` is `{label, command, separator}` tables; `icon` overrides the dropdown button (default `⋮`). Supports box model. |
-| `p:tree({...})` | `items`, `indent` (default 2), `on_select`, `on_expand`, `on_command`, `node_menu`, `key_commands` | Expandable tree view. Items are `{id, label, icon, badge, muted, expandable, expanded, children}` tables. `key_commands` maps single chars to commands via `on_command`. |
-| `p:list({...})` | `items`, `on_select`, `on_command`, `node_menu`, `key_commands` | Flat list (backed by TreeWidget, no indentation). |
+| `p:tree({...})` | `items`, `indent` (default 2), `on_select`, `on_expand`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Expandable tree view. Items are `{id, label, icon, badge, muted, expandable, expanded, children}` tables. `key_commands` maps single chars to commands via `on_command`. `truncate_left` truncates overflowing labels from the left (`…tail`) so the end stays visible. |
+| `p:list({...})` | `items`, `on_select`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Flat list (backed by TreeWidget, no indentation). `truncate_left` keeps label tails visible on overflow. |
 | `p:button({...})` | `label`, `on_click` | Clickable button. Label is immutable after creation (accelerator parsing). |
 | `p:input({...})` | `placeholder`, `prefix`, `clear_on_submit`, `on_change(text)`, `on_submit(text)` | Text input field. `clear_on_submit` (bool) clears text after submit. |
 | `p:vstack({...})` | `render(child_panel)`, `gap` | Vertical stack container. The `render` function receives a child panel proxy to emit nested widgets. |

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -71,8 +71,9 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 	})
 
 	cp.Tree = widgets.NewTreeWidget(widgets.TreeConfig{
-		Indent:    1,
-		EmptyText: "No changes",
+		Indent:       1,
+		EmptyText:    "No changes",
+		TruncateLeft: true,
 		OnCommand: func(cmd string, node *widgets.TreeNode) {
 			cp.handleCommand(cmd, node)
 		},

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -350,6 +350,9 @@ func panelTreeWidget(L *lua.LState) int {
 	if v := L.GetField(tbl, "select_on_click"); v == lua.LTrue {
 		desc.SelectOnClick = true
 	}
+	if v := L.GetField(tbl, "truncate_left"); v == lua.LTrue {
+		desc.TruncateLeft = true
+	}
 
 	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetTree, desc)
@@ -382,6 +385,9 @@ func panelListWidget(L *lua.LState) int {
 	}
 	if v := L.GetField(tbl, "select_on_click"); v == lua.LTrue {
 		desc.SelectOnClick = true
+	}
+	if v := L.GetField(tbl, "truncate_left"); v == lua.LTrue {
+		desc.TruncateLeft = true
 	}
 
 	parseBoxModel(L, tbl, &desc)

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -362,6 +362,7 @@ func createTreeWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
 		Indent:        desc.Indent,
 		NodeMenu:      desc.NodeMenu,
 		SelectOnClick: desc.SelectOnClick,
+		TruncateLeft:  desc.TruncateLeft,
 	})
 	wireTreeCallbacks(tw, desc, p)
 	applyBoxModel(&tw.Box, desc)
@@ -373,6 +374,7 @@ func createListWidget(desc WidgetDesc, p *Plugin) *widgets.TreeWidget {
 		Items:         desc.Items,
 		NodeMenu:      desc.NodeMenu,
 		SelectOnClick: desc.SelectOnClick,
+		TruncateLeft:  desc.TruncateLeft,
 	})
 	wireTreeCallbacks(tw, desc, p)
 	applyBoxModel(&tw.Box, desc)

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -85,6 +85,7 @@ type WidgetDesc struct {
 	Items         []*widgets.TreeNode
 	Indent        int
 	SelectOnClick bool
+	TruncateLeft  bool
 	OnSelect      func(node *widgets.TreeNode)
 	OnExpand      func(node *widgets.TreeNode)
 	OnCommand     func(command string, node *widgets.TreeNode)

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -42,6 +42,7 @@ type TreeConfig struct {
 	ActiveID       string      `json:"-"`
 	EmptyText      string      `json:"emptyText,omitempty"`
 	SelectOnClick  bool        `json:"-"`
+	TruncateLeft   bool        `json:"truncateLeft,omitempty"` // truncate labels from the left (…tail) so the end stays visible
 
 	OnCommand  func(command string, node *TreeNode)
 	OnMenu     func(entries []MenuEntry, node *TreeNode, screenX, screenY int)
@@ -372,6 +373,13 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		labelStyle = term.StyleMuted
 	}
 	labelRunes := []rune(node.Label)
+	if t.Config.TruncateLeft {
+		if avail := maxX - x; avail > 0 && len(labelRunes) > avail {
+			// Keep the tail visible: leading … then the last avail-1 runes.
+			tail := labelRunes[len(labelRunes)-(avail-1):]
+			labelRunes = append([]rune{'…'}, tail...)
+		}
+	}
 	labelFits := x+len(labelRunes) <= maxX
 	for i, ch := range labelRunes {
 		if x >= maxX {

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -1,6 +1,7 @@
 package widgets
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/term"
@@ -207,6 +208,29 @@ func TestTreeRenderEllipsisTruncation(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("long label should be truncated with ellipsis, got %q", row)
+	}
+}
+
+func TestTreeRenderTruncateLeft(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		TruncateLeft: true,
+		Items: []*TreeNode{
+			{ID: "path", Label: "internal/app/changes_panel.go"},
+		},
+	})
+	// maxX = w - 2 = 10; the leading … plus the tail of the path must be shown.
+	s := renderWidget(tree, 0, 0, 12, 5)
+	row := surfaceRowText(s, 0)
+
+	if []rune(row)[0] != '…' {
+		t.Errorf("left-truncated label should start with …, got %q", row)
+	}
+	// The filename tail must survive; the head (internal/app) must be dropped.
+	if !strings.Contains(row, "panel.go") {
+		t.Errorf("left truncation should keep the tail visible, got %q", row)
+	}
+	if strings.Contains(row, "internal") {
+		t.Errorf("left truncation should drop the head, got %q", row)
 	}
 }
 


### PR DESCRIPTION
Closes #359.

## What

Adds an opt-in **left-truncation** mode to the tree/list widget. When a label overflows the available width, it is truncated from the *left* with a leading `…`, keeping the end of the text visible — instead of the default right-side ellipsis that cuts off the tail.

For the **Changes panel** this means long paths keep their filename readable:

- before: `internal/app/cha…`
- after: `…app/changes_panel.go`

## Changes

- `internal/widgets/tree.go` — new `TruncateLeft bool` on `TreeConfig`; `renderNode` drops the head and prepends `…`, keeping the last `avail-1` runes.
- `internal/app/changes_panel.go` — enable `TruncateLeft` on the Changes panel tree.
- Plugin widget API — expose as `truncate_left` on `p:tree` and `p:list` (wired through `widget_desc.go`, `widget_builder.go`, `lua_panel.go`).
- `CLAUDE.md` — document `truncate_left` on the tree/list rows.

Default behavior is unchanged (right-truncation); this is opt-in per widget.

## Tests

- `TestTreeRenderTruncateLeft` — asserts the leading `…`, the tail (`panel.go`) survives, and the head (`internal`) is dropped.
- `go build ./...`, `gofmt`, and the widgets/app/plugin package tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)