### PR TITLE
fix: inherit indentation on Enter regardless of autoIndent

### DIFF
--- a/internal/ui/autoindent_test.go
+++ b/internal/ui/autoindent_test.go
@@ -118,3 +118,51 @@ func TestAutoIndentEnabledByDefault(t *testing.T) {
 		t.Fatal("expected auto-indent to be enabled by default")
 	}
 }
+
+// With auto-indent off, a new line should still inherit the previous line's
+// indentation. Auto-indent only governs the bracket-aware extra level, not
+// basic indentation inheritance.
+func TestAutoIndentOffInheritsIndentation(t *testing.T) {
+	e := newEditorWithLines("    foo")
+	e.AutoIndent = false
+	e.Cursor.Col = 7
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	if e.Buf.Lines[1] != "    " {
+		t.Fatalf("expected new line to inherit 4-space indent, got %q", e.Buf.Lines[1])
+	}
+	if e.Cursor.Col != 4 {
+		t.Fatalf("expected cursor at col 4, got %d", e.Cursor.Col)
+	}
+}
+
+// Single-cursor and multi-cursor Enter must indent identically. Previously the
+// multi-cursor path inherited indentation unconditionally while the single
+// path gated it behind AutoIndent, so they diverged with auto-indent off.
+func TestAutoIndentOffEnterConsistentAcrossCursorModes(t *testing.T) {
+	single := newEditorWithLines("    foo")
+	single.AutoIndent = false
+	single.Cursor.Line, single.Cursor.Col = 0, 7
+	single.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+	singleIndent := single.Buf.Lines[1]
+
+	multi := newEditorWithLines("    foo", "    bar")
+	multi.AutoIndent = false
+	multi.Cursor.Line, multi.Cursor.Col = 0, 7
+	multi.ensureMulti()
+	multi.Multi.Add(1, 7)
+	multi.syncFromMulti()
+	if !multi.isMultiActive() {
+		t.Fatal("expected multi-cursor mode to be active")
+	}
+	multi.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+	multiIndent := multi.Buf.Lines[1]
+
+	if singleIndent != multiIndent {
+		t.Fatalf("indent diverged with auto-indent off: single=%q multi=%q", singleIndent, multiIndent)
+	}
+	if singleIndent != "    " {
+		t.Fatalf("expected both to inherit 4-space indent, got %q", singleIndent)
+	}
+}

--- a/internal/ui/editor_widget_keyboard.go
+++ b/internal/ui/editor_widget_keyboard.go
@@ -263,30 +263,34 @@ func (e *EditorPaneWidget) execEnter() {
 	e.exec(&undo.SplitLineCommand{Line: e.Cursor.Line, Col: col})
 	e.Cursor.Line++
 	e.Cursor.Col = 0
+
+	// Indentation inheritance is baseline behavior and always applies; the
+	// AutoIndent flag only governs the bracket-aware extra level and dedent.
+	indent := leadingWhitespace(line)
+	newIndent := indent
+	runes := []rune(line)
+	charAfter := ' '
+	if col < len(runes) {
+		charAfter = runes[col]
+	}
+	extraIndent := false
 	if e.AutoIndent {
-		indent := leadingWhitespace(line)
-		runes := []rune(line)
 		charBefore := ' '
 		if col > 0 && col <= len(runes) {
 			charBefore = runes[col-1]
 		}
-		charAfter := ' '
-		if col < len(runes) {
-			charAfter = runes[col]
-		}
-		extraIndent := indentOpeners[charBefore]
-		newIndent := indent
+		extraIndent = indentOpeners[charBefore]
 		if extraIndent {
 			newIndent += e.indentUnit()
 		}
-		if len(newIndent) > 0 {
-			e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line, Col: 0, Text: newIndent})
-			e.Cursor.Col = len([]rune(newIndent))
-		}
-		if extraIndent && closingBrackets[charAfter] {
-			e.exec(&undo.SplitLineCommand{Line: e.Cursor.Line, Col: e.Cursor.Col})
-			e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line + 1, Col: 0, Text: indent})
-		}
+	}
+	if len(newIndent) > 0 {
+		e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line, Col: 0, Text: newIndent})
+		e.Cursor.Col = len([]rune(newIndent))
+	}
+	if extraIndent && closingBrackets[charAfter] {
+		e.exec(&undo.SplitLineCommand{Line: e.Cursor.Line, Col: e.Cursor.Col})
+		e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line + 1, Col: 0, Text: indent})
 	}
 }
 


### PR DESCRIPTION
Fixes #368.

## Problem

With `editor.autoIndent` **off**, single-cursor and multi-cursor Enter diverged:

| Cursors | Enter on an indented line |
|---|---|
| single | dropped to column 0 (indentation lost) |
| multiple | inherited the previous line's indentation |

`execEnter` gated *all* indentation — including basic `leadingWhitespace` inheritance — behind `AutoIndent`, while `multiExecEnter` inherited unconditionally. (Latent since #366; the recent editor_widget refactor only relocated the code, byte-for-byte.)

## Fix

Ungate inheritance in `execEnter`: the previous line's indentation is now always inherited, and `AutoIndent` governs only the bracket-aware extra level (`{ ( [ :`) and the closing-bracket dedent. This matches what `multiExecEnter` already does, so the two paths agree.

Net effect: `autoIndent: false` now means "keep indentation, no bracket magic" (VS Code's `keep` mode) instead of "no indentation at all" — the more expected behavior, and consistent across cursor modes.

## Tests (written first, confirmed failing, then fixed)

- `TestAutoIndentOffInheritsIndentation` — single-cursor Enter with `autoIndent` off inherits the previous indent.
- `TestAutoIndentOffEnterConsistentAcrossCursorModes` — single- and multi-cursor Enter produce identical indentation with `autoIndent` off (this one printed the bug: `single="" multi="    "`).

Both failed before the change and pass after. Existing auto-indent tests (including `autoIndent: true` bracket behavior and the disabled-dedent case) still pass, plus full `go test ./...` and the auto-indent / multi-cursor functional suites.

## Follow-up (not in this PR)

`multiExecEnter` still doesn't apply the bracket extra-indent when `autoIndent` is on (it only inherits) — noted in #368 as low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)