### PR TITLE
feat: add exec_command, list_commands plugin APIs and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,9 @@ Core segments use priorities 100–500 (branch=100, blame=200 on left; position=
 - `ttt.set_status_item(side, id, text, opts)` — add or update a status bar segment. `side` is `"left"` or `"right"`. `id` is scoped to the plugin (prefixed with `pluginName:`). `opts` is an optional table with `priority` (number, default 1000) and `on_click` (function).
 - `ttt.remove_status_item(id)` — remove a segment by ID.
 
+**Command execution:**
+- `ttt.exec_command(id)` — execute any registered command by ID (e.g., `"editor.undo"`, `"file.save"`). Returns `true` if the command was found and executed, `false` otherwise. Requires `commands` permission.
+
 These callbacks are only available after `WirePlugin` — call them from command handlers or event callbacks, not at plugin init time.
 
 ### Testing

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -278,6 +278,71 @@ Use `notify` for lightweight, non-blocking feedback (a linter's "binary missing"
 hint, "added to dictionary", and so on). For anything the user must respond to,
 use [`ttt.confirm`](#ttt-confirm) or [`ttt.show_info`](#ttt-show_info) instead.
 
+### `ttt.set_status_item(side, id, text, [opts])`
+
+Add or update a status bar segment. Requires the `commands` permission.
+
+| Parameter | Type   | Required | Description                                                        |
+|-----------|--------|----------|--------------------------------------------------------------------|
+| `side`    | string | yes      | `"left"` or `"right"` — which side of the status bar.              |
+| `id`      | string | yes      | Unique segment identifier (scoped per plugin: stored as `pluginName:id`). |
+| `text`    | string | yes      | Text to display in the segment.                                    |
+| `opts`    | table  | no       | Options table (see below).                                         |
+
+**Options:**
+
+| Field      | Type     | Default | Description                                      |
+|------------|----------|---------|--------------------------------------------------|
+| `priority` | number   | `1000`  | Lower = closer to the edge. Core segments use 100–500. |
+| `on_click` | function | nil     | Callback when the segment is clicked.            |
+
+```lua
+-- Simple status item
+ttt.set_status_item("left", "mode", "NORMAL")
+
+-- With priority and click handler
+ttt.set_status_item("right", "stats", "Ln 42", {
+  priority = 50,
+  on_click = function()
+    ttt.exec_command("editor.goToLine")
+  end,
+})
+```
+
+### `ttt.remove_status_item(id)`
+
+Remove a status bar segment previously added with `set_status_item`. The `id` is scoped per plugin (same `id` used when creating). Requires the `commands` permission.
+
+```lua
+ttt.remove_status_item("mode")
+```
+
+### `ttt.exec_command(id)`
+
+Execute any registered command by its ID (the same IDs shown in the command palette). Requires the `commands` permission.
+
+**Returns:** `true` if the command was found and executed, `false` otherwise.
+
+```lua
+local ok = ttt.exec_command("editor.undo")
+if not ok then
+  ttt.log("warn", "command not found")
+end
+```
+
+### `ttt.list_commands()`
+
+Return a list of all registered commands. Requires the `commands` permission.
+
+**Returns:** An array of tables, each with `id` (string) and `title` (string) fields.
+
+```lua
+local cmds = ttt.list_commands()
+for _, cmd in ipairs(cmds) do
+  ttt.log(cmd.id .. " — " .. cmd.title)
+end
+```
+
 ### `ttt.open_drawer(config)`
 
 Open a drawer panel anchored to the left or right side of the editor. Requires `panel.drawer` permission.
@@ -1932,7 +1997,7 @@ local id = crypto.uuid()               -- "550e8400-e29b-41d4-a716-446655440000"
 
 | Module         | Description                    |
 |----------------|--------------------------------|
-| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `notify`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown`, `screenshot`, `debug`, `click`, `drag`, `quit` |
+| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `notify`, `set_status_item`, `remove_status_item`, `exec_command`, `list_commands`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown`, `screenshot`, `debug`, `click`, `drag`, `quit` |
 | `ttt.json`     | JSON encode/decode             |
 | `ttt.editor`   | Editor buffer read/write       |
 | `ttt.diagnostics` | Publish editor diagnostics (squiggles) |

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -386,6 +386,9 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	p.RemoveStatusItem = func(id string) {
 		a.Status.RemoveSegment(id)
 	}
+	p.ExecCommand = func(id string) bool {
+		return a.Reg.Execute(id)
+	}
 	p.PostAsync = func(result *plugin.PluginAsyncResult) {
 		a.Screen.PostEvent(tcell.NewEventInterrupt(result))
 	}

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -389,6 +389,14 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	p.ExecCommand = func(id string) bool {
 		return a.Reg.Execute(id)
 	}
+	p.ListCommands = func() []plugin.CommandInfo {
+		cmds := a.Reg.List()
+		result := make([]plugin.CommandInfo, len(cmds))
+		for i, cmd := range cmds {
+			result[i] = plugin.CommandInfo{ID: cmd.ID, Title: cmd.Title}
+		}
+		return result
+	}
 	p.PostAsync = func(result *plugin.PluginAsyncResult) {
 		a.Screen.PostEvent(tcell.NewEventInterrupt(result))
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -84,6 +84,7 @@ type Plugin struct {
 	SetStatusItem      func(side, id, text string, priority int, onClick func())
 	RemoveStatusItem   func(id string)
 	ExecCommand        func(id string) bool
+	ListCommands       func() []CommandInfo
 	PublishDiagnostics func(path string, items []DiagnosticItem)
 	ClearDiagnostics   func(path string)
 
@@ -103,6 +104,11 @@ type Plugin struct {
 
 	timers      map[int]func()
 	nextTimerID int
+}
+
+type CommandInfo struct {
+	ID    string
+	Title string
 }
 
 type pendingDrawerCall struct {
@@ -244,6 +250,7 @@ func (p *Plugin) Destroy() {
 	p.SetStatusItem = nil
 	p.RemoveStatusItem = nil
 	p.ExecCommand = nil
+	p.ListCommands = nil
 	p.PublishDiagnostics = nil
 	p.ClearDiagnostics = nil
 	p.EditorContextProvider = nil

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -83,6 +83,7 @@ type Plugin struct {
 	Notify             func(message, level string)
 	SetStatusItem      func(side, id, text string, priority int, onClick func())
 	RemoveStatusItem   func(id string)
+	ExecCommand        func(id string) bool
 	PublishDiagnostics func(path string, items []DiagnosticItem)
 	ClearDiagnostics   func(path string)
 
@@ -242,6 +243,7 @@ func (p *Plugin) Destroy() {
 	p.Notify = nil
 	p.SetStatusItem = nil
 	p.RemoveStatusItem = nil
+	p.ExecCommand = nil
 	p.PublishDiagnostics = nil
 	p.ClearDiagnostics = nil
 	p.EditorContextProvider = nil

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -308,6 +308,24 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 1
 		}))
 
+		L.SetField(mod, "list_commands", L.NewFunction(func(L *lua.LState) int {
+			if err := p.Granted.Check("commands"); err != nil {
+				L.ArgError(1, "commands permission not granted")
+				return 0
+			}
+			tbl := L.NewTable()
+			if p.ListCommands != nil {
+				for _, cmd := range p.ListCommands() {
+					entry := L.NewTable()
+					L.SetField(entry, "id", lua.LString(cmd.ID))
+					L.SetField(entry, "title", lua.LString(cmd.Title))
+					tbl.Append(entry)
+				}
+			}
+			L.Push(tbl)
+			return 1
+		}))
+
 		L.SetField(mod, "show_info", L.NewFunction(func(L *lua.LState) int {
 			title := L.CheckString(1)
 			tbl := L.CheckTable(2)

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -294,6 +294,20 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "exec_command", L.NewFunction(func(L *lua.LState) int {
+			if err := p.Granted.Check("commands"); err != nil {
+				L.ArgError(1, "commands permission not granted")
+				return 0
+			}
+			id := L.CheckString(1)
+			ok := false
+			if p.ExecCommand != nil {
+				ok = p.ExecCommand(id)
+			}
+			L.Push(lua.LBool(ok))
+			return 1
+		}))
+
 		L.SetField(mod, "show_info", L.NewFunction(func(L *lua.LState) int {
 			title := L.CheckString(1)
 			tbl := L.CheckTable(2)

--- a/tests/functional/plugin-exec-command.test.js
+++ b/tests/functional/plugin-exec-command.test.js
@@ -74,3 +74,40 @@ describe("ttt.exec_command plugin API", () => {
     expect(lastLine).toContain("NOT_FOUND");
   });
 });
+
+describe("ttt.list_commands plugin API", () => {
+  it("returns a table of command entries with id and title", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.list", title = "Test List", handler = function()
+              local cmds = ttt.list_commands()
+              local found = false
+              for _, cmd in ipairs(cmds) do
+                if cmd.id == "editor.undo" then
+                  found = true
+                  break
+                end
+              end
+              ttt.set_status_item("left", "result",
+                found and "HAS_UNDO:" .. #cmds or "MISSING", { priority = 10 })
+            end
+          }
+        }
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.exec("Test List");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const lastLine = snapshots[s].split("\n").pop();
+    expect(lastLine).toContain("HAS_UNDO:");
+  });
+});

--- a/tests/functional/plugin-exec-command.test.js
+++ b/tests/functional/plugin-exec-command.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function writePlugin(dir, name, lua) {
+  const path = join(dir, name);
+  writeFileSync(path, lua, "utf8");
+  return path;
+}
+
+describe("ttt.exec_command plugin API", () => {
+  it("executes a built-in command and returns true", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "line one\nline two\nline three\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.run", title = "Test Run Exec", handler = function()
+              local ok = ttt.exec_command("editor.undo")
+              ttt.set_status_item("left", "result", ok and "OK" or "FAIL", { priority = 10 })
+            end
+          }
+        }
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.type("hello");
+    tui.waitStable();
+    tui.exec("Test Run Exec");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const lastLine = snapshots[s].split("\n").pop();
+    expect(lastLine).toContain("OK");
+  });
+
+  it("returns false for unknown command ID", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.run", title = "Test Run Bad", handler = function()
+              local ok = ttt.exec_command("nonexistent.command")
+              ttt.set_status_item("left", "result", ok and "FOUND" or "NOT_FOUND", { priority = 10 })
+            end
+          }
+        }
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.exec("Test Run Bad");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const lastLine = snapshots[s].split("\n").pop();
+    expect(lastLine).toContain("NOT_FOUND");
+  });
+});

