### PR TITLE
feat: add key.press event for plugin key interception

### DIFF
--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -255,6 +255,7 @@ func LoadPluginFromFile(a *App, path string) {
 
 	a.PluginManager.RegisterDebugPlugin(p)
 	a.WirePlugin(p)
+	a.ensureKeyInterceptor()
 
 	slog.Info("plugin loaded from file", "path", path, "name", name)
 }

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -591,6 +591,19 @@ func (a *App) RegisterStartupPluginCommands() {
 	for _, p := range a.PluginManager.Plugins() {
 		a.WirePlugin(p)
 	}
+	a.ensureKeyInterceptor()
+}
+
+func (a *App) ensureKeyInterceptor() {
+	if a.Root.KeyInterceptor != nil {
+		return
+	}
+	a.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		if a.Root.Focused != a.EditorGroup {
+			return false
+		}
+		return a.PluginManager.DispatchKeyEvent(ev)
+	}
 }
 
 func (a *App) pluginReload() {

--- a/internal/plugin/lua_events.go
+++ b/internal/plugin/lua_events.go
@@ -18,6 +18,10 @@ var editorEvents = map[string]bool{
 	"tab.change":    true,
 }
 
+var keyEvents = map[string]bool{
+	"key.press": true,
+}
+
 func setupEventsModule(L *lua.LState, p *Plugin) {
 	loader := func(L *lua.LState) int {
 		mod := L.NewTable()
@@ -43,6 +47,11 @@ func eventsOn(p *Plugin) lua.LGFunction {
 			}
 		} else if editorEvents[eventName] {
 			if err := p.Granted.Check("events.editor"); err != nil {
+				L.ArgError(1, err.Error())
+				return 0
+			}
+		} else if keyEvents[eventName] {
+			if err := p.Granted.Check("keybindings"); err != nil {
 				L.ArgError(1, err.Error())
 				return 0
 			}

--- a/internal/plugin/lua_events_test.go
+++ b/internal/plugin/lua_events_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -95,6 +96,120 @@ func TestEventsUnknownEvent(t *testing.T) {
 	`)
 	if err == nil {
 		t.Fatal("expected error for unknown event")
+	}
+}
+
+func TestEventsKeyPressConsumed(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("key.press", function(ev)
+			if ev.key == "j" then
+				_G.intercepted = "j"
+				return true
+			end
+			return false
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'j', tcell.ModNone)
+	tbl := keyEventToLua(p.State, ev)
+	if !p.DispatchKeyEvent(tbl) {
+		t.Fatal("expected key.press to be consumed")
+	}
+	if p.State.GetGlobal("intercepted").String() != "j" {
+		t.Errorf("expected 'j', got %q", p.State.GetGlobal("intercepted").String())
+	}
+}
+
+func TestEventsKeyPressNotConsumed(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("key.press", function(ev)
+			return false
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'k', tcell.ModNone)
+	tbl := keyEventToLua(p.State, ev)
+	if p.DispatchKeyEvent(tbl) {
+		t.Fatal("expected key.press not to be consumed")
+	}
+}
+
+func TestEventsKeyPressWithModifiers(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("key.press", function(ev)
+			_G.got_key = ev.key
+			_G.got_mod = ev.mod or ""
+			return true
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	ev := tcell.NewEventKey(tcell.KeyRune, 'w', tcell.ModAlt)
+	tbl := keyEventToLua(p.State, ev)
+	p.DispatchKeyEvent(tbl)
+
+	if p.State.GetGlobal("got_key").String() != "w" {
+		t.Errorf("expected 'w', got %q", p.State.GetGlobal("got_key").String())
+	}
+	if p.State.GetGlobal("got_mod").String() != "alt" {
+		t.Errorf("expected 'alt', got %q", p.State.GetGlobal("got_mod").String())
+	}
+}
+
+func TestEventsKeyPressSpecialKey(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("key.press", function(ev)
+			_G.got_key = ev.key
+			return true
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	ev := tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone)
+	tbl := keyEventToLua(p.State, ev)
+	p.DispatchKeyEvent(tbl)
+
+	if p.State.GetGlobal("got_key").String() != "Esc" {
+		t.Errorf("expected 'Esc', got %q", p.State.GetGlobal("got_key").String())
+	}
+}
+
+func TestEventsKeyPressWithoutPermission(t *testing.T) {
+	p, cleanup := setupTestPluginForEvents(PermissionSet{})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local events = require("ttt.events")
+		events.on("key.press", function() return true end)
+	`)
+	if err == nil {
+		t.Fatal("expected error when events.keys not granted")
 	}
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gdamore/tcell/v2"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -258,6 +259,19 @@ func (m *Manager) wireAPIs(p *Plugin) {
 	if m.logFactory != nil {
 		p.Log = m.logFactory(p.Name)
 	}
+}
+
+func (m *Manager) DispatchKeyEvent(ev *tcell.EventKey) bool {
+	for _, p := range m.plugins {
+		if p.State == nil || len(p.EventListeners["key.press"]) == 0 {
+			continue
+		}
+		tbl := keyEventToLua(p.State, ev)
+		if p.DispatchKeyEvent(tbl) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) DispatchEvent(name string, args ...interface{}) {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -267,6 +267,30 @@ func (p *Plugin) CallSidebarAction(cmd string) {
 	}
 }
 
+func (p *Plugin) DispatchKeyEvent(ev *lua.LTable) bool {
+	listeners := p.EventListeners["key.press"]
+	if len(listeners) == 0 || p.State == nil {
+		return false
+	}
+	for _, fn := range listeners {
+		err := p.State.CallByParam(lua.P{
+			Fn:      fn,
+			NRet:    1,
+			Protect: true,
+		}, ev)
+		if err != nil {
+			p.logError("event key.press", err)
+			continue
+		}
+		ret := p.State.Get(-1)
+		p.State.Pop(1)
+		if lua.LVAsBool(ret) {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Plugin) DispatchEvent(name string, args ...lua.LValue) {
 	listeners := p.EventListeners[name]
 	if len(listeners) == 0 || p.State == nil {

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -41,6 +41,7 @@ type Root struct {
 	ForceKeys        []GlobalKeyBinding // checked even when focused widget wants raw keys
 	ChordKeys        []ChordKeyBinding
 	chord            *chordState
+	KeyInterceptor   func(ev *tcell.EventKey) bool
 	OnRightClick     func(mx, my int)
 	EscapeDismissers []func() bool
 	EscapeFallback   func()
@@ -143,6 +144,10 @@ func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 		if rk, ok := r.Focused.(RawKeyConsumer); ok && rk.WantsRawKeys() {
 			return r.handleRawKeyConsumer(kev)
 		}
+	}
+
+	if r.KeyInterceptor != nil && r.KeyInterceptor(kev) {
+		return EventConsumed
 	}
 
 	if r.Focused != nil {

--- a/tests/e2e/key_interceptor_test.go
+++ b/tests/e2e/key_interceptor_test.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestKeyInterceptorBlocksRune(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	intercepted := false
+	h.app.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		if ev.Key() == tcell.KeyRune && ev.Rune() == 'j' {
+			intercepted = true
+			return true
+		}
+		return false
+	}
+
+	h.pressRune('j')
+
+	if !intercepted {
+		t.Fatal("expected interceptor to be called")
+	}
+	if h.containsText("j") {
+		t.Fatal("expected 'j' to be suppressed by interceptor")
+	}
+}
+
+func TestKeyInterceptorPassthrough(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	h.app.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		return false
+	}
+
+	h.pressRune('x')
+
+	h.assertContains("x")
+}
+
+func TestKeyInterceptorNotCalledForOverlays(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	called := false
+	h.app.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		called = true
+		return true
+	}
+
+	h.exec("command.palette")
+	h.pressRune('a')
+
+	if called {
+		t.Fatal("interceptor should not be called when an overlay is active")
+	}
+}

--- a/tests/functional/plugin-key-intercept.test.js
+++ b/tests/functional/plugin-key-intercept.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function writePlugin(dir, name, lua) {
+  const path = join(dir, name);
+  writeFileSync(path, lua, "utf8");
+  return path;
+}
+
+describe("key.press event", () => {
+  it("intercepts and suppresses a key when returning true", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+    const plugin = writePlugin(dir, "intercept.lua", `
+      local ttt = require("ttt")
+      local events = require("ttt.events")
+      ttt.register({})
+      events.on("key.press", function(ev)
+        if ev.key == "j" then
+          ttt.set_status_item("left", "mode", "INTERCEPTED", { priority = 10 })
+          return true
+        end
+        return false
+      end)
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.press("end");
+    tui.type("j");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).not.toContain("helloj");
+    expect(snapshots[s]).toContain("INTERCEPTED");
+  });
+
+  it("passes key through when returning false", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+    const plugin = writePlugin(dir, "passthrough.lua", `
+      local ttt = require("ttt")
+      local events = require("ttt.events")
+      ttt.register({})
+      events.on("key.press", function(ev)
+        return false
+      end)
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.press("end");
+    tui.type("x");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("hellox");
+  });
+});

--- a/vim.md
+++ b/vim.md
@@ -5,15 +5,14 @@ The core needs several plugin API additions first — all general-purpose, not V
 
 ## Core Plugin API Additions
 
-### 1. Key Interception Hook
+### 1. Key Interception Hook ✅
 
-Plugins currently cannot intercept key events before the editor processes them.
-In Vim Normal mode, pressing `j` must be a motion, not insert a character.
+**Done.** Plugins can now intercept key events before the editor processes them.
 
-**What to add:**
-- `ttt.events.on("key.press", fn)` event where the callback receives the key event and returns `true` to suppress default handling.
-- Hook point in `Root.HandleEvent` (`internal/ui/root.go`) — after ForceKeys and overlays, before the editor widget consumes the key.
-- Must only intercept when the editor pane is focused (not terminal, not plugin panels).
+- `ttt.events.on("key.press", fn)` — callback receives a key event table (`{type, key, rune, mod}`) and returns `true` to suppress default handling.
+- Hook point in `Root.HandleEvent` (`internal/ui/root.go`) via `KeyInterceptor` — after ForceKeys, overlays, escape, chords, and RawKeyConsumer check, before the editor widget consumes the key.
+- Only intercepts when the editor pane is focused (not terminal, not plugin panels).
+- Gated on the existing `keybindings` permission.
 
 ### 2. Persistent Status Bar Section ✅
 


### PR DESCRIPTION
## Summary

- Add `ttt.events.on("key.press", fn)` plugin API that lets plugins intercept key events before the editor processes them
- Callback receives `{type, key, rune, mod}` table and returns `true` to suppress default handling
- Hook point in `Root.HandleEvent` after ForceKeys/overlays/escape/chords/RawKeyConsumer, before the editor widget
- Only intercepts when the editor pane is focused (not terminal or plugin panels)
- Gated on the existing `keybindings` permission (no new permission needed)

## Test plan

- [x] Unit tests: consumed, not-consumed, modifiers, special keys, permission denied
- [x] E2E tests: block rune, passthrough, overlay bypass
- [x] Functional tests: suppress key via plugin, passthrough via plugin
- [x] All 253 functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)