### PR TITLE
fix: Deny action for plugin approval stops the re-prompt loop (#358)

### DIFF
--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -272,10 +272,9 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 	dialog.Borders = *a.Borders
 	dialog.SetContent(content)
 	dialog.Buttons = []widgets.DialogButton{
-		{Label: "&Cancel", Handler: func() {
+		{Label: "&Deny", Handler: func() {
 			a.DismissDialog()
-			a.resetPluginDetailButton(p.Manifest.Name)
-			a.showNextPluginApproval()
+			a.denyPluginApproval(p)
 		}},
 		{Label: "&Allow", Handler: func() {
 			a.DismissDialog()
@@ -291,8 +290,7 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 	}
 	dialog.OnDismiss = func() {
 		a.DismissDialog()
-		a.resetPluginDetailButton(p.Manifest.Name)
-		a.showNextPluginApproval()
+		a.denyPluginApproval(p)
 	}
 	dialog.Build()
 
@@ -784,6 +782,21 @@ func (a *App) PluginRefreshRegistry() {
 		entries, err := plugin.FetchRemoteRegistry(plugin.DefaultRegistryURL)
 		a.Screen.PostEvent(tcell.NewEventInterrupt(&RemoteRegistryResult{Entries: entries, Err: err}))
 	}()
+}
+
+// denyPluginApproval permanently declines a pending plugin: it deletes a fresh
+// ttt-installed clone (or disables an on-disk one) so it stops prompting,
+// resets the install button, and advances to the next pending approval.
+func (a *App) denyPluginApproval(p *plugin.Plugin) {
+	if err := a.PluginManager.DenyPlugin(p); err != nil {
+		slog.Error("deny plugin", "error", err)
+	}
+	a.resetPluginDetailButton(p.Manifest.Name)
+	a.updatePluginDetailButtons()
+	if a.PluginsPanel != nil {
+		a.PluginsPanel.Refresh()
+	}
+	a.showNextPluginApproval()
 }
 
 func (a *App) showNextPluginApproval() {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -427,6 +427,43 @@ func (m *Manager) Uninstall(name string) error {
 	return nil
 }
 
+// DenyPlugin permanently stops a pending plugin from prompting for approval.
+// A plugin ttt freshly cloned into pluginsDir (not yet in the registry) is
+// deleted outright so it leaves no trace. Anything else — a workspace-local
+// plugin, or one already tracked in the registry — is recorded as disabled so
+// LoadAll skips it on the next launch instead of re-prompting forever (#358).
+func (m *Manager) DenyPlugin(p *Plugin) error {
+	if p == nil {
+		return nil
+	}
+	var entry *RegistryEntry
+	if m.registry != nil {
+		entry = m.registry.Find(p.Name)
+	}
+	if entry == nil && withinDir(m.pluginsDir, p.Dir) {
+		if err := os.RemoveAll(p.Dir); err != nil {
+			return fmt.Errorf("remove denied plugin: %w", err)
+		}
+		return nil
+	}
+	if m.registry == nil {
+		return nil
+	}
+	m.registry.AddOrUpdate(p.Manifest.Name, p.Repo, p.RepoPath, p.Manifest.Version, p.Manifest.Permissions)
+	m.registry.SetEnabled(p.Manifest.Name, false)
+	return m.registry.Save()
+}
+
+// withinDir reports whether child lives inside parent (not equal to it, not an
+// escape via ..). Used to confine deny-deletion to ttt's own plugins dir.
+func withinDir(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 func (m *Manager) Update(name string) (*Plugin, bool, error) {
 	dir := filepath.Join(m.pluginsDir, name)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1,0 +1,121 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writePluginDir creates a minimal valid plugin (manifest + entry) in a new
+// subdir of parent and returns its path.
+func writePluginDir(t *testing.T, parent, name string) string {
+	t.Helper()
+	dir := filepath.Join(parent, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := `{"name":"` + name + `","version":"1.0.0","entry":"main.ttt.lua"}`
+	if err := os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(manifest), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.ttt.lua"), []byte("-- noop"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func newTestManager(t *testing.T) (*Manager, string) {
+	t.Helper()
+	pluginsDir := t.TempDir()
+	regPath := filepath.Join(t.TempDir(), "registry.json")
+	m := NewManager(pluginsDir, regPath)
+	m.LoadAll() // initializes m.registry
+	return m, pluginsDir
+}
+
+// TestDenyPluginDeletesFreshInstall: a plugin ttt cloned into its own
+// pluginsDir with no registry entry must be removed on deny (#358).
+func TestDenyPluginDeletesFreshInstall(t *testing.T) {
+	m, pluginsDir := newTestManager(t)
+	dir := writePluginDir(t, pluginsDir, "fresh")
+
+	p := &Plugin{Name: "fresh", Dir: dir, Manifest: Manifest{Name: "fresh", Version: "1.0.0"}}
+	if err := m.DenyPlugin(p); err != nil {
+		t.Fatalf("DenyPlugin: %v", err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatal("denied fresh install should be deleted from disk")
+	}
+	if m.registry.Find("fresh") != nil {
+		t.Fatal("a deleted fresh install should leave no registry entry")
+	}
+}
+
+// TestDenyPluginDisablesOutsideDir: a plugin living outside pluginsDir (e.g.
+// workspace-local) must never be deleted; it's disabled in the registry instead.
+func TestDenyPluginDisablesOutsideDir(t *testing.T) {
+	m, _ := newTestManager(t)
+	externalRoot := t.TempDir()
+	dir := writePluginDir(t, externalRoot, "local")
+
+	p := &Plugin{Name: "local", Dir: dir, Manifest: Manifest{Name: "local", Version: "1.0.0"}}
+	if err := m.DenyPlugin(p); err != nil {
+		t.Fatalf("DenyPlugin: %v", err)
+	}
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("workspace-local plugin must not be deleted: %v", err)
+	}
+	entry := m.registry.Find("local")
+	if entry == nil {
+		t.Fatal("denied on-disk plugin should get a registry entry")
+	}
+	if entry.Enabled {
+		t.Fatal("denied plugin's registry entry must be disabled")
+	}
+}
+
+// TestDenyStopsReprompt is the end-to-end regression for #358: after
+// denying a rediscovered on-disk plugin, a fresh LoadAll must not surface it
+// for approval again.
+func TestDenyStopsReprompt(t *testing.T) {
+	m, _ := newTestManager(t)
+	externalRoot := t.TempDir()
+	dir := writePluginDir(t, externalRoot, "local")
+	m.extraDirs = []string{externalRoot}
+
+	needs := m.LoadAll()
+	if len(needs) != 1 || needs[0].Name != "local" {
+		t.Fatalf("expected 'local' to need approval on first discovery, got %v", needs)
+	}
+
+	if err := m.DenyPlugin(needs[0]); err != nil {
+		t.Fatalf("DenyPlugin: %v", err)
+	}
+
+	if needs := m.LoadAll(); len(needs) != 0 {
+		t.Fatalf("denied plugin must not re-prompt, got %d pending", len(needs))
+	}
+	_ = dir
+}
+
+func TestWithinDir(t *testing.T) {
+	base := filepath.Join("home", "user", "plugins")
+	cases := []struct {
+		child string
+		want  bool
+	}{
+		{filepath.Join(base, "foo"), true},
+		{filepath.Join(base, "foo", "bar"), true},
+		{base, false}, // the dir itself
+		{filepath.Join("home", "user", "other"), false}, // sibling
+		{filepath.Join("home", "user"), false},          // parent
+		{filepath.Join(base, "..", "escape"), false},    // traversal
+	}
+	for _, c := range cases {
+		if got := withinDir(base, c.child); got != c.want {
+			t.Errorf("withinDir(%q, %q) = %v, want %v", base, c.child, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #358.

## Problem

A freshly-installed plugin is cloned into `pluginsDir/<name>` **before** its permission dialog is shown. Choosing **Cancel** (or pressing Esc) left the folder on disk, so on the next launch the plugin was rediscovered with no registry entry, flagged `needsApproval`, and prompted **again** — every startup, with no way to stop it short of manually deleting the folder.

## Fix

Replace the dialog's **Cancel** with a **Deny** action — `[Deny] [Allow]`, the standard permission-prompt pairing.

`Manager.DenyPlugin(p)`:
- **Fresh install** ttt cloned into its own `pluginsDir` with no registry entry → deletes the folder, no trace.
- **Everything else** — workspace-local plugins, or ones already tracked in the registry (e.g. an update's new permissions) → records a **disabled** registry entry so `LoadAll` skips it instead of re-prompting.
- Deletion is confined to `pluginsDir` via `withinDir()`, so user-placed / workspace plugins are never removed.

Dismissing the dialog (Esc) now denies as well — there's no "ask me later" state left that could re-prompt.

## Tests

`internal/plugin/manager_test.go`:
- `TestDenyPluginDeletesFreshInstall` — a fresh clone in `pluginsDir` is removed, no registry entry left.
- `TestDenyPluginDisablesOutsideDir` — a workspace-local plugin is **not** deleted; it gets a disabled registry entry.
- `TestDenyStopsReprompt` — end-to-end: after denying a rediscovered on-disk plugin, a second `LoadAll` surfaces nothing for approval.
- `TestWithinDir` — path-containment guard (self, sibling, parent, `..` traversal).

Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)