### PR TITLE
feat: auto-indent new lines and dedent on closing bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ You can also open these directly from the command palette (**Ctrl+P**): **Prefer
 | `tabSize` | int | `4` | Number of spaces per indentation level |
 | `insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `wordWrap` | bool | `false` | Wrap long lines at the editor width |
+| `autoIndent` | bool | `true` | Auto-indent new lines after `{ ( [ :` and dedent when typing a closing bracket |
 | `lineNumbers` | bool | `true` | Show line numbers in the gutter |
 | `sidebarVisible` | bool | `true` | Show the sidebar on startup |
 | `sidebarWidth` | int | `30` | Width of the sidebar in columns |
@@ -533,6 +534,7 @@ Example `~/.config/ttt/settings.json` (also available at [`config/settings.json`
   "tabSize": 4,
   "insertSpaces": true,
   "wordWrap": false,
+  "autoIndent": true,
   "lineNumbers": true,
   "sidebarVisible": true,
   "sidebarWidth": 30,

--- a/docs-web/src/content/docs/guides/editor.md
+++ b/docs-web/src/content/docs/guides/editor.md
@@ -13,6 +13,10 @@ Matching brackets are highlighted automatically when the cursor is on a bracket 
 
 Bracket pair colorization is also available, rendering each nesting level in a distinct color. It is off by default and can be enabled with the `editor.bracketPairColorization` setting.
 
+## Auto Indent
+
+New lines inherit the indentation of the previous line, and adding an extra level after an open `{`, `(`, `[`, or trailing `:`. Typing a closing `}`, `)`, or `]` on an otherwise-blank line dedents it one level so it lines up with its opening line. Auto indent is on by default; toggle it from the Options menu (**Auto Indent**) or with the `editor.autoIndent` setting.
+
 ## Find and Replace
 
 - **Ctrl+F** opens the find bar with match navigation

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -26,6 +26,7 @@ All editor settings are nested under the `editor` key.
 | `editor.tabSize` | int | `4` | Number of spaces per indentation level |
 | `editor.insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `editor.wordWrap` | bool | `false` | Wrap long lines at the editor width |
+| `editor.autoIndent` | bool | `true` | Auto-indent new lines after `{ ( [ :` and dedent when typing a closing bracket |
 | `editor.lineNumbers` | bool | `true` | Show line numbers in the gutter |
 | `editor.cursorStyle` | string | `""` | Cursor style: `"block"`, `"underline"`, or `"bar"` |
 | `editor.formatOnSave` | bool | `false` | Auto-format the document via LSP on save |
@@ -127,6 +128,7 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
     "tabSize": 4,
     "insertSpaces": true,
     "wordWrap": false,
+    "autoIndent": true,
     "lineNumbers": true,
     "cursorStyle": "",
     "formatOnSave": false,

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -26,6 +26,15 @@ func (a *App) ToggleWordWrap() {
 	config.SaveSettings(*a.Settings)
 }
 
+func (a *App) ToggleAutoIndent() {
+	enabled := !a.Settings.Editor.IsAutoIndentEnabled()
+	a.Settings.Editor.AutoIndent = &enabled
+	if a.EditorGroup.Editor != nil {
+		a.EditorGroup.Editor.AutoIndent = enabled
+	}
+	config.SaveSettings(*a.Settings)
+}
+
 func (a *App) ToggleSyntaxHighlight() {
 	enabled := !a.Settings.Editor.IsSyntaxHighlightEnabled()
 	a.Settings.Editor.SyntaxHighlight = &enabled
@@ -137,6 +146,11 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		bracketColorChecked = ui.MenuChecked
 	}
 
+	autoIndentChecked := ui.MenuUnchecked
+	if a.Settings.Editor.IsAutoIndentEnabled() {
+		autoIndentChecked = ui.MenuChecked
+	}
+
 	lspChecked := ui.MenuUnchecked
 	if a.Settings.LSP.IsEnabled() {
 		lspChecked = ui.MenuChecked
@@ -155,6 +169,7 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
+		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
 		{Label: "Syntax Highlight", Command: "options.toggleSyntaxHighlight", Checked: syntaxChecked},
 		{Label: "Bracket Colors", Command: "options.toggleBracketColors", Checked: bracketColorChecked},
 		{Label: "LSP Code Assist", Command: "options.toggleLSP", Checked: lspChecked},
@@ -190,6 +205,12 @@ func registerOptionsCommands(app *App) {
 		ID: "options.toggleWordWrap", Title: "Toggle Word Wrap",
 		Keywords: []string{"preferences", "settings", "editor", "view"},
 		Handler:  app.ToggleWordWrap,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.toggleAutoIndent", Title: "Toggle Auto Indent",
+		Keywords: []string{"preferences", "settings", "editor", "indentation", "indent"},
+		Handler:  app.ToggleAutoIndent,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -26,6 +26,7 @@ func (a *App) ApplySettings(s config.Settings) {
 	a.EditorGroup.Editor.TabSize = s.Editor.TabSize
 	a.EditorGroup.Editor.LineNumbers = s.Editor.LineNumbers
 	a.EditorGroup.Editor.GutterStyle = s.Editor.GutterStyle
+	a.EditorGroup.Editor.AutoIndent = s.Editor.IsAutoIndentEnabled()
 
 	// Apply cursor style
 	if a.Screen != nil {

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -128,6 +128,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.SyntaxHighlight = cfg.Settings.Editor.IsSyntaxHighlightEnabled()
 	editorGroup.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.Editor.WordWrap = cfg.Settings.Editor.WordWrap
+	editorGroup.Editor.AutoIndent = cfg.Settings.Editor.IsAutoIndentEnabled()
 	editorGroup.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.Editor.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.BracketColorStyles = bracketStyles

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -78,6 +78,7 @@ type EditorSettings struct {
 	FocusOnOpen             bool   `json:"focusOnOpen"`
 	SyntaxHighlight         *bool  `json:"syntaxHighlight,omitempty"`
 	GitGutter               *bool  `json:"gitGutter,omitempty"`
+	AutoIndent              *bool  `json:"autoIndent,omitempty"`
 	GutterStyle             string `json:"gutterStyle,omitempty"`
 	BorderStyle             string `json:"borderStyle,omitempty"`
 	BracketPairColorization bool   `json:"bracketPairColorization"`
@@ -89,6 +90,10 @@ func (e EditorSettings) IsSyntaxHighlightEnabled() bool {
 
 func (e EditorSettings) IsGitGutterEnabled() bool {
 	return e.GitGutter == nil || *e.GitGutter
+}
+
+func (e EditorSettings) IsAutoIndentEnabled() bool {
+	return e.AutoIndent == nil || *e.AutoIndent
 }
 
 func DefaultEditorSettings() EditorSettings {

--- a/internal/ui/autoindent_test.go
+++ b/internal/ui/autoindent_test.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/buffer"
+	"github.com/eugenioenko/ttt/internal/core/cursor"
+	"github.com/eugenioenko/ttt/internal/view"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func newEditorWithLines(lines ...string) *EditorPaneWidget {
+	buf := &buffer.Buffer{Lines: lines}
+	cur := &cursor.Cursor{Line: 0, Col: 0}
+	vp := &view.Viewport{TopLine: 0, LeftCol: 0, Width: 40, Height: 10}
+	return NewEditorPaneWidget(buf, cur, vp)
+}
+
+func TestAutoIndentEnterAfterOpenBrace(t *testing.T) {
+	e := newEditorWithLines("{")
+	e.Cursor.Col = 1
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	if e.Buf.Lines[1] != "    " {
+		t.Fatalf("expected new line indented 4 spaces, got %q", e.Buf.Lines[1])
+	}
+	if e.Cursor.Line != 1 || e.Cursor.Col != 4 {
+		t.Fatalf("expected cursor at (1,4), got (%d,%d)", e.Cursor.Line, e.Cursor.Col)
+	}
+}
+
+func TestAutoIndentEnterBetweenBracesSplitsClosing(t *testing.T) {
+	e := newEditorWithLines("{}")
+	e.Cursor.Col = 1
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	if e.Buf.Lines[0] != "{" || e.Buf.Lines[1] != "    " || e.Buf.Lines[2] != "}" {
+		t.Fatalf("expected {, 4-space line, }, got %q", e.Buf.Lines)
+	}
+	if e.Cursor.Line != 1 || e.Cursor.Col != 4 {
+		t.Fatalf("expected cursor at (1,4), got (%d,%d)", e.Cursor.Line, e.Cursor.Col)
+	}
+}
+
+func TestAutoIndentDedentOnCloseBrace(t *testing.T) {
+	e := newEditorWithLines("{", "    ")
+	e.Cursor.Line = 1
+	e.Cursor.Col = 4
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyRune, '}', 0))
+
+	if e.Buf.Lines[1] != "}" {
+		t.Fatalf("expected closing brace dedented to column 0, got %q", e.Buf.Lines[1])
+	}
+	if e.Cursor.Col != 1 {
+		t.Fatalf("expected cursor at col 1, got %d", e.Cursor.Col)
+	}
+}
+
+func TestAutoIndentDedentNestedRemovesOneLevel(t *testing.T) {
+	e := newEditorWithLines("        ") // two levels of indent
+	e.Cursor.Col = 8
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyRune, '}', 0))
+
+	if e.Buf.Lines[0] != "    }" {
+		t.Fatalf("expected one indent level removed leaving '    }', got %q", e.Buf.Lines[0])
+	}
+	if e.Cursor.Col != 5 {
+		t.Fatalf("expected cursor at col 5, got %d", e.Cursor.Col)
+	}
+}
+
+func TestAutoIndentDedentSkipsMidLine(t *testing.T) {
+	e := newEditorWithLines("    foo")
+	e.Cursor.Col = 7
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyRune, '}', 0))
+
+	if e.Buf.Lines[0] != "    foo}" {
+		t.Fatalf("expected no dedent for mid-line brace, got %q", e.Buf.Lines[0])
+	}
+}
+
+func TestAutoIndentDisabledPlainNewline(t *testing.T) {
+	e := newEditorWithLines("{")
+	e.AutoIndent = false
+	e.Cursor.Col = 1
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	if e.Buf.Lines[1] != "" {
+		t.Fatalf("expected empty new line when auto-indent off, got %q", e.Buf.Lines[1])
+	}
+	if e.Cursor.Line != 1 || e.Cursor.Col != 0 {
+		t.Fatalf("expected cursor at (1,0), got (%d,%d)", e.Cursor.Line, e.Cursor.Col)
+	}
+}
+
+func TestAutoIndentDisabledNoDedent(t *testing.T) {
+	e := newEditorWithLines("    ")
+	e.AutoIndent = false
+	e.Cursor.Col = 4
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyRune, '}', 0))
+
+	if e.Buf.Lines[0] != "    }" {
+		t.Fatalf("expected brace appended without dedent, got %q", e.Buf.Lines[0])
+	}
+}
+
+func TestAutoIndentEnabledByDefault(t *testing.T) {
+	e := newEditorWithLines("")
+	if !e.AutoIndent {
+		t.Fatal("expected auto-indent to be enabled by default")
+	}
+}

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -36,6 +36,7 @@ type EditorPaneWidget struct {
 	LineNumbers             bool
 	GutterStyle             string
 	WordWrap                bool
+	AutoIndent              bool
 	BracketPairColorization bool
 	BracketColorStyles      []term.Style
 	Highlighter             *highlight.Highlighter
@@ -74,6 +75,7 @@ func NewEditorPaneWidget(buf *buffer.Buffer, cur *cursor.Cursor, vp *view.Viewpo
 		Buf:               buf,
 		Cursor:            cur,
 		Viewport:          vp,
+		AutoIndent:        true,
 		bracketColorDirty: true,
 	}
 }
@@ -1021,31 +1023,33 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 				col = lineLen
 			}
 			line := e.Buf.Lines[e.Cursor.Line]
-			indent := leadingWhitespace(line)
-			runes := []rune(line)
-			charBefore := ' '
-			if col > 0 && col <= len(runes) {
-				charBefore = runes[col-1]
-			}
-			charAfter := ' '
-			if col < len(runes) {
-				charAfter = runes[col]
-			}
-			extraIndent := charBefore == '{' || charBefore == '(' || charBefore == '[' || charBefore == ':'
 			e.exec(&undo.SplitLineCommand{Line: e.Cursor.Line, Col: col})
 			e.Cursor.Line++
 			e.Cursor.Col = 0
-			newIndent := indent
-			if extraIndent {
-				newIndent += e.indentUnit()
-			}
-			if len(newIndent) > 0 {
-				e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line, Col: 0, Text: newIndent})
-				e.Cursor.Col = len([]rune(newIndent))
-			}
-			if extraIndent && (charAfter == '}' || charAfter == ')' || charAfter == ']') {
-				e.exec(&undo.SplitLineCommand{Line: e.Cursor.Line, Col: e.Cursor.Col})
-				e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line + 1, Col: 0, Text: indent})
+			if e.AutoIndent {
+				indent := leadingWhitespace(line)
+				runes := []rune(line)
+				charBefore := ' '
+				if col > 0 && col <= len(runes) {
+					charBefore = runes[col-1]
+				}
+				charAfter := ' '
+				if col < len(runes) {
+					charAfter = runes[col]
+				}
+				extraIndent := charBefore == '{' || charBefore == '(' || charBefore == '[' || charBefore == ':'
+				newIndent := indent
+				if extraIndent {
+					newIndent += e.indentUnit()
+				}
+				if len(newIndent) > 0 {
+					e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line, Col: 0, Text: newIndent})
+					e.Cursor.Col = len([]rune(newIndent))
+				}
+				if extraIndent && (charAfter == '}' || charAfter == ')' || charAfter == ']') {
+					e.exec(&undo.SplitLineCommand{Line: e.Cursor.Line, Col: e.Cursor.Col})
+					e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line + 1, Col: 0, Text: indent})
+				}
 			}
 		}
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
@@ -1120,6 +1124,9 @@ func (e *EditorPaneWidget) HandleEvent(ev tcell.Event) EventResult {
 					e.replaceSelection(&undo.InsertRuneCommand{Line: start.Line, Col: start.Col, Rune: r})
 					e.Cursor.Col = start.Col + 1
 				} else {
+					if e.AutoIndent && (r == '}' || r == ')' || r == ']') {
+						e.dedentForCloser()
+					}
 					e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: r})
 					e.Cursor.Col++
 				}
