### PR TITLE
feat: cut/copy the current line when nothing is selected

### DIFF
--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1271,6 +1271,11 @@ func (g *EditorGroupWidget) Copy() {
 		return
 	}
 	if t.Sel == nil || !t.Sel.Active {
+		// No selection: copy the whole current line, including a trailing
+		// newline so a paste inserts it as a full line.
+		if t.Cur.Line >= 0 && t.Cur.Line < len(t.Buf.Lines) {
+			clipboard.Set(t.Buf.Lines[t.Cur.Line] + "\n")
+		}
 		return
 	}
 	text := t.Sel.Text(t.Buf.Lines, t.Cur.Line, t.Cur.Col)
@@ -1279,7 +1284,15 @@ func (g *EditorGroupWidget) Copy() {
 
 func (g *EditorGroupWidget) Cut() {
 	t := g.activeTab()
-	if t == nil || t.Content != nil || t.Sel == nil || !t.Sel.Active {
+	if t == nil || t.Content != nil {
+		return
+	}
+	if t.Sel == nil || !t.Sel.Active {
+		// No selection: cut the whole current line.
+		if t.Cur.Line >= 0 && t.Cur.Line < len(t.Buf.Lines) {
+			clipboard.Set(t.Buf.Lines[t.Cur.Line] + "\n")
+			g.Editor.DeleteLine()
+		}
 		return
 	}
 	text := t.Sel.Text(t.Buf.Lines, t.Cur.Line, t.Cur.Col)

--- a/tests/functional/clipboard-roundtrip.test.js
+++ b/tests/functional/clipboard-roundtrip.test.js
@@ -83,28 +83,47 @@ describe("clipboard roundtrip", () => {
     tui.start(file);
     tui.waitFor("first line");
 
-    // Cursor is on line 1, no selection — copy
+    // Cursor is on line 1, no selection — copy the whole line
     tui.press("ctrl+c");
     tui.waitStable();
 
-    // Move to line 2
+    // Move to line 2 and paste
     tui.press("arrow_down");
     tui.press("end");
-    tui.waitStable();
-
-    // Paste
     tui.press("ctrl+v");
     tui.waitStable();
 
-    // Save and check — documents behavior regardless of whether full line was copied
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    const { snapshots } = tui.run();
+
+    // The whole "first line" was copied, so it now appears twice.
+    const content = readFile(file);
+    expect((content.match(/first line/g) || []).length).toBe(2);
+  });
+
+  it("should cut entire line when nothing is selected", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "linecut.txt", "alpha\nbeta\ngamma");
+
+    tui.start(file);
+    tui.waitFor("beta");
+
+    // Move to line 2 ("beta"), no selection — cut the whole line
+    tui.press("arrow_down");
+    tui.press("ctrl+x");
+    tui.waitStable();
+
     tui.press("ctrl+s");
     tui.waitStable();
 
     const { snapshots } = tui.run();
 
     const content = readFile(file);
-    expect(content).toContain("first line");
-    expect(content).toContain("second line");
+    expect(content).not.toContain("beta");
+    expect(content).toContain("alpha");
+    expect(content).toContain("gamma");
   });
 
   it("should paste the same text multiple times", () => {


### PR DESCRIPTION
Fixes #278.

## Problem

With no text selected, Cut and Copy were silent no-ops. Every mainstream editor cuts/copies the whole current line in that case.

## Fix

In `EditorGroupWidget.Copy` / `Cut`, when there's no active selection:
- **Copy** → copies the current line plus a trailing `\n` (so a paste inserts it as a full line).
- **Cut** → copies the current line and removes it via `DeleteLine` (undoable).

Selection behavior is unchanged.

## Tests

Strengthened the existing placeholder functional test and added a Cut counterpart (both confirmed failing without the fix, passing with it):

- `should copy entire line when nothing is selected` — copies line 1 with no selection, pastes on line 2, asserts `first line` now appears twice.
- `should cut entire line when nothing is selected` — cuts the `beta` line, asserts it's gone and the neighbors remain.

Full `go test ./...` and the clipboard functional suite pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)