### PR TITLE
feat: add multi-cursor plugin API

### DIFF
--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -1349,6 +1349,7 @@ Require the `editor.read` permission.
 | `editor.language()`    | string                                                    | Detected language (e.g. `"go"`, `"lua"`). |
 | `editor.byte_to_col(text, byte)` | number                                          | Convert a 1-based **byte** offset in `text` to a 1-based **rune column**. |
 | `editor.col_to_byte(text, col)`  | number                                          | Convert a 1-based **rune column** in `text` to a 1-based **byte** offset. |
+| `editor.get_cursors()`           | table of `{line, col}`                          | All cursor positions (1-based). Returns a single-element table when no extra cursors are active. |
 
 > **Columns are runes, not bytes.** The editor — and every position in the
 > `editor.replace` and diagnostics APIs — uses 1-based **rune (visual) columns**.
@@ -1382,6 +1383,8 @@ Require the `editor.write` permission.
 | `editor.clear_selection()`                        | Clear the current selection.                   |
 | `editor.begin_undo_group()`                       | Start grouping subsequent edits into a single undo step. |
 | `editor.end_undo_group()`                         | Close the group; all edits since `begin` undo/redo as one operation. |
+| `editor.add_cursor(line, col)`                    | Add a cursor at position (1-based). Duplicates are ignored. |
+| `editor.clear_cursors()`                          | Collapse back to a single cursor (the primary). |
 
 All write operations go through the undo system — they can be undone with Ctrl+Z.
 

--- a/internal/app/plugin_api.go
+++ b/internal/app/plugin_api.go
@@ -277,6 +277,27 @@ func (e *PluginEditorAPI) EndUndoGroup() {
 	ed.Undo.EndTransaction()
 }
 
+func (e *PluginEditorAPI) AddCursor(line, col int) {
+	e.eg.AddCursor(line, col)
+}
+
+func (e *PluginEditorAPI) GetCursors() []plugin.CursorPosition {
+	states := e.eg.GetCursors()
+	if states == nil {
+		line, col := e.eg.ActiveCursor()
+		return []plugin.CursorPosition{{Line: line, Col: col}}
+	}
+	result := make([]plugin.CursorPosition, len(states))
+	for i, cs := range states {
+		result[i] = plugin.CursorPosition{Line: cs.Line, Col: cs.Col}
+	}
+	return result
+}
+
+func (e *PluginEditorAPI) ClearCursors() {
+	e.eg.CollapseMultiCursor()
+}
+
 // PluginFilesystemAPI implements plugin.FilesystemAPI with path restrictions.
 type PluginFilesystemAPI struct {
 	allowedRoots []string

--- a/internal/plugin/api.go
+++ b/internal/plugin/api.go
@@ -51,6 +51,15 @@ type EditorAPI interface {
 	ClearSelection()
 	BeginUndoGroup()
 	EndUndoGroup()
+
+	AddCursor(line, col int)
+	GetCursors() []CursorPosition
+	ClearCursors()
+}
+
+type CursorPosition struct {
+	Line int
+	Col  int
 }
 
 type FileEntry struct {

--- a/internal/plugin/lua_editor.go
+++ b/internal/plugin/lua_editor.go
@@ -27,6 +27,7 @@ func setupEditorModule(L *lua.LState, p *Plugin) {
 			L.SetField(mod, "byte_to_col", L.NewFunction(editorByteToCol(p)))
 			L.SetField(mod, "col_to_byte", L.NewFunction(editorColToByte(p)))
 			L.SetField(mod, "register_context_menu", L.NewFunction(editorRegisterContextMenu(p)))
+			L.SetField(mod, "get_cursors", L.NewFunction(editorGetCursors(p)))
 		}
 
 		if hasWrite {
@@ -40,6 +41,8 @@ func setupEditorModule(L *lua.LState, p *Plugin) {
 			L.SetField(mod, "clear_selection", L.NewFunction(editorClearSelection(p)))
 			L.SetField(mod, "begin_undo_group", L.NewFunction(editorBeginUndoGroup(p)))
 			L.SetField(mod, "end_undo_group", L.NewFunction(editorEndUndoGroup(p)))
+			L.SetField(mod, "add_cursor", L.NewFunction(editorAddCursor(p)))
+			L.SetField(mod, "clear_cursors", L.NewFunction(editorClearCursors(p)))
 		}
 
 		L.Push(mod)
@@ -470,6 +473,48 @@ func editorEndUndoGroup(p *Plugin) lua.LGFunction {
 			return 0
 		}
 		p.Editor.EndUndoGroup()
+		return 0
+	}
+}
+
+func editorAddCursor(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		line := int(L.CheckNumber(1)) - 1
+		col := int(L.CheckNumber(2)) - 1
+		p.Editor.AddCursor(line, col)
+		return 0
+	}
+}
+
+func editorGetCursors(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("editor API not available"))
+			return 2
+		}
+		cursors := p.Editor.GetCursors()
+		tbl := L.NewTable()
+		for _, c := range cursors {
+			entry := L.NewTable()
+			L.SetField(entry, "line", lua.LNumber(c.Line+1))
+			L.SetField(entry, "col", lua.LNumber(c.Col+1))
+			tbl.Append(entry)
+		}
+		L.Push(tbl)
+		return 1
+	}
+}
+
+func editorClearCursors(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		p.Editor.ClearCursors()
 		return 0
 	}
 }

--- a/internal/plugin/lua_editor_test.go
+++ b/internal/plugin/lua_editor_test.go
@@ -38,7 +38,8 @@ type mockEditorAPI struct {
 	setSelEL int
 	setSelEC int
 
-	selCleared bool
+	selCleared   bool
+	extraCursors []CursorPosition
 }
 
 func (m *mockEditorAPI) BufferText() string { return m.bufText }
