### PR TITLE
feat: optional displayName for plugins, separate from the unique name

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "cheat-sheet",
+    "displayName": "Cheat Sheet",
     "author": "eugenioenko",
     "description": "Fetch programming cheat sheets from cheat.sh and display them in an editor tab",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -10,6 +11,7 @@
   },
   {
     "name": "color-picker",
+    "displayName": "Color Picker",
     "author": "eugenioenko",
     "description": "Open a drawer with color swatches. Click a color to insert its hex value at the cursor",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -19,6 +21,7 @@
   },
   {
     "name": "docker-manager",
+    "displayName": "Docker Manager",
     "author": "eugenioenko",
     "description": "Manage Docker containers, images and volumes",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -28,6 +31,7 @@
   },
   {
     "name": "go-test-runner",
+    "displayName": "Go Test Runner",
     "author": "eugenioenko",
     "description": "Run Go tests and view results in a sidebar panel",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -37,6 +41,7 @@
   },
   {
     "name": "http-client",
+    "displayName": "HTTP Client",
     "author": "eugenioenko",
     "description": "Simple HTTP client for testing APIs",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -46,6 +51,7 @@
   },
   {
     "name": "json-viewer",
+    "displayName": "JSON Viewer",
     "author": "eugenioenko",
     "description": "Parse and display JSON from the active editor as an interactive tree",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -55,6 +61,7 @@
   },
   {
     "name": "markdown-preview",
+    "displayName": "Markdown Preview",
     "author": "eugenioenko",
     "description": "Preview markdown files with styled rendering",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -64,6 +71,7 @@
   },
   {
     "name": "notepad",
+    "displayName": "Notepad",
     "author": "eugenioenko",
     "description": "Persistent scratchpad for jotting down notes per workspace",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -73,6 +81,7 @@
   },
   {
     "name": "todo-scanner",
+    "displayName": "TODO Scanner",
     "author": "eugenioenko",
     "description": "Scans workspace for TODO, FIXME, HACK, and NOTE comments",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -82,6 +91,7 @@
   },
   {
     "name": "formatter-gofmt",
+    "displayName": "gofmt Formatter",
     "author": "eugenioenko",
     "description": "Auto-configure gofmt as the Go formatter",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -91,6 +101,7 @@
   },
   {
     "name": "formatter-prettier",
+    "displayName": "Prettier Formatter",
     "author": "eugenioenko",
     "description": "Auto-configure Prettier for JS, TS, CSS, HTML, JSON, Markdown, and YAML",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -100,6 +111,7 @@
   },
   {
     "name": "formatter-black",
+    "displayName": "Black Formatter",
     "author": "eugenioenko",
     "description": "Auto-configure Black as the Python formatter",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -109,6 +121,7 @@
   },
   {
     "name": "formatter-rustfmt",
+    "displayName": "rustfmt Formatter",
     "author": "eugenioenko",
     "description": "Auto-configure rustfmt as the Rust formatter",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -118,6 +131,7 @@
   },
   {
     "name": "formatter-stylua",
+    "displayName": "StyLua Formatter",
     "author": "eugenioenko",
     "description": "Auto-configure StyLua as the Lua formatter",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -127,6 +141,7 @@
   },
   {
     "name": "formatter-clang-format",
+    "displayName": "clang-format Formatter",
     "author": "eugenioenko",
     "description": "Auto-configure clang-format for C and C++ files",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -136,6 +151,7 @@
   },
   {
     "name": "formatter-shfmt",
+    "displayName": "shfmt Formatter",
     "author": "eugenioenko",
     "description": "Auto-configure shfmt as the shell script formatter",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -145,6 +161,7 @@
   },
   {
     "name": "lsp-go",
+    "displayName": "Go Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure gopls as the Go language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -154,6 +171,7 @@
   },
   {
     "name": "lsp-typescript",
+    "displayName": "TypeScript Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure typescript-language-server for TypeScript and JavaScript",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -163,6 +181,7 @@
   },
   {
     "name": "lsp-python",
+    "displayName": "Python Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure pyright as the Python language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -172,6 +191,7 @@
   },
   {
     "name": "lsp-c",
+    "displayName": "C/C++ Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure clangd as the C/C++ language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -181,6 +201,7 @@
   },
   {
     "name": "lsp-rust",
+    "displayName": "Rust Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure rust-analyzer as the Rust language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -190,6 +211,7 @@
   },
   {
     "name": "lsp-lua",
+    "displayName": "Lua Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure lua-language-server as the Lua language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -199,6 +221,7 @@
   },
   {
     "name": "lsp-zig",
+    "displayName": "Zig Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure zls as the Zig language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -208,6 +231,7 @@
   },
   {
     "name": "lsp-vue",
+    "displayName": "Vue Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure vue-language-server for Vue files",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -217,6 +241,7 @@
   },
   {
     "name": "lsp-svelte",
+    "displayName": "Svelte Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure svelteserver for Svelte files",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -226,6 +251,7 @@
   },
   {
     "name": "lsp-css",
+    "displayName": "CSS Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure vscode-css-language-server for CSS, SCSS, and Less",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -235,6 +261,7 @@
   },
   {
     "name": "lsp-html",
+    "displayName": "HTML Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure vscode-html-language-server for HTML",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -244,6 +271,7 @@
   },
   {
     "name": "lsp-json",
+    "displayName": "JSON Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure vscode-json-language-server for JSON",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -253,6 +281,7 @@
   },
   {
     "name": "lsp-yaml",
+    "displayName": "YAML Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure yaml-language-server for YAML",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -262,6 +291,7 @@
   },
   {
     "name": "lsp-bash",
+    "displayName": "Bash Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure bash-language-server for shell scripts",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -271,6 +301,7 @@
   },
   {
     "name": "lsp-docker",
+    "displayName": "Docker Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure docker-langserver for Dockerfiles",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -280,6 +311,7 @@
   },
   {
     "name": "lsp-tailwindcss",
+    "displayName": "Tailwind CSS Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure tailwindcss-language-server for Tailwind CSS",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -289,6 +321,7 @@
   },
   {
     "name": "lsp-kotlin",
+    "displayName": "Kotlin Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure kotlin-language-server for Kotlin",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -298,6 +331,7 @@
   },
   {
     "name": "lsp-java",
+    "displayName": "Java Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure jdtls as the Java language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -307,6 +341,7 @@
   },
   {
     "name": "lsp-ruby",
+    "displayName": "Ruby Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure ruby-lsp as the Ruby language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -316,6 +351,7 @@
   },
   {
     "name": "lsp-dart",
+    "displayName": "Dart Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure dart language-server for Dart",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -325,6 +361,7 @@
   },
   {
     "name": "lsp-elixir",
+    "displayName": "Elixir Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure elixir-ls as the Elixir language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -334,6 +371,7 @@
   },
   {
     "name": "lsp-php",
+    "displayName": "PHP Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure phpactor as the PHP language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -343,6 +381,7 @@
   },
   {
     "name": "lsp-terraform",
+    "displayName": "Terraform Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure terraform-ls for Terraform files",
     "repo": "https://github.com/eugenioenko/ttt-plugins",
@@ -352,6 +391,7 @@
   },
   {
     "name": "lsp-markdown",
+    "displayName": "Markdown Language Server",
     "author": "eugenioenko",
     "description": "Auto-configure marksman as the Markdown language server",
     "repo": "https://github.com/eugenioenko/ttt-plugins",

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -31,6 +31,7 @@ Every plugin requires a `plugin.ttt.json` manifest file at the root of its direc
 ```json
 {
   "name": "my-plugin",
+  "displayName": "My Plugin",
   "description": "A short description of what this plugin does",
   "version": "1.0.0",
   "author": "Your Name",
@@ -44,7 +45,8 @@ Every plugin requires a `plugin.ttt.json` manifest file at the root of its direc
 
 | Field         | Type   | Required | Description                                         |
 |---------------|--------|----------|-----------------------------------------------------|
-| `name`        | string | yes      | Unique plugin identifier. Must match directory name. |
+| `name`        | string | yes      | Unique plugin identifier. Must match directory name. Used for the install directory, registry key, and panel IDs — keep it stable and kebab-case. |
+| `displayName` | string | no       | Human-facing name shown in the plugin list, approval dialog, and detail view. Falls back to `name` when omitted. |
 | `description` | string | no       | Shown in the plugin list dialog.                    |
 | `version`     | string | no       | Semver version string.                              |
 | `author`      | string | no       | Plugin author name.                                 |

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -109,7 +109,7 @@ func (a *App) showPluginList() {
 			status = "error"
 		}
 		entries = append(entries, widgets.KeyValueEntry{
-			Key:   p.Name,
+			Key:   p.Manifest.Title(),
 			Value: status + " v" + p.Manifest.Version,
 		})
 	}
@@ -268,7 +268,7 @@ func (a *App) ShowPluginApprovalDialog(p *plugin.Plugin) {
 	content.InvertStyles = true
 
 	dialog := widgets.NewDialogWidget(50)
-	dialog.Title = p.Manifest.Name + " requests"
+	dialog.Title = p.Manifest.Title() + " requests"
 	dialog.Borders = *a.Borders
 	dialog.SetContent(content)
 	dialog.Buttons = []widgets.DialogButton{

--- a/internal/app/plugin_detail.go
+++ b/internal/app/plugin_detail.go
@@ -60,7 +60,7 @@ func (a *App) OpenPluginDetail(entry plugin.RemoteRegistryEntry) {
 	}
 
 	nameLabel := widgets.NewLabelWidget(widgets.LabelConfig{
-		Text:  entry.Name,
+		Text:  entry.Title(),
 		Style: term.StyleHoverBold,
 	})
 
@@ -117,7 +117,7 @@ func (a *App) OpenPluginDetail(entry plugin.RemoteRegistryEntry) {
 	content := widgets.NewVStackWidget(header, divider, scroll)
 	adapter := ui.NewWidgetAdapter(content)
 
-	a.EditorGroup.OpenPluginTab(tabID, entry.Name, adapter)
+	a.EditorGroup.OpenPluginTab(tabID, entry.Title(), adapter)
 
 	go func() {
 		readme, err := fetchPluginReadme(entry.Repo, entry.Path)

--- a/internal/app/plugins_panel.go
+++ b/internal/app/plugins_panel.go
@@ -153,15 +153,18 @@ func (pp *PluginsPanel) Refresh() {
 		var icon string
 		var iconStyle term.Style
 
+		label := name
 		p := pp.manager.FindPlugin(name)
 		if p != nil && p.Enabled {
 			badge = "v" + p.Manifest.Version
 			icon = "●"
 			iconStyle = term.StyleSuccess
+			label = p.Manifest.Title()
 		} else {
 			if reg != nil {
 				if entry := reg.Find(name); entry != nil {
 					badge = "v" + entry.Version
+					label = entry.Title()
 				}
 			}
 			icon = "○"
@@ -170,7 +173,7 @@ func (pp *PluginsPanel) Refresh() {
 
 		node := &widgets.TreeNode{
 			ID:        name,
-			Label:     name,
+			Label:     label,
 			Badge:     badge,
 			Icon:      icon,
 			IconStyle: iconStyle,
@@ -203,7 +206,7 @@ func (pp *PluginsPanel) refreshAvailable() {
 		}
 		items = append(items, &widgets.TreeNode{
 			ID:    "available." + entry.Name,
-			Label: entry.Name,
+			Label: entry.Title(),
 			Badge: entry.Description,
 		})
 	}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -161,6 +161,7 @@ func (m *Manager) ApproveAndLoad(p *Plugin) error {
 
 	m.registry.AddOrUpdate(
 		p.Manifest.Name,
+		p.Manifest.DisplayName,
 		p.Repo,
 		p.RepoPath,
 		p.Manifest.Version,
@@ -449,7 +450,7 @@ func (m *Manager) DenyPlugin(p *Plugin) error {
 	if m.registry == nil {
 		return nil
 	}
-	m.registry.AddOrUpdate(p.Manifest.Name, p.Repo, p.RepoPath, p.Manifest.Version, p.Manifest.Permissions)
+	m.registry.AddOrUpdate(p.Manifest.Name, p.Manifest.DisplayName, p.Repo, p.RepoPath, p.Manifest.Version, p.Manifest.Permissions)
 	m.registry.SetEnabled(p.Manifest.Name, false)
 	return m.registry.Save()
 }

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -13,12 +13,22 @@ const SupportedAPIVersion = 1
 
 type Manifest struct {
 	Name        string        `json:"name"`
+	DisplayName string        `json:"displayName,omitempty"`
 	Description string        `json:"description"`
 	Version     string        `json:"version"`
 	Author      string        `json:"author"`
 	Entry       string        `json:"entry"`
 	API         int           `json:"api,omitempty"`
 	Permissions PermissionSet `json:"permissions"`
+}
+
+// Title is the human-facing plugin name shown in the UI: DisplayName when the
+// author set one, otherwise the unique kebab-case Name identifier.
+func (m Manifest) Title() string {
+	if m.DisplayName != "" {
+		return m.DisplayName
+	}
+	return m.Name
 }
 
 func LoadManifest(dir string) (Manifest, error) {

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -40,6 +40,30 @@ func TestLoadManifest(t *testing.T) {
 	}
 }
 
+func TestLoadManifestDisplayName(t *testing.T) {
+	dir := t.TempDir()
+	data := `{"name":"my-plugin","displayName":"My Plugin","entry":"init.lua"}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.DisplayName != "My Plugin" {
+		t.Errorf("expected displayName 'My Plugin', got %q", m.DisplayName)
+	}
+	if m.Title() != "My Plugin" {
+		t.Errorf("Title() should use displayName, got %q", m.Title())
+	}
+}
+
+func TestManifestTitleFallsBackToName(t *testing.T) {
+	m := Manifest{Name: "my-plugin"}
+	if m.Title() != "my-plugin" {
+		t.Errorf("Title() should fall back to name, got %q", m.Title())
+	}
+}
+
 func TestLoadManifestMissingName(t *testing.T) {
 	dir := t.TempDir()
 	data := `{"entry": "main.ttt.lua"}`

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -8,11 +8,20 @@ import (
 
 type RegistryEntry struct {
 	Name        string        `json:"name"`
+	DisplayName string        `json:"displayName,omitempty"`
 	Repo        string        `json:"repo,omitempty"`
 	Path        string        `json:"path,omitempty"`
 	Version     string        `json:"version"`
 	Enabled     bool          `json:"enabled"`
 	Permissions PermissionSet `json:"permissions"`
+}
+
+// Title is the human-facing name: DisplayName when set, else the unique Name.
+func (e RegistryEntry) Title() string {
+	if e.DisplayName != "" {
+		return e.DisplayName
+	}
+	return e.Name
 }
 
 type Registry struct {
@@ -77,9 +86,10 @@ func (r *Registry) Remove(name string) {
 	}
 }
 
-func (r *Registry) AddOrUpdate(name, repo, path, version string, perms PermissionSet) {
+func (r *Registry) AddOrUpdate(name, displayName, repo, path, version string, perms PermissionSet) {
 	entry := r.Find(name)
 	if entry != nil {
+		entry.DisplayName = displayName
 		entry.Repo = repo
 		entry.Path = path
 		entry.Version = version
@@ -89,6 +99,7 @@ func (r *Registry) AddOrUpdate(name, repo, path, version string, perms Permissio
 	}
 	r.Entries = append(r.Entries, RegistryEntry{
 		Name:        name,
+		DisplayName: displayName,
 		Repo:        repo,
 		Path:        path,
 		Version:     version,

--- a/internal/plugin/registry_remote.go
+++ b/internal/plugin/registry_remote.go
@@ -12,12 +12,22 @@ const DefaultRegistryURL = "https://raw.githubusercontent.com/eugenioenko/ttt/ma
 
 type RemoteRegistryEntry struct {
 	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName,omitempty"`
 	Repo        string   `json:"repo"`
 	Description string   `json:"description"`
 	Author      string   `json:"author"`
 	Version     string   `json:"version,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
 	Path        string   `json:"path,omitempty"`
+}
+
+// Title is the human-facing name shown in the registry UI: DisplayName when the
+// entry provides one, otherwise the unique Name identifier.
+func (e RemoteRegistryEntry) Title() string {
+	if e.DisplayName != "" {
+		return e.DisplayName
+	}
+	return e.Name
 }
 
 func FetchRemoteRegistry(url string) ([]RemoteRegistryEntry, error) {

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -20,7 +20,7 @@ func TestLoadRegistryMissing(t *testing.T) {
 func TestRegistryRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("test", "github.com/test/test", "", "1.0.0", PermissionSet{PanelSidebar: true})
+	r.AddOrUpdate("test", "Test Plugin", "github.com/test/test", "", "1.0.0", PermissionSet{PanelSidebar: true})
 
 	if err := r.Save(); err != nil {
 		t.Fatalf("save error: %v", err)
@@ -36,6 +36,12 @@ func TestRegistryRoundTrip(t *testing.T) {
 	if r2.Entries[0].Name != "test" {
 		t.Errorf("expected name test, got %s", r2.Entries[0].Name)
 	}
+	if r2.Entries[0].DisplayName != "Test Plugin" {
+		t.Errorf("expected displayName to round-trip, got %q", r2.Entries[0].DisplayName)
+	}
+	if r2.Entries[0].Title() != "Test Plugin" {
+		t.Errorf("expected Title() to use displayName, got %q", r2.Entries[0].Title())
+	}
 	if !r2.Entries[0].Permissions.PanelSidebar {
 		t.Error("expected panel.sidebar to be true")
 	}
@@ -44,8 +50,8 @@ func TestRegistryRoundTrip(t *testing.T) {
 func TestRegistryFind(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("alpha", "", "", "1.0", PermissionSet{})
-	r.AddOrUpdate("beta", "", "", "2.0", PermissionSet{})
+	r.AddOrUpdate("alpha", "", "", "", "1.0", PermissionSet{})
+	r.AddOrUpdate("beta", "", "", "", "2.0", PermissionSet{})
 
 	if r.Find("alpha") == nil {
 		t.Error("expected to find alpha")
@@ -58,7 +64,7 @@ func TestRegistryFind(t *testing.T) {
 func TestRegistrySetEnabled(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("test", "", "", "1.0", PermissionSet{})
+	r.AddOrUpdate("test", "", "", "", "1.0", PermissionSet{})
 
 	r.SetEnabled("test", false)
 	entry := r.Find("test")
@@ -70,7 +76,7 @@ func TestRegistrySetEnabled(t *testing.T) {
 func TestRegistryUpdatePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "plugins.ttt.json")
 	r := &Registry{path: path}
-	r.AddOrUpdate("test", "", "", "1.0", PermissionSet{})
+	r.AddOrUpdate("test", "", "", "", "1.0", PermissionSet{})
 
 	r.UpdatePermissions("test", PermissionSet{Commands: true})
 	entry := r.Find("test")


### PR DESCRIPTION
## Problem

A plugin's `name` was doing double duty: it's the **unique identifier** (install dir `pluginsDir/<name>`, registry key, panel IDs `plugin.<name>`, diagnostics source) *and* the string shown in the UI. So kebab-case ids like `github-comments` leaked into the approval dialog, the plugin lists, and the detail header.

## Fix

Add an optional **`displayName`** to the manifest, with a `Title()` helper that falls back to `name`:

- `Manifest.DisplayName` + `Manifest.Title()`
- `RemoteRegistryEntry.DisplayName` + `Title()` (for the not-yet-installed / available list, which is populated from `community-plugins.json` before the manifest is downloaded)
- `RegistryEntry.DisplayName` + `Title()`, persisted via `AddOrUpdate`, so the installed list shows a nice name even for a disabled/not-loaded plugin

Display sites now use `Title()`; every identity use stays on `name`:
- approval dialog title (`<displayName> requests`)
- installed plugin list label
- available plugin list label
- plugin detail header + tab title
- info dialog ("Installed Plugins")

`displayName` is optional and free-form; existing manifests keep working unchanged.

## Data

- `community-plugins.json` — all 40 entries get a `displayName`.
- The plugin manifests in **ttt-plugins** are updated to match: eugenioenko/ttt-plugins#4

## Tests

- `TestLoadManifestDisplayName`, `TestManifestTitleFallsBackToName`
- `TestRegistryRoundTrip` extended to assert `displayName` round-trips and `Title()` uses it
- Full `go test ./...` passes; `gofmt` clean.

Docs: plugin-authoring manifest table documents `displayName` and clarifies `name` is the stable identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)