### PR TITLE
fix: delete active selection on Ctrl+Backspace / Ctrl+Delete

### DIFF
--- a/internal/ui/delete_word_selection_test.go
+++ b/internal/ui/delete_word_selection_test.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/selection"
+)
+
+// With an active selection, Ctrl+Backspace deletes the selection rather than a
+// word from the cursor (matching VS Code).
+func TestDeleteWordLeftDeletesSelectionFirst(t *testing.T) {
+	e := newEditorWithLines("foobar")
+	e.Selection = &selection.Selection{}
+	e.Selection.Start(0, 3) // anchor at col 3
+	e.Cursor.Line, e.Cursor.Col = 0, 6
+
+	e.DeleteWordLeft()
+
+	if e.Buf.Lines[0] != "foo" {
+		t.Fatalf("expected selection %q deleted leaving %q, got %q", "bar", "foo", e.Buf.Lines[0])
+	}
+	if e.Selection.Active {
+		t.Fatal("expected selection cleared after delete")
+	}
+}
+
+// With an active selection, Ctrl+Delete deletes the selection rather than a word
+// to the right of the cursor.
+func TestDeleteWordRightDeletesSelectionFirst(t *testing.T) {
+	e := newEditorWithLines("foobar")
+	e.Selection = &selection.Selection{}
+	e.Selection.Start(0, 0) // anchor at col 0
+	e.Cursor.Line, e.Cursor.Col = 0, 3
+
+	e.DeleteWordRight()
+
+	if e.Buf.Lines[0] != "bar" {
+		t.Fatalf("expected selection %q deleted leaving %q, got %q", "foo", "bar", e.Buf.Lines[0])
+	}
+	if e.Selection.Active {
+		t.Fatal("expected selection cleared after delete")
+	}
+}

--- a/internal/ui/editor_widget_text.go
+++ b/internal/ui/editor_widget_text.go
@@ -116,6 +116,12 @@ func (e *EditorPaneWidget) MoveWordRight(shift bool) {
 }
 
 func (e *EditorPaneWidget) DeleteWordLeft() {
+	if e.Selection != nil && e.Selection.Active {
+		e.deleteSelection()
+		e.clampCursor()
+		e.scrollViewport()
+		return
+	}
 	if e.Cursor.Col == 0 {
 		return
 	}
@@ -132,6 +138,12 @@ func (e *EditorPaneWidget) DeleteWordLeft() {
 }
 
 func (e *EditorPaneWidget) DeleteWordRight() {
+	if e.Selection != nil && e.Selection.Active {
+		e.deleteSelection()
+		e.clampCursor()
+		e.scrollViewport()
+		return
+	}
 	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
 	runes := []rune(e.Buf.Lines[e.Cursor.Line])
 	if e.Cursor.Col >= len(runes) {


### PR DESCRIPTION
Fixes #313.

## Problem

With text selected, `Ctrl+Backspace` (DeleteWordLeft) and `Ctrl+Delete` (DeleteWordRight) ignored the selection and deleted a word from the cursor position instead. VS Code deletes the selection in this case.

## Fix

Check `Selection.Active` at the top of both functions; if active, `deleteSelection()` and return.

## Tests (written first, confirmed failing)

- `TestDeleteWordLeftDeletesSelectionFirst` / `TestDeleteWordRightDeletesSelectionFirst` — use a selection that differs from the word-delete range so the two behaviors are distinguishable. Both failed before the fix (produced the word-delete result), pass after.

Full `go test ./...`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)