### PR TITLE
fix: BUG-001..004 col-0 selection convention for line commands

### DIFF
--- a/internal/ui/editor_widget_keyboard.go
+++ b/internal/ui/editor_widget_keyboard.go
@@ -23,8 +23,6 @@ func (e *EditorPaneWidget) handleKey(kev *tcell.EventKey) EventResult {
 	}
 
 	shift := mods&tcell.ModShift != 0
-	hasSel := e.Selection != nil && e.Selection.Active
-
 	multi := e.isMultiActive()
 
 	switch kev.Key() {
@@ -205,10 +203,8 @@ func (e *EditorPaneWidget) handleKey(kev *tcell.EventKey) EventResult {
 			break
 		}
 		tabSize := e.resolveTabSize()
-		if hasSel {
-			start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
-			end.Line = e.Buf.ClampLine(end.Line)
-			for line := start.Line; line <= end.Line; line++ {
+		if startLine, endLine, ok := e.selectedLineRange(); ok {
+			for line := startLine; line <= endLine; line++ {
 				remove := leadingIndentWidth(e.Buf.Lines[line], tabSize)
 				if remove > 0 {
 					e.exec(&undo.DeleteSelectionCommand{
@@ -236,9 +232,8 @@ func (e *EditorPaneWidget) handleKey(kev *tcell.EventKey) EventResult {
 			break
 		}
 		indent := e.indentUnit()
-		if hasSel {
-			start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
-			for line := start.Line; line <= end.Line; line++ {
+		if startLine, endLine, ok := e.selectedLineRange(); ok {
+			for line := startLine; line <= endLine; line++ {
 				e.exec(&undo.InsertStringCommand{Line: line, Col: 0, Text: indent})
 			}
 		} else {

--- a/internal/ui/editor_widget_lines.go
+++ b/internal/ui/editor_widget_lines.go
@@ -8,13 +8,11 @@ import (
 )
 
 func (e *EditorPaneWidget) MoveLineUp() {
-	hasSel := e.Selection != nil && e.Selection.Active
-	if hasSel {
-		start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
-		if start.Line <= 0 {
+	if startLine, endLine, ok := e.selectedLineRange(); ok {
+		if startLine <= 0 {
 			return
 		}
-		for line := start.Line; line <= end.Line; line++ {
+		for line := startLine; line <= endLine; line++ {
 			e.exec(&undo.SwapLineCommand{Line1: line, Line2: line - 1})
 		}
 		e.Cursor.Line--
@@ -31,13 +29,11 @@ func (e *EditorPaneWidget) MoveLineUp() {
 }
 
 func (e *EditorPaneWidget) MoveLineDown() {
-	hasSel := e.Selection != nil && e.Selection.Active
-	if hasSel {
-		start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
-		if end.Line >= len(e.Buf.Lines)-1 {
+	if startLine, endLine, ok := e.selectedLineRange(); ok {
+		if endLine >= len(e.Buf.Lines)-1 {
 			return
 		}
-		for line := end.Line; line >= start.Line; line-- {
+		for line := endLine; line >= startLine; line-- {
 			e.exec(&undo.SwapLineCommand{Line1: line, Line2: line + 1})
 		}
 		e.Cursor.Line++
@@ -54,30 +50,45 @@ func (e *EditorPaneWidget) MoveLineDown() {
 }
 
 func (e *EditorPaneWidget) DuplicateLine() {
-	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
-	text := e.Buf.Lines[e.Cursor.Line]
-	e.exec(&undo.InsertLineCommand{Idx: e.Cursor.Line + 1, Text: text})
-	e.Cursor.Line++
+	startLine, endLine, hasSel := e.selectedLineRange()
+	if !hasSel {
+		startLine = e.Buf.ClampLine(e.Cursor.Line)
+		endLine = startLine
+	}
+	texts := e.copyLines(startLine, endLine)
+	for i, text := range texts {
+		e.exec(&undo.InsertLineCommand{Idx: endLine + 1 + i, Text: text})
+	}
+	blockSize := endLine - startLine + 1
+	e.Cursor.Line += blockSize
+	if hasSel {
+		e.Selection.Anchor.Line += blockSize
+	}
 	e.clampCursor()
 	e.scrollViewport()
 }
 
 func (e *EditorPaneWidget) DeleteLine() {
-	e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
-	if len(e.Buf.Lines) <= 1 {
-		e.exec(&undo.DeleteSelectionCommand{
-			StartLine: 0, StartCol: 0,
-			EndLine: 0, EndCol: len([]rune(e.Buf.Lines[0])),
-		})
-		e.Cursor.Col = 0
-	} else {
-		e.exec(&undo.DeleteLineCommand{Idx: e.Cursor.Line})
-		e.Cursor.Line = e.Buf.ClampLine(e.Cursor.Line)
+	startLine, endLine, hasSel := e.selectedLineRange()
+	if !hasSel {
+		startLine = e.Buf.ClampLine(e.Cursor.Line)
+		endLine = startLine
 	}
-	lineLen := len([]rune(e.Buf.Lines[e.Cursor.Line]))
-	if e.Cursor.Col > lineLen {
-		e.Cursor.Col = lineLen
+	for i := endLine; i >= startLine; i-- {
+		if len(e.Buf.Lines) <= 1 {
+			e.exec(&undo.DeleteSelectionCommand{
+				StartLine: 0, StartCol: 0,
+				EndLine: 0, EndCol: len([]rune(e.Buf.Lines[0])),
+			})
+			break
+		}
+		e.exec(&undo.DeleteLineCommand{Idx: i})
 	}
+	if hasSel {
+		e.Selection.Active = false
+	}
+	e.Cursor.Line = e.Buf.ClampLine(startLine)
+	e.Cursor.Col = 0
 	e.clampCursor()
 	e.scrollViewport()
 }
@@ -223,16 +234,26 @@ func (e *EditorPaneWidget) ToggleLineComment() {
 	e.scrollViewport()
 }
 
-// lineRange returns the start and end line indices for the current selection,
-// or the full buffer range if no selection is active.
-func (e *EditorPaneWidget) lineRange() (int, int) {
+// selectedLineRange returns the start and end line indices for the current
+// selection applying the col-0 convention, and true. If no selection is
+// active it returns (0, 0, false).
+func (e *EditorPaneWidget) selectedLineRange() (int, int, bool) {
 	if e.Selection != nil && e.Selection.Active {
 		start, end := e.Selection.Range(e.Cursor.Line, e.Cursor.Col)
 		endLine := end.Line
 		if end.Col == 0 && endLine > start.Line {
 			endLine--
 		}
-		return e.Buf.ClampLine(start.Line), e.Buf.ClampLine(endLine)
+		return e.Buf.ClampLine(start.Line), e.Buf.ClampLine(endLine), true
+	}
+	return 0, 0, false
+}
+
+// lineRange returns the start and end line indices for the current selection,
+// or the full buffer range if no selection is active.
+func (e *EditorPaneWidget) lineRange() (int, int) {
+	if start, end, ok := e.selectedLineRange(); ok {
+		return start, end
 	}
 	end := len(e.Buf.Lines) - 1
 	if end > 0 && e.Buf.Lines[end] == "" {

--- a/tests/e2e/audit_selection_bugs_test.go
+++ b/tests/e2e/audit_selection_bugs_test.go
@@ -16,7 +16,7 @@ import (
 // synthesize tcell.KeyBacktab; only direct event injection reaches
 // the KeyBacktab branch in editor_widget_keyboard.go.
 func TestBacktabExcludesColZeroSelectionLine(t *testing.T) {
-	t.Skip("BUG-004, see audit/2026-07-12-ux-bug-audit.md — outdent includes line past col-0 selection end")
+	// BUG-004 fixed: outdent now applies col-0 convention via selectedLineRange()
 
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()

--- a/tests/functional/audit-selection-bugs.test.js
+++ b/tests/functional/audit-selection-bugs.test.js
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe("BUG-003: Duplicate/Delete Line ignore active multi-line selection", () => {
-  it.fails("Duplicate Line duplicates the selected block", () => {
+  it("Duplicate Line duplicates the selected block", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "dupblock.txt", FIVE_LINES);
 
@@ -42,7 +42,7 @@ describe("BUG-003: Duplicate/Delete Line ignore active multi-line selection", ()
     expect(readFile(file)).toBe("line0\nline1\nline2\nline1\nline2\nline3\nline4\n");
   });
 
-  it.fails("Delete Line deletes the selected block", () => {
+  it("Delete Line deletes the selected block", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "delblock.txt", FIVE_LINES);
 
@@ -66,7 +66,7 @@ describe("BUG-003: Duplicate/Delete Line ignore active multi-line selection", ()
 });
 
 describe("BUG-002: Tab indent with selection ending at col 0", () => {
-  it.fails("indents only lines the selection actually covers", () => {
+  it("indents only lines the selection actually covers", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "indent.txt", FIVE_LINES);
 
@@ -89,7 +89,7 @@ describe("BUG-002: Tab indent with selection ending at col 0", () => {
 });
 
 describe("BUG-001: Move Line with selection ending at col 0", () => {
-  it.fails("moves only the selected block, not the trailing col-0 line", () => {
+  it("moves only the selected block, not the trailing col-0 line", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "moveblock.txt", FIVE_LINES);
 


### PR DESCRIPTION
## Summary
- Added `selectedLineRange()` helper that applies the col-0 selection convention (a selection ending at col 0 of a line excludes that line), matching what `JoinLines`/`ToggleLineComment` already do
- Wired it into `MoveLineUp/Down`, `DuplicateLine`, `DeleteLine`, Tab (indent), and Backtab (outdent)
- Made `DuplicateLine` and `DeleteLine` selection-aware (BUG-003 — previously they ignored selections entirely)
- Refactored `lineRange()` to delegate to the new helper

## Test plan
- [x] Flipped 4 `it.fails` → `it` in `tests/functional/audit-selection-bugs.test.js` — all pass
- [x] Removed `t.Skip` in `tests/e2e/audit_selection_bugs_test.go` (BUG-004 backtab) — passes
- [x] Full functional suite: 204 passed, 0 regressions
- [x] Full Go test suite: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)