@@ -1302,6 +1309,35 @@ func (e *EditorPaneWidget) indentUnit() string {
 		return "\t"
 	}
 	return strings.Repeat(" ", e.resolveTabSize())
+}
+
+// dedentForCloser removes one indent level from the current line when a closing
+// bracket is typed on an otherwise-blank line, so `}` lands back at the
+// indentation of its opening line. It is a no-op when there is non-whitespace
+// before the cursor or less than a full indent unit to remove.
+func (e *EditorPaneWidget) dedentForCloser() {
+	runes := []rune(e.Buf.Lines[e.Cursor.Line])
+	col := e.Cursor.Col
+	if col > len(runes) {
+		col = len(runes)
+	}
+	for i := 0; i < col; i++ {
+		if runes[i] != ' ' && runes[i] != '\t' {
+			return
+		}
+	}
+	remove := leadingIndentWidth(e.Buf.Lines[e.Cursor.Line], e.resolveTabSize())
+	if remove <= 0 || remove > col {
+		return
+	}
+	e.exec(&undo.DeleteSelectionCommand{
+		StartLine: e.Cursor.Line, StartCol: 0,
+		EndLine: e.Cursor.Line, EndCol: remove,
+	})
+	e.Cursor.Col -= remove
+	if e.Cursor.Col < 0 {
+		e.Cursor.Col = 0
+	}
 }
 
 func leadingIndentWidth(line string, tabSize int) int {

--- a/tests/functional/auto-indent.test.js
+++ b/tests/functional/auto-indent.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("auto indent", () => {
+  it("indents a new line after an open brace", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "");
+
+    tui.start(file);
+    tui.waitStable();
+
+    tui.type("if x {");
+    tui.press("enter");
+    tui.type("return");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    // The new line inherits no indent but gains one level from the open brace.
+    expect(snapshots[s0]).toContain("    return");
+  });
+
+  it("dedents when typing a closing brace on a blank line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "");
+
+    tui.start(file);
+    tui.waitStable();
+
+    tui.type("if x {");
+    tui.press("enter");
+    tui.type("return");
+    tui.press("enter");
+    tui.type("}");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    // The body stays indented, but the closing brace snaps back to column 0.
+    expect(snapshots[s0]).toContain("    return");
+    expect(snapshots[s0]).not.toContain("    }");
+  });
+});


