### PR TITLE
refactor: rename autoIndent to autoDedent, gate only the dedent

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ You can also open these directly from the command palette (**Ctrl+P**): **Prefer
 | `tabSize` | int | `4` | Number of spaces per indentation level |
 | `insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `wordWrap` | bool | `false` | Wrap long lines at the editor width |
-| `autoIndent` | bool | `true` | Auto-indent new lines after `{ ( [ :` and dedent when typing a closing bracket |
+| `autoDedent` | bool | `true` | Dedent one level when typing a closing `} ) ]` on a blank line (indentation inheritance and indent after `{ ( [ :` always apply) |
 | `lineNumbers` | bool | `true` | Show line numbers in the gutter |
 | `sidebarVisible` | bool | `true` | Show the sidebar on startup |
 | `sidebarWidth` | int | `30` | Width of the sidebar in columns |
@@ -534,7 +534,7 @@ Example `~/.config/ttt/settings.json` (also available at [`config/settings.json`
   "tabSize": 4,
   "insertSpaces": true,
   "wordWrap": false,
-  "autoIndent": true,
+  "autoDedent": true,
   "lineNumbers": true,
   "sidebarVisible": true,
   "sidebarWidth": 30,

--- a/docs-web/src/content/docs/guides/editor.md
+++ b/docs-web/src/content/docs/guides/editor.md
@@ -15,7 +15,9 @@ Bracket pair colorization is also available, rendering each nesting level in a d
 
 ## Auto Indent
 
-New lines inherit the indentation of the previous line, and adding an extra level after an open `{`, `(`, `[`, or trailing `:`. Typing a closing `}`, `)`, or `]` on an otherwise-blank line dedents it one level so it lines up with its opening line. Auto indent is on by default; toggle it from the Options menu (**Auto Indent**) or with the `editor.autoIndent` setting.
+New lines inherit the indentation of the previous line and gain an extra level after an open `{`, `(`, `[`, or trailing `:`. These always apply.
+
+Typing a closing `}`, `)`, or `]` on an otherwise-blank line dedents it one level so it lines up with its opening line. This dedent is on by default; toggle it from the Options menu (**Auto Dedent**) or with the `editor.autoDedent` setting.
 
 ## Find and Replace
 

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -26,7 +26,7 @@ All editor settings are nested under the `editor` key.
 | `editor.tabSize` | int | `4` | Number of spaces per indentation level |
 | `editor.insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `editor.wordWrap` | bool | `false` | Wrap long lines at the editor width |
-| `editor.autoIndent` | bool | `true` | Auto-indent new lines after `{ ( [ :` and dedent when typing a closing bracket |
+| `editor.autoDedent` | bool | `true` | Dedent one level when typing a closing `} ) ]` on a blank line (indentation inheritance and indent after `{ ( [ :` always apply) |
 | `editor.lineNumbers` | bool | `true` | Show line numbers in the gutter |
 | `editor.cursorStyle` | string | `""` | Cursor style: `"block"`, `"underline"`, or `"bar"` |
 | `editor.formatOnSave` | bool | `false` | Auto-format the document via LSP on save |
@@ -128,7 +128,7 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
     "tabSize": 4,
     "insertSpaces": true,
     "wordWrap": false,
-    "autoIndent": true,
+    "autoDedent": true,
     "lineNumbers": true,
     "cursorStyle": "",
     "formatOnSave": false,

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -26,11 +26,11 @@ func (a *App) ToggleWordWrap() {
 	config.SaveSettings(*a.Settings)
 }
 
-func (a *App) ToggleAutoIndent() {
-	enabled := !a.Settings.Editor.IsAutoIndentEnabled()
-	a.Settings.Editor.AutoIndent = &enabled
+func (a *App) ToggleAutoDedent() {
+	enabled := !a.Settings.Editor.IsAutoDedentEnabled()
+	a.Settings.Editor.AutoDedent = &enabled
 	if a.EditorGroup.Editor != nil {
-		a.EditorGroup.Editor.AutoIndent = enabled
+		a.EditorGroup.Editor.AutoDedent = enabled
 	}
 	config.SaveSettings(*a.Settings)
 }
@@ -146,9 +146,9 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		bracketColorChecked = ui.MenuChecked
 	}
 
-	autoIndentChecked := ui.MenuUnchecked
-	if a.Settings.Editor.IsAutoIndentEnabled() {
-		autoIndentChecked = ui.MenuChecked
+	autoDedentChecked := ui.MenuUnchecked
+	if a.Settings.Editor.IsAutoDedentEnabled() {
+		autoDedentChecked = ui.MenuChecked
 	}
 
 	lspChecked := ui.MenuUnchecked
@@ -169,7 +169,7 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
-		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
+		{Label: "Auto Dedent", Command: "options.toggleAutoDedent", Checked: autoDedentChecked},
 		{Label: "Syntax Highlight", Command: "options.toggleSyntaxHighlight", Checked: syntaxChecked},
 		{Label: "Bracket Colors", Command: "options.toggleBracketColors", Checked: bracketColorChecked},
 		{Label: "LSP Code Assist", Command: "options.toggleLSP", Checked: lspChecked},
@@ -208,9 +208,9 @@ func registerOptionsCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "options.toggleAutoIndent", Title: "Toggle Auto Indent",
-		Keywords: []string{"preferences", "settings", "editor", "indentation", "indent"},
-		Handler:  app.ToggleAutoIndent,
+		ID: "options.toggleAutoDedent", Title: "Toggle Auto Dedent",
+		Keywords: []string{"preferences", "settings", "editor", "indentation", "dedent", "bracket"},
+		Handler:  app.ToggleAutoDedent,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -26,7 +26,7 @@ func (a *App) ApplySettings(s config.Settings) {
 	a.EditorGroup.Editor.TabSize = s.Editor.TabSize
 	a.EditorGroup.Editor.LineNumbers = s.Editor.LineNumbers
 	a.EditorGroup.Editor.GutterStyle = s.Editor.GutterStyle
-	a.EditorGroup.Editor.AutoIndent = s.Editor.IsAutoIndentEnabled()
+	a.EditorGroup.Editor.AutoDedent = s.Editor.IsAutoDedentEnabled()
 
 	// Apply cursor style
 	if a.Screen != nil {

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -128,7 +128,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.SyntaxHighlight = cfg.Settings.Editor.IsSyntaxHighlightEnabled()
 	editorGroup.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.Editor.WordWrap = cfg.Settings.Editor.WordWrap
-	editorGroup.Editor.AutoIndent = cfg.Settings.Editor.IsAutoIndentEnabled()
+	editorGroup.Editor.AutoDedent = cfg.Settings.Editor.IsAutoDedentEnabled()
 	editorGroup.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.Editor.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.BracketColorStyles = bracketStyles

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -78,7 +78,7 @@ type EditorSettings struct {
 	FocusOnOpen             bool   `json:"focusOnOpen"`
 	SyntaxHighlight         *bool  `json:"syntaxHighlight,omitempty"`
 	GitGutter               *bool  `json:"gitGutter,omitempty"`
-	AutoIndent              *bool  `json:"autoIndent,omitempty"`
+	AutoDedent              *bool  `json:"autoDedent,omitempty"`
 	GutterStyle             string `json:"gutterStyle,omitempty"`
 	BorderStyle             string `json:"borderStyle,omitempty"`
 	BracketPairColorization bool   `json:"bracketPairColorization"`
@@ -92,8 +92,8 @@ func (e EditorSettings) IsGitGutterEnabled() bool {
 	return e.GitGutter == nil || *e.GitGutter
 }
 
-func (e EditorSettings) IsAutoIndentEnabled() bool {
-	return e.AutoIndent == nil || *e.AutoIndent
+func (e EditorSettings) IsAutoDedentEnabled() bool {
+	return e.AutoDedent == nil || *e.AutoDedent
 }
 
 func DefaultEditorSettings() EditorSettings {

--- a/internal/ui/autoindent_test.go
+++ b/internal/ui/autoindent_test.go
@@ -85,24 +85,26 @@ func TestAutoIndentDedentSkipsMidLine(t *testing.T) {
 	}
 }
 
-func TestAutoIndentDisabledPlainNewline(t *testing.T) {
+// Open-brace indentation applies on Enter regardless of AutoDedent; the flag
+// only controls the closing-bracket dedent.
+func TestOpenIndentAppliesRegardlessOfAutoDedent(t *testing.T) {
 	e := newEditorWithLines("{")
-	e.AutoIndent = false
+	e.AutoDedent = false
 	e.Cursor.Col = 1
 
 	e.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
 
-	if e.Buf.Lines[1] != "" {
-		t.Fatalf("expected empty new line when auto-indent off, got %q", e.Buf.Lines[1])
+	if e.Buf.Lines[1] != "    " {
+		t.Fatalf("expected open-brace indent even with auto-dedent off, got %q", e.Buf.Lines[1])
 	}
-	if e.Cursor.Line != 1 || e.Cursor.Col != 0 {
-		t.Fatalf("expected cursor at (1,0), got (%d,%d)", e.Cursor.Line, e.Cursor.Col)
+	if e.Cursor.Line != 1 || e.Cursor.Col != 4 {
+		t.Fatalf("expected cursor at (1,4), got (%d,%d)", e.Cursor.Line, e.Cursor.Col)
 	}
 }
 
-func TestAutoIndentDisabledNoDedent(t *testing.T) {
+func TestAutoDedentDisabledNoDedent(t *testing.T) {
 	e := newEditorWithLines("    ")
-	e.AutoIndent = false
+	e.AutoDedent = false
 	e.Cursor.Col = 4
 
 	e.HandleEvent(tcell.NewEventKey(tcell.KeyRune, '}', 0))
@@ -112,19 +114,17 @@ func TestAutoIndentDisabledNoDedent(t *testing.T) {
 	}
 }
 
-func TestAutoIndentEnabledByDefault(t *testing.T) {
+func TestAutoDedentEnabledByDefault(t *testing.T) {
 	e := newEditorWithLines("")
-	if !e.AutoIndent {
-		t.Fatal("expected auto-indent to be enabled by default")
+	if !e.AutoDedent {
+		t.Fatal("expected auto-dedent to be enabled by default")
 	}
 }
 
-// With auto-indent off, a new line should still inherit the previous line's
-// indentation. Auto-indent only governs the bracket-aware extra level, not
-// basic indentation inheritance.
-func TestAutoIndentOffInheritsIndentation(t *testing.T) {
+// Indentation inheritance always applies on Enter, independent of AutoDedent.
+func TestEnterInheritsIndentation(t *testing.T) {
 	e := newEditorWithLines("    foo")
-	e.AutoIndent = false
+	e.AutoDedent = false
 	e.Cursor.Col = 7
 
 	e.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
@@ -137,18 +137,14 @@ func TestAutoIndentOffInheritsIndentation(t *testing.T) {
 	}
 }
 
-// Single-cursor and multi-cursor Enter must indent identically. Previously the
-// multi-cursor path inherited indentation unconditionally while the single
-// path gated it behind AutoIndent, so they diverged with auto-indent off.
-func TestAutoIndentOffEnterConsistentAcrossCursorModes(t *testing.T) {
+// Single-cursor and multi-cursor Enter must indent identically.
+func TestEnterIndentConsistentAcrossCursorModes(t *testing.T) {
 	single := newEditorWithLines("    foo")
-	single.AutoIndent = false
 	single.Cursor.Line, single.Cursor.Col = 0, 7
 	single.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
 	singleIndent := single.Buf.Lines[1]
 
 	multi := newEditorWithLines("    foo", "    bar")
-	multi.AutoIndent = false
 	multi.Cursor.Line, multi.Cursor.Col = 0, 7
 	multi.ensureMulti()
 	multi.Multi.Add(1, 7)
@@ -160,7 +156,7 @@ func TestAutoIndentOffEnterConsistentAcrossCursorModes(t *testing.T) {
 	multiIndent := multi.Buf.Lines[1]
 
 	if singleIndent != multiIndent {
-		t.Fatalf("indent diverged with auto-indent off: single=%q multi=%q", singleIndent, multiIndent)
+		t.Fatalf("indent diverged between cursor modes: single=%q multi=%q", singleIndent, multiIndent)
 	}
 	if singleIndent != "    " {
 		t.Fatalf("expected both to inherit 4-space indent, got %q", singleIndent)

--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -35,7 +35,7 @@ type EditorPaneWidget struct {
 	LineNumbers             bool
 	GutterStyle             string
 	WordWrap                bool
-	AutoIndent              bool
+	AutoDedent              bool
 	BracketPairColorization bool
 	BracketColorStyles      []term.Style
 	Highlighter             *highlight.Highlighter
@@ -74,7 +74,7 @@ func NewEditorPaneWidget(buf *buffer.Buffer, cur *cursor.Cursor, vp *view.Viewpo
 		Buf:               buf,
 		Cursor:            cur,
 		Viewport:          vp,
-		AutoIndent:        true,
+		AutoDedent:        true,
 		bracketColorDirty: true,
 	}
 }

--- a/internal/ui/editor_widget_keyboard.go
+++ b/internal/ui/editor_widget_keyboard.go
@@ -264,25 +264,23 @@ func (e *EditorPaneWidget) execEnter() {
 	e.Cursor.Line++
 	e.Cursor.Col = 0
 
-	// Indentation inheritance is baseline behavior and always applies; the
-	// AutoIndent flag only governs the bracket-aware extra level and dedent.
+	// Indentation inheritance and the bracket-aware extra level both always
+	// apply on Enter. Only the closing-bracket dedent (see execRune) is
+	// gated, behind the AutoDedent flag.
 	indent := leadingWhitespace(line)
 	newIndent := indent
 	runes := []rune(line)
+	charBefore := ' '
+	if col > 0 && col <= len(runes) {
+		charBefore = runes[col-1]
+	}
 	charAfter := ' '
 	if col < len(runes) {
 		charAfter = runes[col]
 	}
-	extraIndent := false
-	if e.AutoIndent {
-		charBefore := ' '
-		if col > 0 && col <= len(runes) {
-			charBefore = runes[col-1]
-		}
-		extraIndent = indentOpeners[charBefore]
-		if extraIndent {
-			newIndent += e.indentUnit()
-		}
+	extraIndent := indentOpeners[charBefore]
+	if extraIndent {
+		newIndent += e.indentUnit()
 	}
 	if len(newIndent) > 0 {
 		e.exec(&undo.InsertStringCommand{Line: e.Cursor.Line, Col: 0, Text: newIndent})
@@ -361,7 +359,7 @@ func (e *EditorPaneWidget) execRune(r rune) {
 		e.Cursor.Col = start.Col + 1
 		return
 	}
-	if e.AutoIndent && closingBrackets[r] {
+	if e.AutoDedent && closingBrackets[r] {
 		e.dedentForCloser()
 	}
 	e.exec(&undo.InsertRuneCommand{Line: e.Cursor.Line, Col: e.Cursor.Col, Rune: r})


### PR DESCRIPTION
## Rationale

A code editor should always auto-indent — dropping to column 0 after `{` is never what anyone wants. The one bracket behavior that's genuinely opinionated is the **dedent**: it fires mid-keystroke as you type `}` and reshapes the line you're on, which some users dislike. So the flag should gate only that.

## Change

- **Always on now** (no longer gated): indentation inheritance on Enter, and the extra indent level after an open `{ ( [ :` (plus the `{|}` split). These only fire on a deliberate Enter and never surprise you.
- **Gated by the new `editor.autoDedent`** (default `true`): the closing-bracket dedent when typing `} ) ]` on a blank line.
- Renamed `editor.autoIndent` → `editor.autoDedent` (struct field, `IsAutoDedentEnabled()` helper, `options.toggleAutoDedent` command, **Auto Dedent** menu entry).

`autoDedent: false` is a coherent state — you get indent-after-`{` and inheritance, and manage your own closing braces (how editors worked before auto-dedent existed). The rejected alternative (gating indent-on-open) would have stranded users indented with no way back; gating the dedent leaves no silly configuration.

Pre-release, so no migration concern with the key rename.

## Tests

- `TestOpenIndentAppliesRegardlessOfAutoDedent` — Enter after `{` indents even with `autoDedent` off.
- `TestAutoDedentDisabledNoDedent` — typing `}` with the flag off does not dedent.
- `TestEnterInheritsIndentation`, `TestEnterIndentConsistentAcrossCursorModes`, `TestAutoDedentEnabledByDefault` — updated for the new semantics.

Full `go test ./...`, `go vet`, `gofmt`, and the auto-indent functional suite on the real binary all pass. Docs updated (README, settings reference, editor guide).

## Not addressed (tracked in #368)

Under multiple cursors, neither the open-indent nor the dedent applies. Pre-existing, low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)