### PR TITLE
fix: BUG-011 Replace All ignores case-sensitive/regex toggles

### DIFF
--- a/audit/2026-07-12-ux-bug-audit.md
+++ b/audit/2026-07-12-ux-bug-audit.md
@@ -143,14 +143,12 @@ Status values: `pending` → `in progress` → `swept (N findings)` / `swept (cl
 - **Actual:** F3 jumps to the stale line index — cursor lands on "beta". `SearchMatches` is never recomputed after buffer edits while the bar is open.
 - **Test:** `tests/functional/audit-findreplace-bugs.test.js` (`it.fails`)
 
-### BUG-011: Replace All ignores the Case-Sensitive/Regex toggles the bar itself displays
+### BUG-011: Replace All ignores the Case-Sensitive/Regex toggles the bar itself displays — ✅ FIXED
 - **Area:** Find/replace
 - **Severity:** high
-- **Status:** confirmed (agent-reported, orchestrator re-verified)
-- **Repro:** `ctrl+r`, query `Foo`, `alt+c` (bar shows 1/1), replacement `X`, `alt+r`
-- **Expected:** only the exact-case "Foo" replaced
-- **Actual:** all of "Foo"/"foo"/"FOO" replaced — `EditorGroupWidget.ReplaceAll` (`internal/ui/editor_group.go`) re-runs `FindInLines` with a fresh default `SearchOptions{}` instead of the bar's current options
-- **Test:** `tests/functional/audit-findreplace-bugs.test.js` (`it.fails`)
+- **Status:** ✅ **FIXED** — `ReplaceBarWidget.OnReplaceAll` now carries the bar's current `Options` (case/regex), threaded through the `commands_search.go` callback into `EditorGroupWidget.ReplaceAll(query, replacement, opts)`, which passes them to `FindInLines` instead of a fresh `SearchOptions{}`. (The sidebar global-search path already did this; only the in-editor replace bar was broken.) Verified: full functional suite green, repro test flipped `it.fails`→`it`.
+- **Repro (now fixed):** `ctrl+r`, query `Foo`, `alt+c` (bar shows 1/1), replacement `X`, `alt+r` → only "Foo" replaced
+- **Test:** `tests/functional/audit-findreplace-bugs.test.js` (now real `it`)
 
 ### BUG-012: Replace All is not atomic in undo — one Ctrl+Z leaves a never-seen garbled state
 - **Area:** Find/replace × undo

--- a/internal/app/commands_search.go
+++ b/internal/app/commands_search.go
@@ -67,8 +67,8 @@ func (a *App) OpenFindReplace() {
 	bar.OnReplace = func(match ui.FindMatch, replacement string) {
 		a.EditorGroup.ReplaceMatch(match, replacement)
 	}
-	bar.OnReplaceAll = func(query, replacement string) {
-		a.EditorGroup.ReplaceAll(query, replacement)
+	bar.OnReplaceAll = func(query, replacement string, opts ui.SearchOptions) {
+		a.EditorGroup.ReplaceAll(query, replacement, opts)
 	}
 	bar.OnDismiss = func() {
 		a.DismissDialog()

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1070,11 +1070,11 @@ func (g *EditorGroupWidget) ReplaceMatch(match FindMatch, replacement string) {
 	g.Editor.scrollViewport()
 }
 
-func (g *EditorGroupWidget) ReplaceAll(query, replacement string) {
+func (g *EditorGroupWidget) ReplaceAll(query, replacement string, opts SearchOptions) {
 	if !g.IsEditorActive() || query == "" {
 		return
 	}
-	matches, _ := FindInLines(g.Editor.Buf.Lines, query, SearchOptions{})
+	matches, _ := FindInLines(g.Editor.Buf.Lines, query, opts)
 	for i := len(matches) - 1; i >= 0; i-- {
 		g.ReplaceMatch(matches[i], replacement)
 	}

--- a/internal/ui/replacebar_widget.go
+++ b/internal/ui/replacebar_widget.go
@@ -18,7 +18,7 @@ type ReplaceBarWidget struct {
 	OnSearch     func(query string, opts SearchOptions) []FindMatch
 	OnNavigate   func(match FindMatch)
 	OnReplace    func(match FindMatch, replacement string)
-	OnReplaceAll func(query, replacement string)
+	OnReplaceAll func(query, replacement string, opts SearchOptions)
 	OnDismiss    func()
 	focusRow     int
 	btnPrev      HitRegion
@@ -60,7 +60,7 @@ func NewReplaceBarWidget() *ReplaceBarWidget {
 		}},
 		{Label: "All", OnClick: func() {
 			if r.OnReplaceAll != nil {
-				r.OnReplaceAll(r.SearchInput.Text, r.ReplaceInput.Text)
+				r.OnReplaceAll(r.SearchInput.Text, r.ReplaceInput.Text, r.Options)
 				r.search()
 			}
 		}},
@@ -283,7 +283,7 @@ func (r *ReplaceBarWidget) handleKey(kev *tcell.EventKey) EventResult {
 		switch kev.Rune() {
 		case 'r':
 			if r.OnReplaceAll != nil {
-				r.OnReplaceAll(r.SearchInput.Text, r.ReplaceInput.Text)
+				r.OnReplaceAll(r.SearchInput.Text, r.ReplaceInput.Text, r.Options)
 				r.search()
 			}
 			return EventConsumed

--- a/tests/functional/audit-findreplace-bugs.test.js
+++ b/tests/functional/audit-findreplace-bugs.test.js
@@ -50,7 +50,7 @@ describe("BUG-010: search matches go stale after buffer edits", () => {
 });
 
 describe("BUG-011: Replace All ignores case-sensitive toggle", () => {
-  it.fails("replace-all with case-sensitive on replaces only exact matches", () => {
+  it("replace-all with case-sensitive on replaces only exact matches", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "case.txt", "Foo\nfoo\nFOO\nbar\n");
 
@@ -72,8 +72,8 @@ describe("BUG-011: Replace All ignores case-sensitive toggle", () => {
     tui.waitStable();
     tui.run();
 
-    // Buggy behavior: ReplaceAll re-runs the search with default options,
-    // replacing all three case variants.
+    // Fixed: ReplaceAll now threads the bar's current Options (case/regex)
+    // into FindInLines, so case-sensitive replaces only the exact match.
     expect(readFile(file)).toBe("X\nfoo\nFOO\nbar\n");
   });
 });


### PR DESCRIPTION
## BUG-011 (high)

The in-editor **replace bar**'s Replace All ignored the case-sensitive/regex toggles it displays: `EditorGroupWidget.ReplaceAll` re-ran `FindInLines` with a fresh default `SearchOptions{}` instead of the bar's current `Options`. So with case-sensitive **on** and the bar showing `1/1`, "Replace All" still replaced every case variant (`Foo`/`foo`/`FOO`).

### Fix
Thread the bar's `Options` through the callback chain:
- `ReplaceBarWidget.OnReplaceAll` now includes `opts SearchOptions` (passes `r.Options`)
- the `commands_search.go` callback forwards it to `EditorGroupWidget.ReplaceAll(query, replacement, opts)`
- `ReplaceAll` passes `opts` to `FindInLines`

The sidebar **global search** already threaded options correctly (`search_widget.go`); only the in-editor replace bar was broken.

### Verification
- Repro test flipped `it.fails` → real `it` and passes.
- Full functional suite green (**200 passed | 33 expected-fail, 0 failures**); `go test ./...` clean.

Part of the post-1.0.0 audit fix pass (see `audit/2026-07-12-ux-bug-audit.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmSB77x6gMxYPiBqFnunb1