@@ -100,6 +101,17 @@ func (m *mockEditorAPI) ClearSelection() {
 }
 func (m *mockEditorAPI) BeginUndoGroup() {}
 func (m *mockEditorAPI) EndUndoGroup()   {}
+func (m *mockEditorAPI) AddCursor(line, col int) {
+	m.extraCursors = append(m.extraCursors, CursorPosition{Line: line, Col: col})
+}
+func (m *mockEditorAPI) GetCursors() []CursorPosition {
+	result := []CursorPosition{{Line: m.cursorLine, Col: m.cursorCol}}
+	result = append(result, m.extraCursors...)
+	return result
+}
+func (m *mockEditorAPI) ClearCursors() {
+	m.extraCursors = nil
+}
 
 func setupTestPluginWithEditor(perms PermissionSet, editor *mockEditorAPI) (*Plugin, func()) {
 	p, cleanup := newTestPluginBase(perms)

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1266,6 +1266,24 @@ func (g *EditorGroupWidget) CollapseMultiCursor() {
 	}
 }
 
+func (g *EditorGroupWidget) AddCursor(line, col int) {
+	if !g.IsEditorActive() {
+		return
+	}
+	g.Editor.ensureMulti()
+	g.Editor.syncToMulti()
+	g.Editor.Multi.Add(line, col)
+	g.Editor.syncFromMulti()
+	g.saveMultiState()
+}
+
+func (g *EditorGroupWidget) GetCursors() []multicursor.CursorState {
+	if !g.IsEditorActive() || g.Editor.Multi == nil {
+		return nil
+	}
+	return g.Editor.Multi.Cursors
+}
+
 func (g *EditorGroupWidget) Copy() {
 	t := g.activeTab()
 	if t == nil {

--- a/tests/functional/plugin-editor-api.test.js
+++ b/tests/functional/plugin-editor-api.test.js
@@ -210,3 +210,68 @@ describe("editor.begin_undo_group / end_undo_group plugin API", () => {
     expect(snapshots[s2]).toContain("ccc");
   });
 });
+
+describe("editor.add_cursor / get_cursors / clear_cursors plugin API", () => {
+  it("adds cursors and returns all cursor positions", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "aaa\nbbb\nccc\nddd\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      local editor = require("ttt.editor")
+      ttt.register({
+        commands = {
+          { id = "test.addcursors", title = "Test AddCursors", handler = function()
+              editor.add_cursor(2, 1)
+              editor.add_cursor(3, 1)
+              local cursors = editor.get_cursors()
+              ttt.set_status_item("left", "result",
+                "N:" .. #cursors, { priority = 10 })
+            end
+          }
+        }
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.exec("Test AddCursors");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const lastLine = snapshots[s].split("\n").pop();
+    expect(lastLine).toContain("N:3");
+  });
+
+  it("clear_cursors collapses back to single cursor", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "aaa\nbbb\nccc\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      local editor = require("ttt.editor")
+      ttt.register({
+        commands = {
+          { id = "test.clearcursors", title = "Test ClearCursors", handler = function()
+              editor.add_cursor(2, 1)
+              editor.add_cursor(3, 1)
+              editor.clear_cursors()
+              local cursors = editor.get_cursors()
+              ttt.set_status_item("left", "result",
+                "N:" .. #cursors, { priority = 10 })
+            end
+          }
+        }
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.exec("Test ClearCursors");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const lastLine = snapshots[s].split("\n").pop();
+    expect(lastLine).toContain("N:1");
+  });
+});

--- a/vim.md
+++ b/vim.md
@@ -57,11 +57,10 @@ In Vim Normal mode, pressing `j` must be a motion, not insert a character.
 - `editor.end_undo_group()` — close the group; all edits since `begin` undo/redo as one operation. Gated on `editor.write`.
 - Backed by `UndoStack.BeginTransaction()` / `EndTransaction()` which wraps accumulated commands in a `BatchCommand`.
 
-### 7. Multi-Cursor API (nice-to-have)
+### 7. Multi-Cursor API ✅
 
-Internal multi-cursor support exists but is not exposed to plugins. Would enable Vim visual-block mode.
+**Done.** Plugins can now add, query, and clear multiple cursors.
 
-**What to add (later):**
-- `editor.add_cursor(line, col)`
-- `editor.get_cursors()` — returns list of `{line, col}` tables.
-- `editor.clear_cursors()` — back to single cursor.
+- `editor.add_cursor(line, col)` — add a cursor at position (1-based). Duplicates ignored. Gated on `editor.write`.
+- `editor.get_cursors()` — returns list of `{line, col}` tables (1-based). Gated on `editor.read`.
+- `editor.clear_cursors()` — collapse back to single cursor. Gated on `editor.write`.


### PR DESCRIPTION
## Summary
- `editor.add_cursor(line, col)` — add a cursor at position (1-based, duplicates ignored). Requires `editor.write`.
- `editor.get_cursors()` — returns all cursor positions as `{line, col}` tables (1-based). Requires `editor.read`.
- `editor.clear_cursors()` — collapse back to single cursor. Requires `editor.write`.

Item 7 from the Vim plugin API checklist (`vim.md`).

## Test plan
- [x] Mock interface updated with working add/get/clear
- [x] 2 functional tests: add + count cursors, clear + verify single
- [x] `go test ./...` passes
- [x] `cd tests/functional && pnpm test` passes (253 tests)
- [x] Docs-web plugin authoring guide updated (read & write tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRqgLUNS2yYGxwRFvsWgfR