### PR TITLE
docs: add NixOS install tab to the installation page

### DIFF
--- a/docs-web/src/content/docs/getting-started/installation.mdx
+++ b/docs-web/src/content/docs/getting-started/installation.mdx
@@ -36,6 +36,27 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     yay -S ttt
     ```
   </TabItem>
+  <TabItem label="NixOS">
+    :::note
+    The flake tracks `main`. A future tagged release will ship a pinned flake; until then, install from `main`.
+    :::
+
+    Try it without installing:
+
+    ```sh
+    nix run github:eugenioenko/ttt
+    ```
+
+    Add to your `flake.nix` inputs:
+
+    ```nix
+    {
+      inputs.ttt.url = "github:eugenioenko/ttt";
+    }
+    ```
+
+    Then add `inputs.ttt.packages.${system}.default` to your `environment.systemPackages` or home-manager packages.
+  </TabItem>
 </Tabs>
 
 ## Download Binary


### PR DESCRIPTION
The docs-web installation page had tabs for macOS, Linux, and Arch Linux (AUR) but was missing **NixOS** — even though the README already documents it.

Adds a NixOS tab matching the README's wording: the "flake tracks main" note, `nix run github:eugenioenko/ttt`, the `flake.nix` input, and the `systemPackages` / home-manager instruction.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)