### PR TITLE
ci: fix LSP tests by pinning to TypeScript 5 (TS7 lacks tsserver.js)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,19 +143,20 @@ jobs:
       - name: Install LSP servers
         run: |
           go install golang.org/x/tools/gopls@latest
-          npm install -g typescript typescript-language-server
+          npm install -g typescript@5 typescript-language-server
           npm install -g vscode-langservers-extracted
           npm install -g yaml-language-server
           npm install -g svelte-language-server
           pip install pyright
           sudo apt-get install -y clangd
 
-      # typescript-language-server resolves the "typescript" package via Node's
-      # module resolution. The temp fixture workspaces have no node_modules, so
-      # point NODE_PATH at the global install (inherited by the LSP subprocess)
-      # to avoid "Could not find a valid TypeScript installation".
-      - name: Expose global node_modules to language servers
-        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
+      # typescript-language-server needs classic TypeScript 5.x (with
+      # lib/tsserver.js); `typescript` latest is now the TS7 native rewrite,
+      # which lacks tsserver.js -> "Could not find a valid TypeScript
+      # installation". Install TS5 into the TS fixture so the harness copies it
+      # into each temp workspace, where the server resolves it.
+      - name: Provide typescript to the TS fixture workspace
+        run: npm install --prefix tests/integration/lsp/typescript --no-save typescript@5
 
       - name: Install test dependencies
         working-directory: tests/integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
           pip install pyright
           sudo apt-get install -y clangd
 
+      # typescript-language-server resolves the "typescript" package via Node's
+      # module resolution. The temp fixture workspaces have no node_modules, so
+      # point NODE_PATH at the global install (inherited by the LSP subprocess)
+      # to avoid "Could not find a valid TypeScript installation".
+      - name: Expose global node_modules to language servers
+        run: echo "NODE_PATH=$(npm root -g)" >> "$GITHUB_ENV"
+
       - name: Install test dependencies
         working-directory: tests/integration
         run: pnpm install

--- a/tests/integration/lsp-autocomplete-trigger.test.js
+++ b/tests/integration/lsp-autocomplete-trigger.test.js
@@ -52,7 +52,9 @@ function lspServerAvailable() {
 
 const available = lspServerAvailable();
 
-describe("lsp autocomplete trigger characters", () => {
+// Retry: tsserver can be slow to respond in CI; each retry re-runs setup for a
+// fresh server attempt.
+describe("lsp autocomplete trigger characters", { retry: 2 }, () => {
   let dir;
 
   beforeEach(() => {

--- a/tests/integration/lsp-completion-insert.test.js
+++ b/tests/integration/lsp-completion-insert.test.js
@@ -52,7 +52,9 @@ function lspServerAvailable() {
 
 const available = lspServerAvailable();
 
-describe("lsp completion insertion", () => {
+// Retry: tsserver can be slow to respond in CI; each retry re-runs setup for a
+// fresh server attempt.
+describe("lsp completion insertion", { retry: 2 }, () => {
   let dir;
 
   beforeEach(() => {

--- a/tests/integration/lsp.test.js
+++ b/tests/integration/lsp.test.js
@@ -73,7 +73,10 @@ const languages = readdirSync(LSP_DIR, { withFileTypes: true })
   .filter((d) => existsSync(resolve(LSP_DIR, d.name, "spec.json")))
   .map((d) => d.name);
 
-describe("lsp", () => {
+// Retry: language servers (notably tsserver) can be slow to start/respond in
+// CI, intermittently exceeding the wait windows. Each retry re-runs beforeEach,
+// giving a fresh server attempt.
+describe("lsp", { retry: 2 }, () => {
   let dir;
 
   beforeEach(() => {

--- a/tests/integration/lsp/typescript/install.sh
+++ b/tests/integration/lsp/typescript/install.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -e
-npm install -g typescript typescript-language-server
+# typescript-language-server needs classic TS5 (has lib/tsserver.js);
+# `typescript` latest is now the TS7 native rewrite, which lacks it.
+npm install -g typescript@5 typescript-language-server


### PR DESCRIPTION
## Root cause (a regression, not flakiness)

The `lsp-tests` job failed on every recent run. The log showed:

```
initialize LSP for typescript: -32603: Could not find a valid TypeScript
installation. Please ensure that the "typescript" dependency is installed
in the workspace or that a valid tsserver.path is specified.
```

`npm install typescript` now resolves to **TypeScript 7.0.2** — the new native/Go rewrite, which ships `@typescript` native binaries with a `dist/` layout and **no classic `lib/tsserver.js`**. `typescript-language-server` requires classic **TypeScript 5.x** (which has `tsserver.js`), so it failed to initialize the moment TS7 became npm `latest`. Verified locally: TS 5.9.3 has `lib/tsserver.js`; TS 7.0.2 does not.

## Fix

Pin to TypeScript 5:
- CI global install: `typescript@5`.
- Install TS5 into the TS fixture; the harness copies it into each temp workspace (where the server resolves `typescript`, walking up from the temp project root).
- Fixture `install.sh` pinned to match, for local runs.

## Retry (secondary)

`retry: 2` on the three LSP `describe` blocks, scoped to the LSP files — a safety net for genuine tsserver slowness, not the fix.

## Validation

Confirmed on this PR's own run: `lsp-tests` **passed — 36/36 tests, 3 files**. Two wrong theories were ruled out empirically along the way (retry-only still failed → deterministic, not flaky; NODE_PATH still failed → the server resolves from the workspace, not NODE_PATH).

Generated with Claude Code