--- a/vim.md
+++ b/vim.md
@@ -25,13 +25,13 @@ In Vim Normal mode, pressing `j` must be a motion, not insert a character.
 - Segments sorted by priority (lower = closer to edge). Same priority tiebreaks by registration order.
 - Core segments: branch(L:100), blame(L:200), position(R:100), indent(R:200), encoding(R:300), eol(R:400), language(R:500).
 
-### 3. Command Execution API
+### 3. Command Execution API ✅
 
-Plugins cannot programmatically invoke editor commands. A Vim plugin needs undo, redo, save, delete-line, join-lines, etc.
+**Done.** Plugins can now invoke any registered command by ID.
 
-**What to add:**
-- `ttt.exec(command_id)` — execute any registered command by ID (e.g., `"editor.undo"`, `"editor.joinLines"`, `"file.save"`).
-- Expose through the Lua sandbox in `internal/plugin/sandbox.go`.
+- `ttt.exec_command(id)` — execute a command by ID, returns `true` if found and executed, `false` otherwise.
+- Gated on the existing `commands` permission (same as command registration).
+- Wired via `Plugin.ExecCommand` callback → `App.Reg.Execute(id)`.
 
 ### 4. Single-Line Buffer Access
 


### PR DESCRIPTION
## Summary
- Add `ttt.exec_command(id)` — plugins can invoke any registered command by ID, gated on `commands` permission
- Add `ttt.list_commands()` — plugins can discover all available commands (returns `{id, title}` tables), gated on `commands` permission
- Update docs-web plugin authoring guide with documentation for `ttt.set_status_item`, `ttt.remove_status_item`, `ttt.exec_command`, and `ttt.list_commands`

## Test plan
- [x] Functional test: exec_command returns true for known commands
- [x] Functional test: exec_command returns false for unknown commands
- [x] Functional test: list_commands returns table with id/title fields, includes built-in commands
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRqgLUNS2yYGxwRFvsWgfR