### PR DESCRIPTION
## What

Adds automatic dedent when typing a closing bracket, and gates all auto-indent behavior behind a new `editor.autoIndent` setting (default **on**).

Previously the editor added an indent level after an open `{ ( [ :` on Enter, but typing the matching `}` left the line one level too deep — you had to backspace manually. Now the closing bracket snaps back to the indentation of its opening line, matching VS Code / Sublime / JetBrains.

## Behavior

- **Enter after an opener** (`{ ( [ :`) — new line gains one indent level (unchanged, now gated).
- **Typing `} ) ]` on an otherwise-blank line** — removes one indent unit before inserting, so the closer lines up with its opener. No-op when there's non-whitespace before the cursor (mid-line brackets are untouched) or less than a full indent unit to remove.
- **`editor.autoIndent: false`** — disables both: Enter produces a plain newline at column 0, and closing brackets insert verbatim.

The dedent reuses the existing `leadingIndentWidth` primitive (the same "one indent unit" used by Backtab), so it's a clean inverse of the Enter-after-`{` indent and works for both spaces and tabs.

Discoverable via **Options → Auto Indent** (checkable) and the `Toggle Auto Indent` command. Follows the existing `*bool`-defaults-on pattern used by `syntaxHighlight` / `gitGutter`.

## Tests

- **Unit** (`internal/ui/autoindent_test.go`): Enter-after-brace, split-closing-brace, dedent on close, nested one-level dedent, mid-line skip, disabled paths, default-on.
- **Functional** (`tests/functional/auto-indent.test.js`): drives the real binary end-to-end — indents `return` after `{`, dedents the closing `}`.

Docs updated: README settings table + example, docs-web settings reference, editor guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)