### PR TITLE
fix: Simulate Click dialog missing Build, adapter, and dismiss

### DIFF
--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -86,10 +86,14 @@ func (a *App) debugSimulateClick() {
 	dialog.Title = "Simulate Click"
 	dialog.Borders = *a.Borders
 	dialog.Buttons = []widgets.DialogButton{
-		{Label: "Click", Handler: func() { submit(input.Text()) }},
+		{Label: "&Click", Handler: func() { submit(input.Text()) }},
 	}
+	dialog.OnDismiss = func() { a.DismissDialog() }
 	dialog.SetContent(input)
-	a.ShowDialog(dialog)
+	dialog.Build()
+
+	adapter := ui.NewWidgetAdapter(dialog)
+	a.ShowDialog(adapter)
 }
 
 func (a *App) debugRunPlugin() {


### PR DESCRIPTION
## Summary
- The Debug: Simulate Click dialog was missing `Build()` (button never created), `WidgetAdapter` wrapping (input/focus broken), and `OnDismiss` (Escape didn't close it)
- All other `DialogWidget` callers were checked — this was the only one affected

## Test plan
- [ ] Open command palette → "Debug: Simulate Click"
- [ ] Verify the "Click" button is visible
- [ ] Verify typing coordinates works
- [ ] Verify Enter submits and Escape dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)