### PR TITLE
Vim compatibility layer (plugin) + supporting plugin-API work

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -67,6 +67,7 @@ type cliFlags struct {
 	configFile   string
 	pluginFile   string
 	exec         string
+	execSplitOn  string
 	sizeW, sizeH int
 	debug        bool
 }
@@ -89,6 +90,11 @@ func parseFlags() cliFlags {
 		case "--exec":
 			if i+1 < len(args) {
 				f.exec = args[i+1]
+				i++
+			}
+		case "--exec-split-on":
+			if i+1 < len(args) {
+				f.execSplitOn = args[i+1]
 				i++
 			}
 		case "--size":
@@ -141,6 +147,8 @@ Options:
   --workspace <file>  Open a saved workspace (.ttt file)
   --config <file>     Use a custom config file
   --exec "commands"   Execute semicolon-separated commands after startup
+  --exec-split-on <s> Split --exec on <s> instead of ";" (for scripts that
+                      need to send a literal semicolon)
 
 Examples:
   ttt                                           Open current directory
@@ -335,7 +343,7 @@ Docs: https://tttedit.dev
 	}
 
 	if flags.exec != "" {
-		go app.RunExecScript(editor, flags.exec)
+		go app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
 	}
 
 	app.RunEventLoop(screen, renderer, editor, &running, editor.CloseTerminal)

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -343,6 +343,77 @@ for _, cmd in ipairs(cmds) do
 end
 ```
 
+### `ttt.command_line` Module
+
+A single-line, framed input docked directly above the status bar — the `:` prompt of a modal editor. It is drawn as a modal overlay, so opening it never resizes the editor underneath and the buffer does not jump.
+
+All four functions require the `keybindings` permission: taking the command line is a keyboard-focus grab, the same class of capability as claiming a key binding.
+
+While the command line is open it consumes **all** keys. In particular, a plugin's `key.press` listener stops receiving events until it closes — so a modal plugin goes silent for free, with no mode flag to track.
+
+#### `ttt.command_line.show(config)`
+
+Open the command line and move focus to it. If one is already open, it is replaced rather than stacked. The call is a no-op while another overlay (a dialog, the command palette, a menu) is up.
+
+| Field       | Type     | Description                                                        |
+|-------------|----------|--------------------------------------------------------------------|
+| `prefix`    | string   | Prompt character shown before the text. Default `":"`. Typically `":"`, `"/"`, or `"?"`. |
+| `text`      | string   | Initial text. Default empty.                                       |
+| `on_change` | function | Called with the full text after every edit. Use for incremental search. |
+| `on_submit` | function | Called with the full text when Enter is pressed. The command line closes first. |
+| `on_cancel` | function | Called when Escape is pressed. The command line closes first.      |
+
+```lua
+local ttt = require("ttt")
+local events = require("ttt.events")
+
+events.on("key.press", function(ev)
+  if ev.key == ":" then
+    ttt.command_line.show({
+      prefix = ":",
+      on_submit = function(text)
+        if text == "w" then
+          ttt.exec_command("file.save")
+        elseif text == "q" then
+          ttt.exec_command("tab.close")
+        end
+      end,
+    })
+    return true
+  end
+  return false
+end)
+```
+
+Incremental search, using `on_change`:
+
+```lua
+ttt.command_line.show({
+  prefix = "/",
+  on_change = function(query)
+    highlight_matches(query)   -- runs on every keystroke
+  end,
+  on_submit = function(query)
+    jump_to_first_match(query)
+  end,
+  on_cancel = clear_highlights,
+})
+```
+
+Focus returns to whatever was focused before `show` — normally the editor — on submit, on cancel, and on `hide()`.
+
+#### `ttt.command_line.hide()`
+
+Close the command line without firing `on_submit` or `on_cancel`. No-op if none is open.
+
+#### `ttt.command_line.set_text(text)`
+
+Replace the current text. Fires `on_change`, exactly as typing would. No-op if no command line is open.
+
+#### `ttt.command_line.active()`
+
+**Returns:** `true` while a command line is open, `false` otherwise.
+
 ### `ttt.open_drawer(config)`
 
 Open a drawer panel anchored to the left or right side of the editor. Requires `panel.drawer` permission.
@@ -1756,7 +1827,44 @@ Register an event listener. Multiple listeners can be registered for the same ev
 | `cursor.change` | Cursor position changed (line or column). |
 | `tab.change`    | The active file changed — a tab switch, or a file opened from the CLI. Useful for re-scanning the newly active file. |
 
-All callbacks receive the file path of the affected file as their single argument.
+File and editor callbacks receive the file path of the affected file as their single argument.
+
+**Key events** (require `keybindings` permission):
+
+| Event       | Description                                    |
+|-------------|------------------------------------------------|
+| `key.press` | A key was pressed while the editor has focus.  |
+
+`key.press` is the hook for modal editing: it lets a plugin own the keyboard. The callback receives an event table and its return value decides what happens to the key.
+
+| Field  | Type   | Description                                                                 |
+|--------|--------|-----------------------------------------------------------------------------|
+| `type` | string | Always `"key"`.                                                             |
+| `key`  | string | For printable keys, the character itself (`"j"`, `":"`). Otherwise the key name (`"Enter"`, `"Escape"`, `"Ctrl-D"`). |
+| `rune` | string | The character, present only for printable keys.                             |
+| `mod`  | string | Active modifiers joined by `+` (`"ctrl"`, `"ctrl+shift"`, `"alt"`). Absent when there are none. |
+
+**Returning `true` consumes the key** — the editor never sees it. Returning `false` (or nothing) lets it through to normal handling.
+
+Note that control keys set **both** fields: `ctrl+d` arrives as `{ key = "Ctrl-D", mod = "ctrl" }`. Match on `key`, and check `mod` only when you need to distinguish (for example `"j"` from `alt+j`).
+
+```lua
+local events = require("ttt.events")
+
+events.on("key.press", function(ev)
+  if ev.key == "u" and not ev.mod then
+    ttt.exec_command("editor.undo")
+    return true    -- consumed
+  end
+  if ev.key == "Ctrl-D" then
+    ttt.exec_command("editor.deleteLine")
+    return true
+  end
+  return false     -- passed through
+end)
+```
+
+`key.press` fires only when the editor itself has focus, and it is bypassed entirely while an overlay is open — a dialog, the command palette, or `ttt.command_line`. Force keys (such as the terminal toggle) and any chord already in flight also outrank it, so a plugin can never trap the user.
 
 **Example:**
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -85,6 +85,8 @@ type App struct {
 	Output                 *ui.OutputWidget
 	pluginDetailWidgets    map[string]*pluginDetailState
 	pluginDrawer           ui.Widget
+	commandLine            *ui.CommandLineWidget
+	commandLinePrevFocus   ui.Widget
 	settingsView           *settingsView
 	// appliedSettings is the last value ApplySettings acted on. Callers routinely
 	// mutate a.Settings before calling it, so a.Settings cannot serve as "before".

--- a/internal/app/commandline.go
+++ b/internal/app/commandline.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+// ShowCommandLine opens the framed command line above the status bar as a modal
+// overlay and moves focus to it. Any of the callbacks may be nil.
+//
+// Calling it while a command line is already open replaces it rather than
+// stacking a second one, so the saved focus never gets lost behind two layers.
+// If some other overlay (dialog, palette, menu) is up, the call is a no-op —
+// the usual HasOverlay guard.
+func (a *App) ShowCommandLine(prefix string, onChange, onSubmit func(string), onCancel func()) *ui.CommandLineWidget {
+	if a.commandLine != nil {
+		a.HideCommandLine()
+	} else if a.Root.HasOverlay() {
+		return nil
+	}
+
+	w := ui.NewCommandLineWidget(prefix)
+	w.Borders = a.Borders
+	w.OnChange = onChange
+	w.OnSubmit = func(text string) {
+		a.HideCommandLine()
+		if onSubmit != nil {
+			onSubmit(text)
+		}
+	}
+	w.OnCancel = func() {
+		a.HideCommandLine()
+		if onCancel != nil {
+			onCancel()
+		}
+	}
+
+	a.commandLinePrevFocus = a.Root.Focused
+	a.commandLine = w
+	a.Root.PushOverlay(ui.Overlay{Widget: w, Modal: true})
+	a.Root.SetFocus(w)
+	return w
+}
+
+// HideCommandLine closes the command line and restores the focus that was
+// active when it opened.
+func (a *App) HideCommandLine() {
+	w := a.commandLine
+	if w == nil {
+		return
+	}
+	prev := a.commandLinePrevFocus
+	a.commandLine = nil
+	a.commandLinePrevFocus = nil
+
+	a.Root.RemoveOverlay(w)
+	if prev != nil {
+		a.Root.SetFocus(prev)
+	} else {
+		a.FocusEditor()
+	}
+}
+
+func (a *App) CommandLineActive() bool { return a.commandLine != nil }
+
+func (a *App) CommandLineText() string {
+	if a.commandLine == nil {
+		return ""
+	}
+	return a.commandLine.Text()
+}
+
+// SetCommandLineText replaces the current text. It is a no-op when no command
+// line is open.
+func (a *App) SetCommandLineText(text string) {
+	if a.commandLine == nil {
+		return
+	}
+	a.commandLine.SetText(text)
+}

--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -245,8 +245,15 @@ func LoadPluginFromFile(a *App, path string) {
 			NetworkHTTP:       plugin.NetworkHTTP{All: true},
 			EventsFile:        true,
 			EventsEditor:      true,
+			Settings:          true,
+			SettingsKeys:      []string{"*"},
 		},
 	}
+
+	// Wire the settings API before init so plugins loaded via --plugin can read
+	// settings at startup, matching the production ApproveAndLoad path where
+	// wireAPIs runs before Init.
+	p.Settings = NewPluginSettingsAPI(a)
 
 	if err := p.InitFromSource(string(source)); err != nil {
 		slog.Error("init plugin from file", "path", path, "error", err)

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/core/diff"
 )
 
 func (a *App) editorPathLang() (string, string) {
@@ -219,8 +220,88 @@ func (a *App) Quit() {
 	})
 }
 
+// hunkStarts returns the buffer-line indices (0-based) at which each diff hunk
+// begins. A hunk is a maximal run of consecutive non-Unchanged lines; its start
+// is the first line of that run.
+func hunkStarts(changes []diff.LineChangeKind) []int {
+	var starts []int
+	for i := 0; i < len(changes); i++ {
+		if changes[i] != diff.LineUnchanged && (i == 0 || changes[i-1] == diff.LineUnchanged) {
+			starts = append(starts, i)
+		}
+	}
+	return starts
+}
+
+// DiffNextHunk moves the cursor to the start of the next changed hunk after the
+// current cursor line. No-op when git-gutter data is unavailable or there is no
+// following hunk.
+func (a *App) DiffNextHunk() {
+	if !a.EditorGroup.IsEditorActive() {
+		return
+	}
+	changes := a.EditorGroup.Editor.LineChanges
+	if len(changes) == 0 {
+		a.StatusNotify("No changes in this file")
+		return
+	}
+	line, _ := a.EditorGroup.ActiveCursor() // 0-based
+	target := -1
+	for _, s := range hunkStarts(changes) {
+		if s > line {
+			target = s
+			break
+		}
+	}
+	if target < 0 {
+		a.StatusNotify("No more changes below")
+		return
+	}
+	a.EditorGroup.GoToLine(target + 1) // GoToLine is 1-based
+}
+
+// DiffPrevHunk moves the cursor to the start of the previous changed hunk before
+// the current cursor line. No-op when git-gutter data is unavailable or there is
+// no preceding hunk.
+func (a *App) DiffPrevHunk() {
+	if !a.EditorGroup.IsEditorActive() {
+		return
+	}
+	changes := a.EditorGroup.Editor.LineChanges
+	if len(changes) == 0 {
+		a.StatusNotify("No changes in this file")
+		return
+	}
+	line, _ := a.EditorGroup.ActiveCursor() // 0-based
+	target := -1
+	for _, s := range hunkStarts(changes) {
+		if s < line {
+			target = s
+		} else {
+			break
+		}
+	}
+	if target < 0 {
+		a.StatusNotify("No more changes above")
+		return
+	}
+	a.EditorGroup.GoToLine(target + 1) // GoToLine is 1-based
+}
+
 func registerEditorCommands(app *App) {
 	reg := app.Reg
+
+	reg.Register(command.Command{
+		ID: "diff.nextHunk", Title: "Git: Next Changed Hunk",
+		Keywords: []string{"git", "diff", "hunk", "change", "navigate"},
+		Handler:  app.DiffNextHunk,
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.prevHunk", Title: "Git: Previous Changed Hunk",
+		Keywords: []string{"git", "diff", "hunk", "change", "navigate"},
+		Handler:  app.DiffPrevHunk,
+	})
 
 	reg.Register(command.Command{
 		ID: "editor.focus", Title: "View: Focus Editor",

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -147,8 +147,77 @@ func (a *App) OpenPullRequestDialog() {
 	})
 }
 
+// changedFilePaths returns the ordered, de-duplicated list of absolute paths for
+// every file that currently appears in the Changes panel (staged and unstaged).
+func (a *App) changedFilePaths() []string {
+	var paths []string
+	seen := make(map[string]bool)
+	add := func(dir, rel string) {
+		p := filepath.Join(dir, rel)
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	for _, g := range a.Changes.Groups() {
+		for _, s := range g.Staged {
+			add(g.Dir, s.Path)
+		}
+		for _, s := range g.Unstaged {
+			add(g.Dir, s.Path)
+		}
+	}
+	return paths
+}
+
+func (a *App) changesNavFile(dir int) {
+	paths := a.changedFilePaths()
+	if len(paths) == 0 {
+		a.StatusNotify("No changed files")
+		return
+	}
+	current := a.EditorGroup.ActiveFilePath()
+	idx := -1
+	for i, p := range paths {
+		if p == current {
+			idx = i
+			break
+		}
+	}
+	target := paths[0]
+	if idx >= 0 {
+		n := (idx + dir) % len(paths)
+		if n < 0 {
+			n += len(paths)
+		}
+		target = paths[n]
+	}
+	a.EditorGroup.OpenFile(target)
+	a.FocusEditorIfEnabled()
+}
+
+// ChangesNextFile opens the next changed file relative to the active file,
+// wrapping around at the end of the list.
+func (a *App) ChangesNextFile() { a.changesNavFile(1) }
+
+// ChangesPrevFile opens the previous changed file relative to the active file,
+// wrapping around at the start of the list.
+func (a *App) ChangesPrevFile() { a.changesNavFile(-1) }
+
 func registerGitCommands(app *App) {
 	reg := app.Reg
+
+	reg.Register(command.Command{
+		ID: "changes.nextFile", Title: "Git: Next Changed File",
+		Keywords: []string{"git", "changes", "file", "navigate", "next"},
+		Handler:  app.ChangesNextFile,
+	})
+
+	reg.Register(command.Command{
+		ID: "changes.prevFile", Title: "Git: Previous Changed File",
+		Keywords: []string{"git", "changes", "file", "navigate", "previous"},
+		Handler:  app.ChangesPrevFile,
+	})
 
 	reg.Register(command.Command{
 		ID: "changes.openDiff", Title: "Git: Open Compact Diff",

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -389,6 +389,21 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	p.ExecCommand = func(id string) bool {
 		return a.Reg.Execute(id)
 	}
+	p.ShowCommandLine = func(prefix, text string, onChange, onSubmit func(string), onCancel func()) {
+		w := a.ShowCommandLine(prefix, onChange, onSubmit, onCancel)
+		if w != nil && text != "" {
+			w.SetText(text)
+		}
+	}
+	p.HideCommandLine = func() {
+		a.HideCommandLine()
+	}
+	p.SetCommandLineText = func(text string) {
+		a.SetCommandLineText(text)
+	}
+	p.CommandLineActive = func() bool {
+		return a.CommandLineActive()
+	}
 	p.ListCommands = func() []plugin.CommandInfo {
 		cmds := a.Reg.List()
 		result := make([]plugin.CommandInfo, len(cmds))

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -13,11 +13,25 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
-// RunExecScript parses a semicolon-separated script string and executes
-// each command sequentially. Intended to be run in a goroutine after
-// the event loop starts.
+// DefaultExecSeparator splits exec scripts when no override is given.
+const DefaultExecSeparator = ";"
+
+// RunExecScript parses a separator-delimited script string and executes each
+// command sequentially. Intended to be run in a goroutine after the event loop
+// starts.
 func RunExecScript(a *App, script string) {
-	commands := strings.Split(script, ";")
+	RunExecScriptSep(a, script, DefaultExecSeparator)
+}
+
+// RunExecScriptSep is RunExecScript with a caller-chosen separator. Semicolons
+// are unusable when the script must type or send one -- `;` is a Vim motion,
+// for instance -- so callers can pick a delimiter that cannot collide with
+// their payload.
+func RunExecScriptSep(a *App, script, sep string) {
+	if sep == "" {
+		sep = DefaultExecSeparator
+	}
+	commands := strings.Split(script, sep)
 	for _, raw := range commands {
 		cmd := strings.TrimSpace(raw)
 		if cmd == "" {

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -38,6 +38,10 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 			i++
 			continue
 		}
+		if args[i] == "--exec-split-on" && i+1 < len(args) {
+			i++
+			continue
+		}
 		if args[i] == "--plugin" && i+1 < len(args) {
 			i++
 			continue

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -173,6 +173,63 @@ type Settings struct {
 	// default, so the zero value and "unset" mean the same thing.
 	Plugins    PluginSettings    `json:"plugins,omitzero"`
 	Formatters map[string]string `json:"formatters,omitempty"`
+	// Extra holds top-level keys that are not part of the core schema — chiefly
+	// plugin-namespaced settings (e.g. "vim"). Without this, json.Unmarshal into
+	// the struct would silently drop them, making ttt.settings.get/set unusable
+	// for plugins. It is populated/emitted by the custom (Un)MarshalJSON below.
+	Extra map[string]json.RawMessage `json:"-"`
+}
+
+// knownSettingsKeys is the set of top-level JSON keys owned by the core schema.
+// Any other top-level key is preserved via Settings.Extra.
+var knownSettingsKeys = map[string]bool{
+	"version": true, "theme": true, "debugMode": true, "editor": true,
+	"search": true, "explorer": true, "terminal": true, "lsp": true,
+	"autocomplete": true, "markdown": true, "plugins": true, "formatters": true,
+}
+
+func (s Settings) MarshalJSON() ([]byte, error) {
+	type alias Settings
+	base, err := json.Marshal(alias(s))
+	if err != nil {
+		return nil, err
+	}
+	if len(s.Extra) == 0 {
+		// Byte-identical to the plain struct encoding — keeps field ordering
+		// stable for the settings-roundtrip test when no plugin keys are present.
+		return base, nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(base, &m); err != nil {
+		return nil, err
+	}
+	for k, v := range s.Extra {
+		if !knownSettingsKeys[k] {
+			m[k] = v
+		}
+	}
+	return json.Marshal(m)
+}
+
+func (s *Settings) UnmarshalJSON(data []byte) error {
+	type alias Settings
+	aux := (*alias)(s)
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	for k, v := range m {
+		if !knownSettingsKeys[k] {
+			if s.Extra == nil {
+				s.Extra = make(map[string]json.RawMessage)
+			}
+			s.Extra[k] = v
+		}
+	}
+	return nil
 }
 
 func DefaultSettings() Settings {

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -227,3 +227,58 @@ func TestReferenceSettingsMatchesDefaults(t *testing.T) {
 			"Got %d bytes, want %d bytes", len(refData), len(generated))
 	}
 }
+
+// TestSettingsPreservesPluginKeys verifies that top-level keys outside the core
+// schema (e.g. plugin-namespaced "vim") survive a load/marshal roundtrip via the
+// Extra catch-all. Without this, ttt.settings.get/set could never read or persist
+// plugin settings such as vim.enabled.
+func TestSettingsPreservesPluginKeys(t *testing.T) {
+	raw := []byte(`{"version":1,"vim":{"enabled":false,"clipboard":true}}`)
+
+	var s Settings
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.Extra["vim"] == nil {
+		t.Fatal("expected vim key captured in Extra")
+	}
+
+	out, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	vim, ok := m["vim"].(map[string]any)
+	if !ok {
+		t.Fatalf("vim key not preserved through marshal, got: %s", out)
+	}
+	if vim["enabled"] != false {
+		t.Errorf("expected vim.enabled=false, got %v", vim["enabled"])
+	}
+	if vim["clipboard"] != true {
+		t.Errorf("expected vim.clipboard=true, got %v", vim["clipboard"])
+	}
+}
+
+// TestSettingsEmptyExtraByteIdentical guards that with no plugin keys present the
+// custom MarshalJSON produces exactly the plain struct encoding (field ordering
+// preserved), which the settings-roundtrip relies on.
+func TestSettingsEmptyExtraByteIdentical(t *testing.T) {
+	s := DefaultSettings()
+	s.Theme = "default-dark"
+	got, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	type alias Settings
+	want, err := json.Marshal(alias(s))
+	if err != nil {
+		t.Fatalf("marshal alias: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("empty-Extra MarshalJSON diverged from struct encoding:\n got: %s\nwant: %s", got, want)
+	}
+}

--- a/internal/plugin/lua_commandline.go
+++ b/internal/plugin/lua_commandline.go
@@ -1,0 +1,100 @@
+package plugin
+
+import (
+	lua "github.com/yuin/gopher-lua"
+)
+
+// newCommandLineModule builds the `ttt.command_line` table.
+//
+// Every entry is gated on the `keybindings` permission: opening the command
+// line is a keyboard-focus grab, the same class of capability as claiming a
+// key binding.
+func newCommandLineModule(L *lua.LState, p *Plugin) *lua.LTable {
+	mod := L.NewTable()
+
+	L.SetField(mod, "show", L.NewFunction(func(L *lua.LState) int {
+		if err := p.Granted.Check("keybindings"); err != nil {
+			L.ArgError(1, "keybindings permission not granted")
+			return 0
+		}
+		opts := L.OptTable(1, L.NewTable())
+
+		prefix := ":"
+		if v := L.GetField(opts, "prefix"); v != lua.LNil {
+			prefix = v.String()
+		}
+		text := ""
+		if v := L.GetField(opts, "text"); v != lua.LNil {
+			text = v.String()
+		}
+
+		onChange := luaTextCallback(p, L.GetField(opts, "on_change"), "command_line.on_change")
+		onSubmit := luaTextCallback(p, L.GetField(opts, "on_submit"), "command_line.on_submit")
+
+		var onCancel func()
+		if fn, ok := L.GetField(opts, "on_cancel").(*lua.LFunction); ok {
+			onCancel = func() {
+				if err := p.CallLuaFunc(fn); err != nil {
+					p.logError("command_line.on_cancel", err)
+				}
+			}
+		}
+
+		if p.ShowCommandLine != nil {
+			p.ShowCommandLine(prefix, text, onChange, onSubmit, onCancel)
+		}
+		return 0
+	}))
+
+	L.SetField(mod, "hide", L.NewFunction(func(L *lua.LState) int {
+		if err := p.Granted.Check("keybindings"); err != nil {
+			L.ArgError(1, "keybindings permission not granted")
+			return 0
+		}
+		if p.HideCommandLine != nil {
+			p.HideCommandLine()
+		}
+		return 0
+	}))
+
+	L.SetField(mod, "set_text", L.NewFunction(func(L *lua.LState) int {
+		if err := p.Granted.Check("keybindings"); err != nil {
+			L.ArgError(1, "keybindings permission not granted")
+			return 0
+		}
+		text := L.CheckString(1)
+		if p.SetCommandLineText != nil {
+			p.SetCommandLineText(text)
+		}
+		return 0
+	}))
+
+	L.SetField(mod, "active", L.NewFunction(func(L *lua.LState) int {
+		if err := p.Granted.Check("keybindings"); err != nil {
+			L.ArgError(1, "keybindings permission not granted")
+			return 0
+		}
+		active := false
+		if p.CommandLineActive != nil {
+			active = p.CommandLineActive()
+		}
+		L.Push(lua.LBool(active))
+		return 1
+	}))
+
+	return mod
+}
+
+// luaTextCallback wraps a Lua function taking a single string argument in a
+// protected call, so a plugin error is logged instead of unwinding the editor.
+func luaTextCallback(p *Plugin, v lua.LValue, context string) func(string) {
+	fn, ok := v.(*lua.LFunction)
+	if !ok {
+		return nil
+	}
+	return func(text string) {
+		if err := p.CallLuaFunc(fn, lua.LString(text)); err != nil {
+			p.logError(context, err)
+		}
+	}
+}

--- a/internal/plugin/lua_commandline_test.go
+++ b/internal/plugin/lua_commandline_test.go
@@ -1,0 +1,206 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+)
+
+type commandLineRecorder struct {
+	shown    bool
+	prefix   string
+	text     string
+	hidden   int
+	active   bool
+	onChange func(string)
+	onSubmit func(string)
+	onCancel func()
+}
+
+func setupCommandLinePlugin(t *testing.T, perms PermissionSet) (*Plugin, *commandLineRecorder, func()) {
+	t.Helper()
+	p, cleanup := newTestPluginBase(perms)
+	rec := &commandLineRecorder{}
+	p.ShowCommandLine = func(prefix, text string, onChange, onSubmit func(string), onCancel func()) {
+		rec.shown = true
+		rec.prefix = prefix
+		rec.text = text
+		rec.onChange = onChange
+		rec.onSubmit = onSubmit
+		rec.onCancel = onCancel
+		rec.active = true
+	}
+	p.HideCommandLine = func() {
+		rec.hidden++
+		rec.active = false
+	}
+	p.SetCommandLineText = func(text string) { rec.text = text }
+	p.CommandLineActive = func() bool { return rec.active }
+	return p, rec, cleanup
+}
+
+func TestCommandLineShow(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.command_line.show({ prefix = "/", text = "seed" })
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !rec.shown {
+		t.Fatal("expected show to be called")
+	}
+	if rec.prefix != "/" || rec.text != "seed" {
+		t.Fatalf("expected prefix %q text %q, got %q / %q", "/", "seed", rec.prefix, rec.text)
+	}
+}
+
+func TestCommandLineShowDefaultsToColonPrefix(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	if err := p.State.DoString(`require("ttt").command_line.show({})`); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if rec.prefix != ":" {
+		t.Fatalf("expected default prefix %q, got %q", ":", rec.prefix)
+	}
+}
+
+func TestCommandLineCallbacks(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		_G.changed = ""
+		_G.submitted = ""
+		_G.cancelled = false
+		ttt.command_line.show({
+			on_change = function(text) _G.changed = text end,
+			on_submit = function(text) _G.submitted = text end,
+			on_cancel = function() _G.cancelled = true end,
+		})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	rec.onChange("ab")
+	rec.onSubmit("wq")
+	rec.onCancel()
+
+	if got := p.State.GetGlobal("changed").String(); got != "ab" {
+		t.Errorf("on_change: expected %q, got %q", "ab", got)
+	}
+	if got := p.State.GetGlobal("submitted").String(); got != "wq" {
+		t.Errorf("on_submit: expected %q, got %q", "wq", got)
+	}
+	if got := p.State.GetGlobal("cancelled").String(); got != "true" {
+		t.Errorf("on_cancel: expected true, got %q", got)
+	}
+}
+
+// A callback that raises must be contained: it is logged, not propagated.
+func TestCommandLineCallbackErrorIsContained(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	var logged []string
+	p.Log = func(level, message string) { logged = append(logged, level+": "+message) }
+
+	err := p.State.DoString(`
+		require("ttt").command_line.show({
+			on_submit = function() error("boom") end,
+		})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	rec.onSubmit("x") // must not panic
+
+	found := false
+	for _, l := range logged {
+		if strings.Contains(l, "command_line.on_submit") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the callback error to be logged, got %v", logged)
+	}
+}
+
+func TestCommandLineHideAndSetText(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.command_line.show({})
+		ttt.command_line.set_text("noh")
+		_G.was_active = ttt.command_line.active()
+		ttt.command_line.hide()
+		_G.still_active = ttt.command_line.active()
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if rec.text != "noh" {
+		t.Errorf("expected set_text %q, got %q", "noh", rec.text)
+	}
+	if rec.hidden != 1 {
+		t.Errorf("expected 1 hide, got %d", rec.hidden)
+	}
+	if p.State.GetGlobal("was_active").String() != "true" {
+		t.Error("expected active() to be true while open")
+	}
+	if p.State.GetGlobal("still_active").String() != "false" {
+		t.Error("expected active() to be false after hide")
+	}
+}
+
+func TestCommandLineWithoutHostCallbacksIsSafe(t *testing.T) {
+	p, cleanup := newTestPluginBase(PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	// Nothing wired (pre-WirePlugin): calls must be no-ops, not panics.
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		ttt.command_line.show({})
+		ttt.command_line.set_text("x")
+		ttt.command_line.hide()
+		_G.active = ttt.command_line.active()
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if p.State.GetGlobal("active").String() != "false" {
+		t.Error("expected active() to be false with no host callback")
+	}
+}
+
+func TestCommandLinePermissionDenied(t *testing.T) {
+	for _, snippet := range []string{
+		`ttt.command_line.show({})`,
+		`ttt.command_line.hide()`,
+		`ttt.command_line.set_text("x")`,
+		`ttt.command_line.active()`,
+	} {
+		p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{})
+		err := p.State.DoString("local ttt = require(\"ttt\")\n" + snippet)
+		if err == nil {
+			t.Errorf("%s: expected a permission error", snippet)
+		} else if !strings.Contains(err.Error(), "keybindings permission not granted") {
+			t.Errorf("%s: expected a keybindings permission error, got %v", snippet, err)
+		}
+		if rec.shown || rec.hidden > 0 {
+			t.Errorf("%s: host callback must not run without permission", snippet)
+		}
+		cleanup()
+	}
+}

--- a/internal/plugin/lua_settings_test.go
+++ b/internal/plugin/lua_settings_test.go
@@ -322,6 +322,8 @@ func TestCheckSettingsKey(t *testing.T) {
 		{"exact match", []string{"formatters.go"}, "formatters.go", false},
 		{"exact no match", []string{"formatters.go"}, "formatters.py", true},
 		{"no settings permission", nil, "formatters.go", true},
+		{"star wildcard allows any", []string{"*"}, "vim.enabled", false},
+		{"star wildcard allows nested", []string{"*"}, "any.deep.key", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -9,7 +9,13 @@ import (
 
 // SupportedAPIVersion is the plugin API version this editor implements.
 // Manifests without an "api" field are assumed to target version 1.
-const SupportedAPIVersion = 1
+//
+// v2 (ttt 1.1.0) adds the plugin key interceptor's precedence over Escape and
+// chords, the ttt.command_line API, and plugin-namespaced settings. A plugin
+// that needs any of these declares "api": 2; older builds (which only know v1)
+// already reject it via the check in LoadManifest, so it fails cleanly instead
+// of loading into a broken half-state.
+const SupportedAPIVersion = 2
 
 type Manifest struct {
 	Name        string        `json:"name"`

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -121,9 +122,24 @@ func TestLoadManifestAPIVersionSupported(t *testing.T) {
 	}
 }
 
-func TestLoadManifestAPIVersionTooNew(t *testing.T) {
+func TestLoadManifestAPIVersion2Supported(t *testing.T) {
 	dir := t.TempDir()
 	data := `{"name": "test", "entry": "init.lua", "api": 2}`
+	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
+
+	m, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("api 2 should be supported: %v", err)
+	}
+	if m.API != 2 {
+		t.Errorf("expected api 2, got %d", m.API)
+	}
+}
+
+func TestLoadManifestAPIVersionTooNew(t *testing.T) {
+	dir := t.TempDir()
+	// One past the supported version, whatever that currently is.
+	data := fmt.Sprintf(`{"name": "test", "entry": "init.lua", "api": %d}`, SupportedAPIVersion+1)
 	os.WriteFile(filepath.Join(dir, "plugin.ttt.json"), []byte(data), 0644)
 
 	_, err := LoadManifest(dir)

--- a/internal/plugin/permissions.go
+++ b/internal/plugin/permissions.go
@@ -200,7 +200,7 @@ func (ps PermissionSet) CheckSettingsKey(key string) error {
 		return fmt.Errorf("permission denied: settings")
 	}
 	for _, pattern := range ps.SettingsKeys {
-		if pattern == key {
+		if pattern == "*" || pattern == key {
 			return nil
 		}
 		if strings.HasSuffix(pattern, ".*") {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -88,6 +88,11 @@ type Plugin struct {
 	PublishDiagnostics func(path string, items []DiagnosticItem)
 	ClearDiagnostics   func(path string)
 
+	ShowCommandLine    func(prefix, text string, onChange, onSubmit func(string), onCancel func())
+	HideCommandLine    func()
+	SetCommandLineText func(text string)
+	CommandLineActive  func() bool
+
 	EditorContextProvider *lua.LFunction
 
 	Editor     EditorAPI
@@ -253,6 +258,10 @@ func (p *Plugin) Destroy() {
 	p.ListCommands = nil
 	p.PublishDiagnostics = nil
 	p.ClearDiagnostics = nil
+	p.ShowCommandLine = nil
+	p.HideCommandLine = nil
+	p.SetCommandLineText = nil
+	p.CommandLineActive = nil
 	p.EditorContextProvider = nil
 	p.EventListeners = nil
 }

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -308,6 +308,8 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 1
 		}))
 
+		L.SetField(mod, "command_line", newCommandLineModule(L, p))
+
 		L.SetField(mod, "list_commands", L.NewFunction(func(L *lua.LState) int {
 			if err := p.Granted.Check("commands"); err != nil {
 				L.ArgError(1, "commands permission not granted")

--- a/internal/ui/commandline_widget.go
+++ b/internal/ui/commandline_widget.go
@@ -1,0 +1,147 @@
+package ui
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// CommandLineHeight is the number of rows the framed command line occupies.
+const CommandLineHeight = 3
+
+// CommandLineWidget is a framed single-line editor docked directly above the
+// status bar. It is rendered as a modal overlay rather than a layout child so
+// opening it never resizes the editor underneath (which would make the buffer
+// visibly jump).
+//
+// Being a modal overlay is load-bearing beyond the visuals: Root.handleOverlay
+// runs above the plugin KeyInterceptor, so a modal plugin (Vim mode) goes
+// silent for free while the command line is open — no focus stashing, no mode
+// flags.
+type CommandLineWidget struct {
+	BaseWidget
+
+	Prefix  string
+	Borders *term.BorderSet
+
+	OnChange func(text string)
+	OnSubmit func(text string)
+	OnCancel func()
+
+	input *widgets.InputWidget
+
+	// Layout computed by Render and reused by event handlers, so clicks and the
+	// cursor never disagree with what was drawn.
+	boxX, boxY, boxW int
+	laidOut          bool
+}
+
+func NewCommandLineWidget(prefix string) *CommandLineWidget {
+	if prefix == "" {
+		prefix = ":"
+	}
+	c := &CommandLineWidget{Prefix: prefix}
+	c.input = widgets.NewInputWidget(widgets.InputConfig{
+		Prefix: prefix,
+		Style:  term.StyleInput,
+		OnChange: func(text string) {
+			if c.OnChange != nil {
+				c.OnChange(text)
+			}
+		},
+	})
+	c.input.SetFocused(true)
+	return c
+}
+
+func (c *CommandLineWidget) Focusable() bool { return true }
+
+func (c *CommandLineWidget) SetFocused(f bool) { c.input.SetFocused(f) }
+
+func (c *CommandLineWidget) Text() string { return c.input.Text() }
+
+// SetText replaces the text. OnChange fires, matching keystroke behaviour so
+// incremental consumers (search-as-you-type) see every change.
+func (c *CommandLineWidget) SetText(text string) { c.input.SetText(text) }
+
+func (c *CommandLineWidget) Height() int { return CommandLineHeight }
+
+// layout computes the box geometry for a surface of the given size, and reports
+// whether there is room to draw at all. The box sits directly above the
+// one-row status bar.
+func commandLineLayout(w, h int) (x, y, width int, ok bool) {
+	if w < 4 || h < CommandLineHeight+1 {
+		return 0, 0, 0, false
+	}
+	return 0, h - CommandLineHeight - 1, w, true
+}
+
+func (c *CommandLineWidget) Render(surface Surface) {
+	w, h := surface.Size()
+	x, y, width, ok := commandLineLayout(w, h)
+	if !ok {
+		c.laidOut = false
+		return
+	}
+	c.boxX, c.boxY, c.boxW = x, y, width
+	c.laidOut = true
+
+	borders := term.RoundedBorderSet()
+	if c.Borders != nil {
+		borders = *c.Borders
+	}
+
+	surface.ClearRect(x, y, width, CommandLineHeight, term.StyleDefault)
+	surface.DrawBorder(x, y, width, CommandLineHeight, borders, term.StyleBorderActive)
+
+	innerX := x + 2
+	innerY := y + 1
+	innerW := width - 4
+	if innerW <= 0 {
+		return
+	}
+
+	ox, oy := surface.Origin()
+	c.input.SetRect(Rect{X: ox + innerX, Y: oy + innerY, W: innerW, H: 1})
+	c.input.Render(surface.Sub(Rect{X: innerX, Y: innerY, W: innerW, H: 1}))
+}
+
+func (c *CommandLineWidget) CursorPosition() (int, int, bool) {
+	if !c.laidOut {
+		return 0, 0, false
+	}
+	return c.input.CursorPosition()
+}
+
+func (c *CommandLineWidget) HandleEvent(ev tcell.Event) EventResult {
+	switch tev := ev.(type) {
+	case *tcell.EventKey:
+		return c.handleKey(tev)
+	case *tcell.EventMouse:
+		return c.input.HandleEvent(tev)
+	}
+	return EventIgnored
+}
+
+func (c *CommandLineWidget) handleKey(kev *tcell.EventKey) EventResult {
+	switch kev.Key() {
+	case tcell.KeyEnter:
+		// The overlay sits above Root's Escape handling, so submit/cancel are
+		// ours to own.
+		if c.OnSubmit != nil {
+			c.OnSubmit(c.input.Text())
+		}
+		return EventConsumed
+	case tcell.KeyEscape:
+		if c.OnCancel != nil {
+			c.OnCancel()
+		}
+		return EventConsumed
+	}
+	return c.input.HandleEvent(kev)
+}
+
+// Input exposes the inner line editor. Clipboard keys are handled by the input
+// itself, so this exists for tests and callers that need finer control.
+func (c *CommandLineWidget) Input() *widgets.InputWidget { return c.input }

--- a/internal/ui/commandline_widget_test.go
+++ b/internal/ui/commandline_widget_test.go
@@ -1,0 +1,192 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func newCommandLineSurface(w, h int) ([][]term.Cell, Surface) {
+	cells := make([][]term.Cell, h)
+	for y := range cells {
+		cells[y] = make([]term.Cell, w)
+		for x := range cells[y] {
+			cells[y][x] = term.Cell{Ch: ' '}
+		}
+	}
+	return cells, NewRenderSurface(cells, Rect{X: 0, Y: 0, W: w, H: h})
+}
+
+func cellRow(cells [][]term.Cell, y int) string {
+	var b strings.Builder
+	for _, c := range cells[y] {
+		ch := c.Ch
+		if ch == 0 {
+			ch = ' '
+		}
+		b.WriteRune(ch)
+	}
+	return b.String()
+}
+
+func typeInto(c *CommandLineWidget, s string) {
+	for _, r := range s {
+		c.HandleEvent(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone))
+	}
+}
+
+func TestCommandLineRendersAboveStatusBar(t *testing.T) {
+	c := NewCommandLineWidget(":")
+	typeInto(c, "%s/old/new/g")
+
+	cells, surface := newCommandLineSurface(40, 10)
+	c.SetRect(Rect{X: 0, Y: 0, W: 40, H: 10})
+	c.Render(surface)
+
+	// 3 rows ending one row above the status bar row (h-1).
+	top, text, bottom := cellRow(cells, 6), cellRow(cells, 7), cellRow(cells, 8)
+	if !strings.HasSuffix(strings.TrimRight(top, " "), "╮") {
+		t.Errorf("expected top border on row 6, got %q", top)
+	}
+	if !strings.Contains(text, ":%s/old/new/g") {
+		t.Errorf("expected prefix+text on row 7, got %q", text)
+	}
+	if !strings.HasSuffix(strings.TrimRight(bottom, " "), "╯") {
+		t.Errorf("expected bottom border on row 8, got %q", bottom)
+	}
+	// The status bar row must be left untouched.
+	if strings.TrimSpace(cellRow(cells, 9)) != "" {
+		t.Errorf("expected row 9 (status bar) untouched, got %q", cellRow(cells, 9))
+	}
+}
+
+func TestCommandLineRendersAtVariousWidths(t *testing.T) {
+	for _, w := range []int{12, 40, 200} {
+		c := NewCommandLineWidget("/")
+		typeInto(c, "abc")
+
+		cells, surface := newCommandLineSurface(w, 10)
+		c.SetRect(Rect{X: 0, Y: 0, W: w, H: 10})
+		c.Render(surface)
+
+		row := cellRow(cells, 7)
+		if !strings.Contains(row, "/abc") {
+			t.Errorf("width %d: expected %q to contain \"/abc\"", w, row)
+		}
+		if len([]rune(row)) != w {
+			t.Errorf("width %d: row width %d", w, len([]rune(row)))
+		}
+	}
+}
+
+func TestCommandLineTinyTerminalDoesNotPanic(t *testing.T) {
+	for _, size := range [][2]int{{3, 10}, {40, 3}, {1, 1}, {0, 0}} {
+		c := NewCommandLineWidget(":")
+		typeInto(c, "x")
+		_, surface := newCommandLineSurface(size[0], size[1])
+		c.SetRect(Rect{X: 0, Y: 0, W: size[0], H: size[1]})
+		c.Render(surface)
+		if _, _, visible := c.CursorPosition(); visible {
+			t.Errorf("size %v: cursor should be hidden when there is no room", size)
+		}
+	}
+}
+
+func TestCommandLineTypingAndBackspace(t *testing.T) {
+	c := NewCommandLineWidget(":")
+	typeInto(c, "wqa")
+	if c.Text() != "wqa" {
+		t.Fatalf("expected %q, got %q", "wqa", c.Text())
+	}
+	c.HandleEvent(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModNone))
+	if c.Text() != "wq" {
+		t.Fatalf("expected %q after backspace, got %q", "wq", c.Text())
+	}
+}
+
+func TestCommandLineOnChangeFiresPerKeystroke(t *testing.T) {
+	c := NewCommandLineWidget("/")
+	var seen []string
+	c.OnChange = func(text string) { seen = append(seen, text) }
+
+	typeInto(c, "abc")
+	c.HandleEvent(tcell.NewEventKey(tcell.KeyBackspace2, 0, tcell.ModNone))
+
+	want := []string{"a", "ab", "abc", "ab"}
+	if len(seen) != len(want) {
+		t.Fatalf("expected %v, got %v", want, seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, seen)
+		}
+	}
+}
+
+func TestCommandLineEnterSubmits(t *testing.T) {
+	c := NewCommandLineWidget(":")
+	submitted := ""
+	calls := 0
+	c.OnSubmit = func(text string) { submitted = text; calls++ }
+	c.OnCancel = func() { t.Fatal("cancel must not fire on Enter") }
+
+	typeInto(c, "s/a/b/")
+	c.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+
+	if calls != 1 || submitted != "s/a/b/" {
+		t.Fatalf("expected 1 submit of %q, got %d of %q", "s/a/b/", calls, submitted)
+	}
+}
+
+func TestCommandLineEscapeCancels(t *testing.T) {
+	c := NewCommandLineWidget(":")
+	cancelled := 0
+	c.OnCancel = func() { cancelled++ }
+	c.OnSubmit = func(string) { t.Fatal("submit must not fire on Escape") }
+
+	typeInto(c, "q")
+	if res := c.HandleEvent(tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone)); res != EventConsumed {
+		t.Fatalf("expected Escape to be consumed, got %v", res)
+	}
+	if cancelled != 1 {
+		t.Fatalf("expected 1 cancel, got %d", cancelled)
+	}
+}
+
+func TestCommandLineSetTextNotifies(t *testing.T) {
+	c := NewCommandLineWidget(":")
+	var last string
+	c.OnChange = func(text string) { last = text }
+	c.SetText("noh")
+	if c.Text() != "noh" || last != "noh" {
+		t.Fatalf("expected text and OnChange %q, got %q / %q", "noh", c.Text(), last)
+	}
+}
+
+func TestCommandLineCursorFollowsText(t *testing.T) {
+	c := NewCommandLineWidget(":")
+	typeInto(c, "abc")
+
+	_, surface := newCommandLineSurface(40, 10)
+	c.SetRect(Rect{X: 0, Y: 0, W: 40, H: 10})
+	c.Render(surface)
+
+	x, y, visible := c.CursorPosition()
+	if !visible {
+		t.Fatal("expected cursor to be visible")
+	}
+	// box x=0, inner starts at 2, one prefix rune, three typed runes.
+	if x != 2+1+3 || y != 7 {
+		t.Fatalf("expected cursor at (6,7), got (%d,%d)", x, y)
+	}
+}
+
+func TestCommandLineDefaultPrefix(t *testing.T) {
+	c := NewCommandLineWidget("")
+	if c.Prefix != ":" {
+		t.Fatalf("expected default prefix %q, got %q", ":", c.Prefix)
+	}
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -119,6 +119,18 @@ func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 		return r.handleMouse(ev)
 	}
 
+	// Plugin key interceptors run before Escape handling and chords so modal
+	// plugins (e.g. Vim mode) can own the keyboard. ForceKeys and overlays stay
+	// above: a plugin must never be able to swallow the terminal-toggle escape
+	// hatch or steal keys from a modal dialog.
+	//
+	// A chord already in flight also outranks the interceptor: its continuation
+	// keys are plain runes (the `s` of `ctrl+k s`), which a modal plugin would
+	// otherwise consume, silently breaking every chord binding.
+	if r.chord == nil && r.KeyInterceptor != nil && r.KeyInterceptor(kev) {
+		return EventConsumed
+	}
+
 	if kev.Key() == tcell.KeyEscape {
 		for _, dismiss := range r.EscapeDismissers {
 			if dismiss() {
@@ -144,10 +156,6 @@ func (r *Root) HandleEvent(ev tcell.Event) EventResult {
 		if rk, ok := r.Focused.(RawKeyConsumer); ok && rk.WantsRawKeys() {
 			return r.handleRawKeyConsumer(kev)
 		}
-	}
-
-	if r.KeyInterceptor != nil && r.KeyInterceptor(kev) {
-		return EventConsumed
 	}
 
 	if r.Focused != nil {

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -5,14 +5,14 @@ Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
 
 ## Status
 
-Under construction, built in phases. Currently at **Phase 2**.
+Under construction, built in phases. Currently at **Phase 3**.
 
 | Phase | Scope | State |
 |---|---|---|
 | 0 | Mode state machine, normal/insert, Esc, status indicator | ✅ |
 | 1 | Motions and counts | ✅ |
 | 2 | Insert mode and simple edits | ✅ |
-| 3 | Operators and text objects | ⬜ |
+| 3 | Operators and text objects | ✅ |
 | 4 | Visual modes | ⬜ |
 | 5 | Registers, marks, macros, `.` repeat | ⬜ |
 | 6 | Ex command line, search, editor integration | ⬜ |
@@ -48,8 +48,7 @@ Every motion below accepts a `{count}` prefix (`3j`, `5w`, `2fx`, `10G`).
 | `~` | Toggle case of `{count}` characters and advance |
 | `J` `gJ` | Join `{count}` lines, with / without an inserted space |
 | `u` `Ctrl-R` | Undo / redo `{count}` times (delegates to `editor.undo` / `editor.redo`) |
-| `>>` `<<` | Indent / dedent `{count}` lines by one shiftwidth |
-| `==` | Reindent `{count}` lines (heuristic, see below) |
+| `p` `P` | Paste `{count}` times after / before the cursor (linewise- and charwise-aware) |
 | `Ctrl-A` `Ctrl-X` | Increment / decrement the number at or after the cursor by `{count}` |
 
 ### Motions
@@ -86,7 +85,62 @@ Normal mode also overrides `Ctrl-D`, `Ctrl-U`, `Ctrl-E`, `Ctrl-F`, `Ctrl-Y`,
 `editor.cut` and `search.replace`. That is intended — those commands remain
 reachable from insert mode, the command palette, and with Vim mode disabled.
 
-### Known gaps in Phase 2
+### Operators
+
+Full `{count}{operator}{count}{motion|textobject}` composition — the two counts
+multiply, so `2d3w` deletes six words.
+
+| Key | Action |
+|---|---|
+| `d` `c` `y` | Delete / change / yank over a motion or text object |
+| `>` `<` `=` | Indent / dedent / reindent (always linewise) |
+| `gu` `gU` `g~` | Lowercase / uppercase / swap case over a motion or text object |
+| `dd` `cc` `yy` `>>` `<<` `==` | Doubled form: `{count}` whole lines |
+| `guu` `gUU` `g~~` | Doubled form of the case operators (`gugu`, `gUgU`, `g~g~` also work) |
+| `D` `C` `Y` | Shorthand for `d$`, `c$`, `y$` |
+
+Every motion in the table above is a valid operator target, with counts on both
+sides: `d2w`, `3dw`, `2d3w`, `c$`, `y3j`, `dfx`, `dtx`, `d}`, `dG`, `dgg`, `d%`.
+
+Exclusive/inclusive is modelled explicitly, so `dw` stops before the character
+it lands on while `de`, `d$`, `dfx` and `d%` include it, and `dtx` excludes the
+target. Both of Vim's exclusive-motion adjustments are implemented (a motion
+ending in column 1 backs up to the end of the previous line, and becomes
+linewise when it started at or before the first non-blank), which is what makes
+`d}` delete whole paragraph lines. `cw` on a non-blank behaves like `ce`, and a
+`w` motion whose last word ends a line stops there instead of eating the
+newline.
+
+### Text objects
+
+Only valid after an operator.
+
+| Key | Object |
+|---|---|
+| `iw` `aw` `iW` `aW` | Word / WORD, inner or with surrounding whitespace |
+| `i"` `a"` `i'` `a'` | Quoted string (line-scoped, as in Vim) |
+| ``i` `` ``a` `` | Backtick-quoted string |
+| `i(` `a(` `i)` `a)` `ib` `ab` | Parenthesised block |
+| `i[` `a[` `i]` `a]` | Square-bracketed block |
+| `i{` `a{` `i}` `a}` `iB` `aB` | Braced block |
+| `i<` `a<` `i>` `a>` | Angle-bracketed block |
+| `it` `at` | HTML/XML tag body, or the tag including its delimiters |
+| `ip` `ap` | Paragraph (linewise) |
+| `is` `as` | Sentence |
+
+Bracket objects nest and span lines, and take a count (`d2i(` reaches the
+enclosing pair). An inner block whose open brace ends a line and whose close
+brace starts one becomes linewise, which is what makes `di{` clear a code body
+without leaving a blank line.
+
+### Registers
+
+Phase 3 keeps exactly one register: the unnamed `"`. `d`, `c`, `y`, `x`, `X`,
+`s`, `S`, `D`, `C` and `Y` all fill it, and `p` / `P` read it. A linewise yank
+pastes onto a new line below / above; a charwise one pastes after / before the
+cursor. Named registers, the numbered ring and `"x` prefixes are Phase 5.
+
+### Known gaps in Phases 2-3
 
 - **Counts on insert-entry commands are ignored.** `3o` / `3i` repeat the typed
   text on `Esc`, which needs the per-keystroke change log that arrives with `.`
@@ -101,6 +155,17 @@ reachable from insert mode, the command palette, and with Vim mode disabled.
   bracket.
 - **Shiftwidth is hardcoded to 4 spaces.** Reading `editor.tabSize` needs a
   `settings` permission the manifest does not request; wiring it is Phase 7.
+- **`Y` is `y$`, not `yy`.** ttt follows Neovim's default rather than Vim's, so
+  `Y` lines up with `D` and `C`.
+- **`cc` / `S` always preserve indentation**, where Vim only does so with
+  `autoindent` set.
+- **`it` / `at` scan a 500-line window** around the cursor rather than the whole
+  buffer, to keep the key-press path bounded. Tags nested further apart than
+  that are not found.
+- **`is` / `as` are scoped to the paragraph** around the cursor, and recognise
+  `.`/`!`/`?` (plus trailing quotes and brackets) as sentence ends. Vim's
+  abbreviation handling is not reproduced.
+- **No visual mode, registers, marks, macros or `.`** — Phases 4 and 5.
 
 Commands: `Vim: Toggle Vim Mode`, `Vim: Enable Vim Mode`, `Vim: Disable Vim Mode`.
 
@@ -149,6 +214,13 @@ the same buffer.
 side, so every scrolling routine moves the cursor *first* and calls `scroll_to`
 *last* — the other order gets silently undone.
 
+**gopher-lua does not swap.** Multiple assignment is *not* simultaneous when a
+target also appears on the right-hand side: `a, b = b, a` evaluates to `b, b`,
+and `sl, sc, el, ec = el, ec, sl, sc` to `el, ec, el, ec`. This is a gopher-lua
+register-allocation bug, not a Lua semantic — real Lua 5.1 swaps correctly. Every
+swap in `init.lua` therefore goes through explicit temporaries. It is a silent
+wrong-answer bug, so treat any `x, y = y, x` in a ttt plugin as broken.
+
 **Lua 5.1.** gopher-lua implements 5.1 — no `%g` character class, no `goto`.
 Errors thrown inside a `key.press` listener are swallowed and the key falls
 through, which reads exactly like "the plugin ignored my key". Suspect a Lua
@@ -174,5 +246,6 @@ unaffected.
 Tests:
 
 ```sh
-cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js vim-edits.test.js
+cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js \
+  vim-edits.test.js vim-operators.test.js vim-textobjects.test.js
 ```

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -5,7 +5,7 @@ Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
 
 ## Status
 
-Under construction, built in phases. Currently at **Phase 4**.
+Under construction, built in phases. Currently at **Phase 5**.
 
 | Phase | Scope | State |
 |---|---|---|
@@ -14,7 +14,7 @@ Under construction, built in phases. Currently at **Phase 4**.
 | 2 | Insert mode and simple edits | ✅ |
 | 3 | Operators and text objects | ✅ |
 | 4 | Visual modes | ✅ |
-| 5 | Registers, marks, macros, `.` repeat | ⬜ |
+| 5 | Registers, marks, macros, `.` repeat | ✅ |
 | 6 | Ex command line, search, editor integration | ⬜ |
 | 7 | Settings, docs, handoff to `ttt-plugins` | ⬜ |
 
@@ -182,10 +182,72 @@ left edge are skipped rather than padded.
 
 ### Registers
 
-Phase 3 keeps exactly one register: the unnamed `"`. `d`, `c`, `y`, `x`, `X`,
-`s`, `S`, `D`, `C` and `Y` all fill it, and `p` / `P` read it. A linewise yank
-pastes onto a new line below / above; a charwise one pastes after / before the
-cursor. Named registers, the numbered ring and `"x` prefixes are Phase 5.
+A register holds text plus a *kind* — charwise, linewise or blockwise. `d`, `c`,
+`y`, `x`, `X`, `s`, `S`, `D`, `C` and `Y` fill registers, and `p` / `P` read
+them. A linewise register pastes onto a new line below / above, a charwise one
+after / before the cursor, and a blockwise one re-inserts its rectangle
+(padding short rows with spaces and creating lines past the end of the buffer).
+
+`"{register}` prefixes an operator, a `p` / `P`, or a visual-mode operator.
+
+| Register | Meaning |
+|---|---|
+| `""` | Unnamed — every yank and delete lands here |
+| `"a`–`"z` | Named. `"A`–`"Z` *append* to the same slot. |
+| `"0` | The last yank, untouched by deletes |
+| `"1`–`"9` | The delete ring: each linewise or multi-line delete shifts it down |
+| `"-` | The last small (single-line, charwise) delete |
+| `"_` | Blackhole — writes are discarded and the unnamed register is left alone |
+| `"+` `"*` | System clipboard (see the gaps below) |
+
+### Marks
+
+| Key | Action |
+|---|---|
+| `m{a-zA-Z}` | Set a mark at the cursor |
+| `` `{mark} `` | Jump to the exact position |
+| `'{mark}` | Jump to the first non-blank of the marked line |
+| ``` `` ``` `''` | Jump back to the position before the last jump |
+| `` `. `` `'.` | The position of the last change |
+| ``d`a`` `d'a` | Marks are operator targets — backtick exclusive charwise, `'` linewise |
+
+Marks are also settable and jumpable from visual mode, where a jump extends the
+selection. Line numbers are kept correct across edits: an insert or delete above
+a mark shifts it, and a mark inside a deleted span collapses onto the start of
+that span.
+
+### Macros
+
+| Key | Action |
+|---|---|
+| `q{a-z}` | Start recording into a register |
+| `q{A-Z}` | Append to an existing macro |
+| `q` | Stop recording (the status bar shows `recording @q` while it runs) |
+| `@{a-z}` | Replay |
+| `@@` | Replay the last macro played |
+| `{count}@{reg}` | Replay `{count}` times |
+
+Recording captures canonical *tokens*, the same normalized form `token_of()`
+produces, so a replay is literally "feed the tokens back through the dispatcher".
+A replay is not itself recorded, recursion is capped at a depth of 10, and a
+20000-key budget stops a macro that loops without recursing. Each operation in a
+replay is its own undo step, as in Vim.
+
+### Dot repeat
+
+`.` repeats the last buffer-changing command, and `{count}.` re-runs it with a
+new count. It replays a *resolved payload* — operator, target (motion, text
+object, find, mark or doubled key), count, register and any text typed in insert
+mode — rather than replaying keystrokes, so `.` is always exactly one undo step.
+
+Covered: every operator with every target, the single-key edits (`x`, `X`, `D`,
+`~`, `J`, `p`, `P`, `Ctrl-A`, `Ctrl-X`), `r{char}`, every insert-entry command
+with its typed text (`i`, `I`, `a`, `A`, `o`, `O`, `s`, `S`, `C`, `c{motion}`),
+and `R`. A yank changes nothing, so it leaves `.` armed with the previous change
+rather than disarming it.
+
+Counts on insert-entry commands work off the same change log: `3i`, `5a` and
+`3o` type their text once and repeat it on `Esc`, all inside one undo step.
 
 ### Known gaps in Phase 4
 
@@ -202,9 +264,6 @@ cursor. Named registers, the numbered ring and `"x` prefixes are Phase 5.
   line highlights, and blockwise draws its rows with `add_cursor`. The true Vim
   cursor is kept in Lua, so motions and operators are correct; only the status
   bar reading differs.
-- **A blockwise yank is stored charwise**, rows joined with newlines, because
-  the register model has no blockwise flag yet. `p` therefore pastes the rows as
-  lines rather than re-inserting a column. Blockwise paste is Phase 5.
 - **Blockwise `A` does not pad short rows.** Vim fills with spaces out to the
   block's right edge; here the append clamps to the end of the row.
 - **Text objects replace the selection rather than growing it.** `viw` selects
@@ -214,15 +273,35 @@ cursor. Named registers, the numbered ring and `"x` prefixes are Phase 5.
   ordinary binding, not a force key, so the plugin interceptor wins. Paste stays
   reachable from insert mode, the Edit menu and the command palette.
 
+### Known gaps in Phase 5
+
+- **`"+` / `"*` cannot read or write text directly.** There is no clipboard
+  binding in the plugin Lua API (`internal/core/clipboard` exists on the Go side
+  but is not exposed), so `"+y` selects the range and runs `editor.copy`, and
+  `"+p` positions the cursor and runs `editor.paste`. Two consequences: the
+  clipboard carries no register kind, so `"+p` pastes whatever core makes of the
+  text rather than honouring linewise/blockwise; and `{count}"+p` is one undo
+  step per repetition, because core opens its own transaction and undo groups do
+  not nest.
+- **`.` does not repeat a visual-mode operator.** Vim re-applies it to a
+  same-sized region from the cursor; here a visual operator records no payload,
+  so `.` keeps repeating the last normal-mode change instead.
+- **A macro only replays keys the plugin owns.** Pass-through keys (arrows,
+  `Ctrl-S`, chords) are recorded but do nothing on replay, because the replay
+  feeds tokens to the plugin dispatcher rather than to the terminal. Text typed
+  in insert mode *is* replayed — the dispatcher inserts it directly.
+- **An insert session containing an unrepeatable key is not repeatable.** Arrow
+  keys or a paste inside insert mode mark the session dirty, and `.` then keeps
+  the previous change rather than repeating a half-known one.
+- **Marks are not per-buffer and uppercase marks are not global.** `m{A-Z}` sets
+  a mark in the same table as `m{a-z}`; switching tabs does not switch marks.
+- **A mark inside deleted text collapses rather than being invalidated.** Vim
+  drops such a mark; here it moves to the start of the deleted span.
+
 ### Known gaps in Phases 2-3
 
-- **Counts on insert-entry commands are ignored.** `3o` / `3i` repeat the typed
-  text on `Esc`, which needs the per-keystroke change log that arrives with `.`
-  repeat in Phase 5.
 - **`o` / `O` do not autoindent.** They open a column-1 line, matching vanilla
   Vim without `autoindent`.
-- **Backspace in `R` only walks left.** Vim restores the overwritten character;
-  that also needs the Phase 5 change log.
 - **`==` is a heuristic, not an indent engine.** ttt has none, so `==` copies
   the previous non-blank line's (space) indent, adds one shiftwidth if that line
   ends with `{`/`(`/`[`/`:`, and removes one if this line starts with a closing
@@ -239,7 +318,6 @@ cursor. Named registers, the numbered ring and `"x` prefixes are Phase 5.
 - **`is` / `as` are scoped to the paragraph** around the cursor, and recognise
   `.`/`!`/`?` (plus trailing quotes and brackets) as sentence ends. Vim's
   abbreviation handling is not reproduced.
-- **No registers, marks, macros or `.`** — Phase 5.
 
 Commands: `Vim: Toggle Vim Mode`, `Vim: Enable Vim Mode`, `Vim: Disable Vim Mode`.
 
@@ -284,6 +362,13 @@ group themselves and let `leave_insert()` close it on `Esc`, which is what makes
 one. It appends `"\n"` at the end of the current line instead, which produces
 the same buffer.
 
+**Marks ride on an editor shim.** There is no buffer-change event to hang mark
+adjustment off, so `init.lua` wraps `editor.insert`, `editor.replace` and
+`editor.set_line` in a table that forwards everything else to the real module
+through `__index`. The wrappers shift mark line numbers by the newline delta of
+the edit and record the `.` mark. The module itself is never mutated, so no
+other plugin sees the override.
+
 **Cursor writes scroll.** `set_cursor` calls `EnsureCursorVisible` on the Go
 side, so every scrolling routine moves the cursor *first* and calls `scroll_to`
 *last* — the other order gets silently undone.
@@ -322,5 +407,5 @@ Tests:
 ```sh
 cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js \
   vim-edits.test.js vim-operators.test.js vim-textobjects.test.js \
-  vim-visual.test.js
+  vim-visual.test.js vim-registers.test.js vim-macros.test.js
 ```

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -5,7 +5,7 @@ Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
 
 ## Status
 
-Under construction, built in phases. Currently at **Phase 3**.
+Under construction, built in phases. Currently at **Phase 4**.
 
 | Phase | Scope | State |
 |---|---|---|
@@ -13,7 +13,7 @@ Under construction, built in phases. Currently at **Phase 3**.
 | 1 | Motions and counts | ✅ |
 | 2 | Insert mode and simple edits | ✅ |
 | 3 | Operators and text objects | ✅ |
-| 4 | Visual modes | ⬜ |
+| 4 | Visual modes | ✅ |
 | 5 | Registers, marks, macros, `.` repeat | ⬜ |
 | 6 | Ex command line, search, editor integration | ⬜ |
 | 7 | Settings, docs, handoff to `ttt-plugins` | ⬜ |
@@ -82,7 +82,8 @@ equivalent. The binding is still in the motion table, so rebinding
 Normal mode also overrides `Ctrl-D`, `Ctrl-U`, `Ctrl-E`, `Ctrl-F`, `Ctrl-Y`,
 `Ctrl-A`, `Ctrl-X` and `Ctrl-R`, which core binds to `multicursor.selectNext`,
 `editor.autocomplete`, `editor.redo`, `search.find`, `editor.selectAll`,
-`editor.cut` and `search.replace`. That is intended — those commands remain
+`editor.cut` and `search.replace`. `Ctrl-V` (`editor.paste`) is overridden the
+same way, for visual block mode. That is intended — those commands remain
 reachable from insert mode, the command palette, and with Vim mode disabled.
 
 ### Operators
@@ -133,12 +134,85 @@ enclosing pair). An inner block whose open brace ends a line and whose close
 brace starts one becomes linewise, which is what makes `di{` clear a code body
 without leaving a blank line.
 
+### Visual modes
+
+| Key | Action |
+|---|---|
+| `v` `V` `Ctrl-V` | Charwise / linewise / blockwise visual. The same key again exits; a different one switches mode and keeps the anchor. |
+| `Esc` | Leave visual mode, cursor stays where the motion left it |
+| `o` | Swap the cursor and the anchor |
+| `O` | Blockwise: swap the corners horizontally. Elsewhere the same as `o`. |
+| `gv` | Reselect the previous visual range (also after an operator ran on it) |
+
+Every motion in the table above extends the selection from the anchor, counts
+included (`v3l`, `v2e`, `Vjj`, `vfx`). Visual mode is *inclusive*, so `vwd`
+deletes the character `w` lands on, unlike normal-mode `dw`.
+
+| Operator | Action |
+|---|---|
+| `d` `x` | Delete the selection |
+| `c` `s` | Delete the selection and insert |
+| `y` | Yank the selection |
+| `p` `P` | Replace the selection with the register; the replaced text becomes the new unnamed register |
+| `>` `<` `=` | Shift / reindent the lines the selection touches (`{count}>` shifts repeatedly) |
+| `gu` `gU` `g~` | Lowercase / uppercase / swap case |
+| `u` `U` `~` | Visual-mode shorthands for `gu` / `gU` / `g~` |
+| `r{c}` | Replace every selected character with `{c}` |
+| `J` | Join the selected lines |
+| `X` `D` `S` `C` `R` `Y` | Force the operation linewise |
+
+Text objects (`iw`, `aw`, `i(`, `a"`, `ip`, `it`, … — the full table below) *set*
+the selection to the object instead of running an operator, so `viw` selects a
+word and `vipd` deletes a paragraph. A linewise object switches the mode to
+`-- VISUAL LINE --`.
+
+Blockwise adds:
+
+| Key | Action |
+|---|---|
+| `I` | Insert at the left edge of every row |
+| `A` | Append at the right edge of every row |
+| `$` | Ragged right edge — every row runs to its own end |
+| `d` `x` `c` `y` `r` `gu` `gU` `g~` | Operate on the column range of every row |
+
+Blockwise `I`, `A` and `c` place a cursor on every row and hand typing to ttt's
+native multi-cursor path, so the whole thing — the block edit plus everything
+typed before `Esc` — is a single undo step. Rows too short to reach the block's
+left edge are skipped rather than padded.
+
 ### Registers
 
 Phase 3 keeps exactly one register: the unnamed `"`. `d`, `c`, `y`, `x`, `X`,
 `s`, `S`, `D`, `C` and `Y` all fill it, and `p` / `P` read it. A linewise yank
 pastes onto a new line below / above; a charwise one pastes after / before the
 cursor. Named registers, the numbered ring and `"x` prefixes are Phase 5.
+
+### Known gaps in Phase 4
+
+- **The character under the cursor is not painted in a forward charwise
+  selection.** ttt renders a selection as `Selection.Start` .. *live cursor*
+  (`internal/core/selection`), so the anchor is the only value the plugin can
+  choose. Keeping the real cursor on the Vim cursor means a forward range paints
+  `[anchor, cursor)` and the cursor block itself stands in for the last
+  character. A *backward* selection has no such problem — the anchor is shifted
+  one column right and the range is exactly Vim's. Operators are unaffected:
+  `visual_range()` is always inclusive.
+- **`Ln, Col` is not the Vim cursor in `V` and `Ctrl-V` modes.** Linewise
+  parks the real cursor at the end (or start) of the outer line so the whole
+  line highlights, and blockwise draws its rows with `add_cursor`. The true Vim
+  cursor is kept in Lua, so motions and operators are correct; only the status
+  bar reading differs.
+- **A blockwise yank is stored charwise**, rows joined with newlines, because
+  the register model has no blockwise flag yet. `p` therefore pastes the rows as
+  lines rather than re-inserting a column. Blockwise paste is Phase 5.
+- **Blockwise `A` does not pad short rows.** Vim fills with spaces out to the
+  block's right edge; here the append clamps to the end of the row.
+- **Text objects replace the selection rather than growing it.** `viw` selects
+  the word; repeating `iw` re-selects the same word instead of extending to the
+  next one.
+- **`Ctrl-V` overrides `editor.paste`** in normal and visual mode. It is an
+  ordinary binding, not a force key, so the plugin interceptor wins. Paste stays
+  reachable from insert mode, the Edit menu and the command palette.
 
 ### Known gaps in Phases 2-3
 
@@ -165,7 +239,7 @@ cursor. Named registers, the numbered ring and `"x` prefixes are Phase 5.
 - **`is` / `as` are scoped to the paragraph** around the cursor, and recognise
   `.`/`!`/`?` (plus trailing quotes and brackets) as sentence ends. Vim's
   abbreviation handling is not reproduced.
-- **No visual mode, registers, marks, macros or `.`** — Phases 4 and 5.
+- **No registers, marks, macros or `.`** — Phase 5.
 
 Commands: `Vim: Toggle Vim Mode`, `Vim: Enable Vim Mode`, `Vim: Disable Vim Mode`.
 
@@ -247,5 +321,6 @@ Tests:
 
 ```sh
 cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js \
-  vim-edits.test.js vim-operators.test.js vim-textobjects.test.js
+  vim-edits.test.js vim-operators.test.js vim-textobjects.test.js \
+  vim-visual.test.js
 ```

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -5,13 +5,13 @@ Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
 
 ## Status
 
-Under construction, built in phases. Currently at **Phase 1**.
+Under construction, built in phases. Currently at **Phase 2**.
 
 | Phase | Scope | State |
 |---|---|---|
 | 0 | Mode state machine, normal/insert, Esc, status indicator | ✅ |
 | 1 | Motions and counts | ✅ |
-| 2 | Insert mode and simple edits | ⬜ |
+| 2 | Insert mode and simple edits | ✅ |
 | 3 | Operators and text objects | ⬜ |
 | 4 | Visual modes | ⬜ |
 | 5 | Registers, marks, macros, `.` repeat | ⬜ |
@@ -29,9 +29,28 @@ Every motion below accepts a `{count}` prefix (`3j`, `5w`, `2fx`, `10G`).
 
 | Key | Action |
 |---|---|
-| `i` | Enter insert mode |
-| `Esc`, `Ctrl-[` | Return to normal mode (cursor clamps back onto a character) |
+| `i` `a` | Insert before / after the cursor |
+| `I` `A` | Insert at the first non-blank / end of line |
+| `o` `O` | Open a line below / above and insert |
+| `gi` | Resume insert where it was last left |
+| `R` | Replace (overtype) mode until `Esc` |
+| `Esc`, `Ctrl-[` | Return to normal mode (cursor steps one column left and clamps onto a character) |
 | — | Printable keys in normal mode are swallowed, never typed |
+
+### Edits
+
+| Key | Action |
+|---|---|
+| `x` `X` | Delete `{count}` characters forward / backward |
+| `D` `C` | Delete / change to end of line (`{count}` extends over following lines) |
+| `s` `S` | Substitute `{count}` characters / whole lines, then insert |
+| `r{c}` | Replace `{count}` characters with `{c}` (refused if it runs past the line end) |
+| `~` | Toggle case of `{count}` characters and advance |
+| `J` `gJ` | Join `{count}` lines, with / without an inserted space |
+| `u` `Ctrl-R` | Undo / redo `{count}` times (delegates to `editor.undo` / `editor.redo`) |
+| `>>` `<<` | Indent / dedent `{count}` lines by one shiftwidth |
+| `==` | Reindent `{count}` lines (heuristic, see below) |
+| `Ctrl-A` `Ctrl-X` | Increment / decrement the number at or after the cursor by `{count}` |
 
 ### Motions
 
@@ -61,10 +80,27 @@ interceptor by design (`internal/ui/root.go`). `PgUp` is provided as the
 equivalent. The binding is still in the motion table, so rebinding
 `sidebar.toggle` makes `Ctrl-B` work.
 
-Normal mode also overrides `Ctrl-D`, `Ctrl-U`, `Ctrl-E`, `Ctrl-F` and `Ctrl-Y`,
-which core binds to `multicursor.selectNext`, `editor.autocomplete`,
-`editor.redo` and `search.find`. That is intended — those commands remain
+Normal mode also overrides `Ctrl-D`, `Ctrl-U`, `Ctrl-E`, `Ctrl-F`, `Ctrl-Y`,
+`Ctrl-A`, `Ctrl-X` and `Ctrl-R`, which core binds to `multicursor.selectNext`,
+`editor.autocomplete`, `editor.redo`, `search.find`, `editor.selectAll`,
+`editor.cut` and `search.replace`. That is intended — those commands remain
 reachable from insert mode, the command palette, and with Vim mode disabled.
+
+### Known gaps in Phase 2
+
+- **Counts on insert-entry commands are ignored.** `3o` / `3i` repeat the typed
+  text on `Esc`, which needs the per-keystroke change log that arrives with `.`
+  repeat in Phase 5.
+- **`o` / `O` do not autoindent.** They open a column-1 line, matching vanilla
+  Vim without `autoindent`.
+- **Backspace in `R` only walks left.** Vim restores the overwritten character;
+  that also needs the Phase 5 change log.
+- **`==` is a heuristic, not an indent engine.** ttt has none, so `==` copies
+  the previous non-blank line's (space) indent, adds one shiftwidth if that line
+  ends with `{`/`(`/`[`/`:`, and removes one if this line starts with a closing
+  bracket.
+- **Shiftwidth is hardcoded to 4 spaces.** Reading `editor.tabSize` needs a
+  `settings` permission the manifest does not request; wiring it is Phase 7.
 
 Commands: `Vim: Toggle Vim Mode`, `Vim: Enable Vim Mode`, `Vim: Disable Vim Mode`.
 
@@ -91,10 +127,23 @@ Two rules follow from that:
   friends keep working without the plugin needing to know about chords.
 
 **Cursor semantics.** Normal mode puts the cursor *on* a character, so columns
-clamp to `#line`; insert mode allows one past the end. `clamp_cursor()` runs on
-the insert → normal transition. (Vim additionally steps the cursor one column
-left on `Esc`; that belongs with the Phase 2 insert-mode work and is not done
-yet.)
+clamp to `#line`; insert mode allows one past the end. `leave_insert()` runs on
+the insert → normal transition: it records the position for `gi`, steps the
+cursor one column left the way Vim does, then clamps.
+
+**Undo atomicity.** Every Vim operation is exactly one undo step — `3x` undoes
+as one `u`. Each edit is bracketed by `editor.begin_undo_group()` /
+`end_undo_group()`. Undo transactions do **not** nest: `BeginTransaction` resets
+the transaction start index (`internal/core/undo/undo.go`), so a second `begin`
+mid-operation silently drops everything before it from the group. Commands that
+edit *and then* enter insert mode (`o`, `C`, `s`, `S`, `gi`) therefore open the
+group themselves and let `leave_insert()` close it on `Esc`, which is what makes
+`o` + typing + `Esc` a single undo.
+
+**`o` on the last line.** `PluginEditorAPI.Insert` rejects `line >= len(Lines)`
+(`internal/app/plugin_api.go`), so `o` cannot address the line *after* the last
+one. It appends `"\n"` at the end of the current line instead, which produces
+the same buffer.
 
 **Cursor writes scroll.** `set_cursor` calls `EnsureCursorVisible` on the Go
 side, so every scrolling routine moves the cursor *first* and calls `scroll_to`
@@ -125,5 +174,5 @@ unaffected.
 Tests:
 
 ```sh
-cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js
+cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js vim-edits.test.js
 ```

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -5,7 +5,7 @@ Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
 
 ## Status
 
-Under construction, built in phases. Currently at **Phase 5**.
+Under construction, built in phases. Currently at **Phase 6**.
 
 | Phase | Scope | State |
 |---|---|---|
@@ -15,7 +15,7 @@ Under construction, built in phases. Currently at **Phase 5**.
 | 3 | Operators and text objects | ✅ |
 | 4 | Visual modes | ✅ |
 | 5 | Registers, marks, macros, `.` repeat | ✅ |
-| 6 | Ex command line, search, editor integration | ⬜ |
+| 6 | Ex command line, search, editor integration | ✅ |
 | 7 | Settings, docs, handoff to `ttt-plugins` | ⬜ |
 
 `cheatsheet.md` is a vendored copy of [ibhagwan/vim-cheatsheet](https://github.com/ibhagwan/vim-cheatsheet),
@@ -249,6 +249,162 @@ rather than disarming it.
 Counts on insert-entry commands work off the same change log: `3i`, `5a` and
 `3o` type their text once and repeat it on `Esc`, all inside one undo step.
 
+### Search
+
+| Key | Action |
+|---|---|
+| `/{pattern}` `?{pattern}` | Search forward / backward. The cursor previews the first match as you type; `Enter` confirms, `Esc` restores the position you started from. |
+| `n` `N` | Next / previous match, in the direction of the original search and reversed. Wraps, and says so (`search hit BOTTOM, continuing at TOP`). |
+| `{count}n` | Skip `{count}` matches. |
+| `*` `#` | Search forward / backward for the whole word under the cursor. |
+| `d/pat` `c/pat` `y/pat` | A search is an ordinary exclusive charwise motion, so it is a valid operator target. `.` repeats it against the *next* match, as in Vim. |
+
+The preview only moves the cursor and scrolls; it never edits the buffer.
+Search is case sensitive by default; `\c` anywhere in the pattern makes that
+one search case insensitive, `\C` forces it back on.
+
+### Ex commands
+
+| Command | Action |
+|---|---|
+| `:{n}` `:$` `:.` | Jump to line *n* / the last line / the current line. A bare range lands on its last address, so `:1,5` goes to line 5. |
+| `:w` | Save (`file.save`) |
+| `:w {file}` | Write the buffer to another path (see the gaps below) |
+| `:q` | Quit (`editor.quit`), which prompts when anything is unsaved |
+| `:q!` | Quit immediately, discarding changes |
+| `:wq` `:x` | Save, then quit |
+| `:e {file}` | Open a file in a new tab |
+| `:noh` | Clear the find highlights (`search.clearFind`) |
+| `:reg` | Show the registers |
+| `:marks` | Show the marks |
+| `:s/…` | Substitute (below) |
+
+Relative paths in `:w` and `:e` are resolved against the **directory of the file
+being edited**, not the process working directory — ttt is normally launched
+from somewhere else entirely.
+
+### Substitution
+
+`:[range]s{delim}{pattern}{delim}{replacement}{delim}[flags]`. The delimiter is
+whatever character follows the `s`, so `:s#a#b#` works as well as `:s/a/b/`.
+
+| Range | Meaning |
+|---|---|
+| *(none)* | The current line |
+| `%` | The whole file |
+| `{n}` | Line *n* |
+| `{n},{m}` | Lines *n* to *m* |
+| `.,$` | The cursor line to the end |
+
+| Flag | Meaning |
+|---|---|
+| `g` | Every match on the line, not just the first |
+| `i` | Ignore case |
+| `c` | Confirm each match. The command line becomes the prompt, and a single `y`, `n`, `a` or `q` answers it — no Enter needed. |
+
+A whole run is **one undo step**, however many lines it touched: `:%s/a/b/g`
+across a thousand lines undoes with a single `u`. With `c`, every match is
+located up front and nothing is written until the last answer is in, so the
+confirmed run is atomic too.
+
+In the replacement, `&` and `\0` stand for the whole match, `\1`–`\9` for the
+groups, and `\&` `\\` for literal `&` and `\`.
+
+#### Which regex subset is supported
+
+**Vim regexes are not Lua patterns, and Lua patterns are not a regex engine.**
+Rather than silently misreading a pattern, anything that cannot be represented
+is *rejected* with a message. What is translated:
+
+| Vim | Meaning |
+|---|---|
+| `.` `*` `^` `$` | Any character, zero-or-more, start-of-line, end-of-line |
+| `[abc]` `[^abc]` `[a-z]` | Character class, including `\d`-style escapes inside it |
+| `\+` | One or more |
+| `\?` `\=` | Zero or one |
+| `\( \)` | Capture group — but a Lua group **cannot be quantified**, so it is only useful for capturing, never as `\(ab\)\+` |
+| `\d \D \s \S \a \A \l \L \u \U \x \X \o` | Character classes |
+| `\w \W` | Word character, Vim's definition (`[A-Za-z0-9_]`) |
+| `\n \t \e` | Literal control characters |
+| `\c` `\C` | Force case insensitive / sensitive for this pattern |
+| `\< \>` | Word boundary, **only at the very start / end of the pattern** |
+| `( ) + ? { } \| ~ &` | Literal, as in Vim's default "magic" mode |
+
+Rejected with an error, never guessed at:
+
+- `\|` alternation
+- `\{n,m}` counted repeats
+- `\@=` `\@!` and the rest of the lookaround family
+- `\%(` groups, `\zs`, `\ze`
+- `\<` or `\>` anywhere except the pattern edges
+- a replacement containing `
+` or `
+` (a substitution cannot split a line)
+
+Two further deviations worth knowing:
+
+- **`\<` / `\>` are not compiled into the pattern.** gopher-lua has no `%f`
+  frontier pattern, so the boundary is checked against the neighbouring byte
+  after a match is found. That is why they only work at the edges. `*` and `#`
+  use the same mechanism, so they are reliably whole-word.
+- **Empty matches are skipped.** Vim would accept them; here they are useless
+  for `n` and dangerous for `:s`.
+
+### Editor integration
+
+| Key | Command |
+|---|---|
+| `gt` `gT` | `tab.next` / `tab.prev` |
+| `za` | `fold.toggle` |
+| `zR` `zM` | `fold.expandAll` / `fold.collapseAll` |
+| `Ctrl-W w` `Ctrl-W W` | `focus.nextGroup` / `focus.prevGroup` |
+
+Everything here delegates to a core command. Keys with **no core equivalent are
+deliberately absent** rather than approximated:
+
+- **`]c` / `[c` (next/previous changed hunk) and `]f` / `[f` (next/previous
+  changed file) are not implemented.** ttt has no hunk- or changed-file
+  navigation commands at all — only `changes.refresh` and `sidebar.changes`.
+  They need Go-side commands first.
+- **`zo` / `zc` are not implemented.** Core registers `fold.toggle`,
+  `fold.expandAll` and `fold.collapseAll`, but no open-only or close-only
+  command, and mapping both `zo` and `zc` onto a toggle would be wrong.
+- **`Ctrl-W` splits are not implemented.** ttt has no editor split or window
+  model; `ContentSplit` is a fixed editor/bottom-panel layout. Only the two
+  focus-cycling commands have a genuine analogue, so only `Ctrl-W w` and
+  `Ctrl-W W` are bound.
+
+**`Ctrl-W` is a prefix in normal mode**, which overrides core's `tab.close`
+binding — the same trade as `Ctrl-V`, `Ctrl-D` and the rest. Close-tab stays
+reachable from the tab bar, the File menu and the command palette.
+
+### Known gaps in Phase 6
+
+- **`:w {file}` is scoped to the workspace roots.** It goes through
+  `ttt.fs.write`, and `PluginFilesystemAPI` refuses any path outside a workspace
+  folder (`internal/app/plugin_api.go`). Opening a bare *file* rather than a
+  folder therefore leaves `:w {file}` with nowhere to write. There is no core
+  command that saves to a supplied path — `file.saveAs` opens its own dialog and
+  cannot be given one, because `command.Command.Handler` is `func()` and takes
+  no arguments.
+- **`:q` quits the editor rather than closing a window.** ttt has no window
+  model, and `editor.quit` is the command that already prompts on unsaved
+  changes. `:q!` goes through `ttt.quit()`, since no force-quit command is
+  registered.
+- **Search matches are not highlighted.** There is no plugin API for adding
+  editor highlights, so `/` moves the cursor and nothing more. `:noh` delegates
+  to `search.clearFind`, which clears core's own find highlights.
+- **`:s` cannot add or remove lines.** The replacement is applied with
+  `editor.set_line`, so `\r` in a replacement is rejected rather than splitting
+  the line.
+- **`:s` with an empty pattern reuses the last *search* pattern**, not the last
+  *substitute* pattern, and `~` in a replacement is a literal tilde rather than
+  the previous replacement.
+- **`/`, `?`, `n`, `N` and `:` are normal-mode only.** In visual mode they fall
+  through; Vim would extend the selection to the match and prefill `:'<,'>`.
+- **Only `{n}`, `.`, `$` and `%` are valid addresses.** `:/pat/`, `:'a,'b`,
+  `:+3` and `:-2` are not parsed.
+
 ### Known gaps in Phase 4
 
 - **The character under the cursor is not painted in a forward charwise
@@ -380,6 +536,15 @@ register-allocation bug, not a Lua semantic — real Lua 5.1 swaps correctly. Ev
 swap in `init.lua` therefore goes through explicit temporaries. It is a silent
 wrong-answer bug, so treat any `x, y = y, x` in a ttt plugin as broken.
 
+**200 locals per function.** The main chunk is a single Lua function, and Lua
+5.1 allows at most 200 local variables in one — `init.lua` is now within a
+handful of slots of that ceiling. Phase 6 is therefore wrapped in a `do ... end`
+block, which releases its registers at `end`, and re-exports the handful of
+names the dispatcher needs through one `vim6` table. Without it the whole file
+fails to load with `compile error: too many local variables`, which surfaces as
+the plugin simply not being there — no status indicator, every key passed
+through. Future phases should follow the same pattern.
+
 **Lua 5.1.** gopher-lua implements 5.1 — no `%g` character class, no `goto`.
 Errors thrown inside a `key.press` listener are swallowed and the key falls
 through, which reads exactly like "the plugin ignored my key". Suspect a Lua
@@ -407,5 +572,6 @@ Tests:
 ```sh
 cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js \
   vim-edits.test.js vim-operators.test.js vim-textobjects.test.js \
-  vim-visual.test.js vim-registers.test.js vim-macros.test.js
+  vim-visual.test.js vim-registers.test.js vim-macros.test.js \
+  vim-search.test.js vim-ex.test.js
 ```

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -5,12 +5,12 @@ Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
 
 ## Status
 
-Under construction, built in phases. Currently at **Phase 0**.
+Under construction, built in phases. Currently at **Phase 1**.
 
 | Phase | Scope | State |
 |---|---|---|
 | 0 | Mode state machine, normal/insert, Esc, status indicator | ✅ |
-| 1 | Motions and counts | ⬜ |
+| 1 | Motions and counts | ✅ |
 | 2 | Insert mode and simple edits | ⬜ |
 | 3 | Operators and text objects | ⬜ |
 | 4 | Visual modes | ⬜ |
@@ -23,11 +23,48 @@ used as the coverage checklist.
 
 ## Supported today
 
+Every motion below accepts a `{count}` prefix (`3j`, `5w`, `2fx`, `10G`).
+
+### Modes
+
 | Key | Action |
 |---|---|
 | `i` | Enter insert mode |
-| `Esc`, `Ctrl-[` | Return to normal mode |
+| `Esc`, `Ctrl-[` | Return to normal mode (cursor clamps back onto a character) |
 | — | Printable keys in normal mode are swallowed, never typed |
+
+### Motions
+
+| Key | Action |
+|---|---|
+| `h` `j` `k` `l` | Left, down, up, right. `j`/`k` keep a sticky goal column. |
+| `+` `-` | First non-blank of the next / previous line |
+| `0` `^` `$` `g_` | Line start, first non-blank, line end, last non-blank |
+| `w` `W` `b` `B` | Word / WORD forward and backward |
+| `e` `E` `ge` `gE` | End of next / previous word / WORD |
+| `gg` `G` | First / last line (`{n}gg` and `{n}G` jump to line *n*) |
+| `f{c}` `F{c}` | Forward / backward to `{c}` on the current line |
+| `t{c}` `T{c}` | Forward / backward until just before `{c}` |
+| `;` `,` | Repeat the last `f`/`F`/`t`/`T`, same / opposite direction |
+| `{` `}` | Previous / next blank line |
+| `%` | Matching bracket (delegates to `editor.goToMatchingBracket`) |
+| `H` `M` `L` | Top / middle / bottom of the screen |
+| `Ctrl-D` `Ctrl-U` | Half page down / up |
+| `Ctrl-F` `Ctrl-B`\* | Full page down / up |
+| `PgDn` `PgUp` | Full page down / up (always available, see below) |
+| `Ctrl-E` `Ctrl-Y` | Scroll view one line down / up |
+| `zz` `zt` `zb` | Centre / top / bottom the view on the cursor |
+
+\* **`Ctrl-B` does not reach the plugin.** Core registers it as a *force key*
+for `sidebar.toggle`, and force keys are checked before the plugin key
+interceptor by design (`internal/ui/root.go`). `PgUp` is provided as the
+equivalent. The binding is still in the motion table, so rebinding
+`sidebar.toggle` makes `Ctrl-B` work.
+
+Normal mode also overrides `Ctrl-D`, `Ctrl-U`, `Ctrl-E`, `Ctrl-F` and `Ctrl-Y`,
+which core binds to `multicursor.selectNext`, `editor.autocomplete`,
+`editor.redo` and `search.find`. That is intended — those commands remain
+reachable from insert mode, the command palette, and with Vim mode disabled.
 
 Commands: `Vim: Toggle Vim Mode`, `Vim: Enable Vim Mode`, `Vim: Disable Vim Mode`.
 
@@ -53,6 +90,16 @@ Two rules follow from that:
 - Core skips the interceptor while a chord is in flight, so `ctrl+k s` and
   friends keep working without the plugin needing to know about chords.
 
+**Cursor semantics.** Normal mode puts the cursor *on* a character, so columns
+clamp to `#line`; insert mode allows one past the end. `clamp_cursor()` runs on
+the insert → normal transition. (Vim additionally steps the cursor one column
+left on `Esc`; that belongs with the Phase 2 insert-mode work and is not done
+yet.)
+
+**Cursor writes scroll.** `set_cursor` calls `EnsureCursorVisible` on the Go
+side, so every scrolling routine moves the cursor *first* and calls `scroll_to`
+*last* — the other order gets silently undone.
+
 **Lua 5.1.** gopher-lua implements 5.1 — no `%g` character class, no `goto`.
 Errors thrown inside a `key.press` listener are swallowed and the key falls
 through, which reads exactly like "the plugin ignored my key". Suspect a Lua
@@ -67,7 +114,16 @@ bin/ttt --size 100x30 --plugin plugins/vim/init.lua file.txt \
 ```
 
 Note that running from the repo root also auto-discovers `plugins/vim/` and
-raises a one-time permission dialog. Passing `--plugin` explicitly grants all
-permissions and skips approval.
+raises a one-time permission dialog — for the *discovered* copy, which is a
+second instance alongside the `--plugin` one. That modal swallows every
+keystroke, so a manual `--exec` probe launched from the repo root looks like the
+plugin is ignoring keys. Launch probes from a scratch directory (with an
+absolute `--plugin` path and an absolute file path) to avoid it; the functional
+tests run from `tests/functional/`, which has no `plugins/` dir, so they are
+unaffected.
 
-Tests: `cd tests/functional && npx vitest run vim-mode.test.js`
+Tests:
+
+```sh
+cd tests/functional && npx vitest run vim-mode.test.js vim-motions.test.js
+```

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -3,9 +3,15 @@
 A Vim compatibility layer for ttt, implemented entirely as a Lua plugin.
 Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
 
+> **Requires ttt 1.1.0 or newer.** The plugin depends on core changes that ship
+> in 1.1.0 — the key interceptor's precedence over Escape (needed to leave
+> insert mode) and the `ttt.command_line` API (needed for `:` and `/`). On
+> older builds Esc will not return you to normal mode and the command line will
+> not open.
+
 ## Status
 
-Under construction, built in phases. Currently at **Phase 6**.
+Feature-complete across all seven planned phases.
 
 | Phase | Scope | State |
 |---|---|---|
@@ -16,10 +22,35 @@ Under construction, built in phases. Currently at **Phase 6**.
 | 4 | Visual modes | ✅ |
 | 5 | Registers, marks, macros, `.` repeat | ✅ |
 | 6 | Ex command line, search, editor integration | ✅ |
-| 7 | Settings, docs, handoff to `ttt-plugins` | ⬜ |
+| 7 | Settings, editor-integration commands, docs | ✅ |
 
 `cheatsheet.md` is a vendored copy of [ibhagwan/vim-cheatsheet](https://github.com/ibhagwan/vim-cheatsheet),
 used as the coverage checklist.
+
+## Configuration
+
+Settings live in `settings.json` under a `vim` object and are read through the
+`ttt.settings` API (the manifest requests the `settings` permission with a
+`vim.enabled` / `vim.clipboard` allowlist). Missing keys fall back to the
+default, so an absent `vim` object leaves everything at its default.
+
+| Key | Type | Default | Effect |
+|---|---|---|---|
+| `vim.enabled` | bool | `true` | When `false`, the plugin starts with Vim mode **off**. It can still be toggled on from the command palette (`Vim: Enable Vim Mode` / `Vim: Toggle Vim Mode`). |
+| `vim.clipboard` | bool | `false` | When `true`, every unnamed yank/delete (a plain `y`, `d`, `x`, …) is also mirrored to the system clipboard, reusing the same `editor.copy` path as the `"+` / `"*` registers. When `false`, only explicit `"+` / `"*` touch the clipboard. |
+
+Example:
+
+```json
+{
+  "vim": { "enabled": true, "clipboard": true }
+}
+```
+
+**`vim.timeoutlen` is intentionally not supported.** The dispatcher has no
+pending-key timer — multi-key sequences (`gg`, `dw`, `]c`, …) resolve on the
+next key, not on a timeout — so a timeout length would be a no-op. There is
+nothing to configure.
 
 ## Supported today
 
@@ -358,14 +389,19 @@ Two further deviations worth knowing:
 | `za` | `fold.toggle` |
 | `zR` `zM` | `fold.expandAll` / `fold.collapseAll` |
 | `Ctrl-W w` `Ctrl-W W` | `focus.nextGroup` / `focus.prevGroup` |
+| `]c` `[c` | `diff.nextHunk` / `diff.prevHunk` (next/previous changed hunk) |
+| `]f` `[f` | `changes.nextFile` / `changes.prevFile` (next/previous changed file) |
+
+`]c` / `[c` jump between changed hunks in the current file (the git-gutter
+`LineChanges`); with the gutter disabled or the file untracked they are silent
+no-ops. `]f` / `[f` cycle through the files in the Changes panel, wrapping
+around. Both `[` and `]` are prefixes in normal mode, waiting for the second
+key. The commands they delegate to (`diff.nextHunk`, `diff.prevHunk`,
+`changes.nextFile`, `changes.prevFile`) were added to core in Phase 7.
 
 Everything here delegates to a core command. Keys with **no core equivalent are
 deliberately absent** rather than approximated:
 
-- **`]c` / `[c` (next/previous changed hunk) and `]f` / `[f` (next/previous
-  changed file) are not implemented.** ttt has no hunk- or changed-file
-  navigation commands at all — only `changes.refresh` and `sidebar.changes`.
-  They need Go-side commands first.
 - **`zo` / `zc` are not implemented.** Core registers `fold.toggle`,
   `fold.expandAll` and `fold.collapseAll`, but no open-only or close-only
   command, and mapping both `zo` and `zc` onto a toggle would be wrong.
@@ -438,7 +474,8 @@ reachable from the tab bar, the File menu and the command palette.
   clipboard carries no register kind, so `"+p` pastes whatever core makes of the
   text rather than honouring linewise/blockwise; and `{count}"+p` is one undo
   step per repetition, because core opens its own transaction and undo groups do
-  not nest.
+  not nest. The `vim.clipboard` setting routes plain unnamed yanks/deletes
+  through this same `editor.copy` path, so it inherits the same limitations.
 - **`.` does not repeat a visual-mode operator.** Vim re-applies it to a
   same-sized region from the cursor; here a visual operator records no payload,
   so `.` keeps repeating the last normal-mode change instead.
@@ -462,8 +499,10 @@ reachable from the tab bar, the File menu and the command palette.
   the previous non-blank line's (space) indent, adds one shiftwidth if that line
   ends with `{`/`(`/`[`/`:`, and removes one if this line starts with a closing
   bracket.
-- **Shiftwidth is hardcoded to 4 spaces.** Reading `editor.tabSize` needs a
-  `settings` permission the manifest does not request; wiring it is Phase 7.
+- **Shiftwidth is hardcoded to 4 spaces.** Reading `editor.tabSize` needs it in
+  the manifest's `settings_keys` allowlist. The manifest now requests `settings`,
+  but scoped to `vim.enabled` / `vim.clipboard` only, so `editor.tabSize` is
+  still out of reach — wiring it is a separate change.
 - **`Y` is `y$`, not `yy`.** ttt follows Neovim's default rather than Vim's, so
   `Y` lines up with `D` and `C`.
 - **`cc` / `S` always preserve indentation**, where Vim only does so with

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -1,0 +1,73 @@
+# Vim Mode
+
+A Vim compatibility layer for ttt, implemented entirely as a Lua plugin.
+Tracks [issue #386](https://github.com/eugenioenko/ttt/issues/386).
+
+## Status
+
+Under construction, built in phases. Currently at **Phase 0**.
+
+| Phase | Scope | State |
+|---|---|---|
+| 0 | Mode state machine, normal/insert, Esc, status indicator | ✅ |
+| 1 | Motions and counts | ⬜ |
+| 2 | Insert mode and simple edits | ⬜ |
+| 3 | Operators and text objects | ⬜ |
+| 4 | Visual modes | ⬜ |
+| 5 | Registers, marks, macros, `.` repeat | ⬜ |
+| 6 | Ex command line, search, editor integration | ⬜ |
+| 7 | Settings, docs, handoff to `ttt-plugins` | ⬜ |
+
+`cheatsheet.md` is a vendored copy of [ibhagwan/vim-cheatsheet](https://github.com/ibhagwan/vim-cheatsheet),
+used as the coverage checklist.
+
+## Supported today
+
+| Key | Action |
+|---|---|
+| `i` | Enter insert mode |
+| `Esc`, `Ctrl-[` | Return to normal mode |
+| — | Printable keys in normal mode are swallowed, never typed |
+
+Commands: `Vim: Toggle Vim Mode`, `Vim: Enable Vim Mode`, `Vim: Disable Vim Mode`.
+
+## Design notes
+
+**Single file.** The plugin sandbox strips `package.loaders` down to the preload
+loader (`internal/plugin/sandbox.go`), so a plugin cannot `require` sibling
+`.lua` files. `init.lua` is therefore one file, organized into delimited
+sections.
+
+**Key normalization.** `key.press` delivers `{key, rune, mod}`. Ctrl+letter
+arrives with *both* `key="Ctrl-D"` and `mod="ctrl"`, so `token_of` normalizes
+off the key name first. Canonical tokens: runes keep case (`g` vs `G`), named
+keys lowercase (`esc`), control keys collapse to `ctrl-d`.
+
+**Pass-through discipline.** The core key interceptor sits above Escape
+handling and chords (`internal/ui/root.go`), so this plugin must return `false`
+for every key it does not own — otherwise it silently breaks global bindings.
+Two rules follow from that:
+
+- Esc is passed through when there is nothing Vim-side to cancel, so core
+  `EscapeDismissers` still run.
+- Core skips the interceptor while a chord is in flight, so `ctrl+k s` and
+  friends keep working without the plugin needing to know about chords.
+
+**Lua 5.1.** gopher-lua implements 5.1 — no `%g` character class, no `goto`.
+Errors thrown inside a `key.press` listener are swallowed and the key falls
+through, which reads exactly like "the plugin ignored my key". Suspect a Lua
+error first when a binding mysteriously does nothing.
+
+## Development
+
+```sh
+make build
+bin/ttt --size 100x30 --plugin plugins/vim/init.lua file.txt \
+  --exec "wait 300; type ihello; key esc; wait 100; screenshot /tmp/s.txt; quit"
+```
+
+Note that running from the repo root also auto-discovers `plugins/vim/` and
+raises a one-time permission dialog. Passing `--plugin` explicitly grants all
+permissions and skips approval.
+
+Tests: `cd tests/functional && npx vitest run vim-mode.test.js`

--- a/plugins/vim/cheatsheet.md
+++ b/plugins/vim/cheatsheet.md
@@ -1,0 +1,834 @@
+# iBhagwan's (n)vim cheatsheet
+
+\*\*This cheatsheet was inspired by [Hackjutsu's Vim cheatsheet](https://github.com/hackjutsu/vim-cheatsheet) and Laurent Gregoire's excellent [Vim Quick Reference Card](http://tnerual.eriogerg.free.fr/vimqrc.html).
+
+I've been using vi for over 20 years but always limited it's use for basically only editing \*nix system config files, recently I (re-)discovered (n)vim as the magical editor that it is and decided to make it my main editor for coding, writing markdown and the likes so down the rabbit hole I went. The more I researched the more I fell in love with the software, the below is the accumulation of all my notes and findings.
+
+The cheatsheet assumes at least minimal understanding of motions and operators, to better understand motions, operators and how it all comes together in what is referred to as "the vim language" I highly recommend reading [Jim Denis's stackoverflow answer: Your problem with Vim is that you don't grok vi](https://gist.github.com/nifl/1178878).
+
+Note that everything below works with vanilla vim/nvim and does not require the use of any plugins. I am not opposed to plugins and even use a few which I find extremely helpful but as a philosophy I try to use as much built-in functionality (with minimal keymap changes) as I can before turning to plugins. As you can see below there is **so much** you can do with vanilla Vim that I decided to leave plugins out of the scope of this document. If you'd like to take a look at my custom mappings and plugins, refer to my nvim lua configuration at [nvim-lua](https://github.com/ibhagwan/nvim-lua).
+
+If you'd like to take your Vim to the next level, I highly recommend watching all of [Drew Neil's VimCasts](http://vimcasts.org/episodes/page/8/) they are absolutely wonderful and will blow your mind. When you're ready to jump in the water and test your skills [Vimgolf](http://www.vimgolf.com) is fantastic exercise which will cement all your Vim knowledge and add new tricks to your arsenal. Download [Vimgolf client from here](https://github.com/igrigorik/vimgolf) or it's [lesser known python client by Daniel Stein](https://github.com/dstein64/vimgolf) if you wish to avoid the ruby dependencies.
+
+**Thanks to [/u/-romainl-](https://www.reddit.com/user/-romainl-/) for [his great feedback](https://www.reddit.com/r/vim/comments/gha79v/i_wrote_an_advanced_comprehensive_cheatsheet_for/fq7qeop?utm_source=share&utm_medium=web2x) correcting previous inaccuracies.**
+
+
+### Table of contents:
+
+- [Saving & Exiting Vim](#saving-exiting-vim)
+- [Navigation](#navigation)
+    + [Movement](#movement)
+    + [Scrolling](#scrolling)
+- [Editing](#Editing)
+    + [Insert & Exit](#insert-exit)
+    + [Undo & Repeat](#undo-repeat)
+    + [Basic Editing](#basic-editing)
+    + [INSERT mode](#insert-mode)
+    + [Cut, copy & paste](#cut-copy-and-paste)
+- [VISUAL mode](#visual-mode)
+    + [Selections](#selections)
+    + [Operators](#operators)
+- [Text Objects](#text-objects)
+- [Search & Replace](#search-replace)
+    + [REGEX Examples](#regex-examples)
+    + [Multiple Files](#multiple-files)
+- [Macros](#macros)
+    + [Recursive Macros](#recursive-macros)
+- [Marks](#marks)
+- [Files and Windows](#files-and-windows)
+- [Tabs](#tabs)
+- [Terminal](#term)
+- [Spellcheck](#spellcheck)
+- [Misc Commands](#misc-commands)
+- [Ctrl-R and the Expression Register](#ctrl-r-and-the-expression-register)
+- [Comparing buffers with vimdiff](#comparing-buffers-with-vimdiff)
+- [Folding](#folding)
+
+## <a id="saving-exiting-vim">Saving & Exiting Vim</a>
+```vim
+:w              " write the current file
+:w {file}       " write to {file}
+:wq {file}      " write to {file} and quit
+:saveas {file}  " write to {file}
+:update {file}  " write only if buffer was modified
+:w !sudo tee %  " write the current file using sudo
+:wq :x ZZ       " write the current file and quit
+:q              " quit (fails if there are unsaved changes)
+:q! ZQ          " quit and throw away unsaved changes
+:cq             " quit Vim with exit code
+```
+
+**NOTE:** the `:cq` command is useful in situations when we need to exit-cancel, for example when running `<Esc>v` in bash shell `set -o vi`, when exiting using `:cq` the command won't be executed automatically. Another example is when exiting the output window of `git rebase`, `:cq` will cancel the rebase operation.
+
+## <a id="navigation">Navigation</a>
+### <a id="movement">Movement</a>
+```vim
+    k           " up
+h       l       " left, right
+    j           " down
+```
+```vim
++ -             " first non-blank char line above, below
+H M L           " [H]igh, [M]iddle, [L]ow line of the window
+{n}H {n}L       " line {n} from the top, bottom of the window
+b w             " beginning of word left, right (punctuation considered words)
+B W             " beginning of WORD left, right (spaces separate words)
+e ge            " end of word left, right (punctuation considered words)
+E gE            " end of WORD left, right (spaces separate words)
+0 g0            " start of the line, visual-line
+^ g^            " first non-blank character of the line, visual-line
+$ g$            " last character of the line, visual-line (include <CR>)
+_ g_            " first, last non-blank character of the line (not including <CR>)
+{n}_            " down {n-1} lines on first non-blank character
+gm              " middle of the line
+{n}gg {n}G      " goto line {n}, default first, last line of buffer
+:{n}<CR>        " goto line {n}, (ex mode)
+{n}%            " jump to buf % (e.g. 50% jump to middle of buffer)
+{n}|            " jump to screen column {n} of current line
+f{c} F{c}       " next, previous occurrence of character {c}
+t{c} T{c}       " before ([t]ill) next, previous occurrence of {c}
+; ,             " repeat last fFtT in the same, opposite direction
+( )             " previous, next sentence (jumps after the next '.' or EOL)
+{ }             " previous, next paragraph (jumps to next empty line)
+%               " jump to matching parenthesis ([{}])
+[[ ]]           " backward, forward start section
+[] ][           " backward, forward end of section
+[( ])           " backward, forward unclosed (, )
+[{ ]}           " backward, forward unclosed {, }
+```
+**Note:** When navigating lines with `hjkl^$`, if a line is too long and is wrapped, pressing `j` will move down to the next line even if the current line is wrapping 2 or more lines, to go down 1 "visual" line use `gj` instead. The `g` prefix works the same for other navigation commands `hjkl^$` (`g^` and `g$` for start and end of visual line). A very useful mapping is to map `<up><down>` or `jk` to move by visual lines as long as they aren't prefixed with {count} so we can still use up and down motions (e.g. `10j`) for whole lines:
+
+```
+nnoremap <expr> <Down> (v:count == 0 ? 'g<down>' : '<down>')
+vnoremap <expr> <Down> (v:count == 0 ? 'g<down>' : '<down>')
+nnoremap <expr> <Up> (v:count == 0 ? 'g<up>' : '<up>')
+vnoremap <expr> <Up> (v:count == 0 ? 'g<up>' : '<up>')
+```
+
+### <a id="scrolling">Scrolling</a>
+```vim
+zz or z.        " center screen on cursor
+zb or z-        " scroll the screen so the cursor is at the (b)ottom
+zt or z<cr>     " scroll the screen so the cursor is at the (t)op
+zh zl           " scroll one character to the left, right
+zH zL           " scroll half screen to the left, right
+<ctrl-b>        " move back one full screen
+<ctrl-f>        " move forward one full screen
+<ctrl-d>        " move forward 1/2 a screen
+<ctrl-u>        " move back 1/2 a screen
+<ctrl-e>        " scroll the screen up
+<ctrl-y>        " scroll the screen down
+<ctrl-o>        " jump to previous location in :jumps
+<ctrl-i>        " jump to next location in :jumps
+``              " jump to last jump location
+`.              " jump to last edit location
+'.              " jump to start of line of last edit
+g; g,           " cycle backwards, forwards in `:changes` (edit locations)
+```
+
+## <a id="Editing">Editing</a>
+### <a id="insert-exit">Insert & Exit</a>
+```vim
+<Esc>           " exit insert mode
+<ctrl-c>        " exit insert mode
+i a             " insert before, after the cursor
+I A             " insert at beginning, end of line
+gi gI           " insert at last insert location, first column
+o O             " open a new line below, above the current line
+R               " enter REPLACE mode, cursor overwrites everything
+gR              " like R but without affecting layout
+```
+
+### <a id="undo-repeat">Undo & Repeat</a>
+```vim
+u U             " undo last command, restore last changed line
+<ctrl-r>        " redo
+.               " repeat last edit
+{n}.            " repeat last edit {n} times
+```
+
+### <a id="basic-editing">Basic Editing</a>
+```vim
+x X             " delete a single character under, before cursor
+{n}x {n}X       " repeat x, X {n} times
+r{c}            " replace character under cursor with {c}
+gr{c}           " like r, without affecting layout
+~               " switch case a single character
+g~{m}           " switch case of motion {m} (i.e. `g~iw~` for word)
+gu{m} gU{m}     " lower, upper case of motion {m}
+J gJ            " join current line with next, without space
+dd D            " delete (cut) entire line, to end of line
+dw              " delete (cut) to the next word
+cc C            " change (replace) entire line, to end of line
+cw              " change (replace) to the end of the current word
+caw             " change (replace) the current word (including spaces)
+ciw             " change (replace) the current word (not including spaces)
+ce              " change (replace) forwards to the end of a word
+cb              " change (replace) backwards to the start of a word
+c0              " change (replace) to the start of the line
+c$              " change (replace) to the end of the line
+c/pattern       " change (replace) to first occurrence of 'pattern'
+s               " delete character and substitute text (equal to `cl`)
+S               " delete line and substitute text (equal to `cc`)
+xp              " transpose two letters (delete and paste)
+ylxp            " transpose two letters (yank, delete and paste)
+vyxp            " transpose two letters (yank, delete and paste)
+>>              " indent current line right
+<<              " indent current line left
+==              " re-indent line (using 'equalprg' if specified)
+=%              " indent current block of code
+gg=G            " re-indent entire buffer
+<ctrl-a>        " find number in current line and increment by 1
+<ctrl-x>        " find number in current line and decrement by 1
+{num}<ctrl-a>   " find number in current line and increment by {num}
+{count}:        " will translate {count} to :{range} in ex mode
+```
+**Notes:**
+- All (c)hange commands end with the editor in INSERT mode
+
+- All double-char commands (i.e. `dd`, `cc`, `yy`, etc) can be thought of as a shortcut to `0{operator}$`, the breakdown is as follows:
+```vim
+    0           " go to the start of the line
+    {operator}  " {operator} of your choice
+    $           " go the end of the line
+```
+
+- The above can also be combined with a {count} prefix, for example 2dd will delete 2 lines below. A similar result could also be achieved using the full expression of the operator and motion: `{operator}{count}{motion}`, i.e. `d1j` will delete 2 lines down (cursor line + 1 down) and `y2w` will yank 2 words forward. In similar fashion the VISUAL mode operator `v` can be used, e.g. `vi}` will visually select everything inside the curly braces.
+
+### <a id="insert-mode">INSERT mode</a>
+```vim
+<ctrl-w>        " delete a word backwards
+<ctrl-u>        " undo edit on current line, <BS><CR> on empty lines
+<ctrl-d>        " shift left one shift width
+<ctrl-y>        " put text from the above line column
+<ctrl-e>        " put text from the below line column
+<ctrl-r>{reg}   " put register {reg}
+<ctrl-g>u       " break the (u)ndo chain
+<ctrl-v>{c}     " insert char {c} literally
+<ctrl-v>{n}     " insert char by decimal value
+<ctrl-v>u{n}    " insert unicode char by decimal value
+<ctrl-a>        " insert previously inserted text (equal to `<ctrl-r>.`)
+<ctrl-@@>       " same as <ctrl-a> + exit INSERT mode
+<ctrl-p>        " auto-complete after cursor
+<ctrl-n>        " auto-complete before cursor
+<ctrl-o>{cmd}   " execute one NORMAL mode command (see below note)
+<alt-{cmd}>     " like <ctrl-o>, does not work on all keyboards
+^x^e ^x^y       " scroll up, down
+```
+**Note:** Any NORMAL mode motion can be run from INSERT mode by using `<ctrl-o>{op}` or `<alt+{op}>` (only works on some keyboards). Alternatively, if we're in ex mode we can use `:norm {cmd}`. For example: say we want to append text at the end of the line we can simply press `<alt+A>` or `<ctrl-o>A` which will take us to the end of the line, all without leaving INSERT mode. The same can be achieved from ex mode with `<Esc>:norm A`, even though the latter isn't useful for this specific example it can be useful in many other cases where more complex commands are required (e.g. using the `global` command: `:g/regex/norm >>` will indent all lines matching the regex)
+
+### <a id="cut-copy-and-paste">Cut, copy and paste</a>
+```vim
+p P             " (p)ut or (p)aste clipboard after, before cursor
+]p [P           " like p, P with indent adjusted
+gp gP           " like p, P leaving cursor after new text
+yy              " yank (copy) a line
+{n}yy           " yank (copy) {n} lines
+yl              " yank a single character (l = to the right)
+vy              " yank a single character (using VISUAL mode)
+yw              " yank (copy) to the next word
+yiw             " yank (copy) (i)nner word (entire word)
+yaw             " yank (copy) (a) word (entire word, including spaces
+y$              " yank (copy) to end of line
+dd              " delete (cut) a line
+{n}dd           " delete (cut) {n} lines
+dw              " delete (cut) to the next word
+D               " delete (cut) to the end of the line
+d$              " delete (cut) to the end of the line
+d^              " delete (cut) to the first non-blank character of the line
+d0              " delete (cut) to the beginning of the line
+d/pattern       " delete (cut) to first occurrence of 'pattern'
+x X             " delete (cut) character under, before the cursor
+"+p             " paste the `+` register (the clipboard)
+"0p             " paste the yank `0` register
+"{reg}p         " paste {reg} (:registers)
+"{reg}yy        " yank current line into {reg} (:registers)
+"_dd            " delete line into the 'blackhole' register (no clipboard)
+
+```
+**Copy paste using ex mode:**
+```vim
+:{range}y           " yank {range} into the default register
+:{range}m{line}     " move {range} below {line}
+:{range}co{line}    " copy {range} to below {line}
+:{range}t{line}     " shortcut to the `:co[opy]` command above
+:-2co .             " copy line 2 above cursor to line below cursor
+:+2t 0              " copy line 2 below cursor to start of file
+:.,$t $             " copy all lines from the cursor to end of file to end of file
+:1,3co 5            " copy lines 1-3 to below line 5
+```
+
+**Notes:**
+- To paste a register directly from INSERT or ex mode use `<ctrl-r>` followed by a register name.
+
+- By default the `Y` command is mapped to `yy` (yank line) which isn't consisnt with the behaviors of `C` and `D` (from cursor to end of line), a very useful mapping for both NORMAL and VISUAL mode is:
+
+```vim
+    nnoremap Y y$
+    xnoremap Y <Esc>y$gv
+```
+
+- By default all modification operators `d c x` copy the modified text to the unnamed `"` register (unless `set clipboard` was set) which can be confusing at first. For example, let's say we want to overwrite a word with yanked text, we would naturally do `ciw<Esc>p` or `ciw<ctrl-r>"` only to find out the same word would be pasted (and not our yanked text), to work around that we can tell the `c` operator to copy the text into the 'blackhole' register instead: `"_ciw`. Alternatively we can also use the yank register `0` which contains the content of the last yank operation using `"0p` or `"0P` (to paste before the cursor). A few useful mappings for my leader key (by default `\`, personally I use `\<space>`) are below, so if I want to change a word without it polluting my registers I would run `<leader>bciw`, similarly if I wish to delete a line I would run `<leader>dd`:
+
+```vim
+    nnoremap <leader>b "_
+    nnoremap <leader>d "_d
+    nnoremap <leader>D "_D
+    nnoremap <leader>dd "_dd
+    xnoremap <leader>b "_
+    xnoremap <leader>D "_D
+    xnoremap <leader>D "_D
+    xnoremap <leader>x "_x
+```
+
+- In addition to being copied to the default register (`"` or `*`), every 'deleted' text is also copied into the 'small delete' registers {1-9}. To view the latest deletes run `:reg[isters]` or `:di[splay]`. A neat trick to cycle through the delete registers is to use `"1p` and then run `u.`, the undo+repeat advances the 'pasted register' so it will perform `"2p`, `"3p` and so forth.
+
+## <a id="visual-mode">VISUAL mode</a>
+### <a id="selections">Selections</a>
+```vim
+<Esc>           " exit visual mode
+<ctrl-c>        " exit visual mode
+v               " start VISUAL mode in 'character' mode
+V               " start VISUAL mode in 'line' mode
+<ctrl-v>        " start VISUAL mode in 'block' mode
+o               " move to other end of marked area
+O               " move to other corner of block
+$               " select to end of line (include newline)
+g_              " select to end of line (exclude newline)
+aw              " select a word
+ab              " select a block with ()
+aB              " select a block with {}
+ib              " select inner block with ()
+iB              " select inner block with {}
+gv              " NORMAL mode: reselect last visual selection
+```
+
+**Notes:**
+- The above are just some of the available commands as any text object or motion can be used, e.g. `viw` will visually select current word or `vat` will select an entire tag: `<a>some text</a>`
+
+- A neat trick you can do with VISUAL mode is using visual modes as motion operators, If you perform `d2j`, it will delete all three lines. That’s because `j` is a linewise motion. If you instead pressed `d<c-V>2j`, it would convert the motion to blockwise and delete just the column characters instead. For more information read [Hillel Wayne's blog: At least one Vim trick you might not know](https://www.hillelwayne.com/post/intermediate-vim/).
+
+- VISUAL mode has a nice feature to expand selection based on blocks, say we wanted to select the inside of an `if` condition in C, we do so with `vi(` or `vi)`, if we wanted to expand the selection to the outer block we can just run `i{` or `i}` (without having to cancel the selection and press `v` again).
+
+### <a id="operators">Operators</a>
+```vim
+~               " switch case
+d               " delete
+c               " change
+y               " yank
+>               " indent right 
+<               " indent left 
+!               " filter through external command 
+=               " re-indent line (using 'equalprg' if specified)
+gq              " format lines to 'textwidth' length (cursor moves to end)
+gw              " format lines to 'textwidth' length (cursor stays in place)
+gu              " make selection lower-case
+gU              " make selection UPPER-case
+v<ctrl-a>       " increment digit under the cursor
+{num}<ctrl-a>   " increment current selection by {num} (lines separately increment)
+{num}<ctrl-x>   " decrement current selection by {num} (lines separately decrement)
+{num}g<ctrl-a>  " increment current selection by {num} (lines serially increment)
+```
+
+**Notes:**
+- Some operators, namely the repeat `.` and paste `pP` operators have unique behaviors when used after a VISUAL 'block' mode edit, that is extremely useful when editing text as blocks. Say we wanted to append semicolon to the end of a paragraph we could simply do `<ctrl-v>}A;<Esc>` we can then repeat the operation using `.` which will replicate the change to the same block range under the cursor. Similarly we can use the paste before and after the cursor `p` and `P` to paste entire columns, the following will duplicate the first column of a paragraph: `<ctrl-v>}yp` which you can easily undo as an atomic operation with `u`.
+
+- If you want to preform an {ex} command on visual selection press `:` (with selected visuals), vim will automatically prefix your ex command with the visual range `:'<,'>` so you can execute any command on the selected text, e.g. `:'<,'>norm @q` will execute macro `q` on all visually selected lines.
+
+- A shortcut to the above can be done with the bang `!` operator, this will automatically put is in ex command mode with the visual selection already entered, the equivalent of `:'<,'>!` ready for entering a command, this is useful in many situations, for example to sort a visual block we can just do `viB!sort` which is the equivalent `viB:!sort`. The same can also be done from NORMAL mode using `!iBsort`.
+
+- When indenting (or any other operation) in VISUAL mode with `<>` you will find that once indented you lose the current selection, to visually reselect the text you can use `gv`, so to indent while keeping current selection use `<gv` and `>gv` respectively. Personally I never want to lose my selection when indenting hence I use the below mappings in [my keymaps](https://github.com/ibhagwan/nvim-lua/blob/main/lua/keymaps.lua):
+
+```vim
+vmap < <gv
+vmap > >gv
+```
+## <a id="text-objects">Text Objects</a></a>
+```vim
+aw              " a word (includes surrounding white space
+iw              " inner word (does not include surrounding white space)
+as              " a sentence
+is              " inner sentence
+ap              " a paragraph
+ip              " inner paragraph
+a"              " a double quoted string
+i"              " inner double quoted string
+a'              " a single quoted string
+i'              " inner single quoted string
+a`              " a back quoted string
+i`              " inner back quoted string
+a) or ab        " a parenthesized block
+i) or ib        " inner parenthesized block
+a]              " a bracketed block
+i]              " inner bracketed block
+a} or aB        " a brace block
+i} or iB        " inner brace block
+at              " a tag block e.g. <a></a>
+it              " inner tag block e.g. <a></a>
+a>              " a single tag
+i>              " inner single tag
+gn              " next occurrence of search pattern
+```
+**Notes:**
+- Text objects can be used with any operator, e.g. `dit` will delete "some text" from `<a>some text</a>` and `yat` will copy the entire tag into the clipboard. For more information [Jared Caroll's: Vim Text Objects: The Definitive Guide](https://blog.carbonfive.com/vim-text-objects-the-definitive-guide/).
+
+- `gn` is a very useful text object, few examples: `cgn` will change the next search pattern match, `vgn` will visually select all text from the cursor to the next match. For more information read [Bennet Hardwick's blog: 8 Vim tips and tricks for advanced beginners](https://bennetthardwick.com/blog/2019-01-06-beginner-advanced-vim-tips-and-tricks/).
+
+- Any text object can also be used with a count. For example, we have the below text (cursor at ^):
+```vim
+    if (function(param1, param2, param3)) {
+                                 ^
+```
+If we run `di)` we will delete all 3 parameters. However we can also run `d2i(` to delete inside the parent parenthesis, thus deleting the entire condition and resulting in the text `if () {`. I found this very useful tip (and others) in [Antoyo's blog](https://blog.antoyo.xyz/vim-tips).
+
+## <a id="search-replace">Search & Replace</a>
+```vim
+# *                         " search word under cursor backward, forward
+g# or g*                    " like #, * but also find partial matches
+/pattern                    " search for pattern
+/pattern<ctrl-g>            " go to next match without exiting search mode `/`
+/pattern<ctrl-t>            " go to prev match without exiting search mode `/`
+/pattern/{-+n}              " put cursor {-+n}th line below/above the match
+/pattern/e{-+n}             " put cursor {-+n}th char before/after match (e)nd
+/pattern/b{-+n}             " put cursor {-+n}th char before/after match (b)egin
+?pattern                    " search backward for pattern
+/<CR>                       " repeat search in same direction
+?<CR>                       " repeat search in opposite direction
+/<ctrl-r>/                  " put last search pattern into search mode
+/<ctrl-r><ctrl-w>           " put word under cursor into search mode
+/<ctrl-r><ctrl-a>           " put WORD under cursor into search mode
+/\v{pattern}                " Search forwards using Vim's 'very magic' pattern
+                            " special characters can be used without esc seq
+n N                         " repeat search in same, opposite direction
+& or :&&                    " repeat last substitute in the same line
+g&                          " repeat last substitute on all lines
+:noh                        " remove highlighting of search matches
+:s/old/new/                 " replace first occurrence of old with new
+:s/old/new/i                " replace first occurrence of old with new (case insensitive)
+:s/old/new/g                " replace all old with new throughout line ('globally')
+:%s/old/new                 " replace first occurrence of old with new throughout file
+:%s/old/new/g               " replace all old with new throughout file ('globally')
+:%s/old/new/gc              " replace all old with new throughout file with confirmations
+:%s/old/'&'/g               " surround all occurrences of old with ' (i.e. 'old')
+:s/\%Vold/new/              " replace all occurrences of old with new in visual selection
+:{range} s/old/new/         " replace all old with in {range} (e.g. `:10,20s/...`)
+:{num},$ s/old/new/         " replace all old with new from line {num} to last line
+:g/regex/{ex}               " run :{ex} for every line matching regex
+:g!/regex/{ex}              " run :{ex} for every line NOT matching regex
+:v/regex/{ex}               " same as above, shortcut to `:g!`
+:g/regex/y {reg}            " copy all matching lines to register {reg}
+                            " capitalize {reg} to append to {reg}
+:g/regex/m $                " move all matching lines to end of file
+:g/regex/-1j                " for every matching line, go up one line and join
+:%s/\s\+$//e                " remove all trailing whitespaces throughout buffer
+:g/^/m0                     " reverse order of all lines in current buffer
+:v/./d                      " delete all empty lines (same as `:g!/./d`)
+/\%>10l\%<20l{regex}        " search for regex between lines 10-20 (excluding ln 20)
+/\v%>10l%<20l{regex}        " same as above using 'very magic'
+/\%u{xxxx}                  " search for unicode character `u+{xxxx}` (e.g. `u+0061` for `a`)
+```
+
+**Notes:**
+
+- You can repeat the last substitute interactively with `g&`
+
+- For more information on the different `.../g` modifiers read `:help s_flags`
+
+- For more information on the "very magic" pattern read [Vim fandom: Simplifying regular expressions using magic and no-magic](https://vim.fandom.com/wiki/Simplifying_regular_expressions_using_magic_and_no-magic).
+
+- The `g` and `v` ex commands are extremely useful, few examples: `:g/pattern/d` or `:g/pattern/norm dd` will delete all lines matching `pattern`, you can also supply a range to the command: `:g/pattern/-1d` will delete one line above all lines matching `pattern`, same can be achieved with `:g/pattern/norm 1jdd`
+
+- `:y {reg}` copies the range to the register {reg}. If {reg} is a capital letter register, this appends to the existing register, i.e. if we do `let @a = '' | %g/regex/y A` it will copy all lines matching regex in the entire file to register a. We can then copy the register to the system clipboard with `let @+ = @a`.
+
+- Important note regarding the use of `:s` vs `:g`: `s` is a shortcut for `substitute` and `g` is a shortcut for `global`, therefore `s` should be used when doing search and replace (substitution) and `g` should be used when you'd like to execute a command for every match (not necessarily substitution), each has it's strength and it's a matter of using the right tool for the job. Example: say we wanted to substitute `bar` with `blah` for every line containing `foo`, we could achieve the same result with both but as you can see the `g` command would be a better fit in this case:
+
+```vim
+    g/foo/s/bar/blah/g  
+
+    :%s/foo/\=substitute(getline('.'), 'bar','blah','g')
+```
+
+### <a id="regex-examples">REGEX Examples</a>
+### Search examples
+```vim
+/^fred.*joe.*bill           " line beginning with fred, followed by joe then bill
+/^[A-J]                     " line beginning A-J
+/^[A-J][a-z]\+\s            " line beginning A-J then one or more lowercase characters then space or tab
+/fred\_.\{-}joe             " fred then anything then joe (over multiple lines)
+/fred\_s\{-}joe             " fred then any whitespace (including newlines) then joe
+/fred\|joe                  " fred OR joe
+```
+
+### Substitution examples
+```vim
+:%s/fred/joe/igc                " general substitute command
+:%s/\r//g                       " delete DOS Carriage Returns (^M)
+:'a,'bg/fred/s/dick/joe/gc      " VERY USEFUL
+:s/\(.*\):\(.*\)/\2 : \1/       " reverse fields separated by :
+" non-greedy matching \{-}      " `:help /\{-}`
+:%s/^.\{-}pdf/new.pdf/          " to first pdf)
+:s/fred/<c-r>a/g                " substitute 'fred' with contents of register 'a'
+:%s/^\(.*\)\n\1/\1$/            " delete duplicate lines
+" running multiple commands
+:%s/suck\|buck/loopy/gc         " ORing
+:s/__date__/\=strftime("%c")/   " insert datestring
+:%s/\f\+\.gif\>/\r&\r/g | v/\.gif$/d | %s/gif/jpg/
+```
+
+### <a id="multiple-files">Multiple Files</a>
+
+> To learn more I recommend watching
+> [Drew Neil: Searching Multiple Files with vimgrep](http://vimcasts.org/episodes/search-multiple-files-with-vimgrep/)
+
+```vim
+:vimgrep /pattern/ {file} " search for a pattern using vimgrep
+:grep /pattern/ {file}    " search for a pattern using an external program
+:copen                    " open the 'quickfix` window containing all matches
+:cn                       " jump to the next match
+:cp                       " jump to the previous match
+:cdo                      " execute a command for each quickfix entry
+:cfdo                     " execute a command for each quickfix file
+```
+
+When just starting to use vim search and replace an entire project at first
+seems overly complex, plugins can definitely help here (fzf comes to mind) but
+once you understand how to use the quickfix list it's actually quite easy.
+
+Vim comes builtin with the `vimgrep` utility which searches for a regex patter
+and populates the quickfix list accordingly. From there, you can manipulate
+matches using the `cdo|cfdo` combo.
+
+Searching the project is as easy as:
+```vim
+" search the current file
+:vimgrep /foo/ %
+" search the entire project
+:vimgrep /foo/ **/*
+```
+
+Personally I prefer to use `:grep` in conjunction with the
+[`rg`](https://github.com/BurntSushi/ripgrep) utility, to do so add the below
+to your `init.vim`:
+```vim
+set grepprg=rg\ --vimgrep\ --no-heading\ --smart-case\ --hidden
+set grepformat=%f:%l:%c:%m
+```
+
+And then run the same search:
+```vim
+" search the current file
+:grep 'foo' %
+" search the entire project
+:grep 'foo'
+" or if you prefer to use the location-list
+:lgrep 'foo'
+```
+
+From here it's very easy to search and replace all matches with
+[any substitute command](#search-replace):
+```vim
+" if you want to run the command once for each entry use `cdo`
+" otherwise the below should suffice as `%s` searches the entire file
+:cfdo %s/foo/bar/g
+" save all changes
+:wall
+```
+
+## <a id="macros">Macros</a>
+```vim
+q{a-z}                  " start recording macro to register {a-z}
+q{A-Z}                  " append recording macro to register {a-z}
+q                       " stop macro recording
+@{a-z}                  " execute macro {a-z}
+{count}@{a-z}           " execute macro {a-z} on {count} lines
+@@                      " repeat execution of last macro
+:@{reg}                 " execute {reg} as an ex command
+@:                      " repeat execution of last ex command e.g. `:s/...`
+@.                      " execute last inserted text as macro
+@='[cmds]'              " execute commands through the expression register
+:'<,'>normal @q         " execute macro `q` on visual selection
+"{a-z}p                 " paste macro {a-z} (register)
+"{a-z}y$                " yank into macro {a-z} to end of line
+```
+
+**Notes:**
+- Macros are essentially just a saved series of keystrokes, if you’re recording a macro and make a mistake, don’t start over, instead, undo it and keep going normally, using macro `q` as an example (recorded with `qq`), once you’re finished with the macro, press `"qp` to paste it to an empty line, remove the mistaken keystrokes and the undo and copy it back into the `q` register with `"qy$`.
+
+- Don’t leave undos in your macro. If you undo in a macro to correct a mistake, always be sure to manually remove the mistake and the undo from the macro. In replay mode, an undo will undo the entire macro up until that point, erasing all of your hard work and bleeding the macro out into the rest of your text.
+
+- The above was taken from [Hillel Wayne's blog: Vim Macro Tricks](https://www.hillelwayne.com/vim-macro-trickz/).
+
+- Alternatively, you can resume recording a macro using the capitalized version of the registers, say we started recording into the `q` register with `qq` we can "pause" the macro recording with `q` and later resume recording with `qQ` (note the capitalized `Q`).
+
+- Macros are not limited to the current buffer, if you wish to transform text between windows just add a windows switch command to your macro (e.g. `<ctrl-w>w`). This makes it very useful to mass manipulate text between different buffers.
+
+- A neat trick to running macros quickly is to use the `.` register which is the last inputed text. Let's say we want to run a macro that does the simple task of transposing two adjacent characters `xp`, what we can do is enter INSERT mode, enter the macro keys, press `u` for undo and then execute the macro with `@.`, thus the entire sequence equals `ixp<Esc>u` and now we can run our macro with `@.`. Alternatively, if you'd like your macro to contain a `<cr>` (down one line) you can run `O~$~<Esc>dd` and then run the macro with `2@"` (since our text was 'cut' into the default register) - this will toggle capitalization of the first and last character in 2 subsequent lines.
+
+- Building on the above, the same `xp` macro can be run using the expression register by running `@='xp'` and then repeat the macro execution with `@@`. You can run more complex commands using the full format `{count}@='[commands]'`. For example, running `3@='v2<ctrl-a>w'` on the text `1 5 8` will increment each digit by 2 resulting in `3 7 10`. This example is equivalent to `qqv2<ctrl-a>wq2@q`: which records the edit to macro `q` and then executes it two more times. (note: if you wish to input special characters (`<Esc>`, `<CR>`, etc.) in the command line, prefix the special character with `<ctrl-v>` e.g. `<ctrl-v><Esc>`.
+
+
+### <a id="recursive-macros">Recursive Macros</a>
+
+A recursive macro, as the name suggests, is a macro that calls itself, in Vim, the call is usually done at the end of the macro, so a recursive macro will usually end with a call to itself `@q` followed by `q` to stop the macro recording. A simple recursive macro that deletes all vimscript comments in an entire buffer would look like this:
+```vim
+    qqq             " empty the q register, VERY IMPORTANT, read below why
+    qqf"D+@qq       " execute on one line and record our recursive macro
+    @q              " execute until fail
+```
+
+If you wish to test your macro before executing on the entire buffer you can take advantage of appending to a register using a capitalized register letter, let's re-do our example from above while also testing our macro:
+```vim
+    qqq             " empty the q register, VERY IMPORTANT, read below why
+    qqf"D+q         " execute on one line and record our macro
+    @q              " execute one time and check the results
+    qQ@qq           " execute one more time and add the recursion call
+    @q              " execute until fail
+```
+
+As you can see from above, recursive macros can be very useful if you wish to run a macro on the entire buffer without having to worry about the number of times required to run the macro, it's similar to running `9999@q` (in a file with less than 9999 lines). Note that this is different than running the ex command `:%norm @q`, in the latter case the macro would run on the entire buffer regardless if there are some lines with errors (e.g. can't find the `"`), this gives us the flexibility to choose between the two approaches, if we want to run until failure we use a recursive macro, if we wish to run on the entire buffer regardless of errors we use the `:%norm @{reg}` or `:0,$norm @{reg}` variant.
+
+**Note:** It is VERY IMPORTANT to clean the destination register (`q` in our case) by running `q{reg}q` **before we start the recording**, the reason for this is when you're recording the macro for first time you are also running it when you're adding the recursion call `@q`, if our register isn't empty the register commands will be executed and most likely mess up our edit.
+
+## <a id="marks">Marks</a>
+```vim
+:marks          " list current marks
+m{a-z,A-Z}      " set mark at cursor position
+                " {a-z} = local file marks
+                " {A=Z} = cross file marks
+'{a-z,A-Z}      " goto first non-blank character in mark {a-z,A-Z}
+`{a-z,A-Z}      " goto exact cursor position of mark {a-z,A-Z}
+```
+
+## <a id="files-and-windows">Files and Windows</a>
+```vim
+:e {file}       " edit a file in a new buffer
+:find {file}    " find and open file in &path (set path?)
+gf              " find and open the file under the cursor
+gF              " find and open the file under the cursor with line number
+:cd %:h         " change pwd to folder of current buffer (all buffers)
+:lcd %:h        " change pwd to folder of current buffer (local buffer)
+:ls             " list all open buffers
+:bnext or :bn   " go to the next buffer
+:bprev or :bp   " go to the previous buffer
+:bd             " delete a buffer (close a file)
+:sp {file}      " open a file in a new buffer and split window
+:vsp {file}     " open a file in a new buffer and vertically split window
+:windo {ex}     " run :{ex} on all windows (e.g. :windo q - quits all windows)
+:bufdo {ex}     " same as above for buffers
+:on             " make current window the 'only' window (close all others)
+:hide or :q     " hide (close) current window
+:new            " new window in a horizontal split
+:vnew           " new window in a vertical split
+<ctrl-w>o       " same as `:on` above
+<ctrl-w>w       " jump to next window
+<ctrl-w>r       " swap windows 
+<ctrl-w>q       " quit a window
+<ctrl-w>s       " split window horizontally
+<ctrl-w>v       " split window vertically
+<ctrl-w>h       " move cursor to the left window (vertical split)
+<ctrl-w>l       " move cursor to the right window (vertical split)
+<ctrl-w>j       " move cursor to the window below (horizontal split)
+<ctrl-w>k       " move cursor to the window above (horizontal split)
+<ctrl-^>        " jump to previous buffer
+<ctrl-g>        " display filename of current buffer (file)
+1<ctrl-g>       " display full path of current buffer (file)
+2<ctrl-g>       " display buf # and full path of current buffer (file)
+```
+
+**Notes:**
+- `:bufdo` and `:windo` can be used for multiple file/window operations, for example to search and replace in all open buffers you can run `:bufdo %s/old/new/g`
+
+- `:find` and `gf` are both dependent on the `&path` variable which by default contains `.` which is the current working directory (`:pwd`), for said commands to be effective be sure to always open Vim from your project directory or use `cd` to change Vim's working directory (best done using `cd %:h`). If you would like `:find` and `gf` to find files recursively in all folders specified by `&path` be sure `path` contains `**`. Use `:set path+=**` if you wish to add `**` to the current `&path`. Personally, I define my path as: `set path=.,,,$PWD/**` (search current directory and project directory recursively).
+
+
+## <a id="tabs">Tabs</a>
+```vim
+:tabnew or :tabnew {file}   " open a file in a new tab
+<ctrl-w>T                   " move the current split window into its own tab
+gt or :tabnext or :tabn     " goto to the next tab
+gT or :tabprev or :tabp     " goto to the previous tab
+{num}gt                     " goto to tab {num}
+:tabmove {num}              " move current tab to the {num}th position (indexed from 0)
+:tabclose or :tabc          " close the current tab and all its windows
+:tabonly or :tabo           " close all tabs except for the current one
+:tabdo {ex}                 " run :{ex} on all tabs (e.g. :tabdo q - closes all opened tabs)
+```
+
+## <a id="term">Terminal</a>
+### Vim:
+```vim
+:term                       " open terminal window inside vim (default shell)
+:term zsh                   " open terminal window inside vim (zsh)
+:vert term zsh              " opens a new terminal in a horizontal split (zsh)
+```
+### Neovim:
+```vim
+:term                       " open terminal window inside vim
+:split term://zsh           " opens a new terminal in a horizontal split
+:vsplit term://zsh          " opens a new terminal in a vertical split
+:new term://bash            " alternates for above commands
+:vnew term://bash           " alternates for above commands
+<ctrl-\> <ctrl-N>           " go back to NORMAL mode
+```
+### Both:
+```vim
+<ctrl-z>                    " suspend vim to background, `fg` in term to resume
+:sus[pend][!] or st[op][!]  " suspend vim (equal to ctrl-z) if `!` is specified
+                            " vim will write changes to all buffers before suspend
+```
+
+## <a id="spellcheck">Spellcheck</a>
+```vim
+:set spell                  " enable spellcheck for current buffer
+:set nospell                " disable spellcheck for current buffer
+:set spelllang={lang}       " set spellcheck lang, i.e. `en_us`
+[s                          " find previous misspelled word
+]s                          " find next misspelled word
+z=                          " see spellcheck suggestions
+{num}z=                     " automatically accept (change) suggestion {num}
+zg                          " add current word to dictionary
+zw                          " add current word to dictionary as a 'bad' word
+zug                         " undo `zg`
+zuw                         " undo `zw`
+```
+
+## <a id="misc-commands">Misc commands</a>
+```vim
+K                           " lookup keyword under cursor with `man`
+ga                          " display dec/hex/oct values of character under cursor
+g8                          " display hex value of utf-8 character under cursor
+g?                          " rot13 a character (cycle 13 alphanumeric chars backwards)
+ggg?G                       " rot13 entire buffer
+g<                          " view last command (:<cmd>!) output
+<ctrl-l>                    " redraw window, clear status message (error messages, search, etc)
+<ctrl-g>                    " display filename and position
+g<ctrl-g>                   " display cursor, line and column position
+```
+```vim
+:help {keyword}             " view help for {keyword}
+:help {keyword}<ctrl-d>     " list help of matching {keyword}
+:helpgrep {keyword}         " help search for {keyword}, open results with :cwindow
+:read {file}                " read {file} below the cursor
+:!{cmd}                     " execute shell command {cmd}
+:!%                         " execute current file
+:!%:p                       " execute current file (use full path)
+:.!{cmd or !!{cmd}          " filter current line through {cmd}
+!!date                      " replace current line with output of `date`
+:read !{cmd}                " read output of {cmd} below cursor
+:<ctrl-f> or q:             " enter command line window, <ctrl-c> or :q to exit
+q/ or q?                    " same as above but for searches
+:echo &{opt}                " echo Vim option to command line (expand values)
+:set {opt}?                 " echo Vim option to commend line (no expand)
+:source                     " 'source': execute a file as a series of commands
+:source $MYVIMRC            " source your $MYVIMRC
+:retab                      " retab current buffer according to `expandtab` and `shiftwidth`
+:earlier {time}             " revert a file to earlier time, e.g. `earlier 1m`
+:later {time}               " revert a file to later time
+:visual :edit               " leave :Ex mode
+:<ctrl-b>                   " go to start of line in command line mode
+:<ctrl-e>                   " go to end of line in command line mode
+```
+
+## <a id="ctrl-r-and-the-expression-register">Ctrl-R and the Expression Register</a>
+
+The expression register (`=`) is used to evaluate expressions and can be accessed using `"=` from NORMAL and VISUAL modes and  `<ctrl-r>` from INSERT and ex command modes, it is very useful to insert registers and other input into the command line or directly to the document when you don't want to leave INSERT mode (useful so you can repeat the entire edit with `.`):
+
+### INSERT and ex modes:
+```vim
+:registers {reg}            " display registers {reg} and their values
+:display "0                 " display value of registers `"` and `0'
+:{line}put                  " put clipboard register under {line}
+:put{reg}                   " put value of {reg} in the line below
+:put={expr}                 " put value of {expr} in the line below
+:let @{reg}={expr}          " manually assign value to {reg}
+:let @*=expand('%')         " expand current file path into `*` (clipboard)
+<ctrl-r>{reg}               " put register {reg}
+<ctrl-r>={expr}             " put the value of {expr}
+<ctrl-r>=[1,2,3]            " put 1<cr>2<cr>3<cr>
+<ctrl-r>%                   " put file path of current buffer
+<ctrl-r>-                   " put last deleted text
+:<ctrl-r><ctrl-w>           " put word under cursor
+:<ctrl-r><ctrl-a>           " put WORD under cursor (includes punctuation)
+:<ctrl-r><ctrl-l>           " put current cursor line
+:<ctrl-r><ctrl-f>           " put file path under cursor (does not expand ~)
+:<ctrl-r><ctrl-p>           " put file path under cursor (expands ~)
+```
+
+### NORMAL and VISUAL modes:
+```vim
+"={expr}                    " evaluate {expr} into the expression register
+"={expr}p                   " evaluate {expr} and paste (also saved in the register)
+"={expr}P                   " save as above, paste before the cursor
+```
+
+**Notes:**
+- For more information on evaluating expressions `:help expression`. For even more information read [Aaron Bieber's: Master Vim Registers With Ctrl R](https://blog.aaronbieber.com/2013/12/03/master-vim-registers-with-ctrl-r.html) and watch [Vimcasts: Simple calculations with Vim's expression register calculations with Vim's expression register](http://vimcasts.org/episodes/simple-calculations-with-vims-expression-register/)
+
+- When inserting a register with `<ctrl-r>{reg}` and then repeating the edit with `.` you will find out that same text will be entered even if the register contents has changed, to have the actual command enter the `.` register we need to use `<ctrl-r><ctrl-o>{reg}` instead. Best shown with an example, say we have the below text and we wish to add parens around the text
+
+```vim
+    one           " we want to change this to => (one)
+    two           " we want to change this to => (two)
+```
+
+  We can modify the first line using `ciw(<ctrl-r>+)` which will result in "(one)" but when we repeat the action for "two" the result would still be "(one)" as the actual text is saved in the register. To circumvent this we can use `ciw(<ctrl-r><ctrl-o>+)` instead which inserts the actual command `^R^O+` into the register, that way when we repeat the action with `.` the result would be as expected "(two)".
+
+- For more information regarding `<ctrl-r><ctrl-o>` read `:help i_ctrl-r_ctrl-o` and watch [Drew Neil's vimcast: Pasting from INSERT mode](http://vimcasts.org/episodes/pasting-from-insert-mode/)
+
+## <a id="comparing-buffers-with-vimdiff">Comparing buffers with vimdiff</a>
+```vim
+:windo diffthis         " Edit current windows in diff mode
+:windo diffoff          " Exit diff mode
+:diffput {bufspec}      " Put diff into {bufspec} from current buffer
+:diffget {bufspec}      " Pull diff from {bufspec} into current buffer
+do                      " diff (o)btain, NORMAL mode for `:diffget`
+dp                      " diff (p)ut, NORMAL mode for `:diffput`
+[c                      " jump to previous (c)hange
+]c                      " jump to next (c)hange
+:windo set scrollbind   " bind all current windows scrolling
+:windo set noscrollbind " unbind all current windows scrolling
+```
+
+**NOTE:** 
+
+- The shortcuts `do` and `dp` also run `:diffupdate`, so the equivalent of `dp` can be thought of as `:diffput {target buffer} | diffupdate`
+
+- `{targetbuffer}` above is automatically resolved as the 'other buffer' on a 2-way split, that works for both `do` and `dp`. However, `do` cannot sensibly decide which buffer to use in a 3-way split (git merge conflict resolution) and therefore cannot be used in this case. `dp` assumes we always want to 'push' changes to the working copy which is always the middle buffer and therefore can be used in a 3-way split from either the left (target) or right (merge) buffers.
+
+## <a id="folding">Folding</a>
+Fold methods (set with `set foldmethod=<method>`:
+
+```vim
+manual                  " folds must be defined by commands (i.e. `zf`)
+indent                  " folds are defined by lines of equal indent
+expr                    " folds are defined by `foldexpr`
+marker                  " folds are defined by `{{{` and `}}}`
+syntax                  " folds are defined by syntax highlighting
+diff                    " folds are defined by non-modified text
+```
+
+```vim
+zo                      " open fold under cursor
+zO                      " open folds under cursor recursively
+zc                      " close fold under cursor
+zC                      " close folds under cursor recursively
+za                      " toggle fold under cursor
+zA                      " toggle folds under cursor recursively
+zM                      " close all folds, set `foldlevel` to 0
+zR                      " open all folds, set `foldlevel` to highest level
+zn                      " sets `nofoldenable`, disable folding
+zN                      " set `foldenable`, restore all previous folds
+zi                      " toggle between `foldenable` and `nofoldenable`
+```
+
+Fold management when `foldmethod` is set to `manual` or `marker`:
+
+```vim
+zf{motion}              " create a fold from current line to motion
+{visual}zf              " create a fold around visual selection
+{count}zF               " create a fold for {count} lines
+:{range}fo[ld]          " create a fold for {range} (e.g. `:.,+3fo`)
+zd                      " delete surrounding fold at the cursor
+zD                      " recursively delete surrounding fold
+zE                      " delete all folds in current window
+```

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -48,7 +48,13 @@ local state = {
 	visual = nil, -- { al, ac, cl, cc, dollar } anchor + Vim cursor while visual
 	last_visual = nil, -- the range `gv` reselects
 	block_insert = false, -- blockwise I/A/c is holding multi-cursors open
+	clipboard = false, -- vim.clipboard: sync the unnamed register to the system clipboard
 }
+
+-- Startup settings are read deferred, at the bottom of this file (see the
+-- ttt.set_timeout call), not here: for an already-approved plugin, LoadAll calls
+-- Init before the host wires the settings API, so a read at init time would
+-- always see nil. state.enabled / state.clipboard keep their defaults until then.
 
 -- ---------------------------------------------------------------------------
 -- Editor shim
@@ -817,7 +823,7 @@ local G_MOTIONS = {
 -- Second key of a `z`-prefixed sequence, passed straight to reposition().
 local Z_COMMANDS = { z = true, t = true, b = true }
 
-local PREFIX_KEYS = { g = true, z = true }
+local PREFIX_KEYS = { g = true, z = true, ["["] = true, ["]"] = true }
 local FIND_KEYS = { f = true, F = true, t = true, T = true }
 
 -- ---------------------------------------------------------------------------
@@ -1101,6 +1107,12 @@ local function set_register(text, kind, is_delete, range)
 	if name then
 		reg_store(name, text, kind)
 		return
+	end
+
+	-- vim.clipboard: an unnamed yank/delete also lands on the system clipboard,
+	-- reusing the same editor.copy path as the "+/"* registers.
+	if state.clipboard and range then
+		clipboard_copy(range[1], range[2], range[3], range[4])
 	end
 
 	if is_delete then
@@ -4428,6 +4440,20 @@ do
 		["ctrl-w"] = "focus.nextGroup",
 	}
 
+	-- `]`/`[` bracket-command targets. `]c`/`[c` jump between changed hunks in the
+	-- current file; `]f`/`[f` cycle through the files in the Changes panel. These
+	-- delegate to core commands; a false return (command absent) is a silent
+	-- no-op. Assigned straight onto vim6 (no locals) to stay under Lua 5.1's
+	-- per-function local cap, which this do-block is already close to.
+	vim6.BRACKET_NEXT = {
+		["c"] = "diff.nextHunk",
+		["f"] = "changes.nextFile",
+	}
+	vim6.BRACKET_PREV = {
+		["c"] = "diff.prevHunk",
+		["f"] = "changes.prevFile",
+	}
+
 	G_MOTIONS["t"] = function(n)
 		for _ = 1, n do
 			exec_or_warn("tab.next")
@@ -4807,6 +4833,26 @@ local function handle_normal(tok)
 		return true
 	end
 
+	-- `]`/`[` bracket commands (]c/[c hunks, ]f/[f changed files). A missing core
+	-- command returns false and is a silent no-op. No new locals: handle_normal is
+	-- large and near Lua 5.1's per-function local cap.
+	if state.pending == "]" then
+		state.pending = ""
+		state.count = nil
+		if vim6.BRACKET_NEXT[tok] then
+			ttt.exec_command(vim6.BRACKET_NEXT[tok])
+		end
+		return true
+	end
+	if state.pending == "[" then
+		state.pending = ""
+		state.count = nil
+		if vim6.BRACKET_PREV[tok] then
+			ttt.exec_command(vim6.BRACKET_PREV[tok])
+		end
+		return true
+	end
+
 	-- Count prefix. A leading `0` is the motion, not a count digit.
 	if #tok == 1 and tok >= "0" and tok <= "9" and not (tok == "0" and state.count == nil) then
 		state.count = (state.count or 0) * 10 + tonumber(tok)
@@ -5081,6 +5127,31 @@ ttt.register({
 
 events.on("key.press", on_key)
 
--- set_status_item is only wired after WirePlugin runs, which is after this file
--- executes, so the initial indicator is deferred by a tick.
-ttt.set_timeout(0, render_status)
+-- Deferred startup: read settings, then draw the initial status indicator. Both
+-- the settings API and set_status_item are only wired after WirePlugin runs
+-- (which is after this file executes), so this is delayed by a tick. get_setting
+-- lives inside the closure so it consumes no permanent top-level local (Lua 5.1
+-- caps the main chunk at 200). Reads are defensive: ttt.settings may be
+-- unavailable or return nil, in which case the default stands, and a denied key
+-- raises a Lua error, so each call is pcall'd. vim.enabled=false starts with Vim
+-- mode off (re-enable from the command palette); vim.clipboard=true mirrors the
+-- unnamed register to the system clipboard on every yank/delete.
+ttt.set_timeout(0, function()
+	local function get_setting(key, default)
+		local ok, mod = pcall(require, "ttt.settings")
+		if not ok or type(mod) ~= "table" or type(mod.get) ~= "function" then
+			return default
+		end
+		local ok2, val = pcall(mod.get, key)
+		if not ok2 or val == nil then
+			return default
+		end
+		return val
+	end
+
+	if not get_setting("vim.enabled", true) then
+		disable()
+	end
+	state.clipboard = get_setting("vim.clipboard", false) and true or false
+	render_status()
+end)

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -6,6 +6,7 @@
 --
 -- Phase 0: mode state machine (normal/insert), Esc handling, status indicator.
 -- Phase 1: normal-mode motions with {count} prefixes.
+-- Phase 2: insert-mode entry points and single-key edits.
 
 local ttt = require("ttt")
 local events = require("ttt.events")
@@ -29,6 +30,8 @@ local state = {
 	find_pending = nil, -- "f" | "F" | "t" | "T" awaiting its target char
 	last_find = nil, -- { op = "f", ch = "x" } for `;` and `,`
 	goal = nil, -- sticky column for j/k
+	replace_pending = nil, -- count for `r{char}` awaiting its replacement char
+	last_insert = nil, -- { line, col } where insert mode was last left, for `gi`
 }
 
 local MODE_LABELS = {
@@ -59,6 +62,7 @@ local function set_mode(mode)
 	state.operator = nil
 	state.register = nil
 	state.find_pending = nil
+	state.replace_pending = nil
 	state.goal = nil
 	render_status()
 end
@@ -132,6 +136,7 @@ local function has_pending()
 		or state.operator ~= nil
 		or state.register ~= nil
 		or state.find_pending ~= nil
+		or state.replace_pending ~= nil
 end
 
 -- ---------------------------------------------------------------------------
@@ -671,14 +676,429 @@ local PREFIX_KEYS = { g = true, z = true }
 local FIND_KEYS = { f = true, F = true, t = true, T = true }
 
 -- ---------------------------------------------------------------------------
+-- Edits
+--
+-- UNDO CONTRACT: every Vim operation is exactly one undo step. Each edit is
+-- bracketed by begin_undo_group()/end_undo_group() so `3x` undoes as one `u`,
+-- not three. Undo transactions do NOT nest -- BeginTransaction resets the
+-- transaction start index (internal/core/undo/undo.go) -- so an operation must
+-- call begin exactly once. Commands that edit *and then* enter insert mode open
+-- the group here and let leave_insert() close it, which is what makes
+-- `cwfoo<Esc>` a single undo the way Vim does it.
+-- ---------------------------------------------------------------------------
+
+-- Vim's 'shiftwidth'. Hardcoded until Phase 7 wires plugin settings; reading
+-- editor.tabSize would need a `settings` permission the manifest does not ask
+-- for, and re-prompting installed users for it is not worth it yet.
+local SHIFTWIDTH = 4
+
+local function line_len(l)
+	return #line_runes(l)
+end
+
+-- The caller must already have opened the undo group.
+local function begin_insert()
+	set_mode("insert")
+end
+
+-- Leaving insert/replace mode. Vim steps the cursor one column left and drops
+-- it back onto a character; the position *before* that step is what `gi`
+-- resumes from.
+local function leave_insert()
+	local cur = editor.cursor()
+	state.last_insert = { line = cur.line, col = cur.col }
+	set_mode("normal")
+	if cur.col > 1 then
+		editor.set_cursor(cur.line, cur.col - 1)
+	end
+	clamp_cursor()
+	editor.end_undo_group()
+end
+
+-- Delete from the cursor to the end of line (cur.line + n - 1), joining the
+-- lines in between. `2D` on "aaa"/"bbb" leaves a single empty line, as in Vim.
+local function delete_to_end(n)
+	local cur = editor.cursor()
+	local last = clamp(cur.line + n - 1, 1, line_count())
+	editor.replace(cur.line, cur.col, last, line_len(last) + 1, "")
+end
+
+local function swap_case(ch)
+	local b = ch:byte(1)
+	if b == nil then
+		return ch
+	end
+	if b >= 0x61 and b <= 0x7a then
+		return string.char(b - 32)
+	end
+	if b >= 0x41 and b <= 0x5a then
+		return string.char(b + 32)
+	end
+	return ch
+end
+
+-- J / gJ. `count` is the number of lines to end up joined, so it performs
+-- count-1 joins (and `J` alone, count 1, still performs one).
+local function join(count, with_space)
+	local l = editor.cursor().line
+	local times = math.max(1, count - 1)
+	local col = 1
+	editor.begin_undo_group()
+	for _ = 1, times do
+		if l >= line_count() then
+			break
+		end
+		local cur_r = line_runes(l)
+		local nxt_r = line_runes(l + 1)
+		local end_col, sep = 1, ""
+		if with_space then
+			local fnb = 1
+			while fnb <= #nxt_r and is_blank(nxt_r[fnb]) do
+				fnb = fnb + 1
+			end
+			end_col = fnb
+			-- Vim adds no space when the joined-to line already ends in
+			-- whitespace, when it is empty, or when the next line starts with
+			-- a closing paren.
+			if fnb <= #nxt_r and #cur_r > 0 and not is_blank(cur_r[#cur_r]) and nxt_r[fnb] ~= ")" then
+				sep = " "
+			end
+		end
+		editor.replace(l, #cur_r + 1, l + 1, end_col, sep)
+		col = #cur_r + 1
+	end
+	editor.end_undo_group()
+	editor.set_cursor(l, col)
+	clamp_cursor()
+end
+
+-- >> and <<. Blank lines are left alone, as in Vim.
+local function indent_lines(n, dir)
+	local cur = editor.cursor()
+	local last = clamp(cur.line + n - 1, 1, line_count())
+	editor.begin_undo_group()
+	for l = cur.line, last do
+		local r = line_runes(l)
+		if #r > 0 then
+			if dir > 0 then
+				editor.insert(l, 1, string.rep(" ", SHIFTWIDTH))
+			else
+				local k = 0
+				while k < SHIFTWIDTH do
+					local ch = r[k + 1]
+					if ch == "\t" then
+						k = k + 1
+						break
+					elseif ch == " " then
+						k = k + 1
+					else
+						break
+					end
+				end
+				if k > 0 then
+					editor.replace(l, 1, l, k + 1, "")
+				end
+			end
+		end
+	end
+	editor.end_undo_group()
+	move_to(cur.line, first_non_blank(cur.line))
+end
+
+-- == reindent. ttt has no indent engine, so this is a deliberate heuristic:
+-- copy the previous non-blank line's indent, add one shiftwidth if that line
+-- opens a block, and remove one if this line closes one. Spaces only.
+local function reindent(n)
+	local cur = editor.cursor()
+	local last = clamp(cur.line + n - 1, 1, line_count())
+	editor.begin_undo_group()
+	for l = cur.line, last do
+		local body = (editor.get_line(l) or ""):match("^[ \t]*(.-)[ \t]*$") or ""
+		if body ~= "" then
+			local width = 0
+			local p = l - 1
+			while p >= 1 do
+				local prev = editor.get_line(p) or ""
+				local pbody = prev:match("^[ \t]*(.-)[ \t]*$") or ""
+				if pbody ~= "" then
+					width = #(prev:match("^ *") or "")
+					if pbody:match("[%{%(%[]$") or pbody:match(":$") then
+						width = width + SHIFTWIDTH
+					end
+					break
+				end
+				p = p - 1
+			end
+			if body:match("^[%}%)%]]") then
+				width = math.max(0, width - SHIFTWIDTH)
+			end
+			editor.set_line(l, string.rep(" ", width) .. body)
+		end
+	end
+	editor.end_undo_group()
+	move_to(cur.line, first_non_blank(cur.line))
+end
+
+-- Ctrl-A / Ctrl-X. Finds the first digit run ending at or after the cursor,
+-- takes an immediately preceding "-" as a sign, and preserves zero padding.
+-- byte_to_col/col_to_byte bridge Lua's byte-oriented patterns to the editor's
+-- rune columns.
+local function bump(count, dir)
+	local cur = editor.cursor()
+	local text = editor.get_line(cur.line) or ""
+	local bcur = editor.col_to_byte(text, cur.col)
+
+	local s, e
+	local from = 1
+	while true do
+		local a, b = text:find("%d+", from)
+		if not a then
+			break
+		end
+		if b >= bcur then
+			s, e = a, b
+			break
+		end
+		from = b + 1
+	end
+	if not s then
+		return
+	end
+
+	local digits = text:sub(s, e)
+	local start, neg = s, false
+	if s > 1 and text:sub(s - 1, s - 1) == "-" then
+		start, neg = s - 1, true
+	end
+
+	local val = tonumber(digits)
+	if neg then
+		val = -val
+	end
+	val = val + dir * count
+
+	local body = string.format("%d", math.abs(val))
+	if digits:sub(1, 1) == "0" and #digits > 1 and #body < #digits then
+		body = string.rep("0", #digits - #body) .. body
+	end
+	local out = (val < 0 and "-" or "") .. body
+
+	local scol = editor.byte_to_col(text, start)
+	editor.begin_undo_group()
+	editor.replace(cur.line, scol, cur.line, editor.byte_to_col(text, e + 1), out)
+	editor.end_undo_group()
+	editor.set_cursor(cur.line, scol + #out - 1)
+end
+
+-- Single-key normal-mode edits. Called as fn(count, had_count).
+local EDITS = {
+	["i"] = function()
+		editor.begin_undo_group()
+		begin_insert()
+	end,
+	["I"] = function()
+		local l = editor.cursor().line
+		move_to(l, first_non_blank(l))
+		editor.begin_undo_group()
+		begin_insert()
+	end,
+	["a"] = function()
+		local cur = editor.cursor()
+		editor.set_cursor(cur.line, math.min(cur.col + 1, line_len(cur.line) + 1))
+		editor.begin_undo_group()
+		begin_insert()
+	end,
+	["A"] = function()
+		local cur = editor.cursor()
+		editor.set_cursor(cur.line, line_len(cur.line) + 1)
+		editor.begin_undo_group()
+		begin_insert()
+	end,
+	-- Insert rejects line >= #Lines (internal/app/plugin_api.go), so `o` on the
+	-- last line appends the newline to the *end* of that line rather than
+	-- addressing the line after it.
+	["o"] = function()
+		local l = editor.cursor().line
+		editor.begin_undo_group()
+		editor.insert(l, line_len(l) + 1, "\n")
+		editor.set_cursor(l + 1, 1)
+		begin_insert()
+	end,
+	["O"] = function()
+		local l = editor.cursor().line
+		editor.begin_undo_group()
+		editor.insert(l, 1, "\n")
+		editor.set_cursor(l, 1)
+		begin_insert()
+	end,
+
+	["x"] = function(n)
+		local cur = editor.cursor()
+		local last = math.min(cur.col + n, line_len(cur.line) + 1)
+		if last <= cur.col then
+			return
+		end
+		editor.begin_undo_group()
+		editor.replace(cur.line, cur.col, cur.line, last, "")
+		editor.end_undo_group()
+		clamp_cursor()
+	end,
+	["X"] = function(n)
+		local cur = editor.cursor()
+		local start = math.max(1, cur.col - n)
+		if start >= cur.col then
+			return
+		end
+		editor.begin_undo_group()
+		editor.replace(cur.line, start, cur.line, cur.col, "")
+		editor.end_undo_group()
+		editor.set_cursor(cur.line, start)
+	end,
+	["D"] = function(n)
+		editor.begin_undo_group()
+		delete_to_end(n)
+		editor.end_undo_group()
+		clamp_cursor()
+	end,
+	["C"] = function(n)
+		editor.begin_undo_group()
+		delete_to_end(n)
+		begin_insert()
+	end,
+	["s"] = function(n)
+		local cur = editor.cursor()
+		local last = math.min(cur.col + n, line_len(cur.line) + 1)
+		editor.begin_undo_group()
+		if last > cur.col then
+			editor.replace(cur.line, cur.col, cur.line, last, "")
+		end
+		begin_insert()
+	end,
+	["S"] = function(n)
+		local cur = editor.cursor()
+		local last = clamp(cur.line + n - 1, 1, line_count())
+		editor.begin_undo_group()
+		editor.replace(cur.line, 1, last, line_len(last) + 1, "")
+		editor.set_cursor(cur.line, 1)
+		begin_insert()
+	end,
+	-- r consumes the next key; the count rides along in replace_pending.
+	["r"] = function(n)
+		state.replace_pending = n
+	end,
+	["R"] = function()
+		editor.begin_undo_group()
+		set_mode("replace")
+	end,
+
+	["~"] = function(n)
+		local cur = editor.cursor()
+		local r = line_runes(cur.line)
+		if #r == 0 then
+			return
+		end
+		local last = math.min(cur.col + n - 1, #r)
+		local out = {}
+		for i = cur.col, last do
+			out[#out + 1] = swap_case(r[i])
+		end
+		editor.begin_undo_group()
+		editor.replace(cur.line, cur.col, cur.line, last + 1, table.concat(out))
+		editor.end_undo_group()
+		editor.set_cursor(cur.line, math.min(last + 1, max_col(r)))
+	end,
+	["J"] = function(n)
+		join(n, true)
+	end,
+
+	["u"] = function(n)
+		for _ = 1, n do
+			ttt.exec_command("editor.undo")
+		end
+		clamp_cursor()
+	end,
+	["ctrl-r"] = function(n)
+		for _ = 1, n do
+			ttt.exec_command("editor.redo")
+		end
+		clamp_cursor()
+	end,
+
+	["ctrl-a"] = function(n)
+		bump(n, 1)
+	end,
+	["ctrl-x"] = function(n)
+		bump(n, -1)
+	end,
+}
+
+-- Doubled-key line operators: >>, <<, ==.
+local LINE_OPERATORS = {
+	[">"] = function(n)
+		indent_lines(n, 1)
+	end,
+	["<"] = function(n)
+		indent_lines(n, -1)
+	end,
+	["="] = function(n)
+		reindent(n)
+	end,
+}
+
+for k in pairs(LINE_OPERATORS) do
+	PREFIX_KEYS[k] = true
+end
+
+-- g-prefixed edits, appended to the Phase 1 motion table.
+G_MOTIONS["i"] = function()
+	local li = state.last_insert
+	editor.begin_undo_group()
+	if li then
+		local l = clamp(li.line, 1, line_count())
+		editor.set_cursor(l, math.min(li.col, line_len(l) + 1))
+	end
+	begin_insert()
+end
+
+G_MOTIONS["J"] = function(n)
+	join(n, false)
+end
+
+-- ---------------------------------------------------------------------------
 -- Mode handlers
 -- ---------------------------------------------------------------------------
 
 local function handle_insert(tok)
 	if ESCAPE_TOKENS[tok] then
-		set_mode("normal")
-		-- Insert mode allows one-past-the-end; normal mode does not.
-		clamp_cursor()
+		leave_insert()
+		return true
+	end
+	return false
+end
+
+-- R: overtype until Esc. Backspace only walks left -- Vim restores the
+-- overwritten characters, which needs the per-keystroke change log that arrives
+-- with `.` repeat in Phase 5.
+local function handle_replace(tok)
+	if ESCAPE_TOKENS[tok] then
+		leave_insert()
+		return true
+	end
+	if tok == "backspace" or tok == "backspace2" then
+		local cur = editor.cursor()
+		if cur.col > 1 then
+			editor.set_cursor(cur.line, cur.col - 1)
+		end
+		return true
+	end
+	if is_printable(tok) then
+		local cur = editor.cursor()
+		if cur.col <= line_len(cur.line) then
+			editor.replace(cur.line, cur.col, cur.line, cur.col + 1, tok)
+		else
+			editor.insert(cur.line, cur.col, tok)
+		end
+		editor.set_cursor(cur.line, cur.col + 1)
 		return true
 	end
 	return false
@@ -696,6 +1116,23 @@ local function handle_normal(tok)
 			return false
 		end
 		set_mode("normal")
+		return true
+	end
+
+	-- r{char} consumes the next key. Vim refuses the whole operation when the
+	-- count runs past the end of the line rather than replacing fewer chars.
+	if state.replace_pending then
+		local n = state.replace_pending
+		state.replace_pending = nil
+		if is_printable(tok) then
+			local cur = editor.cursor()
+			if cur.col + n - 1 <= line_len(cur.line) then
+				editor.begin_undo_group()
+				editor.replace(cur.line, cur.col, cur.line, cur.col + n, tok:rep(n))
+				editor.end_undo_group()
+				editor.set_cursor(cur.line, cur.col + n - 1)
+			end
+		end
 		return true
 	end
 
@@ -717,6 +1154,16 @@ local function handle_normal(tok)
 		local fn = G_MOTIONS[tok]
 		if fn then
 			fn(n, had)
+		end
+		return true
+	end
+
+	if LINE_OPERATORS[state.pending] then
+		local op = state.pending
+		state.pending = ""
+		local n = take_count()
+		if tok == op then
+			LINE_OPERATORS[op](n)
 		end
 		return true
 	end
@@ -753,8 +1200,10 @@ local function handle_normal(tok)
 		return true
 	end
 
-	if tok == "i" then
-		set_mode("insert")
+	local edit = EDITS[tok]
+	if edit then
+		local n, had = take_count()
+		edit(n, had)
 		return true
 	end
 
@@ -771,6 +1220,7 @@ end
 local HANDLERS = {
 	normal = handle_normal,
 	insert = handle_insert,
+	replace = handle_replace,
 }
 
 local function on_key(ev)

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -9,10 +9,11 @@
 -- Phase 2: insert-mode entry points and single-key edits.
 -- Phase 3: operators, motion ranges and text objects.
 -- Phase 4: visual, visual-line and visual-block modes.
+-- Phase 5: registers, marks, macros and `.` repeat.
 
 local ttt = require("ttt")
 local events = require("ttt.events")
-local editor = require("ttt.editor")
+local raw_editor = require("ttt.editor")
 
 -- ---------------------------------------------------------------------------
 -- State
@@ -26,10 +27,18 @@ local state = {
 	operator = nil, -- pending operator, { op = "d", count = n }
 	textobj = nil, -- "i" or "a" awaiting its object key
 	register = nil, -- pending "x register prefix
+	await_register = false, -- `"` typed, waiting for the register name
 	last_change = nil, -- replay payload for `.`
-	registers = {},
-	marks = {},
-	macro = { recording = nil, keys = {}, playing = false },
+	registers = {}, -- name -> { text = s, kind = "char"|"line"|"block" }
+	marks = {}, -- name -> { line = n, col = n }
+	mark_pending = nil, -- "m" (set) | "`" (exact) | "'" (line) awaiting its name
+	macros = {}, -- name -> array of canonical tokens
+	macro = { recording = nil, keys = {}, playing = 0, last = nil },
+	await_macro = nil, -- "q" (record) | "@" (replay) awaiting its register name
+	insert_ctx = nil, -- per-keystroke log for the insert session in flight
+	replace_stack = nil, -- overwritten characters, so `R` + backspace restores
+	replaying = false, -- inside `.`, so the replay does not re-record itself
+	probing = false, -- inside probe_motion, so jump marks are not disturbed
 	find_pending = nil, -- "f" | "F" | "t" | "T" awaiting its target char
 	last_find = nil, -- { op = "f", ch = "x" } for `;` and `,`
 	goal = nil, -- sticky column for j/k
@@ -39,6 +48,56 @@ local state = {
 	last_visual = nil, -- the range `gv` reselects
 	block_insert = false, -- blockwise I/A/c is holding multi-cursors open
 }
+
+-- ---------------------------------------------------------------------------
+-- Editor shim
+--
+-- Marks have to survive edits, and there is no buffer-change event to hang that
+-- off, so the three mutating entry points are wrapped. `editor` is a fresh table
+-- that forwards everything else to the real module via __index -- the module
+-- itself is left untouched, so no other plugin sees the override.
+-- ---------------------------------------------------------------------------
+
+local function count_newlines(s)
+	local n = 0
+	for _ in string.gmatch(s or "", "\n") do
+		n = n + 1
+	end
+	return n
+end
+
+-- Only lines strictly below the edit move; a mark inside a deleted span
+-- collapses onto the start of that span, which is what Vim does too.
+local function shift_marks(after, delta, collapse_from, collapse_to, collapse_col)
+	if delta == 0 and collapse_from == nil then
+		return
+	end
+	for _, m in pairs(state.marks) do
+		if m.line > after then
+			m.line = m.line + delta
+		elseif collapse_from and m.line > collapse_from and m.line <= collapse_to then
+			m.line = collapse_from
+			m.col = collapse_col
+		end
+	end
+end
+
+local editor = setmetatable({
+	insert = function(l, c, text)
+		state.marks["."] = { line = l, col = c }
+		shift_marks(l, count_newlines(text))
+		return raw_editor.insert(l, c, text)
+	end,
+	replace = function(sl, sc, el, ec, text)
+		state.marks["."] = { line = sl, col = sc }
+		shift_marks(el, count_newlines(text) - (el - sl), sl, el, sc)
+		return raw_editor.replace(sl, sc, el, ec, text)
+	end,
+	set_line = function(l, text)
+		state.marks["."] = { line = l, col = 1 }
+		return raw_editor.set_line(l, text)
+	end,
+}, { __index = raw_editor })
 
 local MODE_LABELS = {
 	normal = "-- NORMAL --",
@@ -56,9 +115,15 @@ local MODE_LABELS = {
 local function render_status()
 	if not state.enabled then
 		ttt.remove_status_item("mode")
+		ttt.remove_status_item("macro")
 		return
 	end
 	ttt.set_status_item("left", "mode", MODE_LABELS[state.mode] or state.mode, { priority = 10 })
+	if state.macro.recording then
+		ttt.set_status_item("left", "macro", "recording @" .. state.macro.recording, { priority = 11 })
+	else
+		ttt.remove_status_item("macro")
+	end
 end
 
 local function set_mode(mode)
@@ -68,6 +133,9 @@ local function set_mode(mode)
 	state.operator = nil
 	state.textobj = nil
 	state.register = nil
+	state.await_register = false
+	state.await_macro = nil
+	state.mark_pending = nil
 	state.find_pending = nil
 	state.replace_pending = nil
 	state.goal = nil
@@ -143,6 +211,9 @@ local function has_pending()
 		or state.operator ~= nil
 		or state.textobj ~= nil
 		or state.register ~= nil
+		or state.await_register
+		or state.await_macro ~= nil
+		or state.mark_pending ~= nil
 		or state.find_pending ~= nil
 		or state.replace_pending ~= nil
 end
@@ -485,6 +556,60 @@ local function repeat_find(count, reverse)
 end
 
 -- ---------------------------------------------------------------------------
+-- Marks
+--
+-- state.marks maps a name to { line, col }. Line numbers are kept correct
+-- across edits by the editor shim at the top of this file. Three names are
+-- special and never set by `m`: `'` is the position before the last jump (what
+-- `''` and ``` `` ``` return to), `.` is the position of the last change (set by
+-- the shim), and backtick reads the same slot as `'`.
+-- ---------------------------------------------------------------------------
+
+local function mark_slot(name)
+	if name == "`" or name == "'" then
+		return "'"
+	end
+	return name
+end
+
+local function set_jump_mark()
+	if state.probing then
+		return
+	end
+	local cur = editor.cursor()
+	state.marks["'"] = { line = cur.line, col = cur.col }
+end
+
+local function mark_set(name, line, col)
+	state.marks[mark_slot(name)] = { line = line, col = col }
+end
+
+-- Where a mark points, clamped onto the buffer as it is now. `linewise` is the
+-- `'{mark}` form, which lands on the first non-blank of the line.
+local function mark_target(name, linewise)
+	local m = state.marks[mark_slot(name)]
+	if not m then
+		return nil
+	end
+	local l = clamp(m.line, 1, line_count())
+	if linewise then
+		return l, first_non_blank(l)
+	end
+	return l, clamp(m.col, 1, max_col(line_runes(l)))
+end
+
+local function goto_mark(name, linewise)
+	local l, c = mark_target(name, linewise)
+	if not l then
+		return
+	end
+	set_jump_mark()
+	move_to(l, c)
+end
+
+local MARK_NAME = "^[%a'`%.]$"
+
+-- ---------------------------------------------------------------------------
 -- Screen position and scrolling
 --
 -- SetCursor calls EnsureCursorVisible on the Go side, so every routine here
@@ -613,6 +738,7 @@ local MOTIONS = {
 		word_end(n, true, false)
 	end,
 	["G"] = function(n, had_count)
+		set_jump_mark()
 		goto_line(had_count and n or line_count())
 	end,
 	["{"] = function(n)
@@ -672,6 +798,7 @@ local MOTIONS = {
 -- Second key of a `g`-prefixed sequence.
 local G_MOTIONS = {
 	["g"] = function(n, had_count)
+		set_jump_mark()
 		goto_line(had_count and n or 1)
 	end,
 	["_"] = function(n)
@@ -713,21 +840,126 @@ local function line_len(l)
 	return #line_runes(l)
 end
 
--- The caller must already have opened the undo group.
-local function begin_insert()
+-- ---------------------------------------------------------------------------
+-- The change log
+--
+-- `.` replays a *resolved payload*, not keystrokes: the operator, its target,
+-- the count, the register and (for anything that ends in insert mode) the text
+-- that was typed. The typed text is the one part that cannot be known when the
+-- command starts, so an insert session carries a per-keystroke log
+-- (state.insert_ctx) that is folded into the payload when Esc is pressed. That
+-- same log is what makes `3i` repeat its text and backspace in `R` restore the
+-- character it overwrote.
+-- ---------------------------------------------------------------------------
+
+-- A nil payload means "this command is not repeatable"; the previous `.` target
+-- is kept rather than cleared, so a stray yank or visual operator does not
+-- silently disarm `.`.
+local function record_change(payload)
+	if state.replaying or payload == nil then
+		return
+	end
+	state.last_change = payload
+end
+
+-- One typed key as the text it produced, or nil when it is not something that
+-- can be replayed as plain text (arrows, Ctrl chords, ...).
+local function token_text(t)
+	if t == "enter" then
+		return "\n"
+	end
+	if t == "tab" then
+		return "\t"
+	end
+	local b = t:byte(1)
+	if b == nil then
+		return nil
+	end
+	if #t == 1 then
+		if b >= 0x20 and b <= 0x7e then
+			return t
+		end
+		return nil
+	end
+	if b >= 0xc0 then
+		return t
+	end
+	return nil
+end
+
+-- Insert `text` at (l, c) and return the position just past it.
+local function insert_and_advance(l, c, text)
+	editor.insert(l, c, text)
+	local k = count_newlines(text)
+	if k == 0 then
+		return l, c + #runes_of(text)
+	end
+	return l + k, #runes_of(text:match("[^\n]*$") or "") + 1
+end
+
+local function insert_text_of(ctx)
+	if not ctx or ctx.dirty then
+		return nil
+	end
+	return table.concat(ctx.keys)
+end
+
+-- `{count}i`, `{count}o`, `{count}a`: Vim types the text once and repeats it
+-- count-1 more times when insert mode is left. `o`/`O` repeat onto fresh lines.
+local function repeat_insert(ctx, text)
+	local cur = editor.cursor()
+	local l, c = cur.line, cur.col
+	local open_line = (ctx.tok == "o" or ctx.tok == "O")
+	for _ = 2, ctx.count do
+		if open_line then
+			l, c = insert_and_advance(l, line_len(l) + 1, "\n" .. text)
+		else
+			l, c = insert_and_advance(l, c, text)
+		end
+	end
+	editor.set_cursor(l, c)
+end
+
+-- The caller must already have opened the undo group. `ctx` describes how the
+-- session was entered so it can be counted and repeated; pass nil for sessions
+-- that are neither (blockwise multi-cursor insert).
+local function begin_insert(ctx)
 	set_mode("insert")
+	if ctx then
+		ctx.keys = {}
+		ctx.count = ctx.count or 1
+		state.insert_ctx = ctx
+	end
+	state.replace_stack = {}
 end
 
 -- Leaving insert/replace mode. Vim steps the cursor one column left and drops
 -- it back onto a character; the position *before* that step is what `gi`
 -- resumes from.
 local function leave_insert()
+	local ctx = state.insert_ctx
+	state.insert_ctx = nil
+	state.replace_stack = nil
+
 	-- Blockwise I/A/c parked a cursor on every row; collapse them before reading
 	-- the cursor back, so the position recorded for `gi` is the primary one.
 	if state.block_insert then
 		state.block_insert = false
 		editor.clear_cursors()
+		ctx = nil
 	end
+
+	if ctx then
+		local text = insert_text_of(ctx)
+		if text and text ~= "" and ctx.count > 1 then
+			repeat_insert(ctx, text)
+		end
+		if ctx.change then
+			ctx.change.text = text
+			record_change(text and ctx.change or nil)
+		end
+	end
+
 	local cur = editor.cursor()
 	state.last_insert = { line = cur.line, col = cur.col }
 	set_mode("normal")
@@ -739,12 +971,18 @@ local function leave_insert()
 end
 
 -- ---------------------------------------------------------------------------
--- Text extraction and the unnamed register
+-- Text extraction and registers
 --
--- Phase 3 keeps exactly one register: the unnamed `"`. Named registers, the
--- numbered ring and `"x` prefixes arrive in Phase 5. A register entry is
--- { text, linewise }; linewise text always carries its trailing newline so a
--- paste can be replayed verbatim.
+-- A register entry is { text, kind }, kind being "char", "line" or "block".
+-- Linewise text always carries its trailing newline so a paste can be replayed
+-- verbatim; blockwise text is the rows joined by newlines, and only the kind
+-- distinguishes it from a multi-line charwise yank.
+--
+-- Names: `"` unnamed, `"0` last yank, `"1`-`"9` the delete ring, `"-` small
+-- delete, `"a`-`"z` named (uppercase appends), `"_` blackhole, `"+`/`"*` the
+-- system clipboard. See the README for what the clipboard registers can and
+-- cannot do -- there is no clipboard binding in the plugin Lua API, so they are
+-- routed through the `editor.copy` / `editor.paste` commands.
 -- ---------------------------------------------------------------------------
 
 -- table.concat errors when j runs past the array, so clamp both ends here
@@ -780,16 +1018,129 @@ local function linewise_text(sl, el)
 	return table.concat(parts, "\n") .. "\n"
 end
 
-local function set_register(text, linewise)
-	state.registers['"'] = { text = text, linewise = linewise and true or false }
+local CLIPBOARD_REGISTERS = { ["+"] = true, ["*"] = true }
+
+local function take_register()
+	local r = state.register
+	state.register = nil
+	return r
 end
 
-local function yank_charwise(sl, sc, el, ec)
-	set_register(charwise_text(sl, sc, el, ec), false)
+-- There is no clipboard binding in the plugin Lua API, so `"+y` borrows
+-- editor.copy: select the range, copy, drop the selection, put the cursor back.
+-- set_selection parks the cursor at the end of the range, which is exactly what
+-- Selection.Text reads, so `ec` stays the usual exclusive end column.
+local function clipboard_copy(sl, sc, el, ec)
+	local cur = editor.cursor()
+	local sel = editor.selection()
+	editor.set_selection(sl, sc, el, ec)
+	ttt.exec_command("editor.copy")
+	editor.clear_selection()
+	editor.set_cursor(cur.line, cur.col)
+	if sel and sel.active then
+		editor.set_selection(sel.start_line, sel.start_col, cur.line, cur.col)
+	end
 end
 
-local function yank_linewise(sl, el)
-	set_register(linewise_text(sl, el), true)
+local function reg_store(name, text, kind)
+	if name == "_" then
+		return
+	end
+	local upper = name:match("^(%u)$")
+	if upper then
+		local lower = upper:lower()
+		local prev = state.registers[lower]
+		if prev then
+			local joined
+			if prev.kind == "line" then
+				joined = prev.text .. text
+				if kind ~= "line" then
+					joined = joined .. "\n"
+				end
+			elseif kind == "line" then
+				joined = prev.text .. "\n" .. text
+			else
+				joined = prev.text .. text
+			end
+			state.registers[lower] = { text = joined, kind = prev.kind == "line" and "line" or kind }
+		else
+			state.registers[lower] = { text = text, kind = kind }
+		end
+		state.registers['"'] = state.registers[lower]
+		return
+	end
+	state.registers[name] = { text = text, kind = kind }
+	state.registers['"'] = state.registers[name]
+end
+
+-- Shift "1-"9 down one slot and drop the new text into "1.
+local function shift_delete_ring(text, kind)
+	for i = 9, 2, -1 do
+		state.registers[tostring(i)] = state.registers[tostring(i - 1)]
+	end
+	state.registers["1"] = { text = text, kind = kind }
+end
+
+-- The single write path for every yank and delete. `range` is optional and only
+-- used by the clipboard registers, which need buffer coordinates rather than
+-- text. Vim's defaults: a yank fills "0, a multi-line delete rotates the ring,
+-- a small delete fills "-, and everything also lands in the unnamed register.
+local function set_register(text, kind, is_delete, range)
+	local name = take_register()
+
+	if name and CLIPBOARD_REGISTERS[name] then
+		state.registers[name] = { text = text, kind = kind }
+		state.registers['"'] = state.registers[name]
+		if range then
+			clipboard_copy(range[1], range[2], range[3], range[4])
+		end
+		return
+	end
+
+	if name then
+		reg_store(name, text, kind)
+		return
+	end
+
+	if is_delete then
+		if kind == "line" or text:find("\n", 1, true) then
+			shift_delete_ring(text, kind)
+			state.registers['"'] = state.registers["1"]
+		else
+			state.registers["-"] = { text = text, kind = kind }
+			state.registers['"'] = state.registers["-"]
+		end
+		return
+	end
+
+	state.registers["0"] = { text = text, kind = kind }
+	state.registers['"'] = state.registers["0"]
+end
+
+-- Resolve a register for reading. Uppercase reads the lowercase slot.
+local function get_register(name)
+	name = name or '"'
+	local upper = name:match("^(%u)$")
+	if upper then
+		name = upper:lower()
+	end
+	return state.registers[name]
+end
+
+local function yank_charwise(sl, sc, el, ec, is_delete)
+	set_register(charwise_text(sl, sc, el, ec), "char", is_delete, { sl, sc, el, ec })
+end
+
+local function yank_linewise(sl, el, is_delete)
+	local n = line_count()
+	local ec_line = math.min(el, n)
+	local range
+	if ec_line < n then
+		range = { sl, 1, ec_line + 1, 1 }
+	else
+		range = { sl, 1, ec_line, line_len(ec_line) + 1 }
+	end
+	set_register(linewise_text(sl, el), "line", is_delete, range)
 end
 
 -- Delete whole lines sl..el. Three cases, because the newline that has to go
@@ -812,15 +1163,15 @@ end
 -- Linewise change (`cc`, `S`, `c` with a linewise motion): collapse lines
 -- sl..el to a single line that keeps sl's indent, then enter insert mode. The
 -- caller has already opened the undo group; leave_insert() closes it.
-local function change_lines(sl, el)
+local function change_lines(sl, el, ctx)
 	local n = line_count()
 	sl = clamp(sl, 1, n)
 	el = clamp(el, sl, n)
 	local indent = (editor.get_line(sl) or ""):match("^[ \t]*") or ""
-	yank_linewise(sl, el)
+	yank_linewise(sl, el, true)
 	editor.replace(sl, 1, el, line_len(el) + 1, indent)
 	editor.set_cursor(sl, #runes_of(indent) + 1)
-	begin_insert()
+	begin_insert(ctx)
 end
 
 -- Delete from the cursor to the end of line (cur.line + n - 1), joining the
@@ -828,21 +1179,93 @@ end
 local function delete_to_end(n)
 	local cur = editor.cursor()
 	local last = clamp(cur.line + n - 1, 1, line_count())
-	yank_charwise(cur.line, cur.col, last, line_len(last) + 1)
+	yank_charwise(cur.line, cur.col, last, line_len(last) + 1, true)
 	editor.replace(cur.line, cur.col, last, line_len(last) + 1, "")
 end
 
 -- p / P. A linewise register lands on a new line below/above; a charwise one
 -- lands after/before the cursor. Multi-line charwise text leaves the cursor at
 -- the first pasted character, single-line text on its last, both as in Vim.
+local function split_lines(s)
+	local out = {}
+	local from = 1
+	while true do
+		local at = s:find("\n", from, true)
+		if not at then
+			out[#out + 1] = s:sub(from)
+			break
+		end
+		out[#out + 1] = s:sub(from, at - 1)
+		from = at + 1
+	end
+	return out
+end
+
+-- Blockwise paste re-inserts a rectangle: row i of the register goes onto line
+-- cursor+i-1 at the paste column, padding short lines with spaces and appending
+-- new lines when the block runs past the end of the buffer. `count` repeats each
+-- row horizontally, as in Vim.
+local function paste_block(reg, count, after)
+	local cur = editor.cursor()
+	local rows = split_lines(reg.text)
+	local col = cur.col
+	if after and line_len(cur.line) > 0 then
+		col = math.min(cur.col + 1, line_len(cur.line) + 1)
+	end
+	editor.begin_undo_group()
+	for i = 1, #rows do
+		local l = cur.line + i - 1
+		while line_count() < l do
+			local n = line_count()
+			editor.insert(n, line_len(n) + 1, "\n")
+		end
+		local chunk = rows[i]:rep(count)
+		local len = line_len(l)
+		if len < col - 1 then
+			editor.insert(l, len + 1, string.rep(" ", col - 1 - len) .. chunk)
+		else
+			editor.insert(l, col, chunk)
+		end
+	end
+	editor.end_undo_group()
+	move_to(cur.line, col)
+end
+
+-- `"+p` / `"*p`. The clipboard cannot be read from Lua, so this positions the
+-- cursor and delegates to the core paste command. Consequences: the register
+-- kind is whatever core makes of the text (there is no linewise flag to carry),
+-- and each repetition is its own undo step because core opens its own
+-- transaction and undo groups do not nest.
+local function paste_clipboard(count, after)
+	local cur = editor.cursor()
+	local col = cur.col
+	if after and line_len(cur.line) > 0 then
+		col = math.min(cur.col + 1, line_len(cur.line) + 1)
+	end
+	editor.set_cursor(cur.line, col)
+	for _ = 1, count do
+		ttt.exec_command("editor.paste")
+	end
+	clamp_cursor()
+end
+
 local function paste(count, after)
-	local reg = state.registers['"']
+	local name = take_register()
+	if name and CLIPBOARD_REGISTERS[name] then
+		paste_clipboard(count, after)
+		return
+	end
+	local reg = get_register(name)
 	if not reg or reg.text == "" then
+		return
+	end
+	if reg.kind == "block" then
+		paste_block(reg, count, after)
 		return
 	end
 	local cur = editor.cursor()
 	editor.begin_undo_group()
-	if reg.linewise then
+	if reg.kind == "line" then
 		local body = (reg.text:gsub("\n$", ""))
 		local chunk = body
 		for _ = 2, count do
@@ -1036,46 +1459,58 @@ local function bump(count, dir)
 	editor.set_cursor(cur.line, scol + #out - 1)
 end
 
+-- Context for an insert session opened by a normal-mode command. `text_count`
+-- is how many times the typed text is repeated on Esc (`3i`), `cmd_count` is
+-- the count `.` should re-run the command with (`3s` deletes three characters
+-- but types its text once).
+local function entry_ctx(tok, cmd_count, text_count)
+	return {
+		tok = tok,
+		count = text_count or 1,
+		change = { kind = "insert", tok = tok, count = cmd_count or 1 },
+	}
+end
+
 -- Single-key normal-mode edits. Called as fn(count, had_count).
 local EDITS = {
-	["i"] = function()
+	["i"] = function(n)
 		editor.begin_undo_group()
-		begin_insert()
+		begin_insert(entry_ctx("i", n, n))
 	end,
-	["I"] = function()
+	["I"] = function(n)
 		local l = editor.cursor().line
 		move_to(l, first_non_blank(l))
 		editor.begin_undo_group()
-		begin_insert()
+		begin_insert(entry_ctx("I", n, n))
 	end,
-	["a"] = function()
+	["a"] = function(n)
 		local cur = editor.cursor()
 		editor.set_cursor(cur.line, math.min(cur.col + 1, line_len(cur.line) + 1))
 		editor.begin_undo_group()
-		begin_insert()
+		begin_insert(entry_ctx("a", n, n))
 	end,
-	["A"] = function()
+	["A"] = function(n)
 		local cur = editor.cursor()
 		editor.set_cursor(cur.line, line_len(cur.line) + 1)
 		editor.begin_undo_group()
-		begin_insert()
+		begin_insert(entry_ctx("A", n, n))
 	end,
 	-- Insert rejects line >= #Lines (internal/app/plugin_api.go), so `o` on the
 	-- last line appends the newline to the *end* of that line rather than
 	-- addressing the line after it.
-	["o"] = function()
+	["o"] = function(n)
 		local l = editor.cursor().line
 		editor.begin_undo_group()
 		editor.insert(l, line_len(l) + 1, "\n")
 		editor.set_cursor(l + 1, 1)
-		begin_insert()
+		begin_insert(entry_ctx("o", n, n))
 	end,
-	["O"] = function()
+	["O"] = function(n)
 		local l = editor.cursor().line
 		editor.begin_undo_group()
 		editor.insert(l, 1, "\n")
 		editor.set_cursor(l, 1)
-		begin_insert()
+		begin_insert(entry_ctx("O", n, n))
 	end,
 
 	["x"] = function(n)
@@ -1085,7 +1520,7 @@ local EDITS = {
 			return
 		end
 		editor.begin_undo_group()
-		yank_charwise(cur.line, cur.col, cur.line, last)
+		yank_charwise(cur.line, cur.col, cur.line, last, true)
 		editor.replace(cur.line, cur.col, cur.line, last, "")
 		editor.end_undo_group()
 		clamp_cursor()
@@ -1097,7 +1532,7 @@ local EDITS = {
 			return
 		end
 		editor.begin_undo_group()
-		yank_charwise(cur.line, start, cur.line, cur.col)
+		yank_charwise(cur.line, start, cur.line, cur.col, true)
 		editor.replace(cur.line, start, cur.line, cur.col, "")
 		editor.end_undo_group()
 		editor.set_cursor(cur.line, start)
@@ -1111,22 +1546,22 @@ local EDITS = {
 	["C"] = function(n)
 		editor.begin_undo_group()
 		delete_to_end(n)
-		begin_insert()
+		begin_insert(entry_ctx("C", n, 1))
 	end,
 	["s"] = function(n)
 		local cur = editor.cursor()
 		local last = math.min(cur.col + n, line_len(cur.line) + 1)
 		editor.begin_undo_group()
 		if last > cur.col then
-			yank_charwise(cur.line, cur.col, cur.line, last)
+			yank_charwise(cur.line, cur.col, cur.line, last, true)
 			editor.replace(cur.line, cur.col, cur.line, last, "")
 		end
-		begin_insert()
+		begin_insert(entry_ctx("s", n, 1))
 	end,
 	["S"] = function(n)
 		local cur = editor.cursor()
 		editor.begin_undo_group()
-		change_lines(cur.line, cur.line + n - 1)
+		change_lines(cur.line, cur.line + n - 1, entry_ctx("S", n, 1))
 	end,
 	-- Vim's `Y` is a synonym for `yy`; ttt follows Neovim's default of `y$`,
 	-- which is what the other shorthands (`D`, `C`) do.
@@ -1141,6 +1576,7 @@ local EDITS = {
 	end,
 	["R"] = function()
 		editor.begin_undo_group()
+		begin_insert({ tok = "R", count = 1, change = { kind = "replace_mode" } })
 		set_mode("replace")
 	end,
 
@@ -1277,10 +1713,17 @@ end
 -- editor.replace. Only `c` leaves the undo group open, because it hands off to
 -- insert mode and leave_insert() closes it -- that is what makes `cwfoo<Esc>`
 -- one undo step.
-local function apply_operator(op, sl, sc, el, ec, linewise)
+local function apply_operator(op, sl, sc, el, ec, linewise, payload)
 	local n = line_count()
 	sl = clamp(sl, 1, n)
 	el = clamp(el, 1, n)
+
+	-- `c` hands off to insert mode, so its payload is only complete once the
+	-- typed text is known; leave_insert() records it. Everything else is done
+	-- editing by the time this returns.
+	if op ~= "c" then
+		record_change(payload)
+	end
 
 	if op == "y" then
 		if linewise then
@@ -1298,12 +1741,12 @@ local function apply_operator(op, sl, sc, el, ec, linewise)
 
 	if op == "d" then
 		if linewise then
-			yank_linewise(sl, el)
+			yank_linewise(sl, el, true)
 			delete_lines(sl, el)
 			local l = math.min(sl, line_count())
 			move_to(l, first_non_blank(l))
 		else
-			yank_charwise(sl, sc, el, ec)
+			yank_charwise(sl, sc, el, ec, true)
 			editor.replace(sl, sc, el, ec, "")
 			editor.set_cursor(sl, sc)
 			clamp_cursor()
@@ -1313,13 +1756,14 @@ local function apply_operator(op, sl, sc, el, ec, linewise)
 	end
 
 	if op == "c" then
+		local ctx = { tok = "c", count = 1, change = payload }
 		if linewise then
-			change_lines(sl, el)
+			change_lines(sl, el, ctx)
 		else
-			yank_charwise(sl, sc, el, ec)
+			yank_charwise(sl, sc, el, ec, true)
 			editor.replace(sl, sc, el, ec, "")
 			editor.set_cursor(sl, sc)
-			begin_insert()
+			begin_insert(ctx)
 		end
 		-- Undo group deliberately left open for leave_insert().
 		return
@@ -1366,7 +1810,9 @@ end
 local function probe_motion(fn, n, had_count)
 	local start = editor.cursor()
 	local saved_goal = state.goal
+	state.probing = true
 	fn(n, had_count)
+	state.probing = false
 	local dest = editor.cursor()
 	editor.set_cursor(start.line, start.col)
 	state.goal = saved_goal
@@ -1961,20 +2407,32 @@ local function operator_count()
 	return total, (opc ~= nil or mc ~= nil)
 end
 
+-- The `.` payload for an operator. A yank changes nothing, so it is not
+-- repeatable. state.register is still pending here -- the yank inside
+-- apply_operator is what consumes it -- so the payload can capture it.
+local function op_payload(op, n, target)
+	if op == "y" then
+		return nil
+	end
+	return { kind = "operator", op = op, count = n, register = state.register, target = target }
+end
+
 -- Doubled key: `dd`, `>>`, `guu`. Operates on `count` whole lines from the
 -- cursor down.
 local function run_linewise_operator()
 	local op = state.operator.op
 	local n = operator_count()
+	local payload = op_payload(op, n, { t = "linewise" })
 	local sl = editor.cursor().line
 	local el = clamp(sl + n - 1, 1, line_count())
 	clear_operator()
-	apply_operator(op, sl, 1, el, 1, true)
+	apply_operator(op, sl, 1, el, 1, true, payload)
 end
 
 local function run_motion_operator(tok, gprefix)
 	local op = state.operator.op
 	local n, had = operator_count()
+	local payload = op_payload(op, n, { t = "motion", tok = tok, gprefix = gprefix })
 	local fn, kind
 	if gprefix then
 		kind = G_MOTION_KIND[tok]
@@ -2008,12 +2466,13 @@ local function run_motion_operator(tok, gprefix)
 	if sl == nil then
 		return
 	end
-	apply_operator(op, sl, sc, el, ec, linewise)
+	apply_operator(op, sl, sc, el, ec, linewise, payload)
 end
 
 local function run_find_operator(op_char, ch)
 	local op = state.operator.op
 	local n = operator_count()
+	local payload = op_payload(op, n, { t = "find", op = op_char, ch = ch })
 	local start = editor.cursor()
 	local saved_goal = state.goal
 	find_char(op_char, ch, n, false)
@@ -2032,12 +2491,13 @@ local function run_find_operator(op_char, ch)
 	if sl == nil then
 		return
 	end
-	apply_operator(op, sl, sc, el, ec, linewise)
+	apply_operator(op, sl, sc, el, ec, linewise, payload)
 end
 
 local function run_textobject(inner, tok)
 	local op = state.operator.op
 	local n = operator_count()
+	local payload = op_payload(op, n, { t = "textobj", inner = inner, tok = tok })
 	local fn = TEXT_OBJECTS[tok]
 	clear_operator()
 	if not fn then
@@ -2050,7 +2510,26 @@ local function run_textobject(inner, tok)
 	if not linewise and sl == el and ec <= sc then
 		return
 	end
-	apply_operator(op, sl, sc, el, ec, linewise)
+	apply_operator(op, sl, sc, el, ec, linewise, payload)
+end
+
+-- `d'a` / ``d`a``. Backtick is an exclusive charwise motion, `'` a linewise one.
+local function run_mark_operator(name, linewise_mark)
+	local op = state.operator.op
+	local n = operator_count()
+	local payload = op_payload(op, n, { t = "mark", name = name, linewise = linewise_mark })
+	local start = editor.cursor()
+	local ml, mc = mark_target(name, linewise_mark)
+	clear_operator()
+	if not ml then
+		return
+	end
+	local kind = linewise_mark and "linewise" or "exclusive"
+	local sl, sc, el, ec, lw = motion_to_range(start, { line = ml, col = mc }, kind)
+	if sl == nil then
+		return
+	end
+	apply_operator(op, sl, sc, el, ec, lw, payload)
 end
 
 -- g-prefixed edits, appended to the Phase 1 motion table.
@@ -2205,6 +2684,9 @@ end
 -- Tear down the visual chrome and return to normal mode *without* touching the
 -- cursor. Operators call this before they edit; Esc uses exit_visual().
 local function end_visual()
+	-- set_mode clears the pending `"x` prefix, but a visual operator types its
+	-- register *before* the operator key, so it has to survive this teardown.
+	local reg = state.register
 	save_last_visual()
 	if state.mode == "visual_block" then
 		editor.clear_cursors()
@@ -2212,6 +2694,7 @@ local function end_visual()
 	editor.clear_selection()
 	state.visual = nil
 	set_mode("normal")
+	state.register = reg
 end
 
 local function exit_visual()
@@ -2405,7 +2888,7 @@ end
 -- Visual `p`: the selection is replaced by the register, and the text that was
 -- there becomes the new unnamed register, as in Vim.
 local function visual_paste()
-	local reg = state.registers['"']
+	local reg = get_register(take_register())
 	local sl, sc, el, ec, linewise = visual_range()
 	if state.mode == "visual_block" or not reg or reg.text == "" then
 		return
@@ -2422,16 +2905,16 @@ local function visual_paste()
 
 	editor.begin_undo_group()
 	if linewise then
-		yank_linewise(sl, el)
+		yank_linewise(sl, el, true)
 	else
-		yank_charwise(sl, sc, el, ec)
+		yank_charwise(sl, sc, el, ec, true)
 	end
 
 	local repl
 	if linewise then
-		repl = reg.linewise and body or text
+		repl = (reg.kind == "line") and body or text
 	else
-		repl = reg.linewise and ("\n" .. body .. "\n") or text
+		repl = (reg.kind == "line") and ("\n" .. body .. "\n") or text
 	end
 	editor.replace(sl, a, el, b, repl)
 	editor.end_undo_group()
@@ -2471,12 +2954,12 @@ local function visual_operator(op, force_linewise)
 		local top, bot, left, right = block_rect()
 		local dollar = state.visual.dollar
 		if op == "y" then
-			set_register(block_text(top, bot, left, right, dollar), false)
+			set_register(block_text(top, bot, left, right, dollar), "block", false)
 			end_visual()
 			move_to(top, math.min(left, max_col(line_runes(top))))
 			return
 		end
-		set_register(block_text(top, bot, left, right, dollar), false)
+		set_register(block_text(top, bot, left, right, dollar), "block", true)
 		end_visual()
 		editor.begin_undo_group()
 		block_delete(top, bot, left, right, dollar)
@@ -2547,6 +3030,34 @@ local VISUAL_LINEWISE_OPS = { X = "d", D = "d", R = "c", S = "c", C = "c", Y = "
 local function handle_visual(tok)
 	if ESCAPE_TOKENS[tok] then
 		exit_visual()
+		return true
+	end
+
+	if state.await_register then
+		state.await_register = false
+		if is_printable(tok) then
+			state.register = tok
+		end
+		return true
+	end
+
+	if state.mark_pending then
+		local what = state.mark_pending
+		state.mark_pending = nil
+		if tok:match(MARK_NAME) then
+			if what == "m" then
+				visual_sync()
+				local cur = editor.cursor()
+				mark_set(tok, cur.line, cur.col)
+			else
+				local ml, mc = mark_target(tok, what == "'")
+				if ml then
+					visual_motion(function()
+						move_to(ml, mc)
+					end, 1, false)
+				end
+			end
+		end
 		return true
 	end
 
@@ -2628,6 +3139,16 @@ local function handle_visual(tok)
 		else
 			switch_visual(vm)
 		end
+		return true
+	end
+
+	if tok == '"' then
+		state.await_register = true
+		return true
+	end
+
+	if tok == "m" or tok == "`" or tok == "'" then
+		state.mark_pending = tok
 		return true
 	end
 
@@ -2756,6 +3277,201 @@ local function handle_visual(tok)
 end
 
 -- ---------------------------------------------------------------------------
+-- Dot repeat
+--
+-- `.` replays the resolved payload recorded by the last buffer-changing
+-- command, not the keystrokes that produced it. Everything below re-enters the
+-- very same code paths the original command took, which is what keeps `.` a
+-- single undo step: each of those paths opens exactly one undo group.
+-- ---------------------------------------------------------------------------
+
+local function do_replace_char(n, ch)
+	local cur = editor.cursor()
+	-- Vim refuses the whole operation when the count runs past the end of the
+	-- line rather than replacing fewer characters.
+	if cur.col + n - 1 > line_len(cur.line) then
+		return
+	end
+	editor.begin_undo_group()
+	editor.replace(cur.line, cur.col, cur.line, cur.col + n, ch:rep(n))
+	editor.end_undo_group()
+	editor.set_cursor(cur.line, cur.col + n - 1)
+end
+
+-- Overtype `text` from the cursor, the way `R` does.
+local function overtype(text)
+	for _, ch in ipairs(runes_of(text)) do
+		local cur = editor.cursor()
+		if ch == "\n" then
+			editor.insert(cur.line, cur.col, "\n")
+			editor.set_cursor(cur.line + 1, 1)
+		elseif cur.col <= line_len(cur.line) then
+			editor.replace(cur.line, cur.col, cur.line, cur.col + 1, ch)
+			editor.set_cursor(cur.line, cur.col + 1)
+		else
+			editor.insert(cur.line, cur.col, ch)
+			editor.set_cursor(cur.line, cur.col + 1)
+		end
+	end
+end
+
+-- Finish an insert session that a replay opened: the recorded text has to be
+-- typed by hand, because there is no editor to type it.
+local function replay_insert(tok, text, count)
+	local ctx = state.insert_ctx
+	if ctx then
+		-- The repetition is done here, so leave_insert() must not do it again.
+		ctx.count = 1
+	end
+	if text and text ~= "" then
+		local cur = editor.cursor()
+		local l, c = cur.line, cur.col
+		local open_line = (tok == "o" or tok == "O")
+		for i = 1, math.max(1, count or 1) do
+			if open_line and i > 1 then
+				l, c = insert_and_advance(l, line_len(l) + 1, "\n" .. text)
+			else
+				l, c = insert_and_advance(l, c, text)
+			end
+		end
+		editor.set_cursor(l, c)
+	end
+	leave_insert()
+end
+
+-- The entry commands whose count multiplies the typed text rather than the
+-- amount of buffer they consume (`3i` types three copies, `3s` does not).
+local REPEAT_TEXT = { i = true, I = true, a = true, A = true, o = true, O = true }
+
+local function run_operator_payload(p, count)
+	local n = count or p.count or 1
+	state.operator = { op = p.op, count = n }
+	state.count = nil
+	state.register = p.register
+	local t = p.target or {}
+	if t.t == "linewise" then
+		run_linewise_operator()
+	elseif t.t == "motion" then
+		run_motion_operator(t.tok, t.gprefix)
+	elseif t.t == "textobj" then
+		run_textobject(t.inner, t.tok)
+	elseif t.t == "find" then
+		run_find_operator(t.op, t.ch)
+	elseif t.t == "mark" then
+		run_mark_operator(t.name, t.linewise)
+	else
+		clear_operator()
+	end
+	if p.op == "c" and state.mode == "insert" then
+		replay_insert("c", p.text, 1)
+	end
+	state.register = nil
+end
+
+local function run_change(p, count)
+	if not p then
+		return
+	end
+	state.replaying = true
+	pcall(function()
+		if p.kind == "edit" then
+			state.register = p.register
+			local fn = EDITS[p.tok]
+			if fn then
+				fn(count or p.count or 1, true)
+			end
+			state.register = nil
+		elseif p.kind == "replace_char" then
+			do_replace_char(count or p.count or 1, p.ch)
+		elseif p.kind == "replace_mode" then
+			EDITS["R"](1)
+			overtype(p.text or "")
+			leave_insert()
+		elseif p.kind == "insert" then
+			local n = count or p.count or 1
+			local fn = EDITS[p.tok]
+			if fn then
+				fn(n, true)
+				replay_insert(p.tok, p.text, REPEAT_TEXT[p.tok] and n or 1)
+			end
+		elseif p.kind == "operator" then
+			run_operator_payload(p, count)
+		end
+	end)
+	state.replaying = false
+end
+
+-- ---------------------------------------------------------------------------
+-- Macros
+--
+-- Recording captures canonical tokens, not raw events, so a replay is literally
+-- "feed the tokens back through dispatch()". state.macro.playing is a depth
+-- counter: it stops a replay from being recorded into the macro being recorded,
+-- and caps `@a` calling itself. A key budget caps the other runaway shape, a
+-- macro that loops forever without recursing.
+-- ---------------------------------------------------------------------------
+
+local MACRO_MAX_DEPTH = 10
+local MACRO_MAX_KEYS = 20000
+
+local HANDLERS -- assigned once the mode handlers exist
+local dispatch -- forward declaration; play_macro re-enters it
+
+local function start_recording(name)
+	state.macro.recording = name
+	state.macro.keys = {}
+	render_status()
+end
+
+local function stop_recording()
+	local name = state.macro.recording
+	if not name then
+		return
+	end
+	local slot = name:lower()
+	if name:match("^%u$") and state.macros[slot] then
+		local dst = state.macros[slot]
+		for _, t in ipairs(state.macro.keys) do
+			dst[#dst + 1] = t
+		end
+	else
+		state.macros[slot] = state.macro.keys
+	end
+	state.macro.recording = nil
+	state.macro.keys = {}
+	render_status()
+end
+
+local function play_macro(name, count)
+	local keys = state.macros[name:lower()]
+	if not keys or #keys == 0 then
+		return
+	end
+	if state.macro.playing >= MACRO_MAX_DEPTH then
+		return
+	end
+	state.macro.last = name:lower()
+	if state.macro.playing == 0 then
+		state.macro.budget = MACRO_MAX_KEYS
+	end
+	state.macro.playing = state.macro.playing + 1
+	-- A Lua error mid-replay would otherwise be swallowed by the key.press
+	-- listener and leave the depth counter stuck.
+	pcall(function()
+		for _ = 1, count do
+			for _, tok in ipairs(keys) do
+				state.macro.budget = state.macro.budget - 1
+				if state.macro.budget <= 0 then
+					error("vim: macro key budget exhausted")
+				end
+				dispatch(tok)
+			end
+		end
+	end)
+	state.macro.playing = state.macro.playing - 1
+end
+
+-- ---------------------------------------------------------------------------
 -- Mode handlers
 -- ---------------------------------------------------------------------------
 
@@ -2767,15 +3483,27 @@ local function handle_insert(tok)
 	return false
 end
 
--- R: overtype until Esc. Backspace only walks left -- Vim restores the
--- overwritten characters, which needs the per-keystroke change log that arrives
--- with `.` repeat in Phase 5.
+-- R: overtype until Esc. state.replace_stack remembers what each keystroke
+-- overwrote, so backspace restores the original character the way Vim does --
+-- and, past the start of the session, just walks left.
 local function handle_replace(tok)
 	if ESCAPE_TOKENS[tok] then
 		leave_insert()
 		return true
 	end
 	if tok == "backspace" or tok == "backspace2" then
+		local stack = state.replace_stack
+		local top = stack and stack[#stack] or nil
+		if top then
+			table.remove(stack)
+			if top.orig then
+				editor.replace(top.line, top.col, top.line, top.col + 1, top.orig)
+			else
+				editor.replace(top.line, top.col, top.line, top.col + 1, "")
+			end
+			editor.set_cursor(top.line, top.col)
+			return true
+		end
 		local cur = editor.cursor()
 		if cur.col > 1 then
 			editor.set_cursor(cur.line, cur.col - 1)
@@ -2784,9 +3512,16 @@ local function handle_replace(tok)
 	end
 	if is_printable(tok) then
 		local cur = editor.cursor()
+		local stack = state.replace_stack
 		if cur.col <= line_len(cur.line) then
+			if stack then
+				stack[#stack + 1] = { line = cur.line, col = cur.col, orig = line_runes(cur.line)[cur.col] }
+			end
 			editor.replace(cur.line, cur.col, cur.line, cur.col + 1, tok)
 		else
+			if stack then
+				stack[#stack + 1] = { line = cur.line, col = cur.col, orig = nil }
+			end
 			editor.insert(cur.line, cur.col, tok)
 		end
 		editor.set_cursor(cur.line, cur.col + 1)
@@ -2794,6 +3529,20 @@ local function handle_replace(tok)
 	end
 	return false
 end
+
+-- Single-key edits that change the buffer without entering insert mode, so
+-- their `.` payload is complete the moment they run.
+local SIMPLE_CHANGES = {
+	["x"] = true,
+	["X"] = true,
+	["D"] = true,
+	["~"] = true,
+	["J"] = true,
+	["p"] = true,
+	["P"] = true,
+	["ctrl-a"] = true,
+	["ctrl-x"] = true,
+}
 
 local function handle_normal(tok)
 	if ESCAPE_TOKENS[tok] then
@@ -2804,19 +3553,61 @@ local function handle_normal(tok)
 		return true
 	end
 
-	-- r{char} consumes the next key. Vim refuses the whole operation when the
-	-- count runs past the end of the line rather than replacing fewer chars.
+	-- r{char} consumes the next key.
 	if state.replace_pending then
 		local n = state.replace_pending
 		state.replace_pending = nil
 		if is_printable(tok) then
-			local cur = editor.cursor()
-			if cur.col + n - 1 <= line_len(cur.line) then
-				editor.begin_undo_group()
-				editor.replace(cur.line, cur.col, cur.line, cur.col + n, tok:rep(n))
-				editor.end_undo_group()
-				editor.set_cursor(cur.line, cur.col + n - 1)
+			record_change({ kind = "replace_char", count = n, ch = tok })
+			do_replace_char(n, tok)
+		end
+		return true
+	end
+
+	if state.await_register then
+		state.await_register = false
+		if is_printable(tok) then
+			state.register = tok
+		end
+		return true
+	end
+
+	-- q{a-z} / @{a-z} / @@ consume the next key as a register name.
+	if state.await_macro then
+		local what = state.await_macro
+		state.await_macro = nil
+		local n = take_count()
+		if what == "q" then
+			if tok:match("^%a$") then
+				start_recording(tok)
 			end
+		elseif tok == "@" then
+			if state.macro.last then
+				play_macro(state.macro.last, n)
+			end
+		elseif tok:match("^%a$") then
+			play_macro(tok, n)
+		end
+		return true
+	end
+
+	-- m{name} sets a mark; `{name} and '{name} jump to one, and are valid
+	-- operator targets.
+	if state.mark_pending then
+		local what = state.mark_pending
+		state.mark_pending = nil
+		if not tok:match(MARK_NAME) then
+			clear_operator()
+			return true
+		end
+		if what == "m" then
+			local cur = editor.cursor()
+			mark_set(tok, cur.line, cur.col)
+		elseif state.operator then
+			run_mark_operator(tok, what == "'")
+		else
+			state.count = nil
+			goto_mark(tok, what == "'")
 		end
 		return true
 	end
@@ -2887,6 +3678,40 @@ local function handle_normal(tok)
 		return true
 	end
 
+	if tok == '"' then
+		state.await_register = true
+		return true
+	end
+
+	if tok == "`" or tok == "'" then
+		state.mark_pending = tok
+		return true
+	end
+
+	if not state.operator then
+		if tok == "m" then
+			state.mark_pending = "m"
+			return true
+		end
+		if tok == "q" then
+			if state.macro.recording then
+				stop_recording()
+			else
+				state.await_macro = "q"
+			end
+			return true
+		end
+		if tok == "@" then
+			state.await_macro = "@"
+			return true
+		end
+		if tok == "." then
+			local n, had = take_count()
+			run_change(state.last_change, had and n or nil)
+			return true
+		end
+	end
+
 	-- Operator-pending. This has to precede the motion and edit tables: `d` then
 	-- `i` is "inner text object", not "enter insert mode".
 	if state.operator then
@@ -2934,7 +3759,13 @@ local function handle_normal(tok)
 
 	local edit = EDITS[tok]
 	if edit then
+		local reg = state.register
 		local n, had = take_count()
+		-- Insert-entry edits record their payload in leave_insert() instead,
+		-- once the typed text is known.
+		if SIMPLE_CHANGES[tok] then
+			record_change({ kind = "edit", tok = tok, count = n, register = reg })
+		end
 		edit(n, had)
 		return true
 	end
@@ -2965,7 +3796,7 @@ G_MOTIONS["v"] = function()
 	reselect_visual()
 end
 
-local HANDLERS = {
+HANDLERS = {
 	normal = handle_normal,
 	insert = handle_insert,
 	replace = handle_replace,
@@ -2974,15 +3805,74 @@ local HANDLERS = {
 	visual_block = handle_visual,
 }
 
-local function on_key(ev)
-	if not state.enabled then
-		return false
-	end
+-- The single entry point for a canonical token, whether it came from a real
+-- keystroke or from a macro replay. Everything that needs to observe keys --
+-- macro recording, the insert-mode change log -- hangs off here rather than off
+-- the individual handlers.
+dispatch = function(tok)
 	local handler = HANDLERS[state.mode]
 	if not handler then
 		return false
 	end
-	return handler(token_of(ev))
+
+	-- `q` stops recording, and must not be recorded as part of the macro.
+	if state.macro.recording and state.mode == "normal" and tok == "q" and not has_pending() then
+		stop_recording()
+		return true
+	end
+
+	local ctx = state.insert_ctx
+	local typing = (state.mode == "insert" or state.mode == "replace")
+	-- Sampled before the handler runs: the `a` of `qa` starts the recording and
+	-- must not become the macro's first key.
+	local was_recording = state.macro.recording
+
+	local handled = handler(tok)
+
+	-- Insert mode passes printable keys through to the editor, which types them.
+	-- During a macro replay there is no editor doing that, so this does it.
+	if not handled and typing and state.macro.playing > 0 then
+		local txt = token_text(tok)
+		if txt then
+			local cur = editor.cursor()
+			local l, c = insert_and_advance(cur.line, cur.col, txt)
+			editor.set_cursor(l, c)
+			handled = true
+		end
+	end
+
+	-- Log the typed text for `.` and for `{count}i`. A key that cannot be
+	-- rendered as text makes the session non-repeatable rather than wrong.
+	if ctx and typing and not ESCAPE_TOKENS[tok] then
+		if tok == "backspace" or tok == "backspace2" then
+			if #ctx.keys > 0 then
+				table.remove(ctx.keys)
+			else
+				ctx.dirty = true
+			end
+		else
+			local txt = token_text(tok)
+			if txt then
+				ctx.keys[#ctx.keys + 1] = txt
+			else
+				ctx.dirty = true
+			end
+		end
+	end
+
+	if was_recording and state.macro.recording and state.macro.playing == 0 and (handled or typing) then
+		local keys = state.macro.keys
+		keys[#keys + 1] = tok
+	end
+
+	return handled
+end
+
+local function on_key(ev)
+	if not state.enabled then
+		return false
+	end
+	return dispatch(token_of(ev))
 end
 
 -- ---------------------------------------------------------------------------

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -10,6 +10,7 @@
 -- Phase 3: operators, motion ranges and text objects.
 -- Phase 4: visual, visual-line and visual-block modes.
 -- Phase 5: registers, marks, macros and `.` repeat.
+-- Phase 6: search, the ex command line, substitution, editor integration.
 
 local ttt = require("ttt")
 local events = require("ttt.events")
@@ -3343,6 +3344,1114 @@ end
 -- amount of buffer they consume (`3i` types three copies, `3s` does not).
 local REPEAT_TEXT = { i = true, I = true, a = true, A = true, o = true, O = true }
 
+-- ---------------------------------------------------------------------------
+-- Phase 6: search, ex command line, substitution, editor integration
+--
+-- The command line is a modal overlay, handled *above* the plugin key
+-- interceptor: while it is open `key.press` delivers nothing here at all. So
+-- there is no cmdline mode and no focus flag -- `/`, `?` and `:` call
+-- ttt.command_line.show() and do every bit of their work in the callbacks.
+--
+-- on_change is a preview only. It moves the cursor (which scrolls the view) and
+-- never touches the buffer; a buffer edit from an incremental preview would be
+-- unundoable and would invalidate the very offsets it is searching.
+-- ---------------------------------------------------------------------------
+
+-- Phase 6 lives inside a `do` block on purpose. The main chunk is within a
+-- handful of slots of Lua's 200-locals-per-function ceiling, and a block scope
+-- releases its registers at `end`; without it the whole file fails to compile
+-- with "too many local variables". Everything the dispatcher needs is re-exported
+-- through the single `vim6` table below.
+local vim6 = {}
+
+do
+	local fs_ok, fs = pcall(require, "ttt.fs")
+	if not fs_ok then
+		fs = nil
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Byte <-> rune column conversion
+	--
+	-- The editor API speaks rune columns; Lua's pattern matcher speaks bytes. Every
+	-- match crosses that boundary exactly twice, here.
+	-- ---------------------------------------------------------------------------
+
+	local function rune_len(b)
+		if b >= 0xf0 then
+			return 4
+		elseif b >= 0xe0 then
+			return 3
+		elseif b >= 0xc0 then
+			return 2
+		end
+		return 1
+	end
+
+	-- 1-based byte index at which rune column `col` starts. A col past the end of
+	-- the line yields #s + 1.
+	local function byte_of_col(s, col)
+		local i, k, n = 1, 1, #s
+		while i <= n and k < col do
+			i = i + rune_len(s:byte(i))
+			k = k + 1
+		end
+		return i
+	end
+
+	-- 1-based rune column containing byte index `bi`.
+	local function col_of_byte(s, bi)
+		local i, k, n = 1, 1, #s
+		while i <= n and i < bi do
+			i = i + rune_len(s:byte(i))
+			k = k + 1
+		end
+		return k
+	end
+
+	local function is_word_byte(b)
+		if b == nil then
+			return false
+		end
+		return (b >= 0x30 and b <= 0x39)
+			or (b >= 0x41 and b <= 0x5a)
+			or (b >= 0x61 and b <= 0x7a)
+			or b == 0x5f
+			or b >= 0x80
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Vim regex -> Lua pattern
+	--
+	-- Lua 5.1 patterns are NOT a regex engine: there is no alternation, no
+	-- grouping-with-quantifier, no counted repeat and no lookaround, and gopher-lua
+	-- additionally lacks the %f frontier pattern. Rather than silently
+	-- misinterpreting a pattern, anything that cannot be represented is rejected
+	-- with a message. The supported subset is documented in README.md.
+	--
+	-- Translated:
+	--   .  *  ^  $  [...]        pass through (same meaning in both)
+	--   \+ \? \=                 -> +  ?  ?
+	--   \( \)                    -> capture group (Lua groups cannot be quantified)
+	--   \d \D \s \S \a \l \u \x  -> %d %D %s %S %a %l %u %x  (and their complements)
+	--   \w \W                    -> [%w_] / [^%w_]  (Vim's \w includes underscore)
+	--   \n \t \e                 -> the literal control character
+	--   \c                       -> anywhere in the pattern: ignore case
+	--   \< \>                    -> word boundary, but only at the very start/end
+	--                               of the pattern (there is no %f to compile to),
+	--                               checked against the neighbouring byte instead
+	--   ( ) + ? { } | ~ &        literal, as in Vim's default "magic" mode
+	-- Rejected: \| \{n,m} \@ \% \zs \ze and any other \-escape with a regex meaning.
+	-- ---------------------------------------------------------------------------
+
+	local VIM_CLASS = {
+		d = "%d",
+		D = "%D",
+		s = "%s",
+		S = "%S",
+		w = "[%w_]",
+		W = "[^%w_]",
+		a = "%a",
+		A = "%A",
+		l = "%l",
+		L = "%L",
+		u = "%u",
+		U = "%U",
+		x = "%x",
+		X = "%X",
+		o = "[0-7]",
+		n = "\n",
+		t = "\t",
+		e = "\27",
+	}
+
+	-- \-escapes that mean something in Vim which Lua patterns cannot express.
+	local VIM_UNSUPPORTED = {
+		["|"] = "alternation (\\|)",
+		["{"] = "counted repeats (\\{n,m})",
+		["}"] = "counted repeats (\\{n,m})",
+		["@"] = "lookaround (\\@=, \\@!)",
+		["%"] = "\\%( groups",
+		["z"] = "\\zs / \\ze",
+	}
+
+	local LUA_MAGIC = "^$*+?.([%])-"
+
+	local function lua_escape(ch)
+		if #ch == 1 and LUA_MAGIC:find(ch, 1, true) then
+			return "%" .. ch
+		end
+		return ch
+	end
+
+	-- A literal character, doubled into a set when the match must ignore case.
+	local function emit_literal(out, ch, ic)
+		if ic and ch:match("^%a$") then
+			out[#out + 1] = "[" .. ch:lower() .. ch:upper() .. "]"
+		else
+			out[#out + 1] = lua_escape(ch)
+		end
+	end
+
+	-- Copy a [...] class through, translating \d-style escapes and escaping the
+	-- Lua-only metacharacter `%`. Returns the class text and the index just past
+	-- the closing bracket, or nil when the class is unterminated.
+	local function convert_class(pat, i, ic)
+		local n = #pat
+		local cls = { "[" }
+		local j = i + 1
+		if pat:sub(j, j) == "^" then
+			cls[#cls + 1] = "^"
+			j = j + 1
+		end
+		if pat:sub(j, j) == "]" then
+			cls[#cls + 1] = "%]"
+			j = j + 1
+		end
+		local closed = false
+		while j <= n do
+			local c = pat:sub(j, j)
+			if c == "]" then
+				closed = true
+				j = j + 1
+				break
+			elseif c == "\\" then
+				local nx = pat:sub(j + 1, j + 1)
+				local m = VIM_CLASS[nx]
+				-- Only single %-classes and control characters compose inside a set.
+				if m and (#m == 2 or #m == 1) then
+					cls[#cls + 1] = m
+				elseif nx == "" then
+					cls[#cls + 1] = "%\\"
+				else
+					cls[#cls + 1] = lua_escape(nx)
+				end
+				j = j + 2
+			elseif c == "%" then
+				cls[#cls + 1] = "%%"
+				j = j + 1
+			else
+				if ic and c:match("^%a$") then
+					cls[#cls + 1] = c:lower() .. c:upper()
+				else
+					cls[#cls + 1] = c
+				end
+				j = j + 1
+			end
+		end
+		if not closed then
+			return nil
+		end
+		cls[#cls + 1] = "]"
+		return table.concat(cls), j
+	end
+
+	-- Returns a compiled pattern { lua, word_start, word_end, ic } or nil + message.
+	local function compile_vim_pattern(pat, ignorecase)
+		local ic = ignorecase and true or false
+		if pat:find("\\c", 1, true) then
+			ic = true
+			pat = pat:gsub("\\c", "")
+		end
+		if pat:find("\\C", 1, true) then
+			ic = false
+			pat = pat:gsub("\\C", "")
+		end
+
+		local out = {}
+		local ws, we = false, false
+		local i, n = 1, #pat
+
+		while i <= n do
+			local c = pat:sub(i, i)
+			if c == "\\" then
+				local nx = pat:sub(i + 1, i + 1)
+				i = i + 2
+				if nx == "" then
+					out[#out + 1] = "%\\"
+				elseif nx == "<" then
+					if #out > 0 then
+						return nil, "\\< is only supported at the start of a pattern"
+					end
+					ws = true
+				elseif nx == ">" then
+					if i <= n then
+						return nil, "\\> is only supported at the end of a pattern"
+					end
+					we = true
+				elseif nx == "+" then
+					out[#out + 1] = "+"
+				elseif nx == "?" or nx == "=" then
+					out[#out + 1] = "?"
+				elseif nx == "(" then
+					out[#out + 1] = "("
+				elseif nx == ")" then
+					out[#out + 1] = ")"
+				elseif VIM_UNSUPPORTED[nx] then
+					return nil, VIM_UNSUPPORTED[nx] .. " is not supported"
+				elseif VIM_CLASS[nx] then
+					out[#out + 1] = VIM_CLASS[nx]
+				else
+					emit_literal(out, nx, ic)
+				end
+			elseif c == "[" then
+				local cls, j = convert_class(pat, i, ic)
+				if not cls then
+					return nil, "unterminated [ ] in pattern"
+				end
+				out[#out + 1] = cls
+				i = j
+			elseif c == "." or c == "*" or c == "^" or c == "$" then
+				out[#out + 1] = c
+				i = i + 1
+			elseif c == "%" then
+				out[#out + 1] = "%%"
+				i = i + 1
+			else
+				local b = c:byte(1)
+				if b >= 0x80 then
+					local len = rune_len(b)
+					out[#out + 1] = pat:sub(i, i + len - 1)
+					i = i + len
+				else
+					emit_literal(out, c, ic)
+					i = i + 1
+				end
+			end
+		end
+
+		return { lua = table.concat(out), word_start = ws, word_end = we, ic = ic }
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Replacement text
+	--
+	-- Vim's `&` and `\0`-`\9` become Lua's `%0`-`%9`, which `expand()` below
+	-- substitutes by hand -- string.gsub is not used, because the word-boundary
+	-- flags cannot be expressed as a pattern and have to be checked per match.
+	-- ---------------------------------------------------------------------------
+
+	local function compile_replacement(rep)
+		local out = {}
+		local i, n = 1, #rep
+		while i <= n do
+			local c = rep:sub(i, i)
+			if c == "\\" then
+				local nx = rep:sub(i + 1, i + 1)
+				i = i + 2
+				if nx == "" then
+					out[#out + 1] = "\\"
+				elseif nx == "r" or nx == "n" then
+					return nil, "a replacement cannot contain a line break"
+				elseif nx:match("^%d$") then
+					out[#out + 1] = "%" .. nx
+				elseif nx == "t" then
+					out[#out + 1] = "\t"
+				elseif nx == "%" then
+					out[#out + 1] = "%%"
+				else
+					out[#out + 1] = nx
+				end
+			elseif c == "&" then
+				out[#out + 1] = "%0"
+				i = i + 1
+			elseif c == "%" then
+				out[#out + 1] = "%%"
+				i = i + 1
+			else
+				out[#out + 1] = c
+				i = i + 1
+			end
+		end
+		return table.concat(out)
+	end
+
+	local function expand(rep, whole, caps)
+		local out = {}
+		local i, n = 1, #rep
+		while i <= n do
+			local c = rep:sub(i, i)
+			if c == "%" then
+				local d = rep:sub(i + 1, i + 1)
+				if d == "0" then
+					out[#out + 1] = whole
+				elseif d:match("^%d$") then
+					out[#out + 1] = tostring(caps[tonumber(d)] or "")
+				elseif d == "%" then
+					out[#out + 1] = "%"
+				else
+					out[#out + 1] = d
+				end
+				i = i + 2
+			else
+				out[#out + 1] = c
+				i = i + 1
+			end
+		end
+		return table.concat(out)
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Matching
+	-- ---------------------------------------------------------------------------
+
+	-- Every match of `c` in one line, as { sb, eb, text } with inclusive byte
+	-- bounds and the expanded replacement. Empty matches are skipped: Vim would
+	-- accept them, but they are useless for `n` and dangerous for `:s`.
+	local function line_matches(text, c, rep)
+		local out = {}
+		local anchored = c.lua:sub(1, 1) == "^"
+		local init = 1
+		while init <= #text + 1 do
+			local res = { string.find(text, c.lua, init) }
+			local sb, eb = res[1], res[2]
+			if not sb then
+				break
+			end
+			if eb < sb then
+				init = sb + 1
+			else
+				local ok = true
+				if c.word_start and is_word_byte(text:byte(sb - 1)) then
+					ok = false
+				end
+				if c.word_end and is_word_byte(text:byte(eb + 1)) then
+					ok = false
+				end
+				if ok then
+					local caps = {}
+					for k = 3, #res do
+						caps[k - 2] = res[k]
+					end
+					out[#out + 1] = { sb = sb, eb = eb, text = expand(rep or "", text:sub(sb, eb), caps) }
+				end
+				init = eb + 1
+			end
+			if anchored then
+				break
+			end
+		end
+		return out
+	end
+
+	-- The whole-buffer scan. Deliberately one pass per search rather than per
+	-- keystroke of a motion. Returns line, start col, end col (exclusive), wrapped.
+	local function search_from(c, line, col, dir)
+		local n = line_count()
+		for step = 0, n do
+			local l = line + dir * step
+			local wrapped = false
+			while l > n do
+				l = l - n
+				wrapped = true
+			end
+			while l < 1 do
+				l = l + n
+				wrapped = true
+			end
+			local text = editor.get_line(l) or ""
+			local ms = line_matches(text, c)
+			if #ms > 0 then
+				if step == 0 then
+					local cb = byte_of_col(text, col)
+					if dir > 0 then
+						for _, m in ipairs(ms) do
+							if m.sb > cb then
+								return l, col_of_byte(text, m.sb), col_of_byte(text, m.eb + 1), false
+							end
+						end
+					else
+						for k = #ms, 1, -1 do
+							if ms[k].sb < cb then
+								return l, col_of_byte(text, ms[k].sb), col_of_byte(text, ms[k].eb + 1), false
+							end
+						end
+					end
+				else
+					local m = ms[1]
+					if dir < 0 then
+						m = ms[#ms]
+					end
+					return l, col_of_byte(text, m.sb), col_of_byte(text, m.eb + 1), wrapped
+				end
+			end
+		end
+		return nil
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Search state and the `/`, `?`, `n`, `N`, `*`, `#` commands
+	-- ---------------------------------------------------------------------------
+
+	local search = { pat = nil, compiled = nil, dir = 1 }
+
+	local function set_search(pat, compiled, dir)
+		search.pat = pat
+		search.compiled = compiled
+		search.dir = dir
+	end
+
+	local function report_wrap(dir)
+		if dir > 0 then
+			ttt.notify("search hit BOTTOM, continuing at TOP")
+		else
+			ttt.notify("search hit TOP, continuing at BOTTOM")
+		end
+	end
+
+	local function not_found(pat)
+		ttt.notify("E486: Pattern not found: " .. (pat or ""), "error")
+	end
+
+	-- Jump to the next match of the stored pattern. `dir` is already resolved
+	-- against `n` vs `N`.
+	local function search_step(dir, count)
+		if not search.compiled then
+			ttt.notify("E35: No previous regular expression", "error")
+			return
+		end
+		local wrapped_any = false
+		for _ = 1, count do
+			local cur = editor.cursor()
+			local l, c1, _, wrapped = search_from(search.compiled, cur.line, cur.col, dir)
+			if not l then
+				not_found(search.pat)
+				return
+			end
+			if wrapped then
+				wrapped_any = true
+			end
+			set_jump_mark()
+			move_to(l, c1)
+		end
+		if wrapped_any then
+			report_wrap(dir)
+		end
+	end
+
+	-- The word under (or after) the cursor, for `*` and `#`.
+	local function word_under_cursor()
+		local cur = editor.cursor()
+		local r = line_runes(cur.line)
+		local i = cur.col
+		while i <= #r and class_of(r[i], false) ~= 1 do
+			i = i + 1
+		end
+		if i > #r then
+			return nil
+		end
+		local s = i
+		while s > 1 and class_of(r[s - 1], false) == 1 do
+			s = s - 1
+		end
+		local e = i
+		while e < #r and class_of(r[e + 1], false) == 1 do
+			e = e + 1
+		end
+		return table.concat(r, "", s, e)
+	end
+
+	-- `*` / `#`: search for the word under the cursor, whole-word.
+	local function search_word(dir)
+		local word = word_under_cursor()
+		if not word then
+			ttt.notify("E348: No string under cursor", "error")
+			return
+		end
+		-- The word is matched literally; only the boundaries are pattern-ish, and
+		-- those ride on the word_start/word_end flags rather than on \< and \>,
+		-- which gopher-lua has no %f to compile to.
+		local c = compile_vim_pattern(word)
+		if not c then
+			return
+		end
+		c.word_start = true
+		c.word_end = true
+		set_search("\\<" .. word .. "\\>", c, dir)
+		local cur = editor.cursor()
+		-- Vim starts `*` from the start of the word, so the current one is skipped.
+		local r = line_runes(cur.line)
+		local s = cur.col
+		while s > 1 and class_of(r[s - 1], false) == 1 do
+			s = s - 1
+		end
+		local l, c1, _, wrapped = search_from(c, cur.line, s, dir)
+		if not l then
+			not_found(search.pat)
+			return
+		end
+		set_jump_mark()
+		move_to(l, c1)
+		if wrapped then
+			report_wrap(dir)
+		end
+	end
+
+	-- `d/foo<CR>`: the match position is an exclusive charwise motion target.
+	local function run_search_operator(start, l, c)
+		local op = state.operator.op
+		local payload = op_payload(op, 1, { t = "search", pat = search.pat, dir = search.dir })
+		clear_operator()
+		local sl, sc, el, ec, lw = motion_to_range(start, { line = l, col = c }, "exclusive")
+		if sl == nil then
+			return
+		end
+		apply_operator(op, sl, sc, el, ec, lw, payload)
+	end
+
+	local function open_search(dir)
+		local origin = editor.cursor()
+		local had_operator = state.operator ~= nil
+		local prefix = "/"
+		if dir < 0 then
+			prefix = "?"
+		end
+
+		local function restore()
+			editor.set_cursor(origin.line, origin.col)
+		end
+
+		ttt.command_line.show({
+			prefix = prefix,
+			-- Preview only: cursor and scroll, never the buffer.
+			on_change = function(text)
+				if text == "" then
+					restore()
+					return
+				end
+				local c = compile_vim_pattern(text)
+				if not c then
+					restore()
+					return
+				end
+				local l, c1 = search_from(c, origin.line, origin.col, dir)
+				if l then
+					editor.set_cursor(l, c1)
+				else
+					restore()
+				end
+			end,
+			on_submit = function(text)
+				restore()
+				if text ~= "" then
+					local c, err = compile_vim_pattern(text)
+					if not c then
+						ttt.notify("vim: " .. (err or "bad pattern"), "error")
+						clear_operator()
+						return
+					end
+					set_search(text, c, dir)
+				end
+				if not search.compiled then
+					ttt.notify("E35: No previous regular expression", "error")
+					clear_operator()
+					return
+				end
+				search.dir = dir
+				local l, c1, _, wrapped = search_from(search.compiled, origin.line, origin.col, dir)
+				if not l then
+					not_found(search.pat)
+					clear_operator()
+					return
+				end
+				if had_operator and state.operator then
+					run_search_operator(origin, l, c1)
+				else
+					set_jump_mark()
+					move_to(l, c1)
+				end
+				if wrapped then
+					report_wrap(dir)
+				end
+			end,
+			on_cancel = function()
+				restore()
+				clamp_cursor()
+				clear_operator()
+			end,
+		})
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Substitution
+	-- ---------------------------------------------------------------------------
+
+	-- Rebuild a line from the accepted match spans.
+	local function apply_spans(text, spans)
+		local out, prev = {}, 1
+		for _, s in ipairs(spans) do
+			out[#out + 1] = text:sub(prev, s.sb - 1)
+			out[#out + 1] = s.text
+			prev = s.eb + 1
+		end
+		out[#out + 1] = text:sub(prev)
+		return table.concat(out)
+	end
+
+	-- One undo group for the whole run, however many lines it touched: `:%s/a/b/g`
+	-- across the file is a single `u`.
+	local function apply_work(work)
+		local count, lines, last_line = 0, 0, nil
+		editor.begin_undo_group()
+		for _, w in ipairs(work) do
+			if #w.spans > 0 then
+				local new = apply_spans(w.text, w.spans)
+				if new ~= w.text then
+					editor.set_line(w.line, new)
+					count = count + #w.spans
+					lines = lines + 1
+					last_line = w.line
+				end
+			end
+		end
+		editor.end_undo_group()
+
+		if last_line then
+			move_to(last_line, first_non_blank(last_line))
+		end
+		if count > 0 then
+			local s1 = "s"
+			if count == 1 then
+				s1 = ""
+			end
+			local s2 = "s"
+			if lines == 1 then
+				s2 = ""
+			end
+			ttt.notify(count .. " substitution" .. s1 .. " on " .. lines .. " line" .. s2)
+		end
+	end
+
+	-- The `c` flag. Every match is located up front and nothing is edited until the
+	-- last answer is in, so the positions stay valid and the whole run is still one
+	-- undo step. The prompt is the command line itself, and on_change fires on the
+	-- first keystroke -- which is how a single-key y/n/a/q answer works.
+	local confirm_walk
+
+	confirm_walk = function(work, flat, i)
+		if i > #flat then
+			for _, w in ipairs(work) do
+				local keep = {}
+				for _, s in ipairs(w.spans) do
+					if not s.skip then
+						keep[#keep + 1] = s
+					end
+				end
+				w.spans = keep
+			end
+			apply_work(work)
+			return
+		end
+
+		local item = flat[i]
+		editor.set_cursor(item.line, col_of_byte(item.text, item.span.sb))
+
+		local function skip_rest()
+			for k = i, #flat do
+				flat[k].span.skip = true
+			end
+			ttt.set_timeout(0, function()
+				confirm_walk(work, flat, #flat + 1)
+			end)
+		end
+
+		local answered = false
+		ttt.command_line.show({
+			prefix = "replace with " .. item.span.text .. " (y/n/a/q)? ",
+			on_change = function(text)
+				if answered or text == "" then
+					return
+				end
+				answered = true
+				local ch = text:sub(1, 1):lower()
+				ttt.command_line.hide()
+				if ch == "q" then
+					skip_rest()
+					return
+				end
+				if ch == "a" then
+					ttt.set_timeout(0, function()
+						confirm_walk(work, flat, #flat + 1)
+					end)
+					return
+				end
+				if ch ~= "y" then
+					item.span.skip = true
+				end
+				ttt.set_timeout(0, function()
+					confirm_walk(work, flat, i + 1)
+				end)
+			end,
+			on_cancel = skip_rest,
+		})
+	end
+
+	-- Split `/pat/rep/flags` on its delimiter, honouring `\` escapes. The delimiter
+	-- is whatever character follows the `s`, so `:s#a#b#` works too.
+	local function split_spec(spec)
+		local delim = spec:sub(1, 1)
+		local parts, cur = {}, {}
+		local i, n = 2, #spec
+		while i <= n do
+			local c = spec:sub(i, i)
+			if c == "\\" then
+				local nx = spec:sub(i + 1, i + 1)
+				if nx == delim then
+					cur[#cur + 1] = delim
+				else
+					cur[#cur + 1] = spec:sub(i, i + 1)
+				end
+				i = i + 2
+			elseif c == delim then
+				parts[#parts + 1] = table.concat(cur)
+				cur = {}
+				i = i + 1
+			else
+				cur[#cur + 1] = c
+				i = i + 1
+			end
+		end
+		parts[#parts + 1] = table.concat(cur)
+		return parts
+	end
+
+	local function do_substitute(first, last, spec)
+		local parts = split_spec(spec)
+		local pat = parts[1] or ""
+		local rep = parts[2] or ""
+		local flags = parts[3] or ""
+
+		if pat == "" then
+			if not search.pat then
+				ttt.notify("E35: No previous regular expression", "error")
+				return
+			end
+			pat = search.pat
+		end
+
+		local all = flags:find("g", 1, true) ~= nil
+		local ic = flags:find("i", 1, true) ~= nil
+		local confirm = flags:find("c", 1, true) ~= nil
+
+		local c, perr = compile_vim_pattern(pat, ic)
+		if not c then
+			ttt.notify("vim: " .. (perr or "bad pattern"), "error")
+			return
+		end
+		-- `*` and `#` store their pattern with \< \>, which compile_vim_pattern only
+		-- accepts at the edges; re-applying the flags keeps `:s//x/` after a `*`.
+		if search.pat == pat and search.compiled then
+			c.word_start = search.compiled.word_start
+			c.word_end = search.compiled.word_end
+		end
+		local lrep, rerr = compile_replacement(rep)
+		if lrep == nil then
+			ttt.notify("vim: " .. (rerr or "bad replacement"), "error")
+			return
+		end
+		set_search(pat, c, 1)
+
+		local n = line_count()
+		first = clamp(first, 1, n)
+		last = clamp(last, 1, n)
+		if first > last then
+			local t = first
+			first = last
+			last = t
+		end
+
+		local work = {}
+		for l = first, last do
+			local text = editor.get_line(l) or ""
+			local spans = line_matches(text, c, lrep)
+			if #spans > 0 then
+				if not all then
+					while #spans > 1 do
+						table.remove(spans)
+					end
+				end
+				work[#work + 1] = { line = l, text = text, spans = spans }
+			end
+		end
+
+		if #work == 0 then
+			not_found(pat)
+			return
+		end
+
+		if not confirm then
+			apply_work(work)
+			return
+		end
+
+		local flat = {}
+		for _, w in ipairs(work) do
+			for _, s in ipairs(w.spans) do
+				flat[#flat + 1] = { line = w.line, text = w.text, span = s }
+			end
+		end
+		-- Deferred by a tick: this runs inside the ex command line's own on_submit,
+		-- and show() is a no-op while another overlay is still on screen.
+		ttt.set_timeout(0, function()
+			confirm_walk(work, flat, 1)
+		end)
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Ex commands
+	-- ---------------------------------------------------------------------------
+
+	-- One address: {n}, `.`, `$`. Returns the line and the unconsumed rest, or nil.
+	local function ex_address(s)
+		local d = s:match("^%d+")
+		if d then
+			return tonumber(d), s:sub(#d + 1)
+		end
+		local c = s:sub(1, 1)
+		if c == "$" then
+			return line_count(), s:sub(2)
+		end
+		if c == "." then
+			return editor.cursor().line, s:sub(2)
+		end
+		return nil, s
+	end
+
+	-- A leading range: `%`, `{n}`, `{n},{m}`, `.,$`, ... Returns first, last, rest.
+	-- first is nil when the command had no range of its own.
+	local function parse_range(s)
+		if s:sub(1, 1) == "%" then
+			return 1, line_count(), s:sub(2)
+		end
+		local a, rest = ex_address(s)
+		if not a then
+			return nil, nil, s
+		end
+		if rest:sub(1, 1) == "," then
+			local b, rest2 = ex_address(rest:sub(2))
+			if not b then
+				b = editor.cursor().line
+			end
+			return a, b, rest2
+		end
+		return a, a, rest
+	end
+
+	-- Relative paths are anchored to the directory of the file being edited, not
+	-- to the process cwd: ttt is normally launched from somewhere else entirely,
+	-- and the plugin filesystem API is scoped to the workspace roots anyway.
+	local function resolve_path(path)
+		if path:sub(1, 1) == "/" then
+			return path
+		end
+		local here = editor.file_path()
+		local dir = nil
+		if here then
+			dir = here:match("^(.*)/[^/]*$")
+		end
+		if dir then
+			return dir .. "/" .. path
+		end
+		return path
+	end
+
+	local function ex_write(args)
+		if args == "" then
+			if not ttt.exec_command("file.save") then
+				ttt.notify("vim: file.save is not available", "error")
+			end
+			return
+		end
+		if not fs or not fs.write then
+			ttt.notify("vim: :w {file} needs the fs.write permission", "error")
+			return
+		end
+		local path = resolve_path(args)
+		local ok, err = fs.write(path, editor.buffer_text() or "")
+		if ok then
+			ttt.notify('"' .. path .. '" written')
+		else
+			ttt.notify("vim: " .. tostring(err or "write failed"), "error")
+		end
+	end
+
+	local function ex_registers()
+		local entries = {}
+		local function add(name)
+			local r = state.registers[name]
+			if not r then
+				return
+			end
+			local text = (r.text or ""):gsub("\n", "\\n")
+			entries[#entries + 1] = { key = '"' .. name, value = (r.kind or "char") .. "  " .. text }
+		end
+		add('"')
+		for i = 0, 9 do
+			add(tostring(i))
+		end
+		add("-")
+		local named = {}
+		for name in pairs(state.registers) do
+			if name:match("^%l$") then
+				named[#named + 1] = name
+			end
+		end
+		table.sort(named)
+		for _, name in ipairs(named) do
+			add(name)
+		end
+		if #entries == 0 then
+			entries[#entries + 1] = { key = "", value = "no registers set" }
+		end
+		ttt.show_info("Registers", entries)
+	end
+
+	local function ex_marks()
+		local names = {}
+		for name in pairs(state.marks) do
+			names[#names + 1] = name
+		end
+		table.sort(names)
+		local entries = {}
+		for _, name in ipairs(names) do
+			local m = state.marks[name]
+			local text = editor.get_line(clamp(m.line, 1, line_count())) or ""
+			entries[#entries + 1] = { key = name, value = m.line .. "," .. m.col .. "  " .. text }
+		end
+		if #entries == 0 then
+			entries[#entries + 1] = { key = "", value = "no marks set" }
+		end
+		ttt.show_info("Marks", entries)
+	end
+
+	local function exec_or_warn(id)
+		if not ttt.exec_command(id) then
+			ttt.notify("vim: " .. id .. " is not available", "error")
+		end
+	end
+
+	local function run_ex(text)
+		local cmd = text:gsub("^%s+", ""):gsub("%s+$", "")
+		if cmd == "" then
+			return
+		end
+
+		local first, last, rest = parse_range(cmd)
+		rest = rest:gsub("^%s+", "")
+
+		-- A bare range is a jump: `:12`, `:$`, `:1,5` lands on the last address.
+		if rest == "" then
+			if first then
+				set_jump_mark()
+				goto_line(last)
+			end
+			return
+		end
+
+		-- Substitution has to be recognised before the command-name match, because
+		-- its delimiter can be any punctuation: `s/a/b/`, `s#a#b#`.
+		if rest:sub(1, 1) == "s" then
+			local delim = rest:sub(2, 2)
+			if delim ~= "" and not delim:match("[%w%s]") then
+				local cur = editor.cursor().line
+				return do_substitute(first or cur, last or cur, rest:sub(2))
+			end
+		end
+
+		local name, args = rest:match("^(%a+!?)%s*(.*)$")
+		if not name then
+			name = rest
+			args = ""
+		end
+		local bang = false
+		if name:sub(-1) == "!" then
+			bang = true
+			name = name:sub(1, -2)
+		end
+
+		if name == "w" or name == "write" then
+			ex_write(args)
+		elseif name == "q" or name == "quit" then
+			if bang then
+				ttt.quit()
+			else
+				exec_or_warn("editor.quit")
+			end
+		elseif name == "wq" or name == "x" or name == "xit" then
+			ex_write(args)
+			if bang then
+				ttt.quit()
+			else
+				exec_or_warn("editor.quit")
+			end
+		elseif name == "e" or name == "edit" then
+			if args == "" then
+				ttt.notify("vim: :e needs a file name", "error")
+			else
+				ttt.open_file(resolve_path(args))
+			end
+		elseif name == "noh" or name == "nohl" or name == "nohlsearch" then
+			exec_or_warn("search.clearFind")
+		elseif name == "reg" or name == "registers" or name == "display" then
+			ex_registers()
+		elseif name == "marks" then
+			ex_marks()
+		else
+			ttt.notify("E492: Not an editor command: " .. name, "error")
+		end
+	end
+
+	local function open_ex()
+		ttt.command_line.show({
+			prefix = ":",
+			on_submit = run_ex,
+		})
+	end
+
+	-- ---------------------------------------------------------------------------
+	-- Editor integration
+	--
+	-- Everything here delegates to a core command. Keys with no core equivalent
+	-- (]c, [c, ]f, [f, zo, zc, Ctrl-W splits) are deliberately absent rather than
+	-- approximated -- see README.md.
+	-- ---------------------------------------------------------------------------
+
+	local Z_FOLDS = {
+		["a"] = "fold.toggle",
+		["R"] = "fold.expandAll",
+		["M"] = "fold.collapseAll",
+	}
+
+	local CTRL_W_COMMANDS = {
+		["w"] = "focus.nextGroup",
+		["W"] = "focus.prevGroup",
+		["ctrl-w"] = "focus.nextGroup",
+	}
+
+	G_MOTIONS["t"] = function(n)
+		for _ = 1, n do
+			exec_or_warn("tab.next")
+		end
+	end
+
+	G_MOTIONS["T"] = function(n)
+		for _ = 1, n do
+			exec_or_warn("tab.prev")
+		end
+	end
+
+	vim6.search = search
+	vim6.search_from = search_from
+	vim6.search_step = search_step
+	vim6.search_word = search_word
+	vim6.open_search = open_search
+	vim6.run_search_operator = run_search_operator
+	vim6.open_ex = open_ex
+	vim6.exec_or_warn = exec_or_warn
+	vim6.Z_FOLDS = Z_FOLDS
+	vim6.CTRL_W_COMMANDS = CTRL_W_COMMANDS
+end
+
 local function run_operator_payload(p, count)
 	local n = count or p.count or 1
 	state.operator = { op = p.op, count = n }
@@ -3359,6 +4468,19 @@ local function run_operator_payload(p, count)
 		run_find_operator(t.op, t.ch)
 	elseif t.t == "mark" then
 		run_mark_operator(t.name, t.linewise)
+	elseif t.t == "search" then
+		-- `.` after `d/foo` re-runs the search from wherever the cursor is now,
+		-- which is what Vim does too.
+		local start = editor.cursor()
+		local l, c1
+		if vim6.search.compiled then
+			l, c1 = vim6.search_from(vim6.search.compiled, start.line, start.col, t.dir or 1)
+		end
+		if l then
+			vim6.run_search_operator(start, l, c1)
+		else
+			clear_operator()
+		end
 	else
 		clear_operator()
 	end
@@ -3668,6 +4790,19 @@ local function handle_normal(tok)
 		state.count = nil
 		if Z_COMMANDS[tok] then
 			reposition(tok)
+		elseif vim6.Z_FOLDS[tok] then
+			vim6.exec_or_warn(vim6.Z_FOLDS[tok])
+		end
+		return true
+	end
+
+	-- Ctrl-W is a prefix in normal mode, so core's `tab.close` binding for it is
+	-- overridden -- documented in the README alongside Ctrl-V and friends.
+	if state.pending == "ctrl-w" then
+		state.pending = ""
+		state.count = nil
+		if vim6.CTRL_W_COMMANDS[tok] then
+			vim6.exec_or_warn(vim6.CTRL_W_COMMANDS[tok])
 		end
 		return true
 	end
@@ -3710,6 +4845,45 @@ local function handle_normal(tok)
 			run_change(state.last_change, had and n or nil)
 			return true
 		end
+		if tok == "n" or tok == "N" then
+			local n = take_count()
+			local dir = vim6.search.dir
+			if tok == "N" then
+				dir = -dir
+			end
+			vim6.search_step(dir, n)
+			return true
+		end
+		if tok == "*" or tok == "#" then
+			state.count = nil
+			local dir = 1
+			if tok == "#" then
+				dir = -1
+			end
+			vim6.search_word(dir)
+			return true
+		end
+		if tok == ":" then
+			state.count = nil
+			vim6.open_ex()
+			return true
+		end
+		if tok == "ctrl-w" then
+			state.pending = "ctrl-w"
+			return true
+		end
+	end
+
+	-- `/` and `?` are motions, so they are also operator targets: `d/foo<CR>`
+	-- deletes up to the match. The operator stays pending across the modal
+	-- command line -- no keys reach the plugin while it is open.
+	if tok == "/" or tok == "?" then
+		local dir = 1
+		if tok == "?" then
+			dir = -1
+		end
+		vim6.open_search(dir)
+		return true
 	end
 
 	-- Operator-pending. This has to precede the motion and edit tables: `d` then

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -21,7 +21,8 @@ local state = {
 	mode = "normal", -- normal | insert | visual | visual_line | visual_block | replace
 	pending = "", -- unconsumed keys, e.g. "g", "2d"
 	count = nil, -- pending count prefix
-	operator = nil, -- pending operator
+	operator = nil, -- pending operator, { op = "d", count = n }
+	textobj = nil, -- "i" or "a" awaiting its object key
 	register = nil, -- pending "x register prefix
 	last_change = nil, -- replay payload for `.`
 	registers = {},
@@ -60,6 +61,7 @@ local function set_mode(mode)
 	state.pending = ""
 	state.count = nil
 	state.operator = nil
+	state.textobj = nil
 	state.register = nil
 	state.find_pending = nil
 	state.replace_pending = nil
@@ -134,6 +136,7 @@ local function has_pending()
 	return state.pending ~= ""
 		or state.count ~= nil
 		or state.operator ~= nil
+		or state.textobj ~= nil
 		or state.register ~= nil
 		or state.find_pending ~= nil
 		or state.replace_pending ~= nil
@@ -336,8 +339,17 @@ local function word_forward(count, big)
 		else
 			local cls = class_of(w:ch(), big)
 			if cls ~= 0 then
+				-- A word run must stop at the line boundary: without the line
+				-- check, "two" at the end of one line and "count" at the start
+				-- of the next are walked over as a single word, so `w` (and
+				-- therefore `dw`) skips a word whenever the next line starts on
+				-- a non-blank.
+				local from_line = w.l
 				while class_of(w:ch(), big) == cls do
 					if not w:fwd() then
+						break
+					end
+					if w.l ~= from_line then
 						break
 					end
 				end
@@ -715,12 +727,138 @@ local function leave_insert()
 	editor.end_undo_group()
 end
 
+-- ---------------------------------------------------------------------------
+-- Text extraction and the unnamed register
+--
+-- Phase 3 keeps exactly one register: the unnamed `"`. Named registers, the
+-- numbered ring and `"x` prefixes arrive in Phase 5. A register entry is
+-- { text, linewise }; linewise text always carries its trailing newline so a
+-- paste can be replayed verbatim.
+-- ---------------------------------------------------------------------------
+
+-- table.concat errors when j runs past the array, so clamp both ends here
+-- rather than at every call site.
+local function sub_runes(r, i, j)
+	i = math.max(1, i)
+	j = math.min(j, #r)
+	if i > j then
+		return ""
+	end
+	return table.concat(r, "", i, j)
+end
+
+-- Charwise text for [sl,sc] .. [el,ec) -- ec is an exclusive end column, the
+-- same convention editor.replace uses.
+local function charwise_text(sl, sc, el, ec)
+	if sl == el then
+		return sub_runes(line_runes(sl), sc, ec - 1)
+	end
+	local parts = { sub_runes(line_runes(sl), sc, math.huge) }
+	for l = sl + 1, el - 1 do
+		parts[#parts + 1] = editor.get_line(l) or ""
+	end
+	parts[#parts + 1] = sub_runes(line_runes(el), 1, ec - 1)
+	return table.concat(parts, "\n")
+end
+
+local function linewise_text(sl, el)
+	local parts = {}
+	for l = sl, el do
+		parts[#parts + 1] = editor.get_line(l) or ""
+	end
+	return table.concat(parts, "\n") .. "\n"
+end
+
+local function set_register(text, linewise)
+	state.registers['"'] = { text = text, linewise = linewise and true or false }
+end
+
+local function yank_charwise(sl, sc, el, ec)
+	set_register(charwise_text(sl, sc, el, ec), false)
+end
+
+local function yank_linewise(sl, el)
+	set_register(linewise_text(sl, el), true)
+end
+
+-- Delete whole lines sl..el. Three cases, because the newline that has to go
+-- with the text lives *after* the block normally, but *before* it when the
+-- block runs to the end of the buffer -- and deleting every line has to leave
+-- one empty line behind rather than an empty buffer.
+local function delete_lines(sl, el)
+	local n = line_count()
+	sl = clamp(sl, 1, n)
+	el = clamp(el, sl, n)
+	if sl <= 1 and el >= n then
+		editor.replace(1, 1, n, line_len(n) + 1, "")
+	elseif el >= n then
+		editor.replace(sl - 1, line_len(sl - 1) + 1, el, line_len(el) + 1, "")
+	else
+		editor.replace(sl, 1, el + 1, 1, "")
+	end
+end
+
+-- Linewise change (`cc`, `S`, `c` with a linewise motion): collapse lines
+-- sl..el to a single line that keeps sl's indent, then enter insert mode. The
+-- caller has already opened the undo group; leave_insert() closes it.
+local function change_lines(sl, el)
+	local n = line_count()
+	sl = clamp(sl, 1, n)
+	el = clamp(el, sl, n)
+	local indent = (editor.get_line(sl) or ""):match("^[ \t]*") or ""
+	yank_linewise(sl, el)
+	editor.replace(sl, 1, el, line_len(el) + 1, indent)
+	editor.set_cursor(sl, #runes_of(indent) + 1)
+	begin_insert()
+end
+
 -- Delete from the cursor to the end of line (cur.line + n - 1), joining the
 -- lines in between. `2D` on "aaa"/"bbb" leaves a single empty line, as in Vim.
 local function delete_to_end(n)
 	local cur = editor.cursor()
 	local last = clamp(cur.line + n - 1, 1, line_count())
+	yank_charwise(cur.line, cur.col, last, line_len(last) + 1)
 	editor.replace(cur.line, cur.col, last, line_len(last) + 1, "")
+end
+
+-- p / P. A linewise register lands on a new line below/above; a charwise one
+-- lands after/before the cursor. Multi-line charwise text leaves the cursor at
+-- the first pasted character, single-line text on its last, both as in Vim.
+local function paste(count, after)
+	local reg = state.registers['"']
+	if not reg or reg.text == "" then
+		return
+	end
+	local cur = editor.cursor()
+	editor.begin_undo_group()
+	if reg.linewise then
+		local body = (reg.text:gsub("\n$", ""))
+		local chunk = body
+		for _ = 2, count do
+			chunk = chunk .. "\n" .. body
+		end
+		if after then
+			editor.insert(cur.line, line_len(cur.line) + 1, "\n" .. chunk)
+			move_to(cur.line + 1, first_non_blank(cur.line + 1))
+		else
+			editor.insert(cur.line, 1, chunk .. "\n")
+			move_to(cur.line, first_non_blank(cur.line))
+		end
+	else
+		local chunk = reg.text:rep(count)
+		local col = cur.col
+		if after and line_len(cur.line) > 0 then
+			col = math.min(cur.col + 1, line_len(cur.line) + 1)
+		end
+		editor.insert(cur.line, col, chunk)
+		if chunk:find("\n", 1, true) then
+			editor.set_cursor(cur.line, col)
+		else
+			editor.set_cursor(cur.line, col + #runes_of(chunk) - 1)
+		end
+		clamp_cursor()
+	end
+	editor.end_undo_group()
 end
 
 local function swap_case(ch)
@@ -772,12 +910,15 @@ local function join(count, with_space)
 	clamp_cursor()
 end
 
--- >> and <<. Blank lines are left alone, as in Vim.
-local function indent_lines(n, dir)
-	local cur = editor.cursor()
-	local last = clamp(cur.line + n - 1, 1, line_count())
-	editor.begin_undo_group()
-	for l = cur.line, last do
+-- >> and <<. Blank lines are left alone, as in Vim. The caller owns the undo
+-- group so `>` as an operator and `>>` as a doubled key share one code path.
+local function indent_range(first, last)
+	return clamp(first, 1, line_count()), clamp(last, 1, line_count())
+end
+
+local function indent_lines_range(sl, el, dir)
+	local first, last = indent_range(sl, el)
+	for l = first, last do
 		local r = line_runes(l)
 		if #r > 0 then
 			if dir > 0 then
@@ -801,18 +942,14 @@ local function indent_lines(n, dir)
 			end
 		end
 	end
-	editor.end_undo_group()
-	move_to(cur.line, first_non_blank(cur.line))
 end
 
 -- == reindent. ttt has no indent engine, so this is a deliberate heuristic:
 -- copy the previous non-blank line's indent, add one shiftwidth if that line
 -- opens a block, and remove one if this line closes one. Spaces only.
-local function reindent(n)
-	local cur = editor.cursor()
-	local last = clamp(cur.line + n - 1, 1, line_count())
-	editor.begin_undo_group()
-	for l = cur.line, last do
+local function reindent_range(sl, el)
+	local first, last = indent_range(sl, el)
+	for l = first, last do
 		local body = (editor.get_line(l) or ""):match("^[ \t]*(.-)[ \t]*$") or ""
 		if body ~= "" then
 			local width = 0
@@ -835,8 +972,6 @@ local function reindent(n)
 			editor.set_line(l, string.rep(" ", width) .. body)
 		end
 	end
-	editor.end_undo_group()
-	move_to(cur.line, first_non_blank(cur.line))
 end
 
 -- Ctrl-A / Ctrl-X. Finds the first digit run ending at or after the cursor,
@@ -939,6 +1074,7 @@ local EDITS = {
 			return
 		end
 		editor.begin_undo_group()
+		yank_charwise(cur.line, cur.col, cur.line, last)
 		editor.replace(cur.line, cur.col, cur.line, last, "")
 		editor.end_undo_group()
 		clamp_cursor()
@@ -950,6 +1086,7 @@ local EDITS = {
 			return
 		end
 		editor.begin_undo_group()
+		yank_charwise(cur.line, start, cur.line, cur.col)
 		editor.replace(cur.line, start, cur.line, cur.col, "")
 		editor.end_undo_group()
 		editor.set_cursor(cur.line, start)
@@ -970,17 +1107,22 @@ local EDITS = {
 		local last = math.min(cur.col + n, line_len(cur.line) + 1)
 		editor.begin_undo_group()
 		if last > cur.col then
+			yank_charwise(cur.line, cur.col, cur.line, last)
 			editor.replace(cur.line, cur.col, cur.line, last, "")
 		end
 		begin_insert()
 	end,
 	["S"] = function(n)
 		local cur = editor.cursor()
-		local last = clamp(cur.line + n - 1, 1, line_count())
 		editor.begin_undo_group()
-		editor.replace(cur.line, 1, last, line_len(last) + 1, "")
-		editor.set_cursor(cur.line, 1)
-		begin_insert()
+		change_lines(cur.line, cur.line + n - 1)
+	end,
+	-- Vim's `Y` is a synonym for `yy`; ttt follows Neovim's default of `y$`,
+	-- which is what the other shorthands (`D`, `C`) do.
+	["Y"] = function(n)
+		local cur = editor.cursor()
+		local last = clamp(cur.line + n - 1, 1, line_count())
+		yank_charwise(cur.line, cur.col, last, line_len(last) + 1)
 	end,
 	-- r consumes the next key; the count rides along in replace_pending.
 	["r"] = function(n)
@@ -1010,6 +1152,12 @@ local EDITS = {
 	["J"] = function(n)
 		join(n, true)
 	end,
+	["p"] = function(n)
+		paste(n, true)
+	end,
+	["P"] = function(n)
+		paste(n, false)
+	end,
 
 	["u"] = function(n)
 		for _ = 1, n do
@@ -1032,21 +1180,866 @@ local EDITS = {
 	end,
 }
 
--- Doubled-key line operators: >>, <<, ==.
-local LINE_OPERATORS = {
-	[">"] = function(n)
-		indent_lines(n, 1)
+-- ---------------------------------------------------------------------------
+-- Operators
+--
+-- The full grammar is {count}{operator}{count}{motion|textobject}, with the two
+-- counts multiplying (`2d3w` deletes six words). Every operator ends up calling
+-- apply_operator() with a normalized range plus a linewise flag, so the doubled
+-- forms (`dd`, `>>`, `gugu`) and the motion forms share one code path.
+--
+-- Motion targets are resolved by *running the Phase 1 motion* and reading the
+-- cursor it lands on, then putting the cursor back. That keeps one
+-- implementation of every motion instead of a parallel "where would this go"
+-- table that would inevitably drift.
+-- ---------------------------------------------------------------------------
+
+-- Exclusive vs inclusive is the single most common source of off-by-one bugs in
+-- Vim emulation: `dw` must not delete the character it lands on, `de` must.
+-- Anything not listed here is exclusive, which is Vim's default.
+local MOTION_KIND = {
+	["j"] = "linewise",
+	["k"] = "linewise",
+	["+"] = "linewise",
+	["-"] = "linewise",
+	["G"] = "linewise",
+	["H"] = "linewise",
+	["M"] = "linewise",
+	["L"] = "linewise",
+	["ctrl-d"] = "linewise",
+	["ctrl-u"] = "linewise",
+	["ctrl-f"] = "linewise",
+	["ctrl-b"] = "linewise",
+	["pgup"] = "linewise",
+	["pgdn"] = "linewise",
+	["e"] = "inclusive",
+	["E"] = "inclusive",
+	["$"] = "inclusive",
+	["%"] = "inclusive",
+}
+
+local G_MOTION_KIND = {
+	["g"] = "linewise",
+	["_"] = "inclusive",
+	["e"] = "inclusive",
+	["E"] = "inclusive",
+}
+
+local OPERATORS = { d = true, c = true, y = true, [">"] = true, ["<"] = true, ["="] = true }
+local G_OPERATORS = { u = "gu", U = "gU", ["~"] = "g~" }
+local CASE_OPERATORS = { gu = "lower", gU = "upper", ["g~"] = "swap" }
+
+for _, op in pairs(G_OPERATORS) do
+	OPERATORS[op] = true
+end
+
+-- The token that, typed straight after the operator, makes it linewise. Vim
+-- accepts both `gugu` and the shorthand `guu`; the `g` of `gugu` is consumed by
+-- the normal g-prefix path and lands here as plain `u`, so one entry covers it.
+local OP_DOUBLE = {
+	["d"] = { ["d"] = true },
+	["c"] = { ["c"] = true },
+	["y"] = { ["y"] = true },
+	[">"] = { [">"] = true },
+	["<"] = { ["<"] = true },
+	["="] = { ["="] = true },
+	["gu"] = { ["u"] = true },
+	["gU"] = { ["U"] = true },
+	["g~"] = { ["~"] = true },
+}
+
+local function transform_case(text, how)
+	local out = {}
+	for _, ch in ipairs(runes_of(text)) do
+		if how == "upper" then
+			out[#out + 1] = ch:upper()
+		elseif how == "lower" then
+			out[#out + 1] = ch:lower()
+		else
+			out[#out + 1] = swap_case(ch)
+		end
+	end
+	return table.concat(out)
+end
+
+-- The heart of Phase 3. `ec` is an exclusive end column, matching
+-- editor.replace. Only `c` leaves the undo group open, because it hands off to
+-- insert mode and leave_insert() closes it -- that is what makes `cwfoo<Esc>`
+-- one undo step.
+local function apply_operator(op, sl, sc, el, ec, linewise)
+	local n = line_count()
+	sl = clamp(sl, 1, n)
+	el = clamp(el, 1, n)
+
+	if op == "y" then
+		if linewise then
+			local col = editor.cursor().col
+			yank_linewise(sl, el)
+			move_to(sl, col)
+		else
+			yank_charwise(sl, sc, el, ec)
+			move_to(sl, sc)
+		end
+		return
+	end
+
+	editor.begin_undo_group()
+
+	if op == "d" then
+		if linewise then
+			yank_linewise(sl, el)
+			delete_lines(sl, el)
+			local l = math.min(sl, line_count())
+			move_to(l, first_non_blank(l))
+		else
+			yank_charwise(sl, sc, el, ec)
+			editor.replace(sl, sc, el, ec, "")
+			editor.set_cursor(sl, sc)
+			clamp_cursor()
+		end
+		editor.end_undo_group()
+		return
+	end
+
+	if op == "c" then
+		if linewise then
+			change_lines(sl, el)
+		else
+			yank_charwise(sl, sc, el, ec)
+			editor.replace(sl, sc, el, ec, "")
+			editor.set_cursor(sl, sc)
+			begin_insert()
+		end
+		-- Undo group deliberately left open for leave_insert().
+		return
+	end
+
+	if op == ">" or op == "<" then
+		indent_lines_range(sl, el, op == ">" and 1 or -1)
+		editor.end_undo_group()
+		move_to(sl, first_non_blank(sl))
+		return
+	end
+
+	if op == "=" then
+		reindent_range(sl, el)
+		editor.end_undo_group()
+		move_to(sl, first_non_blank(sl))
+		return
+	end
+
+	local how = CASE_OPERATORS[op]
+	if how then
+		if linewise then
+			sc, ec = 1, line_len(el) + 1
+		end
+		local text = charwise_text(sl, sc, el, ec)
+		if text ~= "" then
+			editor.replace(sl, sc, el, ec, transform_case(text, how))
+		end
+		editor.end_undo_group()
+		move_to(sl, sc)
+		return
+	end
+
+	editor.end_undo_group()
+end
+
+-- ---------------------------------------------------------------------------
+-- Motion targets
+-- ---------------------------------------------------------------------------
+
+-- Run a motion for its cursor position and put the cursor back. state.goal is
+-- saved too: `$` sets it to infinity, which would otherwise leak into the next
+-- j/k after the operator.
+local function probe_motion(fn, n, had_count)
+	local start = editor.cursor()
+	local saved_goal = state.goal
+	fn(n, had_count)
+	local dest = editor.cursor()
+	editor.set_cursor(start.line, start.col)
+	state.goal = saved_goal
+	return start, dest
+end
+
+-- Vim: "When using the `w` motion with an operator and the last word moved over
+-- is at the end of a line, the end of that word becomes the end of the operated
+-- text." Without this, `dw` on the last word of a line eats the newline and the
+-- next line's indent.
+local function clip_word_motion(start, dest)
+	if dest.line <= start.line then
+		return dest
+	end
+	local w = walker(dest.line, dest.col)
+	while w:back() do
+		local ch = w:ch()
+		if ch ~= nil and not is_blank(ch) then
+			break
+		end
+	end
+	if w.l < dest.line and (w.l > start.line or (w.l == start.line and w.c >= start.col)) then
+		return { line = w.l, col = line_len(w.l) + 1 }
+	end
+	return dest
+end
+
+-- Turn a motion result into an operator range. Returns sl, sc, el, ec, linewise
+-- or nil when the motion produced nothing to operate on.
+local function motion_to_range(start, dest, kind)
+	-- NOTE: gopher-lua does NOT evaluate multiple assignment simultaneously when
+	-- a target also appears on the right -- `a, b = b, a` yields `b, b`. Every
+	-- swap below therefore goes through explicit temporaries. See README.
+	if kind == "linewise" then
+		local a, b = start.line, dest.line
+		if a > b then
+			local t = a
+			a = b
+			b = t
+		end
+		return a, 1, b, 1, true
+	end
+
+	local sl, sc, el, ec = start.line, start.col, dest.line, dest.col
+	local backward = (el < sl) or (el == sl and ec < sc)
+	if backward then
+		local tl, tc = sl, sc
+		sl = el
+		sc = ec
+		el = tl
+		ec = tc
+	end
+
+	if kind == "inclusive" then
+		ec = ec + 1
+	else
+		-- Vim's two exclusive-motion adjustments, both keyed off the *original*
+		-- end landing in column 1.
+		if not backward and el > sl and ec == 1 then
+			local prev = el - 1
+			if sc <= first_non_blank(sl) and prev >= sl then
+				return sl, 1, prev, 1, true
+			end
+			el, ec = prev, line_len(prev) + 1
+		end
+	end
+
+	if sl == el and ec <= sc then
+		return nil
+	end
+	return sl, sc, el, ec, false
+end
+
+-- ---------------------------------------------------------------------------
+-- Text objects
+--
+-- Each returns sl, sc, el, ec (exclusive end column), linewise -- the same
+-- shape apply_operator consumes -- or nil when there is no object here.
+-- ---------------------------------------------------------------------------
+
+-- Flatten lines sl..el into a rune array plus an index -> {line, col} map, so
+-- objects that span lines (tags, sentences) can be found with flat scanning.
+local function flatten(sl, el)
+	local runes, map = {}, {}
+	for l = sl, el do
+		local r = line_runes(l)
+		for i = 1, #r do
+			runes[#runes + 1] = r[i]
+			map[#map + 1] = { l, i }
+		end
+		if l < el then
+			runes[#runes + 1] = "\n"
+			map[#map + 1] = { l, #r + 1 }
+		end
+	end
+	return runes, map
+end
+
+local function flat_offset(map, line, col)
+	for i = 1, #map do
+		if map[i][1] == line and map[i][2] >= col then
+			return i
+		end
+		if map[i][1] > line then
+			return i
+		end
+	end
+	return #map
+end
+
+-- iw/aw/iW/aW. Vim counts *chunks* for `iw` (a whitespace run is a chunk of its
+-- own) and whole words-with-their-whitespace for `aw`.
+local function textobj_word(inner, big, count)
+	local cur = editor.cursor()
+	local r = line_runes(cur.line)
+	if #r == 0 then
+		return cur.line, 1, cur.line, 1, false
+	end
+	local i = math.min(cur.col, #r)
+	local cls = class_of(r[i], big)
+	local s, e = i, i
+	while s > 1 and class_of(r[s - 1], big) == cls do
+		s = s - 1
+	end
+	while e < #r and class_of(r[e + 1], big) == cls do
+		e = e + 1
+	end
+
+	local function extend_chunk(from)
+		if from >= #r then
+			return from
+		end
+		local c2 = class_of(r[from + 1], big)
+		local j = from + 1
+		while j < #r and class_of(r[j + 1], big) == c2 do
+			j = j + 1
+		end
+		return j
+	end
+
+	if inner then
+		for _ = 2, count do
+			e = extend_chunk(e)
+		end
+		return cur.line, s, cur.line, e + 1, false
+	end
+
+	for _ = 2, count do
+		while e < #r and is_blank(r[e + 1]) do
+			e = e + 1
+		end
+		e = extend_chunk(e)
+	end
+
+	local had_trailing = false
+	while e < #r and is_blank(r[e + 1]) do
+		e = e + 1
+		had_trailing = true
+	end
+	if not had_trailing then
+		while s > 1 and is_blank(r[s - 1]) do
+			s = s - 1
+		end
+	end
+	return cur.line, s, cur.line, e + 1, false
+end
+
+-- i"/a" and friends. Vim pairs quotes from the start of the line rather than
+-- looking for the nearest one, and searches forward when the cursor sits before
+-- a pair -- both reproduced here. Quotes are line-scoped in Vim too.
+local function textobj_quote(inner, q)
+	local cur = editor.cursor()
+	local r = line_runes(cur.line)
+	local qs = {}
+	for i = 1, #r do
+		if r[i] == q and (i == 1 or r[i - 1] ~= "\\") then
+			qs[#qs + 1] = i
+		end
+	end
+	for k = 1, #qs - 1, 2 do
+		local a, b = qs[k], qs[k + 1]
+		if cur.col <= b then
+			if inner then
+				return cur.line, a + 1, cur.line, b, false
+			end
+			local s, e, had = a, b, false
+			while e < #r and is_blank(r[e + 1]) do
+				e = e + 1
+				had = true
+			end
+			if not had then
+				while s > 1 and is_blank(r[s - 1]) do
+					s = s - 1
+				end
+			end
+			return cur.line, s, cur.line, e + 1, false
+		end
+	end
+	return nil
+end
+
+-- Scan outward for the unmatched open/close of a bracket pair, honouring
+-- nesting. Both walk the buffer, so blocks may span any number of lines.
+local function find_unmatched(open, close, l, c, backward)
+	local w = walker(l, c)
+	local target = backward and open or close
+	local other = backward and close or open
+	if w:ch() == target then
+		return w.l, w.c
+	end
+	local depth = 0
+	while true do
+		-- Not `backward and w:back() or w:fwd()`: when back() returns false at
+		-- the top of the buffer that idiom falls through to fwd() and the search
+		-- silently reverses direction.
+		local moved
+		if backward then
+			moved = w:back()
+		else
+			moved = w:fwd()
+		end
+		if not moved then
+			break
+		end
+		local ch = w:ch()
+		if ch == other then
+			depth = depth + 1
+		elseif ch == target then
+			if depth == 0 then
+				return w.l, w.c
+			end
+			depth = depth - 1
+		end
+	end
+	return nil
+end
+
+local function textobj_block(inner, open, close, count)
+	local cur = editor.cursor()
+	local ol, oc = cur.line, cur.col
+	local cl, cc
+	local from_l, from_c = ol, oc
+	for i = 1, count do
+		local nol, noc = find_unmatched(open, close, from_l, from_c, true)
+		if not nol then
+			return nil
+		end
+		ol, oc = nol, noc
+		local ncl, ncc = find_unmatched(open, close, ol, oc, false)
+		if not ncl then
+			return nil
+		end
+		cl, cc = ncl, ncc
+		-- Only step outside this pair when another level is still wanted;
+		-- stepping unconditionally would leave `oc` one short of the real open
+		-- bracket for the common count-of-one case.
+		if i < count then
+			if oc > 1 then
+				from_l, from_c = ol, oc - 1
+			elseif ol > 1 then
+				from_l = ol - 1
+				from_c = math.max(1, line_len(from_l))
+			else
+				break
+			end
+		end
+	end
+	if not cl then
+		return nil
+	end
+
+	if not inner then
+		return ol, oc, cl, cc + 1, false
+	end
+
+	-- Vim: an inner block whose open brace ends a line and whose close brace
+	-- starts one becomes linewise, which is what makes `di{` clear a code block.
+	if oc >= line_len(ol) and cl > ol + 1 and cc <= first_non_blank(cl) then
+		return ol + 1, 1, cl - 1, 1, true
+	end
+	if ol == cl and cc <= oc + 1 then
+		return ol, oc + 1, cl, oc + 1, false
+	end
+	return ol, oc + 1, cl, cc, false
+end
+
+-- it/at. Tags are found by flat-scanning a window around the cursor; a whole
+-- buffer scan on a key-press path is not acceptable, and 500 lines covers any
+-- realistic nesting.
+local TAG_WINDOW = 250
+
+local function scan_tags(runes)
+	local tags = {}
+	local i = 1
+	local n = #runes
+	while i <= n do
+		if runes[i] == "<" then
+			local j = i + 1
+			local closing = false
+			if runes[j] == "/" then
+				closing = true
+				j = j + 1
+			end
+			local name = {}
+			while j <= n do
+				local ch = runes[j]
+				if ch:match("^[%w_:%-%.]$") then
+					name[#name + 1] = ch
+					j = j + 1
+				else
+					break
+				end
+			end
+			if #name > 0 then
+				local self_closing = false
+				local k = j
+				while k <= n and runes[k] ~= ">" do
+					if runes[k] == "/" and runes[k + 1] == ">" then
+						self_closing = true
+					end
+					k = k + 1
+				end
+				if k <= n then
+					if not self_closing then
+						tags[#tags + 1] = {
+							name = table.concat(name),
+							closing = closing,
+							s = i,
+							e = k,
+						}
+					end
+					i = k
+				end
+			end
+		end
+		i = i + 1
+	end
+	return tags
+end
+
+local function textobj_tag(inner)
+	local cur = editor.cursor()
+	local n = line_count()
+	local sl = math.max(1, cur.line - TAG_WINDOW)
+	local el = math.min(n, cur.line + TAG_WINDOW)
+	local runes, map = flatten(sl, el)
+	local off = flat_offset(map, cur.line, cur.col)
+
+	local tags = scan_tags(runes)
+	local stack = {}
+	local best = nil
+	for _, t in ipairs(tags) do
+		if t.closing then
+			for k = #stack, 1, -1 do
+				if stack[k].name == t.name then
+					local o = stack[k]
+					for _ = k, #stack do
+						table.remove(stack)
+					end
+					if o.s <= off and off <= t.e and best == nil then
+						best = { o = o, c = t }
+					end
+					break
+				end
+			end
+		else
+			stack[#stack + 1] = t
+		end
+	end
+	if not best then
+		return nil
+	end
+
+	local function pos(idx)
+		local m = map[idx]
+		if not m then
+			return el, line_len(el) + 1
+		end
+		return m[1], m[2]
+	end
+
+	if inner then
+		if best.o.e + 1 > best.c.s - 1 then
+			local l, c = pos(best.c.s)
+			return l, c, l, c, false
+		end
+		local a, b = pos(best.o.e + 1)
+		local cl, cc = pos(best.c.s)
+		return a, b, cl, cc, false
+	end
+	local a, b = pos(best.o.s)
+	local cl, cc = pos(best.c.e)
+	return a, b, cl, cc + 1, false
+end
+
+-- ip/ap. Linewise. A run of blank lines is itself a paragraph, so `dap` on a
+-- blank line removes the gap.
+local function textobj_paragraph(inner, count)
+	local n = line_count()
+	local l = editor.cursor().line
+	local function blank(i)
+		return (editor.get_line(i) or "") == ""
+	end
+	local kind = blank(l)
+	local s, e = l, l
+	while s > 1 and blank(s - 1) == kind do
+		s = s - 1
+	end
+	while e < n and blank(e + 1) == kind do
+		e = e + 1
+	end
+
+	-- Each extra step swallows the next block, whose blank-ness alternates.
+	local cur_kind = kind
+	local steps = inner and (count - 1) or count
+	for step = 1, steps do
+		local want = not cur_kind
+		local grew = false
+		while e < n and blank(e + 1) == want do
+			e = e + 1
+			grew = true
+		end
+		if not grew and not inner and step == 1 then
+			-- `ap` with nothing after it takes the preceding block instead.
+			while s > 1 and blank(s - 1) == want do
+				s = s - 1
+			end
+		end
+		cur_kind = want
+	end
+	return s, 1, e, 1, true
+end
+
+-- is/as. Sentences end at . ! or ? followed by closing quotes/brackets and then
+-- whitespace or end of line. Scoped to the paragraph around the cursor.
+local function textobj_sentence(inner, count)
+	local n = line_count()
+	local l = editor.cursor().line
+	local function blank(i)
+		return (editor.get_line(i) or "") == ""
+	end
+	if blank(l) then
+		return l, 1, l, 1, false
+	end
+	local ps, pe = l, l
+	while ps > 1 and not blank(ps - 1) do
+		ps = ps - 1
+	end
+	while pe < n and not blank(pe + 1) do
+		pe = pe + 1
+	end
+
+	local runes, map = flatten(ps, pe)
+	local off = flat_offset(map, editor.cursor().line, editor.cursor().col)
+
+	local starts = { 1 }
+	local i = 1
+	while i <= #runes do
+		local ch = runes[i]
+		if ch == "." or ch == "!" or ch == "?" then
+			local j = i + 1
+			while j <= #runes and (runes[j] == '"' or runes[j] == "'" or runes[j] == ")" or runes[j] == "]") do
+				j = j + 1
+			end
+			if j > #runes then
+				break
+			end
+			if runes[j] == " " or runes[j] == "\t" or runes[j] == "\n" then
+				while j <= #runes and (runes[j] == " " or runes[j] == "\t" or runes[j] == "\n") do
+					j = j + 1
+				end
+				if j <= #runes then
+					starts[#starts + 1] = j
+				end
+				i = j
+			else
+				i = i + 1
+			end
+		else
+			i = i + 1
+		end
+	end
+	starts[#starts + 1] = #runes + 1
+
+	local idx = 1
+	for k = 1, #starts - 1 do
+		if off >= starts[k] and off < starts[k + 1] then
+			idx = k
+			break
+		end
+	end
+	local from = starts[idx]
+	local to = starts[math.min(idx + count, #starts)] - 1
+
+	if inner then
+		while to > from and (runes[to] == " " or runes[to] == "\t" or runes[to] == "\n") do
+			to = to - 1
+		end
+	end
+
+	local function pos(k)
+		local m = map[k]
+		if not m then
+			return pe, line_len(pe) + 1
+		end
+		return m[1], m[2]
+	end
+	local sl, sc = pos(from)
+	local el, ec = pos(to)
+	return sl, sc, el, ec + 1, false
+end
+
+-- Second key after `i`/`a` in operator-pending mode.
+local TEXT_OBJECTS = {
+	["w"] = function(inner, count)
+		return textobj_word(inner, false, count)
 	end,
-	["<"] = function(n)
-		indent_lines(n, -1)
+	["W"] = function(inner, count)
+		return textobj_word(inner, true, count)
 	end,
-	["="] = function(n)
-		reindent(n)
+	['"'] = function(inner)
+		return textobj_quote(inner, '"')
+	end,
+	["'"] = function(inner)
+		return textobj_quote(inner, "'")
+	end,
+	["`"] = function(inner)
+		return textobj_quote(inner, "`")
+	end,
+	["("] = function(inner, count)
+		return textobj_block(inner, "(", ")", count)
+	end,
+	[")"] = function(inner, count)
+		return textobj_block(inner, "(", ")", count)
+	end,
+	["b"] = function(inner, count)
+		return textobj_block(inner, "(", ")", count)
+	end,
+	["["] = function(inner, count)
+		return textobj_block(inner, "[", "]", count)
+	end,
+	["]"] = function(inner, count)
+		return textobj_block(inner, "[", "]", count)
+	end,
+	["{"] = function(inner, count)
+		return textobj_block(inner, "{", "}", count)
+	end,
+	["}"] = function(inner, count)
+		return textobj_block(inner, "{", "}", count)
+	end,
+	["B"] = function(inner, count)
+		return textobj_block(inner, "{", "}", count)
+	end,
+	["<"] = function(inner, count)
+		return textobj_block(inner, "<", ">", count)
+	end,
+	[">"] = function(inner, count)
+		return textobj_block(inner, "<", ">", count)
+	end,
+	["t"] = function(inner)
+		return textobj_tag(inner)
+	end,
+	["p"] = function(inner, count)
+		return textobj_paragraph(inner, count)
+	end,
+	["s"] = function(inner, count)
+		return textobj_sentence(inner, count)
 	end,
 }
 
-for k in pairs(LINE_OPERATORS) do
-	PREFIX_KEYS[k] = true
+-- ---------------------------------------------------------------------------
+-- Operator-pending dispatch
+-- ---------------------------------------------------------------------------
+
+local function clear_operator()
+	state.operator = nil
+	state.textobj = nil
+	state.count = nil
+end
+
+local function start_operator(op)
+	state.operator = { op = op, count = state.count }
+	state.count = nil
+end
+
+-- Both counts multiply, and either one satisfies "had a count" for the
+-- line-number motions (`d3G`).
+local function operator_count()
+	local opc = state.operator and state.operator.count or nil
+	local mc = state.count
+	local total = (opc or 1) * (mc or 1)
+	return total, (opc ~= nil or mc ~= nil)
+end
+
+-- Doubled key: `dd`, `>>`, `guu`. Operates on `count` whole lines from the
+-- cursor down.
+local function run_linewise_operator()
+	local op = state.operator.op
+	local n = operator_count()
+	local sl = editor.cursor().line
+	local el = clamp(sl + n - 1, 1, line_count())
+	clear_operator()
+	apply_operator(op, sl, 1, el, 1, true)
+end
+
+local function run_motion_operator(tok, gprefix)
+	local op = state.operator.op
+	local n, had = operator_count()
+	local fn, kind
+	if gprefix then
+		kind = G_MOTION_KIND[tok]
+		fn = kind and G_MOTIONS[tok] or nil
+	else
+		fn = MOTIONS[tok]
+		kind = MOTION_KIND[tok] or "exclusive"
+	end
+	if not fn then
+		clear_operator()
+		return
+	end
+
+	-- `cw` on a non-blank behaves like `ce`: Vim's own documented special case.
+	if op == "c" and not gprefix and (tok == "w" or tok == "W") then
+		local r = line_runes(editor.cursor().line)
+		local ch = r[editor.cursor().col]
+		if ch ~= nil and not is_blank(ch) then
+			fn = MOTIONS[tok == "w" and "e" or "E"]
+			kind = "inclusive"
+		end
+	end
+
+	local start, dest = probe_motion(fn, n, had)
+	if not gprefix and (tok == "w" or tok == "W") then
+		dest = clip_word_motion(start, dest)
+	end
+	clear_operator()
+
+	local sl, sc, el, ec, linewise = motion_to_range(start, dest, kind)
+	if sl == nil then
+		return
+	end
+	apply_operator(op, sl, sc, el, ec, linewise)
+end
+
+local function run_find_operator(op_char, ch)
+	local op = state.operator.op
+	local n = operator_count()
+	local start = editor.cursor()
+	local saved_goal = state.goal
+	find_char(op_char, ch, n, false)
+	local dest = editor.cursor()
+	editor.set_cursor(start.line, start.col)
+	state.goal = saved_goal
+	clear_operator()
+
+	if dest.line == start.line and dest.col == start.col then
+		return
+	end
+	-- Forward f/t include the character they land on; backward F/T do not
+	-- include the one the cursor started on.
+	local kind = (dest.col > start.col) and "inclusive" or "exclusive"
+	local sl, sc, el, ec, linewise = motion_to_range(start, dest, kind)
+	if sl == nil then
+		return
+	end
+	apply_operator(op, sl, sc, el, ec, linewise)
+end
+
+local function run_textobject(inner, tok)
+	local op = state.operator.op
+	local n = operator_count()
+	local fn = TEXT_OBJECTS[tok]
+	clear_operator()
+	if not fn then
+		return
+	end
+	local sl, sc, el, ec, linewise = fn(inner, n)
+	if sl == nil then
+		return
+	end
+	if not linewise and sl == el and ec <= sc then
+		return
+	end
+	apply_operator(op, sl, sc, el, ec, linewise)
 end
 
 -- g-prefixed edits, appended to the Phase 1 motion table.
@@ -1140,30 +2133,49 @@ local function handle_normal(tok)
 	if state.find_pending then
 		local op = state.find_pending
 		state.find_pending = nil
-		local n = take_count()
-		if is_printable(tok) then
-			state.last_find = { op = op, ch = tok }
-			find_char(op, tok, n, false)
+		if not is_printable(tok) then
+			clear_operator()
+			return true
+		end
+		state.last_find = { op = op, ch = tok }
+		if state.operator then
+			run_find_operator(op, tok)
+		else
+			find_char(op, tok, take_count(), false)
+		end
+		return true
+	end
+
+	-- `i`/`a` after an operator select a text object rather than entering
+	-- insert mode.
+	if state.textobj then
+		local inner = state.textobj == "i"
+		state.textobj = nil
+		if state.operator then
+			run_textobject(inner, tok)
 		end
 		return true
 	end
 
 	if state.pending == "g" then
 		state.pending = ""
+		if state.operator then
+			if OP_DOUBLE[state.operator.op][tok] then
+				run_linewise_operator()
+			else
+				run_motion_operator(tok, true)
+			end
+			return true
+		end
+		local gop = G_OPERATORS[tok]
+		if gop then
+			start_operator(gop)
+			return true
+		end
 		local n, had = take_count()
 		local fn = G_MOTIONS[tok]
 		if fn then
 			fn(n, had)
-		end
-		return true
-	end
-
-	if LINE_OPERATORS[state.pending] then
-		local op = state.pending
-		state.pending = ""
-		local n = take_count()
-		if tok == op then
-			LINE_OPERATORS[op](n)
 		end
 		return true
 	end
@@ -1180,6 +2192,34 @@ local function handle_normal(tok)
 	-- Count prefix. A leading `0` is the motion, not a count digit.
 	if #tok == 1 and tok >= "0" and tok <= "9" and not (tok == "0" and state.count == nil) then
 		state.count = (state.count or 0) * 10 + tonumber(tok)
+		return true
+	end
+
+	-- Operator-pending. This has to precede the motion and edit tables: `d` then
+	-- `i` is "inner text object", not "enter insert mode".
+	if state.operator then
+		if OP_DOUBLE[state.operator.op][tok] then
+			run_linewise_operator()
+			return true
+		end
+		if tok == "i" or tok == "a" then
+			state.textobj = tok
+			return true
+		end
+		if tok == "g" then
+			state.pending = "g"
+			return true
+		end
+		if FIND_KEYS[tok] then
+			state.find_pending = tok
+			return true
+		end
+		run_motion_operator(tok, false)
+		return true
+	end
+
+	if OPERATORS[tok] then
+		start_operator(tok)
 		return true
 	end
 

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -7,6 +7,8 @@
 -- Phase 0: mode state machine (normal/insert), Esc handling, status indicator.
 -- Phase 1: normal-mode motions with {count} prefixes.
 -- Phase 2: insert-mode entry points and single-key edits.
+-- Phase 3: operators, motion ranges and text objects.
+-- Phase 4: visual, visual-line and visual-block modes.
 
 local ttt = require("ttt")
 local events = require("ttt.events")
@@ -33,6 +35,9 @@ local state = {
 	goal = nil, -- sticky column for j/k
 	replace_pending = nil, -- count for `r{char}` awaiting its replacement char
 	last_insert = nil, -- { line, col } where insert mode was last left, for `gi`
+	visual = nil, -- { al, ac, cl, cc, dollar } anchor + Vim cursor while visual
+	last_visual = nil, -- the range `gv` reselects
+	block_insert = false, -- blockwise I/A/c is holding multi-cursors open
 }
 
 local MODE_LABELS = {
@@ -717,6 +722,12 @@ end
 -- it back onto a character; the position *before* that step is what `gi`
 -- resumes from.
 local function leave_insert()
+	-- Blockwise I/A/c parked a cursor on every row; collapse them before reading
+	-- the cursor back, so the position recorded for `gi` is the primary one.
+	if state.block_insert then
+		state.block_insert = false
+		editor.clear_cursors()
+	end
 	local cur = editor.cursor()
 	state.last_insert = { line = cur.line, col = cur.col }
 	set_mode("normal")
@@ -2058,6 +2069,693 @@ G_MOTIONS["J"] = function(n)
 end
 
 -- ---------------------------------------------------------------------------
+-- Visual modes
+--
+-- state.visual holds the anchor (al, ac) and the *Vim* cursor (cl, cc). The
+-- real editor cursor is not always the Vim cursor: ttt renders a selection as
+-- Selection.Start .. live-cursor (internal/core/selection), so the only free
+-- variable is the anchor, and linewise/blockwise need the real cursor parked
+-- somewhere else to draw the range correctly. Keeping (cl, cc) in Lua means
+-- motions still see and produce true Vim positions -- visual_sync() puts the
+-- real cursor back before a motion runs, visual_capture() reads it after.
+--
+-- Blockwise has no native backing at all: it is drawn with add_cursor() per
+-- line and every edit loops the lines by hand.
+-- ---------------------------------------------------------------------------
+
+local VISUAL_KEY_MODE = { v = "visual", V = "visual_line", ["ctrl-v"] = "visual_block" }
+
+local function take_count()
+	local n = state.count
+	state.count = nil
+	return n or 1, n ~= nil
+end
+
+local function visual_sync()
+	local v = state.visual
+	if not v then
+		return
+	end
+	local l = clamp(v.cl, 1, line_count())
+	editor.set_cursor(l, clamp(v.cc, 1, max_col(line_runes(l))))
+end
+
+local function visual_capture()
+	local v = state.visual
+	if not v then
+		return
+	end
+	local c = editor.cursor()
+	v.cl = c.line
+	v.cc = c.col
+end
+
+-- Normalized block corners. `dollar` is the ragged right edge set by `$`.
+local function block_rect()
+	local v = state.visual
+	local top, bot = v.al, v.cl
+	if top > bot then
+		local t = top
+		top = bot
+		bot = t
+	end
+	local left, right = v.ac, v.cc
+	if left > right then
+		local t = left
+		left = right
+		right = t
+	end
+	return top, bot, left, right
+end
+
+local function visual_render()
+	local v = state.visual
+	if not v then
+		return
+	end
+
+	if state.mode == "visual_block" then
+		editor.clear_cursors()
+		editor.clear_selection()
+		local top, bot, _, right = block_rect()
+		local cl = clamp(v.cl, 1, line_count())
+		editor.set_cursor(cl, clamp(v.cc, 1, max_col(line_runes(cl))))
+		for l = top, bot do
+			if l ~= cl then
+				local col = v.dollar and max_col(line_runes(l)) or math.min(right, max_col(line_runes(l)))
+				editor.add_cursor(l, col)
+			end
+		end
+		return
+	end
+
+	if state.mode == "visual_line" then
+		local top, bot = v.al, v.cl
+		if top > bot then
+			local t = top
+			top = bot
+			bot = t
+		end
+		if v.cl >= v.al then
+			editor.set_selection(top, 1, v.cl, line_len(v.cl) + 1)
+		else
+			editor.set_selection(bot, line_len(bot) + 1, v.cl, 1)
+		end
+		return
+	end
+
+	-- Charwise. Forward: the anchor is the start and the cursor is the
+	-- (exclusive) end, so the character *under* the cursor is not painted --
+	-- the cursor block itself stands in for it. Backward: the anchor is shifted
+	-- one column right so the character it sits on stays inside the range, which
+	-- is exactly Vim's inclusive behaviour on that side.
+	local backward = (v.cl < v.al) or (v.cl == v.al and v.cc < v.ac)
+	if backward then
+		editor.set_selection(v.al, math.min(v.ac + 1, line_len(v.al) + 1), v.cl, v.cc)
+	else
+		editor.set_selection(v.al, v.ac, v.cl, v.cc)
+	end
+end
+
+-- The selection as an operator range: sl, sc, el, ec (exclusive end column),
+-- linewise. Charwise visual is inclusive of the character under the cursor.
+local function visual_range()
+	local v = state.visual
+	local sl, sc, el, ec = v.al, v.ac, v.cl, v.cc
+	if (v.cl < v.al) or (v.cl == v.al and v.cc < v.ac) then
+		sl = v.cl
+		sc = v.cc
+		el = v.al
+		ec = v.ac
+	end
+	if state.mode == "visual_line" then
+		return sl, 1, el, 1, true
+	end
+	return sl, sc, el, math.min(ec + 1, line_len(el) + 1), false
+end
+
+local function save_last_visual()
+	local v = state.visual
+	if not v then
+		return
+	end
+	state.last_visual = { mode = state.mode, al = v.al, ac = v.ac, cl = v.cl, cc = v.cc, dollar = v.dollar }
+end
+
+-- Tear down the visual chrome and return to normal mode *without* touching the
+-- cursor. Operators call this before they edit; Esc uses exit_visual().
+local function end_visual()
+	save_last_visual()
+	if state.mode == "visual_block" then
+		editor.clear_cursors()
+	end
+	editor.clear_selection()
+	state.visual = nil
+	set_mode("normal")
+end
+
+local function exit_visual()
+	local v = state.visual
+	local l, c = v and v.cl or nil, v and v.cc or nil
+	end_visual()
+	if l then
+		move_to(l, c)
+	end
+end
+
+local function enter_visual(mode)
+	local cur = editor.cursor()
+	state.visual = { al = cur.line, ac = cur.col, cl = cur.line, cc = cur.col, dollar = false }
+	set_mode(mode)
+	visual_render()
+end
+
+local function switch_visual(mode)
+	if state.mode == "visual_block" and mode ~= "visual_block" then
+		editor.clear_cursors()
+	end
+	if mode ~= "visual_block" then
+		state.visual.dollar = false
+	end
+	set_mode(mode)
+	visual_render()
+end
+
+local function reselect_visual()
+	local lv = state.last_visual
+	if not lv then
+		return
+	end
+	local n = line_count()
+	state.visual = {
+		al = clamp(lv.al, 1, n),
+		ac = lv.ac,
+		cl = clamp(lv.cl, 1, n),
+		cc = lv.cc,
+		dollar = lv.dollar,
+	}
+	set_mode(lv.mode)
+	visual_render()
+end
+
+-- `o`: swap the anchor and the cursor. gopher-lua does not swap in a multiple
+-- assignment when a target appears on the right, so this goes via temporaries.
+local function visual_swap_ends()
+	local v = state.visual
+	local al, ac = v.al, v.ac
+	v.al = v.cl
+	v.ac = v.cc
+	v.cl = al
+	v.cc = ac
+end
+
+-- `O` in blockwise: swap the two corners horizontally, leaving the rows alone.
+local function visual_swap_corners()
+	local v = state.visual
+	local ac = v.ac
+	v.ac = v.cc
+	v.cc = ac
+end
+
+-- Run a Phase 1 motion with the real cursor parked at the Vim cursor, then take
+-- the result back as the new Vim cursor and redraw.
+local function visual_motion(fn, n, had)
+	visual_sync()
+	fn(n, had)
+	visual_capture()
+	visual_render()
+end
+
+-- ---------------------------------------------------------------------------
+-- Blockwise edits
+--
+-- Every one of these loops the rows bottom-to-top: editor.replace shifts the
+-- content of later lines only when it removes a newline, but iterating upward
+-- keeps line indices stable no matter what, and it is the same discipline the
+-- multi-cursor code uses.
+-- ---------------------------------------------------------------------------
+
+-- Column span [lo, hi) for row `l`, clamped onto the line. Returns nil when the
+-- row is too short to contain any of the block.
+local function block_span(l, left, right, dollar)
+	local len = line_len(l)
+	local lo = math.min(left, len + 1)
+	local hi = dollar and (len + 1) or math.min(right + 1, len + 1)
+	if hi <= lo then
+		return nil
+	end
+	return lo, hi
+end
+
+local function block_text(top, bot, left, right, dollar)
+	local parts = {}
+	for l = top, bot do
+		local lo, hi = block_span(l, left, right, dollar)
+		parts[#parts + 1] = lo and sub_runes(line_runes(l), lo, hi - 1) or ""
+	end
+	return table.concat(parts, "\n")
+end
+
+local function block_delete(top, bot, left, right, dollar)
+	for l = bot, top, -1 do
+		local lo, hi = block_span(l, left, right, dollar)
+		if lo then
+			editor.replace(l, lo, l, hi, "")
+		end
+	end
+end
+
+-- I / A / c: park a cursor on every row and hand typing to the editor's native
+-- multi-cursor path, which already coalesces into the open undo group.
+local function block_insert_at(top, bot, col_for)
+	editor.clear_cursors()
+	editor.clear_selection()
+	local primary = col_for(top)
+	editor.set_cursor(top, primary)
+	for l = top + 1, bot do
+		editor.add_cursor(l, col_for(l))
+	end
+	state.block_insert = true
+	begin_insert()
+end
+
+-- ---------------------------------------------------------------------------
+-- Visual-mode operators
+-- ---------------------------------------------------------------------------
+
+local function visual_case(how)
+	local sl, sc, el, ec, linewise = visual_range()
+	local op = (how == "lower" and "gu") or (how == "upper" and "gU") or "g~"
+	if state.mode == "visual_block" then
+		local top, bot, left, right = block_rect()
+		local dollar = state.visual.dollar
+		end_visual()
+		editor.begin_undo_group()
+		for l = bot, top, -1 do
+			local lo, hi = block_span(l, left, right, dollar)
+			if lo then
+				local text = sub_runes(line_runes(l), lo, hi - 1)
+				editor.replace(l, lo, l, hi, transform_case(text, how))
+			end
+		end
+		editor.end_undo_group()
+		move_to(top, math.min(left, max_col(line_runes(top))))
+		return
+	end
+	end_visual()
+	apply_operator(op, sl, sc, el, ec, linewise)
+end
+
+local function visual_replace_char(ch)
+	if state.mode == "visual_block" then
+		local top, bot, left, right = block_rect()
+		local dollar = state.visual.dollar
+		end_visual()
+		editor.begin_undo_group()
+		for l = bot, top, -1 do
+			local lo, hi = block_span(l, left, right, dollar)
+			if lo then
+				editor.replace(l, lo, l, hi, ch:rep(hi - lo))
+			end
+		end
+		editor.end_undo_group()
+		move_to(top, math.min(left, max_col(line_runes(top))))
+		return
+	end
+
+	local sl, sc, el, ec, linewise = visual_range()
+	if linewise then
+		sc = 1
+		ec = line_len(el) + 1
+	end
+	end_visual()
+	editor.begin_undo_group()
+	for l = el, sl, -1 do
+		local lo = (l == sl) and sc or 1
+		local hi = (l == el) and ec or (line_len(l) + 1)
+		hi = math.min(hi, line_len(l) + 1)
+		if hi > lo then
+			editor.replace(l, lo, l, hi, ch:rep(hi - lo))
+		end
+	end
+	editor.end_undo_group()
+	move_to(sl, sc)
+end
+
+-- Visual `p`: the selection is replaced by the register, and the text that was
+-- there becomes the new unnamed register, as in Vim.
+local function visual_paste()
+	local reg = state.registers['"']
+	local sl, sc, el, ec, linewise = visual_range()
+	if state.mode == "visual_block" or not reg or reg.text == "" then
+		return
+	end
+	local text = reg.text
+	local body = (text:gsub("\n$", ""))
+	end_visual()
+
+	local a, b = sc, ec
+	if linewise then
+		a = 1
+		b = line_len(el) + 1
+	end
+
+	editor.begin_undo_group()
+	if linewise then
+		yank_linewise(sl, el)
+	else
+		yank_charwise(sl, sc, el, ec)
+	end
+
+	local repl
+	if linewise then
+		repl = reg.linewise and body or text
+	else
+		repl = reg.linewise and ("\n" .. body .. "\n") or text
+	end
+	editor.replace(sl, a, el, b, repl)
+	editor.end_undo_group()
+	move_to(sl, linewise and first_non_blank(sl) or a)
+end
+
+local function visual_join()
+	local top, bot = state.visual.al, state.visual.cl
+	if top > bot then
+		local t = top
+		top = bot
+		bot = t
+	end
+	end_visual()
+	move_to(top, 1)
+	join(math.max(2, bot - top + 1), true)
+end
+
+local function visual_indent(op, count)
+	local sl, _, el = visual_range()
+	end_visual()
+	editor.begin_undo_group()
+	if op == "=" then
+		reindent_range(sl, el)
+	else
+		for _ = 1, math.max(1, count) do
+			indent_lines_range(sl, el, op == ">" and 1 or -1)
+		end
+	end
+	editor.end_undo_group()
+	move_to(sl, first_non_blank(sl))
+end
+
+-- d / x / c / s / y over the current selection, in whichever visual mode.
+local function visual_operator(op, force_linewise)
+	if state.mode == "visual_block" then
+		local top, bot, left, right = block_rect()
+		local dollar = state.visual.dollar
+		if op == "y" then
+			set_register(block_text(top, bot, left, right, dollar), false)
+			end_visual()
+			move_to(top, math.min(left, max_col(line_runes(top))))
+			return
+		end
+		set_register(block_text(top, bot, left, right, dollar), false)
+		end_visual()
+		editor.begin_undo_group()
+		block_delete(top, bot, left, right, dollar)
+		if op == "c" then
+			block_insert_at(top, bot, function(l)
+				return math.min(left, line_len(l) + 1)
+			end)
+			-- Undo group stays open; leave_insert() closes it.
+			return
+		end
+		editor.end_undo_group()
+		move_to(top, math.min(left, max_col(line_runes(top))))
+		return
+	end
+
+	local sl, sc, el, ec, linewise = visual_range()
+	if force_linewise then
+		sc, ec, linewise = 1, 1, true
+	end
+	end_visual()
+	apply_operator(op, sl, sc, el, ec, linewise)
+end
+
+-- ---------------------------------------------------------------------------
+-- Visual-mode key dispatch
+-- ---------------------------------------------------------------------------
+
+-- Text objects in visual mode *set* the selection to the object rather than
+-- running an operator, so `viw` selects the word under the cursor.
+local function visual_textobject(inner, tok)
+	local fn = TEXT_OBJECTS[tok]
+	local n = state.count or 1
+	state.count = nil
+	if not fn then
+		return
+	end
+	visual_sync()
+	local sl, sc, el, ec, linewise = fn(inner, n)
+	if sl == nil then
+		return
+	end
+	local v = state.visual
+	if linewise then
+		v.al, v.ac = sl, 1
+		v.cl, v.cc = el, 1
+		if state.mode ~= "visual_line" then
+			switch_visual("visual_line")
+			return
+		end
+	else
+		v.al, v.ac = sl, sc
+		v.cl = el
+		v.cc = math.max(1, ec - 1)
+	end
+	visual_render()
+end
+
+-- `$` in blockwise means "ragged right edge"; everywhere else it is the motion.
+local function visual_dollar(n)
+	if state.mode == "visual_block" then
+		state.visual.dollar = true
+	end
+	visual_motion(MOTIONS["$"], n, false)
+end
+
+local VISUAL_LINEWISE_OPS = { X = "d", D = "d", R = "c", S = "c", C = "c", Y = "y" }
+
+local function handle_visual(tok)
+	if ESCAPE_TOKENS[tok] then
+		exit_visual()
+		return true
+	end
+
+	if state.replace_pending then
+		state.replace_pending = nil
+		if is_printable(tok) then
+			visual_replace_char(tok)
+		end
+		return true
+	end
+
+	if state.find_pending then
+		local op = state.find_pending
+		state.find_pending = nil
+		if is_printable(tok) then
+			state.last_find = { op = op, ch = tok }
+			visual_motion(function(n)
+				find_char(op, tok, n, false)
+			end, take_count(), false)
+		end
+		return true
+	end
+
+	if state.textobj then
+		local inner = state.textobj == "i"
+		state.textobj = nil
+		visual_textobject(inner, tok)
+		return true
+	end
+
+	if state.pending == "g" then
+		state.pending = ""
+		if tok == "v" then
+			-- `gv` inside visual mode is a no-op in Vim; swallow it.
+			state.count = nil
+			return true
+		end
+		local gop = G_OPERATORS[tok]
+		if gop then
+			state.count = nil
+			visual_case(CASE_OPERATORS[gop])
+			return true
+		end
+		if tok == "J" then
+			state.count = nil
+			visual_join()
+			return true
+		end
+		local fn = G_MOTIONS[tok]
+		if fn and G_MOTION_KIND[tok] then
+			local n, had = take_count()
+			visual_motion(fn, n, had)
+		else
+			state.count = nil
+		end
+		return true
+	end
+
+	if state.pending == "z" then
+		state.pending = ""
+		state.count = nil
+		if Z_COMMANDS[tok] then
+			reposition(tok)
+		end
+		return true
+	end
+
+	if #tok == 1 and tok >= "0" and tok <= "9" and not (tok == "0" and state.count == nil) then
+		state.count = (state.count or 0) * 10 + tonumber(tok)
+		return true
+	end
+
+	-- Mode keys: the same key exits, a different one switches.
+	local vm = VISUAL_KEY_MODE[tok]
+	if vm then
+		state.count = nil
+		if state.mode == vm then
+			exit_visual()
+		else
+			switch_visual(vm)
+		end
+		return true
+	end
+
+	if tok == "i" or tok == "a" then
+		state.textobj = tok
+		return true
+	end
+
+	if tok == "g" or tok == "z" then
+		state.pending = tok
+		return true
+	end
+
+	if FIND_KEYS[tok] then
+		state.find_pending = tok
+		return true
+	end
+
+	if tok == "o" then
+		state.count = nil
+		visual_swap_ends()
+		visual_render()
+		return true
+	end
+
+	if tok == "O" then
+		state.count = nil
+		if state.mode == "visual_block" then
+			visual_swap_corners()
+		else
+			visual_swap_ends()
+		end
+		visual_render()
+		return true
+	end
+
+	if tok == "$" then
+		local n = take_count()
+		visual_dollar(n)
+		return true
+	end
+
+	if tok == "r" then
+		state.replace_pending = 1
+		return true
+	end
+
+	if tok == "J" then
+		state.count = nil
+		visual_join()
+		return true
+	end
+
+	if tok == "u" or tok == "U" or tok == "~" then
+		state.count = nil
+		visual_case((tok == "u" and "lower") or (tok == "U" and "upper") or "swap")
+		return true
+	end
+
+	if tok == ">" or tok == "<" or tok == "=" then
+		local n = take_count()
+		visual_indent(tok, n)
+		return true
+	end
+
+	if tok == "p" or tok == "P" then
+		state.count = nil
+		visual_paste()
+		return true
+	end
+
+	-- Blockwise insert at the left / right edge of every row.
+	if (tok == "I" or tok == "A") and state.mode == "visual_block" then
+		state.count = nil
+		local top, bot, left, right = block_rect()
+		local dollar = state.visual.dollar
+		end_visual()
+		editor.begin_undo_group()
+		if tok == "I" then
+			block_insert_at(top, bot, function(l)
+				return math.min(left, line_len(l) + 1)
+			end)
+		else
+			block_insert_at(top, bot, function(l)
+				return dollar and (line_len(l) + 1) or math.min(right + 1, line_len(l) + 1)
+			end)
+		end
+		return true
+	end
+
+	if tok == "d" or tok == "x" then
+		state.count = nil
+		visual_operator("d", false)
+		return true
+	end
+	if tok == "c" or tok == "s" then
+		state.count = nil
+		visual_operator("c", false)
+		return true
+	end
+	if tok == "y" then
+		state.count = nil
+		visual_operator("y", false)
+		return true
+	end
+
+	local lw = VISUAL_LINEWISE_OPS[tok]
+	if lw then
+		state.count = nil
+		visual_operator(lw, true)
+		return true
+	end
+
+	local motion = MOTIONS[tok]
+	if motion then
+		local n, had = take_count()
+		visual_motion(motion, n, had)
+		return true
+	end
+
+	if is_printable(tok) or MUTATING_KEYS[tok] then
+		return true
+	end
+
+	return false
+end
+
+-- ---------------------------------------------------------------------------
 -- Mode handlers
 -- ---------------------------------------------------------------------------
 
@@ -2095,12 +2793,6 @@ local function handle_replace(tok)
 		return true
 	end
 	return false
-end
-
-local function take_count()
-	local n = state.count
-	state.count = nil
-	return n or 1, n ~= nil
 end
 
 local function handle_normal(tok)
@@ -2257,10 +2949,29 @@ local function handle_normal(tok)
 	return false
 end
 
+-- Visual-mode entry points, appended to the normal-mode tables. Core binds
+-- Ctrl-V to editor.paste; normal mode overrides it, as documented in the README.
+EDITS["v"] = function()
+	enter_visual("visual")
+end
+EDITS["V"] = function()
+	enter_visual("visual_line")
+end
+EDITS["ctrl-v"] = function()
+	enter_visual("visual_block")
+end
+
+G_MOTIONS["v"] = function()
+	reselect_visual()
+end
+
 local HANDLERS = {
 	normal = handle_normal,
 	insert = handle_insert,
 	replace = handle_replace,
+	visual = handle_visual,
+	visual_line = handle_visual,
+	visual_block = handle_visual,
 }
 
 local function on_key(ev)

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -5,9 +5,11 @@
 -- sibling .lua files. Sections below are delimited and appended phase by phase.
 --
 -- Phase 0: mode state machine (normal/insert), Esc handling, status indicator.
+-- Phase 1: normal-mode motions with {count} prefixes.
 
 local ttt = require("ttt")
 local events = require("ttt.events")
+local editor = require("ttt.editor")
 
 -- ---------------------------------------------------------------------------
 -- State
@@ -24,6 +26,9 @@ local state = {
 	registers = {},
 	marks = {},
 	macro = { recording = nil, keys = {}, playing = false },
+	find_pending = nil, -- "f" | "F" | "t" | "T" awaiting its target char
+	last_find = nil, -- { op = "f", ch = "x" } for `;` and `,`
+	goal = nil, -- sticky column for j/k
 }
 
 local MODE_LABELS = {
@@ -53,6 +58,8 @@ local function set_mode(mode)
 	state.count = nil
 	state.operator = nil
 	state.register = nil
+	state.find_pending = nil
+	state.goal = nil
 	render_status()
 end
 
@@ -120,8 +127,548 @@ local ESCAPE_TOKENS = {
 -- passed through so core EscapeDismissers (clear search highlight, close
 -- panels) still run -- the interceptor now sits above them.
 local function has_pending()
-	return state.pending ~= "" or state.count ~= nil or state.operator ~= nil or state.register ~= nil
+	return state.pending ~= ""
+		or state.count ~= nil
+		or state.operator ~= nil
+		or state.register ~= nil
+		or state.find_pending ~= nil
 end
+
+-- ---------------------------------------------------------------------------
+-- Buffer primitives
+--
+-- The editor Lua API is 1-based for both line and col, and `col` is a visual
+-- (rune) column, not a byte index. Everything below works on rune arrays so
+-- multi-byte lines behave. get_line is used rather than buffer_lines: the
+-- latter copies the whole buffer, which is unacceptable on a key-press path.
+-- ---------------------------------------------------------------------------
+
+-- Split a UTF-8 string into an array of rune strings. Lua 5.1 has no utf8
+-- library, so the lead byte decides the sequence length.
+local function runes_of(s)
+	local out = {}
+	local i, n = 1, #s
+	while i <= n do
+		local b = s:byte(i)
+		local len = 1
+		if b >= 0xf0 then
+			len = 4
+		elseif b >= 0xe0 then
+			len = 3
+		elseif b >= 0xc0 then
+			len = 2
+		end
+		out[#out + 1] = s:sub(i, i + len - 1)
+		i = i + len
+	end
+	return out
+end
+
+local function line_runes(n)
+	return runes_of(editor.get_line(n) or "")
+end
+
+local function line_count()
+	return editor.line_count()
+end
+
+local function clamp(v, lo, hi)
+	if v < lo then
+		return lo
+	end
+	if v > hi then
+		return hi
+	end
+	return v
+end
+
+-- Vim's normal mode puts the cursor *on* a character, so the last valid column
+-- is #line (not #line + 1 as in insert mode). Empty lines still allow col 1.
+local function max_col(r)
+	if #r < 1 then
+		return 1
+	end
+	return #r
+end
+
+-- Move and clear the sticky j/k goal column. Vertical motions bypass this and
+-- manage the goal themselves.
+local function move_to(l, c)
+	l = clamp(l, 1, line_count())
+	local r = line_runes(l)
+	editor.set_cursor(l, clamp(c, 1, max_col(r)))
+	state.goal = nil
+end
+
+local function clamp_cursor()
+	local cur = editor.cursor()
+	local r = line_runes(cur.line)
+	local m = max_col(r)
+	if cur.col > m then
+		editor.set_cursor(cur.line, m)
+	end
+end
+
+local function is_blank(ch)
+	return ch == " " or ch == "\t"
+end
+
+local function first_non_blank(l)
+	local r = line_runes(l)
+	for i = 1, #r do
+		if not is_blank(r[i]) then
+			return i
+		end
+	end
+	return 1
+end
+
+local function last_non_blank(l)
+	local r = line_runes(l)
+	for i = #r, 1, -1 do
+		if not is_blank(r[i]) then
+			return i
+		end
+	end
+	return 1
+end
+
+-- ---------------------------------------------------------------------------
+-- Character classes for word motions
+--
+-- 0 = blank, 1 = word char ([A-Za-z0-9_] plus any multi-byte rune), 2 = other
+-- punctuation. For WORD motions (W/B/E/gE) everything non-blank is class 1.
+-- Lua 5.1 has no %g class, so these are explicit byte ranges.
+-- ---------------------------------------------------------------------------
+
+local function class_of(ch, big)
+	if ch == nil then
+		return nil
+	end
+	if is_blank(ch) then
+		return 0
+	end
+	if big then
+		return 1
+	end
+	local b = ch:byte(1)
+	if b >= 0x80 then
+		return 1
+	end
+	if (b >= 0x30 and b <= 0x39) or (b >= 0x41 and b <= 0x5a) or (b >= 0x61 and b <= 0x7a) or b == 0x5f then
+		return 1
+	end
+	return 2
+end
+
+-- A cursor walker over the buffer, one rune at a time, wrapping across lines.
+local function walker(l, c)
+	local w = { l = l, c = c, r = line_runes(l), n = line_count() }
+
+	function w:ch()
+		return self.r[self.c]
+	end
+
+	function w:empty()
+		return #self.r == 0
+	end
+
+	function w:fwd()
+		if self.c < #self.r then
+			self.c = self.c + 1
+			return true
+		end
+		if self.l >= self.n then
+			return false
+		end
+		self.l = self.l + 1
+		self.r = line_runes(self.l)
+		self.c = 1
+		return true
+	end
+
+	function w:back()
+		if self.c > 1 then
+			self.c = self.c - 1
+			return true
+		end
+		if self.l <= 1 then
+			return false
+		end
+		self.l = self.l - 1
+		self.r = line_runes(self.l)
+		self.c = max_col(self.r)
+		return true
+	end
+
+	-- "End of word": non-blank whose successor on the line is a different class
+	-- or does not exist.
+	function w:at_word_end(big)
+		local cls = class_of(self:ch(), big)
+		if cls == nil or cls == 0 then
+			return false
+		end
+		return self.c >= #self.r or class_of(self.r[self.c + 1], big) ~= cls
+	end
+
+	return w
+end
+
+-- ---------------------------------------------------------------------------
+-- Motions
+-- ---------------------------------------------------------------------------
+
+-- w / W: start of the next word. An empty line counts as a word, matching Vim.
+local function word_forward(count, big)
+	local cur = editor.cursor()
+	local w = walker(cur.line, cur.col)
+	for _ = 1, count do
+		if w:empty() then
+			-- Standing on an empty line: it is its own word, so just leave it.
+			if not w:fwd() then
+				break
+			end
+		else
+			local cls = class_of(w:ch(), big)
+			if cls ~= 0 then
+				while class_of(w:ch(), big) == cls do
+					if not w:fwd() then
+						break
+					end
+				end
+			end
+		end
+		while not w:empty() do
+			local k = class_of(w:ch(), big)
+			if k ~= nil and k ~= 0 then
+				break
+			end
+			if not w:fwd() then
+				break
+			end
+		end
+	end
+	move_to(w.l, w.c)
+end
+
+-- b / B: start of the current or previous word.
+local function word_back(count, big)
+	local cur = editor.cursor()
+	local w = walker(cur.line, cur.col)
+	for _ = 1, count do
+		if not w:back() then
+			break
+		end
+		while not w:empty() and (class_of(w:ch(), big) or 0) == 0 do
+			if not w:back() then
+				break
+			end
+		end
+		local cls = class_of(w:ch(), big)
+		if cls ~= nil and cls ~= 0 then
+			while w.c > 1 and class_of(w.r[w.c - 1], big) == cls do
+				w.c = w.c - 1
+			end
+		end
+	end
+	move_to(w.l, w.c)
+end
+
+-- e / E and ge / gE: scan for the next/previous end-of-word position.
+local function word_end(count, big, backward)
+	local cur = editor.cursor()
+	local w = walker(cur.line, cur.col)
+	for _ = 1, count do
+		local step = backward and w.back or w.fwd
+		if not step(w) then
+			break
+		end
+		while not w:at_word_end(big) do
+			if not step(w) then
+				break
+			end
+		end
+	end
+	move_to(w.l, w.c)
+end
+
+-- j / k, honouring the sticky goal column so travelling through short lines
+-- does not permanently shorten the column.
+local function vertical(dir, count)
+	local cur = editor.cursor()
+	local goal = state.goal or cur.col
+	local l = clamp(cur.line + dir * count, 1, line_count())
+	local r = line_runes(l)
+	editor.set_cursor(l, clamp(goal, 1, max_col(r)))
+	state.goal = goal
+end
+
+local function goto_line(n)
+	local l = clamp(n, 1, line_count())
+	move_to(l, first_non_blank(l))
+end
+
+local function paragraph(dir, count)
+	local n = line_count()
+	local l = editor.cursor().line
+	for _ = 1, count do
+		local probe = l + dir
+		while probe >= 1 and probe <= n do
+			if editor.get_line(probe) == "" then
+				break
+			end
+			probe = probe + dir
+		end
+		l = clamp(probe, 1, n)
+	end
+	move_to(l, 1)
+end
+
+-- f/F/t/T. `skip_adjacent` is used when repeating a till-motion so `;` after
+-- `tx` advances instead of sitting still on the same character.
+local function find_char(op, ch, count, skip_adjacent)
+	local cur = editor.cursor()
+	local r = line_runes(cur.line)
+	local forward = (op == "f" or op == "t")
+	local till = (op == "t" or op == "T")
+	local dir = forward and 1 or -1
+
+	local pos = cur.col + dir
+	if till and skip_adjacent then
+		pos = cur.col + dir * 2
+	end
+
+	local left = count
+	while pos >= 1 and pos <= #r do
+		if r[pos] == ch then
+			left = left - 1
+			if left == 0 then
+				move_to(cur.line, till and (pos - dir) or pos)
+				return
+			end
+		end
+		pos = pos + dir
+	end
+end
+
+local REVERSE_FIND = { f = "F", F = "f", t = "T", T = "t" }
+
+local function repeat_find(count, reverse)
+	local last = state.last_find
+	if not last then
+		return
+	end
+	local op = reverse and REVERSE_FIND[last.op] or last.op
+	find_char(op, last.ch, count, op == "t" or op == "T")
+end
+
+-- ---------------------------------------------------------------------------
+-- Screen position and scrolling
+--
+-- SetCursor calls EnsureCursorVisible on the Go side, so every routine here
+-- moves the cursor FIRST and scrolls LAST; the reverse order gets undone.
+-- ---------------------------------------------------------------------------
+
+local function viewport()
+	local v = editor.viewport()
+	return v.top_line, v.bottom_line, v.height
+end
+
+local function screen_line(where, count)
+	local top, bottom = viewport()
+	local l
+	if where == "H" then
+		l = top + (count - 1)
+	elseif where == "L" then
+		l = bottom - (count - 1)
+	else
+		l = math.floor((top + bottom) / 2)
+	end
+	l = clamp(l, top, bottom)
+	goto_line(l)
+end
+
+local function scroll_page(dir, count, half)
+	local top, _, h = viewport()
+	local n = line_count()
+	local amount = half and math.floor(h / 2) or h
+	amount = math.max(1, amount) * count
+
+	local cur = editor.cursor()
+	move_to(cur.line + dir * amount, cur.col)
+
+	if n > h then
+		editor.scroll_to(clamp(top + dir * amount, 1, math.max(1, n - h + 1)))
+	end
+end
+
+-- Ctrl-E / Ctrl-Y: scroll the view, dragging the cursor along only when it
+-- would otherwise fall off the screen.
+local function scroll_lines(dir, count)
+	local top, _, h = viewport()
+	local n = line_count()
+	if n <= h then
+		return
+	end
+	local new_top = clamp(top + dir * count, 1, math.max(1, n - h + 1))
+	local cur = editor.cursor()
+	local wanted = clamp(cur.line, new_top, math.min(n, new_top + h - 1))
+	if wanted ~= cur.line then
+		move_to(wanted, cur.col)
+	end
+	editor.scroll_to(new_top)
+end
+
+local function reposition(kind)
+	local _, _, h = viewport()
+	local line = editor.cursor().line
+	local top
+	if kind == "t" then
+		top = line
+	elseif kind == "b" then
+		top = line - h + 1
+	else
+		top = line - math.floor(h / 2)
+	end
+	editor.scroll_to(math.max(1, top))
+end
+
+-- ---------------------------------------------------------------------------
+-- Motion table
+-- ---------------------------------------------------------------------------
+
+local MOTIONS = {
+	["h"] = function(n)
+		local cur = editor.cursor()
+		move_to(cur.line, cur.col - n)
+	end,
+	["l"] = function(n)
+		local cur = editor.cursor()
+		move_to(cur.line, cur.col + n)
+	end,
+	["j"] = function(n)
+		vertical(1, n)
+	end,
+	["k"] = function(n)
+		vertical(-1, n)
+	end,
+	["+"] = function(n)
+		goto_line(editor.cursor().line + n)
+	end,
+	["-"] = function(n)
+		goto_line(editor.cursor().line - n)
+	end,
+	["0"] = function()
+		move_to(editor.cursor().line, 1)
+	end,
+	["^"] = function()
+		local l = editor.cursor().line
+		move_to(l, first_non_blank(l))
+	end,
+	["$"] = function(n)
+		local l = clamp(editor.cursor().line + n - 1, 1, line_count())
+		local r = line_runes(l)
+		editor.set_cursor(l, max_col(r))
+		-- Vim keeps the cursor glued to the line end for subsequent j/k.
+		state.goal = math.huge
+	end,
+	["w"] = function(n)
+		word_forward(n, false)
+	end,
+	["W"] = function(n)
+		word_forward(n, true)
+	end,
+	["b"] = function(n)
+		word_back(n, false)
+	end,
+	["B"] = function(n)
+		word_back(n, true)
+	end,
+	["e"] = function(n)
+		word_end(n, false, false)
+	end,
+	["E"] = function(n)
+		word_end(n, true, false)
+	end,
+	["G"] = function(n, had_count)
+		goto_line(had_count and n or line_count())
+	end,
+	["{"] = function(n)
+		paragraph(-1, n)
+	end,
+	["}"] = function(n)
+		paragraph(1, n)
+	end,
+	["%"] = function()
+		ttt.exec_command("editor.goToMatchingBracket")
+	end,
+	["H"] = function(n)
+		screen_line("H", n)
+	end,
+	["M"] = function()
+		screen_line("M", 1)
+	end,
+	["L"] = function(n)
+		screen_line("L", n)
+	end,
+	[";"] = function(n)
+		repeat_find(n, false)
+	end,
+	[","] = function(n)
+		repeat_find(n, true)
+	end,
+	["ctrl-d"] = function(n)
+		scroll_page(1, n, true)
+	end,
+	["ctrl-u"] = function(n)
+		scroll_page(-1, n, true)
+	end,
+	["ctrl-f"] = function(n)
+		scroll_page(1, n, false)
+	end,
+	-- Ctrl-B is registered by core as a *force key* for sidebar.toggle, and force
+	-- keys outrank the plugin interceptor by design (internal/ui/root.go), so it
+	-- never reaches us unless the user rebinds sidebar.toggle. PgUp/PgDn are
+	-- provided as always-available equivalents of Ctrl-B/Ctrl-F.
+	["ctrl-b"] = function(n)
+		scroll_page(-1, n, false)
+	end,
+	["pgdn"] = function(n)
+		scroll_page(1, n, false)
+	end,
+	["pgup"] = function(n)
+		scroll_page(-1, n, false)
+	end,
+	["ctrl-e"] = function(n)
+		scroll_lines(1, n)
+	end,
+	["ctrl-y"] = function(n)
+		scroll_lines(-1, n)
+	end,
+}
+
+-- Second key of a `g`-prefixed sequence.
+local G_MOTIONS = {
+	["g"] = function(n, had_count)
+		goto_line(had_count and n or 1)
+	end,
+	["_"] = function(n)
+		local l = clamp(editor.cursor().line + n - 1, 1, line_count())
+		move_to(l, last_non_blank(l))
+	end,
+	["e"] = function(n)
+		word_end(n, false, true)
+	end,
+	["E"] = function(n)
+		word_end(n, true, true)
+	end,
+}
+
+-- Second key of a `z`-prefixed sequence, passed straight to reposition().
+local Z_COMMANDS = { z = true, t = true, b = true }
+
+local PREFIX_KEYS = { g = true, z = true }
+local FIND_KEYS = { f = true, F = true, t = true, T = true }
 
 -- ---------------------------------------------------------------------------
 -- Mode handlers
@@ -130,9 +677,17 @@ end
 local function handle_insert(tok)
 	if ESCAPE_TOKENS[tok] then
 		set_mode("normal")
+		-- Insert mode allows one-past-the-end; normal mode does not.
+		clamp_cursor()
 		return true
 	end
 	return false
+end
+
+local function take_count()
+	local n = state.count
+	state.count = nil
+	return n or 1, n ~= nil
 end
 
 local function handle_normal(tok)
@@ -141,6 +696,60 @@ local function handle_normal(tok)
 			return false
 		end
 		set_mode("normal")
+		return true
+	end
+
+	-- f/F/t/T consume the very next key as their target, whatever it is.
+	if state.find_pending then
+		local op = state.find_pending
+		state.find_pending = nil
+		local n = take_count()
+		if is_printable(tok) then
+			state.last_find = { op = op, ch = tok }
+			find_char(op, tok, n, false)
+		end
+		return true
+	end
+
+	if state.pending == "g" then
+		state.pending = ""
+		local n, had = take_count()
+		local fn = G_MOTIONS[tok]
+		if fn then
+			fn(n, had)
+		end
+		return true
+	end
+
+	if state.pending == "z" then
+		state.pending = ""
+		state.count = nil
+		if Z_COMMANDS[tok] then
+			reposition(tok)
+		end
+		return true
+	end
+
+	-- Count prefix. A leading `0` is the motion, not a count digit.
+	if #tok == 1 and tok >= "0" and tok <= "9" and not (tok == "0" and state.count == nil) then
+		state.count = (state.count or 0) * 10 + tonumber(tok)
+		return true
+	end
+
+	if PREFIX_KEYS[tok] then
+		state.pending = tok
+		return true
+	end
+
+	if FIND_KEYS[tok] then
+		state.find_pending = tok
+		return true
+	end
+
+	local motion = MOTIONS[tok]
+	if motion then
+		local n, had = take_count()
+		motion(n, had)
 		return true
 	end
 

--- a/plugins/vim/init.lua
+++ b/plugins/vim/init.lua
@@ -1,0 +1,212 @@
+-- Vim compatibility layer for ttt.
+--
+-- Single-file by necessity: the plugin sandbox strips package.loaders down to
+-- the preload loader (internal/plugin/sandbox.go), so a plugin cannot require
+-- sibling .lua files. Sections below are delimited and appended phase by phase.
+--
+-- Phase 0: mode state machine (normal/insert), Esc handling, status indicator.
+
+local ttt = require("ttt")
+local events = require("ttt.events")
+
+-- ---------------------------------------------------------------------------
+-- State
+-- ---------------------------------------------------------------------------
+
+local state = {
+	enabled = true,
+	mode = "normal", -- normal | insert | visual | visual_line | visual_block | replace
+	pending = "", -- unconsumed keys, e.g. "g", "2d"
+	count = nil, -- pending count prefix
+	operator = nil, -- pending operator
+	register = nil, -- pending "x register prefix
+	last_change = nil, -- replay payload for `.`
+	registers = {},
+	marks = {},
+	macro = { recording = nil, keys = {}, playing = false },
+}
+
+local MODE_LABELS = {
+	normal = "-- NORMAL --",
+	insert = "-- INSERT --",
+	visual = "-- VISUAL --",
+	visual_line = "-- VISUAL LINE --",
+	visual_block = "-- VISUAL BLOCK --",
+	replace = "-- REPLACE --",
+}
+
+-- ---------------------------------------------------------------------------
+-- Status indicator
+-- ---------------------------------------------------------------------------
+
+local function render_status()
+	if not state.enabled then
+		ttt.remove_status_item("mode")
+		return
+	end
+	ttt.set_status_item("left", "mode", MODE_LABELS[state.mode] or state.mode, { priority = 10 })
+end
+
+local function set_mode(mode)
+	state.mode = mode
+	state.pending = ""
+	state.count = nil
+	state.operator = nil
+	state.register = nil
+	render_status()
+end
+
+-- ---------------------------------------------------------------------------
+-- Key normalization
+--
+-- key.press delivers {type, key, rune, mod}. `rune` is present only for
+-- printable input; `mod` is nil when unmodified. Verified event shapes:
+--
+--   ctrl+d  -> {key="Ctrl-D", rune=nil, mod="ctrl"}   -- BOTH, not one or the other
+--   esc     -> {key="Esc",    rune=nil, mod=nil}
+--   j       -> {key="j",      rune="j", mod=nil}
+--
+-- tcell folds Ctrl into the key constant and *also* sets ModCtrl, so the key
+-- name must win: normalizing off `mod` alone yields "ctrl+Ctrl-D".
+-- See internal/plugin/event_convert.go and internal/app/keys.go:68-71.
+--
+-- Canonical tokens: runes keep their case ("g" vs "G"); named keys lowercase
+-- ("esc", "enter"); control keys collapse to "ctrl-d"; alt prefixes as "alt-".
+-- ---------------------------------------------------------------------------
+
+local function has_mod(mod, name)
+	return mod ~= nil and mod:find(name, 1, true) ~= nil
+end
+
+local function token_of(ev)
+	local alt = has_mod(ev.mod, "alt")
+
+	if ev.rune and ev.rune ~= "" then
+		return alt and ("alt-" .. ev.rune) or ev.rune
+	end
+
+	local key = ev.key or ""
+	local ctrl_letter = key:match("^Ctrl%-(.+)$")
+	local tok = ctrl_letter and ("ctrl-" .. ctrl_letter:lower()) or key:lower()
+	return alt and ("alt-" .. tok) or tok
+end
+
+-- gopher-lua is Lua 5.1, where the %g character class does not exist, so this
+-- is a byte-range check rather than a pattern match.
+local function is_printable(tok)
+	if #tok ~= 1 then
+		return false
+	end
+	local b = tok:byte(1)
+	return b >= 0x20 and b <= 0x7e
+end
+
+-- Keys that would otherwise mutate the buffer, so normal mode must swallow
+-- them even before the motions/operators that give them meaning exist.
+local MUTATING_KEYS = {
+	["enter"] = true,
+	["backspace"] = true,
+	["backspace2"] = true,
+	["delete"] = true,
+	["tab"] = true,
+}
+
+local ESCAPE_TOKENS = {
+	["esc"] = true,
+	["ctrl-["] = true,
+}
+
+-- True when Esc has something Vim-side to cancel. When it does not, Esc is
+-- passed through so core EscapeDismissers (clear search highlight, close
+-- panels) still run -- the interceptor now sits above them.
+local function has_pending()
+	return state.pending ~= "" or state.count ~= nil or state.operator ~= nil or state.register ~= nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Mode handlers
+-- ---------------------------------------------------------------------------
+
+local function handle_insert(tok)
+	if ESCAPE_TOKENS[tok] then
+		set_mode("normal")
+		return true
+	end
+	return false
+end
+
+local function handle_normal(tok)
+	if ESCAPE_TOKENS[tok] then
+		if not has_pending() then
+			return false
+		end
+		set_mode("normal")
+		return true
+	end
+
+	if tok == "i" then
+		set_mode("insert")
+		return true
+	end
+
+	-- Unhandled printable keys are swallowed rather than inserted: normal mode
+	-- must never type into the buffer. Modified and special keys fall through
+	-- so ctrl+s, ctrl+p and friends keep working.
+	if is_printable(tok) or MUTATING_KEYS[tok] then
+		return true
+	end
+
+	return false
+end
+
+local HANDLERS = {
+	normal = handle_normal,
+	insert = handle_insert,
+}
+
+local function on_key(ev)
+	if not state.enabled then
+		return false
+	end
+	local handler = HANDLERS[state.mode]
+	if not handler then
+		return false
+	end
+	return handler(token_of(ev))
+end
+
+-- ---------------------------------------------------------------------------
+-- Commands
+-- ---------------------------------------------------------------------------
+
+local function enable()
+	state.enabled = true
+	set_mode("normal")
+end
+
+local function disable()
+	state.enabled = false
+	render_status()
+end
+
+local function toggle()
+	if state.enabled then
+		disable()
+	else
+		enable()
+	end
+end
+
+ttt.register({
+	commands = {
+		{ id = "vim.toggle", title = "Vim: Toggle Vim Mode", handler = toggle },
+		{ id = "vim.enable", title = "Vim: Enable Vim Mode", handler = enable },
+		{ id = "vim.disable", title = "Vim: Disable Vim Mode", handler = disable },
+	},
+})
+
+events.on("key.press", on_key)
+
+-- set_status_item is only wired after WirePlugin runs, which is after this file
+-- executes, so the initial indicator is deferred by a tick.
+ttt.set_timeout(0, render_status)

--- a/plugins/vim/plugin.ttt.json
+++ b/plugins/vim/plugin.ttt.json
@@ -1,0 +1,15 @@
+{
+  "name": "vim",
+  "displayName": "Vim Mode",
+  "description": "Vim compatibility layer: modal editing, motions, operators, text objects, registers, marks and macros.",
+  "version": "0.1.0",
+  "author": "ttt",
+  "entry": "init.lua",
+  "api": 1,
+  "permissions": {
+    "keybindings": true,
+    "editor.read": true,
+    "editor.write": true,
+    "commands": true
+  }
+}

--- a/plugins/vim/plugin.ttt.json
+++ b/plugins/vim/plugin.ttt.json
@@ -5,12 +5,14 @@
   "version": "0.1.0",
   "author": "ttt",
   "entry": "init.lua",
-  "api": 1,
+  "api": 2,
   "permissions": {
     "keybindings": true,
     "editor.read": true,
     "editor.write": true,
     "commands": true,
-    "fs.write": true
+    "fs.write": true,
+    "settings": true,
+    "settings_keys": ["vim.enabled", "vim.clipboard"]
   }
 }

--- a/plugins/vim/plugin.ttt.json
+++ b/plugins/vim/plugin.ttt.json
@@ -10,6 +10,7 @@
     "keybindings": true,
     "editor.read": true,
     "editor.write": true,
-    "commands": true
+    "commands": true,
+    "fs.write": true
   }
 }

--- a/tests/e2e/commandline_test.go
+++ b/tests/e2e/commandline_test.go
@@ -1,0 +1,184 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func (h *testHarness) typeText(s string) {
+	h.t.Helper()
+	for _, r := range s {
+		h.pressRune(r)
+	}
+}
+
+func TestCommandLineShowTypeSubmit(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	submitted := ""
+	h.app.ShowCommandLine(":", nil, func(text string) { submitted = text }, nil)
+	h.redraw()
+
+	if !h.app.CommandLineActive() {
+		t.Fatal("expected the command line to be active")
+	}
+
+	h.typeText("wq")
+	h.assertContains(":wq")
+
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+
+	if submitted != "wq" {
+		t.Fatalf("expected submit %q, got %q", "wq", submitted)
+	}
+	if h.app.CommandLineActive() {
+		t.Fatal("expected the command line to close on submit")
+	}
+	if h.app.Root.Focused != h.app.EditorGroup {
+		t.Fatalf("expected focus restored to EditorGroup, got %T", h.app.Root.Focused)
+	}
+	h.assertNotContains(":wq")
+}
+
+func TestCommandLineEscapeCancelsAndRestoresFocus(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	cancelled := false
+	h.app.ShowCommandLine(":", nil, func(string) { t.Fatal("submit must not fire") }, func() { cancelled = true })
+	h.redraw()
+
+	h.typeText("q")
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	if !cancelled {
+		t.Fatal("expected OnCancel to fire")
+	}
+	if h.app.CommandLineActive() {
+		t.Fatal("expected the command line to close on Escape")
+	}
+	if h.app.Root.Focused != h.app.EditorGroup {
+		t.Fatalf("expected focus restored to EditorGroup, got %T", h.app.Root.Focused)
+	}
+
+	// Focus really is back on the editor: typing edits the buffer.
+	h.pressRune('z')
+	h.assertContains("z")
+}
+
+func TestCommandLineOnChangeFires(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	var changes []string
+	h.app.ShowCommandLine("/", func(text string) { changes = append(changes, text) }, nil, nil)
+	h.redraw()
+
+	h.typeText("ab")
+
+	if len(changes) != 2 || changes[0] != "a" || changes[1] != "ab" {
+		t.Fatalf("expected [a ab], got %v", changes)
+	}
+	h.app.HideCommandLine()
+}
+
+// The whole design rests on this: because the command line is a modal overlay,
+// Root.handleOverlay runs above the plugin KeyInterceptor, so a modal plugin
+// (Vim mode) goes silent while the command line is open without any focus
+// stashing or mode flags.
+func TestCommandLineSilencesKeyInterceptor(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	intercepted := 0
+	h.app.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		intercepted++
+		return true
+	}
+
+	// Sanity check: the interceptor is wired and does receive keys normally.
+	h.pressRune('j')
+	if intercepted != 1 {
+		t.Fatalf("expected the interceptor to receive keys before opening, got %d", intercepted)
+	}
+
+	h.app.ShowCommandLine(":", nil, nil, nil)
+	h.redraw()
+
+	h.typeText("abc")
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	if intercepted != 1 {
+		t.Fatalf("expected the interceptor to receive no keys while the command line is open, got %d extra", intercepted-1)
+	}
+
+	// ...and it starts receiving keys again once the command line closes.
+	h.pressRune('j')
+	if intercepted != 2 {
+		t.Fatalf("expected the interceptor to resume after close, got %d", intercepted)
+	}
+}
+
+func TestCommandLineShowReplacesInsteadOfStacking(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	h.app.ShowCommandLine(":", nil, nil, nil)
+	h.app.SetCommandLineText("first")
+	h.app.ShowCommandLine("/", nil, nil, nil)
+	h.redraw()
+
+	if h.app.CommandLineText() != "" {
+		t.Fatalf("expected the second command line to start empty, got %q", h.app.CommandLineText())
+	}
+	h.assertNotContains(":first")
+
+	h.app.HideCommandLine()
+	if h.app.Root.HasOverlay() {
+		t.Fatal("expected no overlays left after a single hide")
+	}
+	if h.app.Root.Focused != h.app.EditorGroup {
+		t.Fatalf("expected focus restored to EditorGroup, got %T", h.app.Root.Focused)
+	}
+}
+
+func TestCommandLineNotShownOverAnotherOverlay(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+	h.exec("command.palette")
+
+	if w := h.app.ShowCommandLine(":", nil, nil, nil); w != nil {
+		t.Fatal("expected ShowCommandLine to decline while another overlay is up")
+	}
+	if h.app.CommandLineActive() {
+		t.Fatal("expected no command line")
+	}
+}
+
+func TestHideCommandLineWithoutShowIsNoop(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+	focus := h.app.Root.Focused
+	h.app.HideCommandLine()
+	h.app.SetCommandLineText("ignored")
+
+	if h.app.Root.Focused != focus {
+		t.Fatal("expected focus to be untouched")
+	}
+}

--- a/tests/e2e/diff_hunk_nav_test.go
+++ b/tests/e2e/diff_hunk_nav_test.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+)
+
+// openHunkFile writes and opens a 20-line file, then stamps a synthetic
+// LineChanges slice on the active editor. Git state is not wired here on
+// purpose: the value under test is the hunk-grouping/navigation logic, which is
+// isolated cleanly by setting LineChanges directly (per the phase-7 plan).
+func openHunkFile(t *testing.T, h *testHarness) {
+	t.Helper()
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, "line "+string(rune('0'+i/10))+string(rune('0'+i%10)))
+	}
+	f := filepath.Join(h.dir, "hunks.txt")
+	os.WriteFile(f, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	// Two hunks: a run at lines 5-6 (0-based 4-5) and a run at line 15
+	// (0-based 14). Everything else unchanged. SetLineChanges stores the slice on
+	// the tab so a redraw does not overwrite it from the (empty) tab state.
+	changes := make([]diff.LineChangeKind, 20)
+	changes[4] = diff.LineModified
+	changes[5] = diff.LineAdded
+	changes[14] = diff.LineModified
+	h.app.EditorGroup.SetLineChanges(f, changes)
+	h.redraw()
+}
+
+func cursorLine1(h *testHarness) int {
+	line, _ := h.app.EditorGroup.ActiveCursor()
+	return line + 1
+}
+
+func TestDiffNextHunk(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	openHunkFile(t, h)
+
+	// Start at line 1.
+	h.app.EditorGroup.GoToLine(1)
+	h.redraw()
+
+	h.exec("diff.nextHunk")
+	if got := cursorLine1(h); got != 5 {
+		t.Fatalf("nextHunk from line 1: expected line 5, got %d", got)
+	}
+
+	// From inside the first hunk (line 5), next jumps past the run to line 15.
+	h.exec("diff.nextHunk")
+	if got := cursorLine1(h); got != 15 {
+		t.Fatalf("nextHunk from line 5: expected line 15, got %d", got)
+	}
+
+	// No hunk below line 15: cursor stays put.
+	h.exec("diff.nextHunk")
+	if got := cursorLine1(h); got != 15 {
+		t.Fatalf("nextHunk from last hunk: expected line 15 (no-op), got %d", got)
+	}
+}
+
+func TestDiffPrevHunk(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	openHunkFile(t, h)
+
+	h.app.EditorGroup.GoToLine(20)
+	h.redraw()
+
+	h.exec("diff.prevHunk")
+	if got := cursorLine1(h); got != 15 {
+		t.Fatalf("prevHunk from line 20: expected line 15, got %d", got)
+	}
+
+	h.exec("diff.prevHunk")
+	if got := cursorLine1(h); got != 5 {
+		t.Fatalf("prevHunk from line 15: expected line 5, got %d", got)
+	}
+
+	// No hunk above line 5: cursor stays put.
+	h.exec("diff.prevHunk")
+	if got := cursorLine1(h); got != 5 {
+		t.Fatalf("prevHunk from first hunk: expected line 5 (no-op), got %d", got)
+	}
+}
+
+func TestDiffHunkNoChanges(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	openHunkFile(t, h)
+
+	// Clear the synthetic changes: both directions must be safe no-ops.
+	h.app.EditorGroup.SetLineChanges(filepath.Join(h.dir, "hunks.txt"), nil)
+	h.app.EditorGroup.GoToLine(10)
+	h.redraw()
+
+	h.exec("diff.nextHunk")
+	if got := cursorLine1(h); got != 10 {
+		t.Fatalf("nextHunk with no changes: expected line 10 (no-op), got %d", got)
+	}
+	h.exec("diff.prevHunk")
+	if got := cursorLine1(h); got != 10 {
+		t.Fatalf("prevHunk with no changes: expected line 10 (no-op), got %d", got)
+	}
+}

--- a/tests/e2e/key_interceptor_test.go
+++ b/tests/e2e/key_interceptor_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
+
+	"github.com/eugenioenko/ttt/internal/ui"
 )
 
 func TestKeyInterceptorBlocksRune(t *testing.T) {
@@ -44,6 +46,89 @@ func TestKeyInterceptorPassthrough(t *testing.T) {
 	h.pressRune('x')
 
 	h.assertContains("x")
+}
+
+// Modal plugins (Vim mode) need Esc to leave insert mode, so the interceptor
+// runs before EscapeDismissers.
+func TestKeyInterceptorConsumesEscape(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	dismissed := false
+	h.app.Root.EscapeDismissers = append(h.app.Root.EscapeDismissers, func() bool {
+		dismissed = true
+		return true
+	})
+
+	intercepted := false
+	h.app.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		if ev.Key() == tcell.KeyEscape {
+			intercepted = true
+			return true
+		}
+		return false
+	}
+
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	if !intercepted {
+		t.Fatal("expected interceptor to receive Escape")
+	}
+	if dismissed {
+		t.Fatal("expected interceptor to preempt EscapeDismissers")
+	}
+}
+
+func TestKeyInterceptorEscapePassthrough(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	dismissed := false
+	h.app.Root.EscapeDismissers = append(h.app.Root.EscapeDismissers, func() bool {
+		dismissed = true
+		return true
+	})
+
+	h.app.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		return false
+	}
+
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	if !dismissed {
+		t.Fatal("expected EscapeDismissers to run when the interceptor declines")
+	}
+}
+
+// A chord in flight outranks the interceptor: its continuation keys are plain
+// runes that a modal plugin would otherwise swallow.
+func TestKeyInterceptorDoesNotBreakChords(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("file.new")
+
+	// Stand in for a modal plugin that consumes every printable key.
+	h.app.Root.KeyInterceptor = func(ev *tcell.EventKey) bool {
+		return ev.Key() == tcell.KeyRune
+	}
+
+	fired := false
+	h.app.Root.AddChordKey([]ui.GlobalKeyBinding{
+		{Key: tcell.KeyCtrlK, Mod: tcell.ModCtrl},
+		{Key: tcell.KeyRune, Rune: 'z'},
+	}, func() { fired = true })
+
+	h.pressCtrl(tcell.KeyCtrlK)
+	h.pressRune('z')
+
+	if !fired {
+		t.Fatal("expected chord to fire despite an interceptor that consumes runes")
+	}
 }
 
 func TestKeyInterceptorNotCalledForOverlays(t *testing.T) {

--- a/tests/functional/commandline.test.js
+++ b/tests/functional/commandline.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function writePlugin(dir, name, lua) {
+  const path = join(dir, name);
+  writeFileSync(path, lua, "utf8");
+  return path;
+}
+
+// A plugin that opens the command line on ":" — the Vim-mode shape this API exists for.
+const CMDLINE_PLUGIN = `
+  local ttt = require("ttt")
+  local events = require("ttt.events")
+  ttt.register({})
+  events.on("key.press", function(ev)
+    if ev.key == ":" then
+      ttt.command_line.show({
+        prefix = ":",
+        on_change = function(text)
+          ttt.set_status_item("left", "chg", "CHG[" .. text .. "]", { priority = 10 })
+        end,
+        on_submit = function(text)
+          ttt.set_status_item("left", "res", "SUBMIT[" .. text .. "]", { priority = 11 })
+        end,
+        on_cancel = function()
+          ttt.set_status_item("left", "res", "CANCEL", { priority = 11 })
+        end,
+      })
+      return true
+    end
+    return false
+  end)
+`;
+
+describe("plugin command line", () => {
+  it("opens a framed command line and submits its text", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+    const plugin = writePlugin(dir, "cmdline.lua", CMDLINE_PLUGIN);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.type(":");
+    tui.waitStable();
+    tui.type("wq");
+    tui.waitStable();
+    const open = tui.snapshot();
+    tui.press("enter");
+    tui.waitStable();
+    const after = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // While open: the prefix + text show inside the box, and OnChange has fired.
+    expect(snapshots[open]).toContain(":wq");
+    expect(snapshots[open]).toContain("CHG[wq]");
+    // The buffer is untouched — the command line overlays, it does not resize.
+    expect(snapshots[open]).toContain("hello");
+
+    // After Enter: submitted with the right text and the box is gone.
+    expect(snapshots[after]).toContain("SUBMIT[wq]");
+    expect(snapshots[after]).not.toContain(":wq");
+  });
+
+  it("cancels on escape and returns focus to the editor", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+    const plugin = writePlugin(dir, "cmdline.lua", CMDLINE_PLUGIN);
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.type(":");
+    tui.waitStable();
+    tui.type("q");
+    tui.waitStable();
+    tui.press("escape");
+    tui.waitStable();
+    tui.press("end");
+    tui.type("Z");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("CANCEL");
+    expect(snapshots[s]).not.toContain("SUBMIT");
+    // Focus went back to the editor, so the keystroke landed in the buffer.
+    expect(snapshots[s]).toContain("helloZ");
+  });
+
+  it("silences the plugin key interceptor while open", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello");
+    const plugin = writePlugin(
+      dir,
+      "counting.lua",
+      `
+      local ttt = require("ttt")
+      local events = require("ttt.events")
+      ttt.register({})
+      local seen = 0
+      events.on("key.press", function(ev)
+        if ev.key == ":" then
+          ttt.command_line.show({ prefix = ":" })
+          return true
+        end
+        seen = seen + 1
+        ttt.set_status_item("left", "seen", "SEEN=" .. seen, { priority = 10 })
+        return true
+      end)
+    `,
+    );
+
+    tui.start("--plugin", plugin, file);
+    tui.waitStable(300);
+    tui.type("a");
+    tui.waitStable();
+    tui.type(":");
+    tui.waitStable();
+    tui.type("bcd");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // "a" reached the interceptor; "bcd" went to the command line instead.
+    expect(snapshots[s]).toContain("SEEN=1");
+    expect(snapshots[s]).toContain(":bcd");
+  });
+});

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -100,12 +100,17 @@ export function snapshot() {
   return idx;
 }
 
+// ASCII unit separator: cannot appear in a key name or typed text, so tests are
+// free to send a literal ";" (a Vim motion, among other things) without it
+// being mistaken for a command boundary.
+const SEP = "\x1f";
+
 export function run(timeout = 15000) {
   commands.push("quit");
-  const script = commands.join("; ");
+  const script = commands.join(SEP);
 
   try {
-    execFileSync(BINARY, ["--size", size, "--exec", script, ...args], {
+    execFileSync(BINARY, ["--size", size, "--exec-split-on", SEP, "--exec", script, ...args], {
       encoding: "utf8",
       timeout,
       stdio: "pipe",

--- a/tests/functional/vim-diff-nav.test.js
+++ b/tests/functional/vim-diff-nav.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+// Drives the real binary directly (not tui.js) so it can git-init the temp dir
+// and open it as a folder — the ]c/[c hunk-nav bindings need a real repo with
+// changes so that the git gutter (LineChanges) is populated.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..", "..");
+const BINARY = join(ROOT, "bin", "ttt");
+const VIM_PLUGIN = join(ROOT, "plugins", "vim", "init.lua");
+const SEP = "\x1f";
+
+let dir;
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = "";
+});
+
+function git(cwd, args) {
+  execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+// Sets up a git repo with a 20-line file, commits, then changes lines 5 and 15
+// so there are two hunks. Runs the given --exec steps and returns the screenshot.
+function runInRepo(steps) {
+  dir = mkdtempSync(join(tmpdir(), "ttt-vimdiff-"));
+  const cfg = join(dir, "config");
+  mkdirSync(cfg, { recursive: true });
+  writeFileSync(join(cfg, "settings.json"), JSON.stringify({ version: 1 }));
+
+  git(dir, ["init", "-q"]);
+  git(dir, ["config", "user.email", "t@t.co"]);
+  git(dir, ["config", "user.name", "t"]);
+  const file = join(dir, "f.txt");
+  const base = Array.from({ length: 20 }, (_, i) => `line ${String(i + 1).padStart(2, "0")}`);
+  writeFileSync(file, base.join("\n") + "\n");
+  git(dir, ["add", "f.txt"]);
+  git(dir, ["commit", "-qm", "init"]);
+  const changed = base.slice();
+  changed[4] = "line 05 CHANGED";
+  changed[14] = "line 15 CHANGED";
+  writeFileSync(file, changed.join("\n") + "\n");
+
+  const shot = join(dir, "shot.txt");
+  const script = [...steps, `screenshot ${shot}`, "quit"].join(SEP);
+  try {
+    execFileSync(
+      BINARY,
+      ["--size", "100x30", "--exec-split-on", SEP, "--exec", script, "--plugin", VIM_PLUGIN, dir, file],
+      { encoding: "utf8", timeout: 15000, stdio: "pipe", env: { ...process.env, TTT_CONFIG_DIR: cfg } },
+    );
+  } catch {
+    // non-zero exit from quit is fine
+  }
+  return readFileSync(shot, "utf8");
+}
+
+describe("vim ]c / [c hunk navigation", () => {
+  it("]c jumps to the next changed hunk", () => {
+    // Wait for the async git gutter to populate, then ]c from the top of file.
+    const screen = runInRepo(["wait 1500", "key ] c", "wait 200"]);
+    expect(screen).toContain("Ln 5,");
+  });
+
+  it("]c twice reaches the second hunk", () => {
+    const screen = runInRepo(["wait 1500", "key ] c", "wait 150", "key ] c", "wait 200"]);
+    expect(screen).toContain("Ln 15,");
+  });
+});

--- a/tests/functional/vim-edits.test.js
+++ b/tests/functional/vim-edits.test.js
@@ -1,0 +1,351 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "plugins", "vim", "init.lua");
+
+// Line 1 is 16 columns of plain words. Line 2 is indented so I/^ differ from 0.
+// Line 3 carries a number for Ctrl-A/Ctrl-X and a zero-padded one for width
+// preservation. Line 4 has a negative number.
+const FIXTURE =
+  "alpha beta gamma\n" + "  indented two\n" + "count 41 and 007\n" + "temp -5 degrees\n" + "last line\n";
+
+const CODE = "function foo() {\n" + "bar()\n" + "}\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content = FIXTURE, name = "test.txt") {
+  dir = createTempDir();
+  const file = createTempFile(dir, name, content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+function send(keys) {
+  for (const k of keys) {
+    if (k.startsWith("<")) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+// Run a script against `content` and return the rendered screen.
+function screenAfter(keys, content = FIXTURE) {
+  startVim(content);
+  send(keys);
+  tui.waitStable();
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+// The status bar is the cleanest cursor readout the harness has.
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+function posAfter(keys, content = FIXTURE) {
+  return pos(screenAfter(keys, content));
+}
+
+describe("vim edits: entering insert mode", () => {
+  it("inserts before the cursor with i", () => {
+    expect(screenAfter(["iX"])).toContain("Xalpha beta gamma");
+  });
+
+  it("inserts after the cursor with a", () => {
+    expect(screenAfter(["aX"])).toContain("aXlpha beta gamma");
+  });
+
+  it("inserts at the first non-blank with I", () => {
+    expect(screenAfter(["j", "$", "IX"])).toContain("  Xindented two");
+  });
+
+  it("appends at end of line with A", () => {
+    expect(screenAfter(["AX"])).toContain("alpha beta gammaX");
+  });
+
+  it("opens a line below with o", () => {
+    const s = screenAfter(["oNEW"]);
+    expect(s).toContain("alpha beta gamma");
+    expect(s).toMatch(/2\s+NEW/);
+    expect(s).toMatch(/3\s+ {2}indented two/);
+  });
+
+  it("opens a line above with O", () => {
+    const s = screenAfter(["jONEW"]);
+    expect(s).toMatch(/2\s+NEW/);
+    expect(s).toMatch(/3\s+ {2}indented two/);
+  });
+
+  // Insert rejects line >= #Lines on the Go side, so `o` on the last line has
+  // to append the newline to that line instead of addressing the line after.
+  it("opens a line below even on the last line", () => {
+    const s = screenAfter(["G", "oEND"]);
+    expect(s).toMatch(/7\s+END/);
+  });
+
+  it("resumes the last insert position with gi", () => {
+    // Insert X at the start, leave, jump away, then gi must come back.
+    const s = screenAfter(["iX", "<escape>", "G", "giY"]);
+    expect(s).toContain("XYalpha beta gamma");
+  });
+
+  it("steps the cursor one column left on Esc, like Vim", () => {
+    // i at col 1, type 5 chars -> col 6 in insert; Esc pulls back to col 5.
+    startVim();
+    tui.type("ihello");
+    tui.waitStable(100);
+    const inInsert = tui.snapshot();
+    tui.press("escape");
+    tui.waitStable();
+    const inNormal = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[inInsert]).toContain("-- INSERT --");
+    expect(pos(snapshots[inInsert])).toBe("1:6");
+    expect(snapshots[inNormal]).toContain("-- NORMAL --");
+    expect(pos(snapshots[inNormal])).toBe("1:5");
+  });
+
+  it("does not step left when insert ended at column 1", () => {
+    expect(posAfter(["i", "<escape>"])).toBe("1:1");
+  });
+});
+
+describe("vim edits: deleting characters", () => {
+  it("deletes forward with x and a count", () => {
+    expect(screenAfter(["x"])).toContain("lpha beta gamma");
+    expect(screenAfter(["3x"])).toContain("ha beta gamma");
+  });
+
+  it("clamps x at the end of the line", () => {
+    const s = screenAfter(["$", "5x"]);
+    expect(s).toContain("alpha beta gamm");
+    expect(pos(s)).toBe("1:15");
+  });
+
+  it("deletes backward with X", () => {
+    expect(screenAfter(["3lX"])).toContain("alha beta gamma");
+    expect(screenAfter(["3l2X"])).toContain("aha beta gamma");
+  });
+
+  it("does nothing for X at column 1", () => {
+    const s = screenAfter(["X"]);
+    expect(s).toContain("alpha beta gamma");
+    expect(pos(s)).toBe("1:1");
+  });
+
+  it("deletes to end of line with D", () => {
+    expect(screenAfter(["5lD"])).toMatch(/1\s+alpha\b/);
+  });
+
+  it("deletes across lines with a counted D", () => {
+    // 2D removes to the end of the line below, joining what is left.
+    const s = screenAfter(["5l2D"]);
+    expect(s).toMatch(/1\s+alpha\s*│/);
+    expect(s).toMatch(/2\s+count 41 and 007/);
+  });
+});
+
+describe("vim edits: change and replace", () => {
+  it("changes to end of line with C", () => {
+    expect(screenAfter(["5lCXYZ"])).toContain("alphaXYZ");
+  });
+
+  it("substitutes characters with s", () => {
+    expect(screenAfter(["sX"])).toContain("Xlpha beta gamma");
+    expect(screenAfter(["3sX"])).toContain("Xha beta gamma");
+  });
+
+  it("substitutes whole lines with S", () => {
+    const s = screenAfter(["SX"]);
+    expect(s).toMatch(/1\s+X\s*│/);
+    expect(s).toMatch(/2\s+ {2}indented two/);
+  });
+
+  it("replaces one character with r", () => {
+    const s = screenAfter(["rZ"]);
+    expect(s).toContain("Zlpha beta gamma");
+    expect(pos(s)).toBe("1:1");
+  });
+
+  it("replaces a counted run with r", () => {
+    const s = screenAfter(["3rZ"]);
+    expect(s).toContain("ZZZha beta gamma");
+    expect(pos(s)).toBe("1:3");
+  });
+
+  it("refuses r when the count runs past the end of the line", () => {
+    expect(screenAfter(["$", "3rZ"])).toContain("alpha beta gamma");
+  });
+
+  it("overtypes in replace mode until Esc", () => {
+    startVim();
+    tui.type("R");
+    tui.waitStable(100);
+    const inReplace = tui.snapshot();
+    tui.type("XYZ");
+    tui.press("escape");
+    tui.waitStable();
+    const done = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[inReplace]).toContain("-- REPLACE --");
+    expect(snapshots[done]).toContain("XYZha beta gamma");
+    expect(snapshots[done]).toContain("-- NORMAL --");
+  });
+
+  it("extends the line when replace mode runs past its end", () => {
+    expect(screenAfter(["$", "RXYZ", "<escape>"])).toContain("alpha beta gammXYZ");
+  });
+});
+
+describe("vim edits: case and joins", () => {
+  it("toggles case with ~ and advances", () => {
+    const s = screenAfter(["~"]);
+    expect(s).toContain("Alpha beta gamma");
+    expect(pos(s)).toBe("1:2");
+  });
+
+  it("toggles a counted run with ~", () => {
+    expect(screenAfter(["5~"])).toContain("ALPHA beta gamma");
+  });
+
+  it("joins two lines with a space using J", () => {
+    const s = screenAfter(["J"]);
+    expect(s).toContain("alpha beta gamma indented two");
+    expect(pos(s)).toBe("1:17"); // cursor sits on the inserted space
+  });
+
+  it("joins a counted run of lines with J", () => {
+    expect(screenAfter(["3J"])).toContain("alpha beta gamma indented two count 41 and 007");
+  });
+
+  it("joins without a space using gJ", () => {
+    expect(screenAfter(["gJ"])).toContain("alpha beta gamma  indented two");
+  });
+});
+
+describe("vim edits: undo and redo", () => {
+  it("undoes with u and redoes with Ctrl-R", () => {
+    const undone = screenAfter(["x", "u"]);
+    expect(undone).toContain("alpha beta gamma");
+
+    const redone = screenAfter(["x", "u", "<ctrl+r>"]);
+    expect(redone).toContain("lpha beta gamma");
+  });
+
+  it("undoes a counted delete as ONE step", () => {
+    const s = screenAfter(["3x", "u"]);
+    expect(s).toContain("alpha beta gamma");
+  });
+
+  it("undoes a counted join as ONE step", () => {
+    const s = screenAfter(["J", "u"]);
+    expect(s).toMatch(/1\s+alpha beta gamma\s*│/);
+    expect(s).toMatch(/2\s+ {2}indented two/);
+  });
+
+  it("undoes a whole insert session as ONE step", () => {
+    expect(screenAfter(["ihello world", "<escape>", "u"])).toContain("alpha beta gamma");
+  });
+
+  it("undoes an o-plus-typing session as ONE step", () => {
+    const s = screenAfter(["oNEW LINE", "<escape>", "u"]);
+    expect(s).not.toContain("NEW LINE");
+    expect(s).toMatch(/2\s+ {2}indented two/);
+  });
+
+  it("undoes a counted change as ONE step", () => {
+    expect(screenAfter(["5lCXYZ", "<escape>", "u"])).toContain("alpha beta gamma");
+  });
+
+  it("undoes a counted indent as ONE step", () => {
+    const s = screenAfter(["2>>", "u"]);
+    expect(s).toMatch(/1\s+alpha beta gamma/);
+    expect(s).not.toMatch(/1\s+ {4}alpha/);
+  });
+
+  it("undoes a counted increment as ONE step", () => {
+    expect(screenAfter(["2j", "10", "<ctrl+a>", "u"])).toContain("count 41 and 007");
+  });
+
+  it("applies a count to u", () => {
+    // Three separate single-char deletes, then one 3u puts them all back.
+    expect(screenAfter(["x", "x", "x", "3u"])).toContain("alpha beta gamma");
+  });
+});
+
+describe("vim edits: indenting", () => {
+  it("indents and dedents with >> and <<", () => {
+    expect(screenAfter([">>"])).toMatch(/1\s+ {4}alpha beta gamma/);
+    expect(screenAfter([">>", "<<"])).toMatch(/1\s+alpha beta gamma/);
+  });
+
+  it("indents a counted run of lines", () => {
+    const s = screenAfter(["2>>"]);
+    expect(s).toMatch(/1\s+ {4}alpha beta gamma/);
+    expect(s).toMatch(/2\s+ {6}indented two/);
+  });
+
+  it("dedents only as far as the existing indent goes", () => {
+    expect(screenAfter(["j<<"])).toMatch(/2\s+indented two/);
+  });
+
+  it("leaves the cursor on the first non-blank after >>", () => {
+    expect(posAfter([">>"])).toBe("1:5");
+  });
+
+  it("reindents with == using the surrounding block", () => {
+    const s = screenAfter(["j2=="], CODE);
+    expect(s).toMatch(/2\s+ {4}bar\(\)/);
+    expect(s).toMatch(/3\s+\}/);
+  });
+});
+
+describe("vim edits: numbers", () => {
+  it("increments and decrements with Ctrl-A and Ctrl-X", () => {
+    expect(screenAfter(["2j", "<ctrl+a>"])).toContain("count 42 and 007");
+    expect(screenAfter(["2j", "<ctrl+x>"])).toContain("count 40 and 007");
+  });
+
+  it("applies a count to Ctrl-A", () => {
+    expect(screenAfter(["2j", "10", "<ctrl+a>"])).toContain("count 51 and 007");
+  });
+
+  it("finds the number after the cursor, not before it", () => {
+    expect(screenAfter(["2j", "$", "<ctrl+a>"])).toContain("count 41 and 008");
+  });
+
+  it("preserves zero padding", () => {
+    expect(screenAfter(["2j", "$", "<ctrl+x>"])).toContain("count 41 and 006");
+  });
+
+  it("treats a leading minus as a sign", () => {
+    expect(screenAfter(["3j", "<ctrl+a>"])).toContain("temp -4 degrees");
+    expect(screenAfter(["3j", "<ctrl+x>"])).toContain("temp -6 degrees");
+  });
+
+  it("does nothing when the line has no number after the cursor", () => {
+    expect(screenAfter(["<ctrl+a>"])).toContain("alpha beta gamma");
+  });
+
+  it("leaves the cursor on the last digit", () => {
+    // "count 41 and 007": 9 Ctrl-A turns 41 into 50, last digit at col 8.
+    expect(posAfter(["2j", "9", "<ctrl+a>"])).toBe("3:8");
+  });
+});

--- a/tests/functional/vim-ex.test.js
+++ b/tests/functional/vim-ex.test.js
@@ -1,0 +1,426 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import {
+  createTempDir,
+  createTempFile,
+  cleanupDir,
+  readFile,
+  fileExists,
+} from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "plugins",
+  "vim",
+  "init.lua",
+);
+
+const FIXTURE = "foo one\nbar two\nfoo three\nbaz foo four\n";
+
+// Ten identical lines, so a :%s across the file is unambiguously many edits.
+const MANY =
+  Array.from({ length: 10 }, (_, i) => `aa line ${i + 1} aa`).join("\n") + "\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+// The whole folder is opened, not just the file: the plugin filesystem API is
+// scoped to the workspace roots, so `:w {file}` only has somewhere to write
+// when a folder is part of the workspace.
+function startVim(content = FIXTURE, name = "test.txt") {
+  dir = createTempDir();
+  const file = createTempFile(dir, name, content);
+  tui.start("--plugin", VIM_PLUGIN, dir, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+// The pattern is deliberately strict: Vim scripts contain "<<" and "<G", which
+// a bare startsWith("<") check would swallow as key names.
+const KEY_TOKEN = /^<[a-z0-9+]+>$/i;
+
+function send(keys) {
+  for (const k of keys) {
+    if (KEY_TOKEN.test(k)) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+function screenAfter(keys, content = FIXTURE) {
+  startVim(content);
+  send(keys);
+  tui.waitStable(350);
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+// Assert that a numbered gutter line holds exactly `text`.
+function line(snapshot, n) {
+  const m = snapshot.match(new RegExp(`\\u2502\\s+${n}\\s{2}(.*?)\\s*\\u2502`));
+  return m ? m[1] : null;
+}
+
+describe("vim ex: the command line itself", () => {
+  it(": opens the command line and shows what is typed", () => {
+    startVim();
+    tui.type(":noh");
+    tui.waitStable(250);
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s]).toContain(":noh");
+  });
+
+  it("Esc closes the command line without running anything", () => {
+    const s = screenAfter([":%s/foo/ZZZ/g", "<esc>"]);
+    expect(line(s, 1)).toBe("foo one");
+    expect(s).toContain("-- NORMAL --");
+  });
+
+  it("an unknown command is reported, not silently ignored", () => {
+    expect(screenAfter([":frobnicate", "<enter>"])).toContain(
+      "Not an editor command",
+    );
+  });
+});
+
+describe("vim ex: line addressing", () => {
+  it(":{n} jumps to that line", () => {
+    expect(pos(screenAfter([":3", "<enter>"]))).toBe("3:1");
+  });
+
+  it(":$ jumps to the last line", () => {
+    // The trailing newline makes line 5 the (empty) last line.
+    expect(pos(screenAfter([":$", "<enter>"]))).toBe("5:1");
+  });
+
+  it(":1 jumps back to the top", () => {
+    expect(pos(screenAfter(["G", ":1", "<enter>"]))).toBe("1:1");
+  });
+
+  it("a line past the end clamps to the last line", () => {
+    expect(pos(screenAfter([":999", "<enter>"]))).toBe("5:1");
+  });
+});
+
+describe("vim ex: :w, :q and friends", () => {
+  it(":w saves the buffer", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", FIXTURE);
+    tui.start("--plugin", VIM_PLUGIN, dir, file);
+    tui.waitStable(300);
+    send(["ihello", "<esc>", ":w", "<enter>"]);
+    tui.waitStable(400);
+    tui.run();
+    expect(readFile(file)).toContain("hellofoo one");
+  });
+
+  it(":w {file} writes to another path, leaving the original alone", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", FIXTURE);
+    const other = join(dir, "copy.txt");
+    tui.start("--plugin", VIM_PLUGIN, dir, file);
+    tui.waitStable(300);
+    send(["iX", "<esc>", ":w copy.txt", "<enter>"]);
+    tui.waitStable(400);
+    tui.run();
+    expect(fileExists(other)).toBe(true);
+    expect(readFile(other)).toContain("Xfoo one");
+    // The buffer was never saved to its own path.
+    expect(readFile(file)).toBe(FIXTURE);
+  });
+
+  it(":q! quits without prompting, even with unsaved changes", () => {
+    startVim();
+    send(["x", ":q!", "<enter>"]);
+    tui.waitStable(300);
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+    // The editor is gone, so the screenshot after it never happened.
+    expect(snapshots[s]).toBe("");
+  });
+
+  it(":q prompts when the buffer is dirty", () => {
+    const s = screenAfter(["x", ":q", "<enter>"]);
+    expect(s).toContain("Unsaved changes");
+  });
+
+  it(":wq saves and then quits", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", FIXTURE);
+    tui.start("--plugin", VIM_PLUGIN, dir, file);
+    tui.waitStable(300);
+    send(["iQ", "<esc>", ":wq", "<enter>"]);
+    tui.waitStable(400);
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(readFile(file)).toContain("Qfoo one");
+    expect(snapshots[s]).toBe("");
+  });
+
+  it(":x behaves like :wq", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", FIXTURE);
+    tui.start("--plugin", VIM_PLUGIN, dir, file);
+    tui.waitStable(300);
+    send(["iQ", "<esc>", ":x", "<enter>"]);
+    tui.waitStable(400);
+    tui.run();
+    expect(readFile(file)).toContain("Qfoo one");
+  });
+
+  it(":e {file} opens another file in a new tab", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", FIXTURE);
+    createTempFile(dir, "other.txt", "other content here\n");
+    tui.start("--plugin", VIM_PLUGIN, dir, file);
+    tui.waitStable(300);
+    send([":e other.txt", "<enter>"]);
+    tui.waitStable(400);
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s]).toContain("other content here");
+    expect(snapshots[s]).toContain("other.txt");
+  });
+
+  it(":e with no file name complains", () => {
+    expect(screenAfter([":e", "<enter>"])).toContain("needs a file name");
+  });
+});
+
+describe("vim ex: :noh, :reg and :marks", () => {
+  it(":noh runs without reporting a missing command", () => {
+    const s = screenAfter([":noh", "<enter>"]);
+    expect(s).not.toContain("is not available");
+    expect(s).toContain("-- NORMAL --");
+  });
+
+  it(":reg lists the registers", () => {
+    const s = screenAfter(["yy", ":reg", "<enter>"]);
+    expect(s).toContain("Registers");
+    expect(s).toContain("foo one");
+  });
+
+  it(":marks lists the marks that have been set", () => {
+    const s = screenAfter(["3G", "ma", ":marks", "<enter>"]);
+    expect(s).toContain("Marks");
+    expect(s).toContain("foo three");
+  });
+});
+
+describe("vim ex: substitution", () => {
+  it(":s replaces the first match on the current line only", () => {
+    const s = screenAfter([":s/foo/X/", "<enter>"], "foo foo\nfoo foo\n");
+    expect(line(s, 1)).toBe("X foo");
+    expect(line(s, 2)).toBe("foo foo");
+  });
+
+  it("the g flag replaces every match on the line", () => {
+    const s = screenAfter([":s/foo/X/g", "<enter>"], "foo foo foo\n");
+    expect(line(s, 1)).toBe("X X X");
+  });
+
+  it(":%s covers the whole file", () => {
+    const s = screenAfter([":%s/foo/X/g", "<enter>"]);
+    expect(line(s, 1)).toBe("X one");
+    expect(line(s, 3)).toBe("X three");
+    expect(line(s, 4)).toBe("baz X four");
+  });
+
+  it("the i flag ignores case", () => {
+    const s = screenAfter([":%s/foo/X/i", "<enter>"], "FOO\nFoo\nfoo\n");
+    expect(line(s, 1)).toBe("X");
+    expect(line(s, 2)).toBe("X");
+    expect(line(s, 3)).toBe("X");
+  });
+
+  it("without the i flag the case must match", () => {
+    const s = screenAfter([":%s/foo/X/", "<enter>"], "FOO\nfoo\n");
+    expect(line(s, 1)).toBe("FOO");
+    expect(line(s, 2)).toBe("X");
+  });
+
+  it("an explicit {n},{m} range limits the substitution", () => {
+    const s = screenAfter([":2,3s/o/0/g", "<enter>"]);
+    expect(line(s, 1)).toBe("foo one");
+    expect(line(s, 2)).toBe("bar tw0");
+    expect(line(s, 3)).toBe("f00 three");
+    expect(line(s, 4)).toBe("baz foo four");
+  });
+
+  it(".,$ runs from the cursor to the end", () => {
+    const s = screenAfter(["3G", ":.,$s/foo/X/g", "<enter>"]);
+    expect(line(s, 1)).toBe("foo one");
+    expect(line(s, 3)).toBe("X three");
+    expect(line(s, 4)).toBe("baz X four");
+  });
+
+  it("an alternate delimiter works", () => {
+    const s = screenAfter([":%s#foo#X#g", "<enter>"]);
+    expect(line(s, 1)).toBe("X one");
+    expect(line(s, 4)).toBe("baz X four");
+  });
+
+  it("& and \\1 refer to the match and its groups", () => {
+    expect(line(screenAfter([":s/foo/[&]/", "<enter>"]), 1)).toBe("[foo] one");
+    expect(
+      line(screenAfter([":s/\\(f\\)\\(oo\\)/\\2\\1/", "<enter>"]), 1),
+    ).toBe("oof one");
+  });
+
+  it("reports when the pattern is not found", () => {
+    expect(screenAfter([":%s/nothing/X/", "<enter>"])).toContain(
+      "Pattern not found",
+    );
+  });
+
+  it("rejects an unsupported regex construct instead of misreading it", () => {
+    const s = screenAfter([":%s/a\\|b/X/", "<enter>"]);
+    expect(s).toContain("alternation");
+    expect(line(s, 1)).toBe("foo one");
+  });
+
+  it("rejects a replacement that would need a line break", () => {
+    expect(screenAfter([":s/foo/a\\rb/", "<enter>"])).toContain("line break");
+  });
+});
+
+describe("vim ex: substitution undo atomicity", () => {
+  it(":%s across ten lines is a single undo step", () => {
+    const s = screenAfter([":%s/aa/ZZ/g", "<enter>", "u"], MANY);
+    for (let i = 1; i <= 10; i++) {
+      expect(line(s, i)).toBe(`aa line ${i} aa`);
+    }
+  });
+
+  it("the substitution itself touched every line", () => {
+    const s = screenAfter([":%s/aa/ZZ/g", "<enter>"], MANY);
+    expect(line(s, 1)).toBe("ZZ line 1 ZZ");
+    expect(line(s, 10)).toBe("ZZ line 10 ZZ");
+  });
+
+  it("one undo is enough: a second undo has nothing left to revert", () => {
+    // If the run had been many undo steps, the first u would only have
+    // restored the last line and the buffer would still be half-substituted.
+    const s = screenAfter([":%s/aa/ZZ/g", "<enter>", "u"], MANY);
+    expect(s).not.toContain("ZZ");
+  });
+
+  it("redo brings the whole substitution back in one step", () => {
+    const s = screenAfter([":%s/aa/ZZ/g", "<enter>", "u", "<ctrl+r>"], MANY);
+    expect(line(s, 1)).toBe("ZZ line 1 ZZ");
+    expect(line(s, 10)).toBe("ZZ line 10 ZZ");
+  });
+});
+
+describe("vim ex: substitution with the c flag", () => {
+  it("prompts for each match and honours y, n and a", () => {
+    startVim("a1\na2\na3\na4\n");
+    tui.type(":%s/a/Z/gc");
+    tui.press("enter");
+    tui.waitStable(350);
+    const prompt = tui.snapshot();
+    tui.type("y");
+    tui.waitStable(300);
+    tui.type("n");
+    tui.waitStable(300);
+    tui.type("a");
+    tui.waitStable(400);
+    const done = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[prompt]).toContain("(y/n/a/q)?");
+    expect(line(snapshots[done], 1)).toBe("Z1");
+    expect(line(snapshots[done], 2)).toBe("a2");
+    expect(line(snapshots[done], 3)).toBe("Z3");
+    expect(line(snapshots[done], 4)).toBe("Z4");
+  });
+
+  it("q stops the run, keeping only what was already accepted", () => {
+    startVim("a1\na2\na3\n");
+    tui.type(":%s/a/Z/gc");
+    tui.press("enter");
+    tui.waitStable(350);
+    tui.type("y");
+    tui.waitStable(300);
+    tui.type("q");
+    tui.waitStable(400);
+    const done = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(line(snapshots[done], 1)).toBe("Z1");
+    expect(line(snapshots[done], 2)).toBe("a2");
+    expect(line(snapshots[done], 3)).toBe("a3");
+  });
+
+  it("a confirmed run is still a single undo step", () => {
+    startVim("a1\na2\na3\n");
+    tui.type(":%s/a/Z/gc");
+    tui.press("enter");
+    tui.waitStable(350);
+    tui.type("a");
+    tui.waitStable(400);
+    tui.type("u");
+    tui.waitStable(300);
+    const done = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(line(snapshots[done], 1)).toBe("a1");
+    expect(line(snapshots[done], 2)).toBe("a2");
+    expect(line(snapshots[done], 3)).toBe("a3");
+  });
+});
+
+describe("vim: editor integration keys", () => {
+  it("gt and gT move between tabs", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", FIXTURE);
+    createTempFile(dir, "other.txt", "other content here\n");
+    tui.start("--plugin", VIM_PLUGIN, dir, file);
+    tui.waitStable(300);
+    send([":e other.txt", "<enter>"]);
+    tui.waitStable(400);
+    send(["gT"]);
+    tui.waitStable(350);
+    const back = tui.snapshot();
+    send(["gt"]);
+    tui.waitStable(350);
+    const fwd = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[back]).toContain("foo one");
+    expect(snapshots[fwd]).toContain("other content here");
+  });
+
+  it("za, zR and zM reach the fold commands without complaining", () => {
+    for (const keys of [["za"], ["zR"], ["zM"]]) {
+      const s = screenAfter(keys);
+      expect(s).not.toContain("is not available");
+      expect(s).toContain("-- NORMAL --");
+    }
+  });
+
+  it("Ctrl-W w moves the focus and does not close the tab", () => {
+    // Core binds Ctrl-W to tab.close; normal mode takes it as a prefix instead.
+    const s = screenAfter(["<ctrl+w>", "w"]);
+    expect(s).toContain("test.txt");
+    expect(s).not.toContain("is not available");
+  });
+});

--- a/tests/functional/vim-macros.test.js
+++ b/tests/functional/vim-macros.test.js
@@ -1,0 +1,304 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "plugins", "vim", "init.lua");
+
+const LINES = "one\ntwo\nthree\nfour\nfive\n";
+const WORDS = "alpha beta gamma\nsecond line here\nthird word list\n";
+const CODE = "foo(a)\nbar(b)\nbaz(c)\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content) {
+  dir = createTempDir();
+  const file = createTempFile(dir, "test.txt", content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+// The pattern is deliberately strict: Vim scripts contain "<<" and "<G", which
+// a bare startsWith("<") check would swallow as key names.
+const KEY_TOKEN = /^<[a-z0-9+]+>$/i;
+
+function send(keys) {
+  for (const k of keys) {
+    if (KEY_TOKEN.test(k)) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+function screenAfter(keys, content = LINES) {
+  startVim(content);
+  send(keys);
+  tui.waitStable();
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+// Assert that a numbered gutter line holds exactly `text`.
+function line(snapshot, n) {
+  const m = snapshot.match(new RegExp(`\\u2502\\s+${n}\\s{2}(.*?)\\s*\\u2502`));
+  return m ? m[1] : null;
+}
+
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+describe("vim macros: recording and replay", () => {
+  it("q{a} records and @{a} replays", () => {
+    const s = screenAfter(["qa", "dd", "q", "@a"]);
+    expect(line(s, 1)).toBe("three");
+  });
+
+  it("the status bar shows the recording register", () => {
+    startVim(LINES);
+    send(["qa", "dd"]);
+    tui.waitStable();
+    const recording = tui.snapshot();
+    send(["q"]);
+    tui.waitStable();
+    const stopped = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[recording]).toContain("recording @a");
+    expect(snapshots[stopped]).not.toContain("recording @a");
+  });
+
+  it("{count}@{a} replays the macro count times", () => {
+    const s = screenAfter(["qa", "dd", "q", "3@a"]);
+    expect(line(s, 1)).toBe("five");
+  });
+
+  it("@@ repeats the last played macro", () => {
+    const s = screenAfter(["qa", "dd", "q", "@a", "@@"]);
+    expect(line(s, 1)).toBe("four");
+  });
+
+  it("a macro replays text typed in insert mode", () => {
+    const s = screenAfter(["qa", "A", "!", "<esc>", "j", "q", "@a"], WORDS);
+    expect(line(s, 1)).toBe("alpha beta gamma!");
+    expect(line(s, 2)).toBe("second line here!");
+  });
+
+  it("a macro replays an operator with a text object", () => {
+    const s = screenAfter(["qa", "f(", "ci(", "X", "<esc>", "j", "0", "q", "@a"], CODE);
+    expect(line(s, 1)).toBe("foo(X)");
+    expect(line(s, 2)).toBe("bar(X)");
+  });
+
+  it("q{A} appends to an existing macro", () => {
+    // "a deletes one line; appending a second dd makes @a delete two.
+    const s = screenAfter(["qa", "dd", "q", "qA", "dd", "q", "@a"]);
+    // Recording itself already deleted two lines, then @a deletes two more.
+    expect(line(s, 1)).toBe("five");
+  });
+
+  it("an empty register replays as a no-op", () => {
+    const s = screenAfter(["@z"]);
+    expect(line(s, 1)).toBe("one");
+  });
+
+  it("a self-recursive macro is capped instead of hanging", () => {
+    // qa records "dd@a", which calls itself. The depth cap has to stop it.
+    const many = Array.from({ length: 40 }, (_, i) => `L${String(i + 1).padStart(2, "0")}`).join("\n") + "\n";
+    const s = screenAfter(["qa", "dd", "@a", "q", "@a"], many);
+    expect(s).toContain("L40");
+    expect(s).not.toContain("L01");
+    expect(s).toContain("-- NORMAL --");
+  });
+
+  it("a macro replay produces one undo step per operation", () => {
+    // @a deletes two lines; two undos restore exactly those two.
+    const s = screenAfter(["qa", "dd", "q", "2@a", "u", "u"]);
+    expect(line(s, 1)).toBe("two");
+    expect(line(s, 2)).toBe("three");
+  });
+});
+
+describe("vim dot repeat: operators", () => {
+  it(". repeats a delete over a motion", () => {
+    const s = screenAfter(["dw", "j", "0", "."], WORDS);
+    expect(line(s, 1)).toBe("beta gamma");
+    expect(line(s, 2)).toBe("line here");
+  });
+
+  it(". repeats a doubled operator", () => {
+    const s = screenAfter(["dd", "."]);
+    expect(line(s, 1)).toBe("three");
+  });
+
+  it(". repeats an operator over a text object", () => {
+    // `ci(` needs the cursor on or inside the parens, in the repeat as well.
+    const s = screenAfter(["f(", "ci(", "X", "<esc>", "j", "f(", "."], CODE);
+    expect(line(s, 1)).toBe("foo(X)");
+    expect(line(s, 2)).toBe("bar(X)");
+  });
+
+  it(". repeats an operator over a find motion", () => {
+    const s = screenAfter(["dta", "j", "0", "."], "xxabc\nyyabc\n");
+    expect(line(s, 1)).toBe("abc");
+    expect(line(s, 2)).toBe("abc");
+  });
+
+  it("{count}. replaces the original count", () => {
+    const s = screenAfter(["dd", "3."]);
+    expect(line(s, 1)).toBe("five");
+  });
+
+  it(". uses the register the original command used", () => {
+    const s = screenAfter(['"add', ".", "G", '"ap']);
+    // "a was overwritten by the repeat, so it holds "two".
+    expect(line(s, 1)).toBe("three");
+    expect(line(s, 5)).toBe("two");
+  });
+
+  it(". repeats an operator with a mark target", () => {
+    const s = screenAfter(["ma", "3j", "d'a", "."], "L1\nL2\nL3\nL4\nL5\nL6\nL7\nL8\n");
+    // d'a removes L1..L4. The mark collapsed onto the start of the deleted
+    // span, so the repeat operates on the single line it now points at.
+    expect(line(s, 1)).toBe("L6");
+  });
+
+  it("a yank is not repeatable and leaves . armed", () => {
+    const s = screenAfter(["x", "j", "0", "yy", "."]);
+    expect(line(s, 1)).toBe("ne");
+    expect(line(s, 2)).toBe("wo");
+  });
+});
+
+describe("vim dot repeat: single-key edits", () => {
+  it(". repeats x with its count", () => {
+    const s = screenAfter(["2x", "j", "0", "."]);
+    expect(line(s, 1)).toBe("e");
+    expect(line(s, 2)).toBe("o");
+  });
+
+  it(". repeats r{char}", () => {
+    const s = screenAfter(["rZ", "j", "0", "."]);
+    expect(line(s, 1)).toBe("Zne");
+    expect(line(s, 2)).toBe("Zwo");
+  });
+
+  it(". repeats p", () => {
+    const s = screenAfter(["yy", "j", "p", "j", "."]);
+    expect(line(s, 3)).toBe("one");
+    expect(line(s, 4)).toBe("three");
+    expect(line(s, 5)).toBe("one");
+  });
+
+  it(". repeats J", () => {
+    const s = screenAfter(["J", "."]);
+    expect(line(s, 1)).toBe("one two three");
+  });
+});
+
+describe("vim dot repeat: insert mode", () => {
+  it(". repeats text typed after i", () => {
+    const s = screenAfter(["i", "ab", "<esc>", "j", "0", "."]);
+    expect(line(s, 1)).toBe("abone");
+    expect(line(s, 2)).toBe("abtwo");
+  });
+
+  it(". repeats an o with its typed text", () => {
+    const s = screenAfter(["o", "new", "<esc>", "."]);
+    expect(line(s, 2)).toBe("new");
+    expect(line(s, 3)).toBe("new");
+  });
+
+  it(". repeats a change with its typed text", () => {
+    const s = screenAfter(["cw", "X", "<esc>", "j", "0", "."], WORDS);
+    expect(line(s, 1)).toBe("X beta gamma");
+    expect(line(s, 2)).toBe("X line here");
+  });
+
+  it(". is one undo step for an insert repeat", () => {
+    const s = screenAfter(["i", "ab", "<esc>", "j", "0", ".", "u"]);
+    expect(line(s, 1)).toBe("abone");
+    expect(line(s, 2)).toBe("two");
+  });
+
+  it(". is one undo step for a change", () => {
+    const s = screenAfter(["cw", "X", "<esc>", "j", "0", ".", "u"], WORDS);
+    expect(line(s, 1)).toBe("X beta gamma");
+    expect(line(s, 2)).toBe("second line here");
+  });
+});
+
+describe("vim counts on insert-entry commands", () => {
+  it("3i repeats the typed text three times", () => {
+    const s = screenAfter(["3i", "ab", "<esc>"]);
+    expect(line(s, 1)).toBe("abababone");
+  });
+
+  it("5a repeats the typed text after the cursor", () => {
+    const s = screenAfter(["5a", "-", "<esc>"]);
+    expect(line(s, 1)).toBe("o-----ne");
+  });
+
+  it("3o opens three lines with the same text", () => {
+    const s = screenAfter(["3o", "X", "<esc>"]);
+    expect(line(s, 2)).toBe("X");
+    expect(line(s, 3)).toBe("X");
+    expect(line(s, 4)).toBe("X");
+    expect(line(s, 5)).toBe("two");
+  });
+
+  it("2O opens two lines above", () => {
+    const s = screenAfter(["j", "2O", "X", "<esc>"]);
+    expect(line(s, 1)).toBe("one");
+    expect(line(s, 2)).toBe("X");
+    expect(line(s, 3)).toBe("X");
+    expect(line(s, 4)).toBe("two");
+  });
+
+  it("a counted insert is a single undo step", () => {
+    const s = screenAfter(["3i", "ab", "<esc>", "u"]);
+    expect(line(s, 1)).toBe("one");
+  });
+
+  it("3s deletes three characters but types its text once", () => {
+    const s = screenAfter(["3s", "X", "<esc>"], "abcdef\n");
+    expect(line(s, 1)).toBe("Xdef");
+  });
+});
+
+describe("vim replace mode: backspace restores", () => {
+  it("backspace puts back the overwritten characters", () => {
+    // "xyz" overwrote "abc"; two backspaces put "b" and "c" back.
+    const s = screenAfter(["R", "xyz", "<backspace>", "<backspace>", "<esc>"], "abcdef\n");
+    expect(line(s, 1)).toBe("xbcdef");
+  });
+
+  it("backspace past the start of the session only walks left", () => {
+    const s = screenAfter(["ll", "R", "x", "<backspace>", "<backspace>", "<esc>"], "abcdef\n");
+    expect(line(s, 1)).toBe("abcdef");
+    expect(pos(s)).toBe("1:1");
+  });
+
+  it("R is a single undo step", () => {
+    const s = screenAfter(["R", "xyz", "<esc>", "u"], "abcdef\n");
+    expect(line(s, 1)).toBe("abcdef");
+  });
+
+  it(". repeats a replace-mode overtype", () => {
+    const s = screenAfter(["R", "XY", "<esc>", "j", "0", "."], "abcdef\nghijkl\n");
+    expect(line(s, 1)).toBe("XYcdef");
+    expect(line(s, 2)).toBe("XYijkl");
+  });
+});

--- a/tests/functional/vim-mode.test.js
+++ b/tests/functional/vim-mode.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "plugins", "vim", "init.lua");
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content = "hello world\nsecond line\n") {
+  dir = createTempDir();
+  const file = createTempFile(dir, "test.txt", content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+describe("vim mode", () => {
+  it("starts in normal mode", () => {
+    startVim();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("-- NORMAL --");
+  });
+
+  it("swallows printable keys in normal mode instead of typing them", () => {
+    startVim();
+    tui.type("jjxx");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("hello world");
+    expect(snapshots[s]).not.toContain("jjxx");
+    expect(snapshots[s]).toContain("-- NORMAL --");
+  });
+
+  it("enters insert mode on i and types text", () => {
+    startVim();
+    tui.type("iABC");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("-- INSERT --");
+    expect(snapshots[s]).toContain("ABChello world");
+    // the `i` that entered insert mode must not itself be typed
+    expect(snapshots[s]).not.toContain("iABC");
+  });
+
+  it("returns to normal mode on escape", () => {
+    startVim();
+    tui.type("iABC");
+    tui.press("escape");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("-- NORMAL --");
+    expect(snapshots[s]).toContain("ABChello world");
+  });
+
+  // The interceptor now sits above handleChord, so a chord's printable
+  // continuation key (the `s` of `ctrl+k s`) must not be eaten by normal mode.
+  it("does not break ctrl+k chords", () => {
+    startVim();
+    tui.pressChord("ctrl+k", "s");
+    tui.waitStable(200);
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s].toLowerCase()).toContain("save as");
+  });
+
+  it("stops swallowing keys once vim mode is disabled", () => {
+    startVim();
+    tui.exec("Vim: Disable Vim Mode");
+    tui.waitStable();
+    tui.type("zzz");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("zzz");
+    expect(snapshots[s]).not.toContain("-- NORMAL --");
+  });
+});

--- a/tests/functional/vim-motions.test.js
+++ b/tests/functional/vim-motions.test.js
@@ -1,0 +1,340 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "plugins", "vim", "init.lua");
+
+// Columns of interest in FIXTURE line 1, "alpha beta gamma delta":
+//   a1 l2 p3 h4 a5 _6 b7 e8 t9 a10 _11 g12 a13 m14 m15 a16 _17 d18 e19 l20 t21 a22
+// Line 2 is indented and has trailing blanks so ^/$/g_ are all distinguishable.
+// Line 3 mixes punctuation and words so w/W and e/E differ. Line 4 is blank.
+const FIXTURE = "alpha beta gamma delta\n" + "  indented line two   \n" + "foo.bar(baz) qux\n" + "\n" + "last line here\n";
+
+// 200 numbered lines, for screen-position and scrolling motions.
+const LONG = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content = FIXTURE, name = "test.txt") {
+  dir = createTempDir();
+  const file = createTempFile(dir, name, content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// The status bar is the cleanest cursor readout the harness has.
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+// Run one keystroke script against FIXTURE and return "line:col".
+function posAfter(keys, content = FIXTURE) {
+  startVim(content);
+  for (const k of keys) {
+    if (k.startsWith("<")) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+  tui.waitStable();
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return pos(snapshots[s]);
+}
+
+describe("vim motions: characters and lines", () => {
+  it("moves with h and l", () => {
+    expect(posAfter(["l"])).toBe("1:2");
+    expect(posAfter(["5l"])).toBe("1:6");
+    expect(posAfter(["5l", "2h"])).toBe("1:4");
+  });
+
+  it("clamps h and l inside the line", () => {
+    // Normal mode puts the cursor ON a character, so col never exceeds #line.
+    expect(posAfter(["99l"])).toBe("1:22");
+    expect(posAfter(["h"])).toBe("1:1");
+  });
+
+  it("moves with j and k, including counts", () => {
+    expect(posAfter(["2j"])).toBe("3:1");
+    expect(posAfter(["3j", "2k"])).toBe("2:1");
+    expect(posAfter(["9j"])).toBe("6:1"); // clamped to the last line
+  });
+
+  it("keeps the goal column across a short line", () => {
+    const short = "abcdefghij\nxy\nabcdefghij\n";
+    expect(posAfter(["9l", "j"], short)).toBe("2:2");
+    expect(posAfter(["9l", "2j"], short)).toBe("3:10");
+  });
+
+  it("moves to line starts and ends with 0 ^ $ g_", () => {
+    expect(posAfter(["j", "0"])).toBe("2:1");
+    expect(posAfter(["j", "^"])).toBe("2:3");
+    expect(posAfter(["j", "$"])).toBe("2:22");
+    expect(posAfter(["j", "g_"])).toBe("2:19");
+  });
+
+  it("keeps the cursor at end-of-line after $ then j", () => {
+    expect(posAfter(["$", "j"])).toBe("2:22");
+  });
+
+  it("moves to first non-blank of neighbouring lines with + and -", () => {
+    expect(posAfter(["+"])).toBe("2:3");
+    expect(posAfter(["2+"])).toBe("3:1");
+    expect(posAfter(["G", "-"])).toBe("5:1");
+  });
+});
+
+describe("vim motions: words", () => {
+  it("moves forward by word with w and counts", () => {
+    expect(posAfter(["w"])).toBe("1:7");
+    expect(posAfter(["3w"])).toBe("1:18");
+  });
+
+  it("treats punctuation as its own word for w but not W", () => {
+    // line 3 is "foo.bar(baz) qux"
+    expect(posAfter(["2j", "w"])).toBe("3:4");
+    expect(posAfter(["2j", "3w"])).toBe("3:8");
+    expect(posAfter(["2j", "W"])).toBe("3:14");
+  });
+
+  it("moves backward by word with b and B", () => {
+    expect(posAfter(["3w", "b"])).toBe("1:12");
+    expect(posAfter(["3w", "2b"])).toBe("1:7");
+    expect(posAfter(["2j", "$", "B"])).toBe("3:14");
+  });
+
+  it("moves to word ends with e and E", () => {
+    expect(posAfter(["e"])).toBe("1:5");
+    expect(posAfter(["3e"])).toBe("1:16");
+    expect(posAfter(["2j", "e"])).toBe("3:3");
+    expect(posAfter(["2j", "E"])).toBe("3:12");
+  });
+
+  it("moves to previous word ends with ge and gE", () => {
+    // 4w lands on line 2's first word, so ge/gE walk back into line 1.
+    expect(posAfter(["4w", "ge"])).toBe("1:22");
+    expect(posAfter(["4w", "gE"])).toBe("1:22");
+    expect(posAfter(["3w", "ge"])).toBe("1:16");
+  });
+
+  it("crosses lines and stops on blank lines", () => {
+    // line 3 has 5 words ("foo" "." "bar" "(" "baz" ...); walking off its end
+    // lands on the blank line 4, which Vim counts as a word.
+    expect(posAfter(["2j", "$", "w"])).toBe("4:1");
+    expect(posAfter(["2j", "$", "2w"])).toBe("5:1");
+  });
+});
+
+describe("vim motions: buffer positions", () => {
+  it("jumps with gg and G", () => {
+    expect(posAfter(["3j", "gg"])).toBe("1:1");
+    expect(posAfter(["G"])).toBe("6:1"); // trailing newline makes a 6th, empty line
+    expect(posAfter(["3G"])).toBe("3:1");
+    expect(posAfter(["2gg"])).toBe("2:3"); // first non-blank of the indented line
+    expect(posAfter(["99G"])).toBe("6:1");
+  });
+
+  it("moves by paragraph with { and }", () => {
+    expect(posAfter(["}"])).toBe("4:1");
+    expect(posAfter(["2}"])).toBe("6:1");
+    expect(posAfter(["G", "{"])).toBe("4:1");
+    expect(posAfter(["G", "2{"])).toBe("1:1");
+  });
+
+  it("jumps between brackets with %", () => {
+    expect(posAfter(["2j", "f(", "%"])).toBe("3:12");
+    expect(posAfter(["2j", "f)", "%"])).toBe("3:8");
+  });
+});
+
+describe("vim motions: character search on the line", () => {
+  it("finds forward with f and t", () => {
+    expect(posAfter(["fg"])).toBe("1:12");
+    expect(posAfter(["fa"])).toBe("1:5");
+    expect(posAfter(["2fa"])).toBe("1:10");
+    expect(posAfter(["3fa"])).toBe("1:13");
+    expect(posAfter(["ta"])).toBe("1:4");
+    expect(posAfter(["2ta"])).toBe("1:9");
+  });
+
+  it("finds backward with F and T", () => {
+    expect(posAfter(["$", "Fa"])).toBe("1:16");
+    expect(posAfter(["$", "2Fa"])).toBe("1:13");
+    expect(posAfter(["$", "Ta"])).toBe("1:17");
+  });
+
+  it("does not move when the character is absent on the line", () => {
+    expect(posAfter(["fz"])).toBe("1:1");
+    expect(posAfter(["$", "Fz"])).toBe("1:22");
+  });
+
+  it("never leaves the current line", () => {
+    // "second"-style characters exist on other lines but f must stay put.
+    expect(posAfter(["j", "fq"])).toBe("2:1");
+  });
+
+  // Sending a literal ";" relies on tui.js driving --exec-split-on with a
+  // non-printable separator; with the default ";" separator these keystrokes
+  // would be swallowed as command boundaries by the harness itself.
+  it("repeats the last find with ;", () => {
+    expect(posAfter(["fa", ";"])).toBe("1:10");
+    expect(posAfter(["fa", ";", ";"])).toBe("1:13");
+    expect(posAfter(["$", "Fa", ";"])).toBe("1:13");
+  });
+
+  it("advances instead of standing still when repeating a till-find", () => {
+    expect(posAfter(["ta", ";"])).toBe("1:9");
+    expect(posAfter(["$", "Ta", ";"])).toBe("1:14");
+  });
+
+  it("repeats a find in the opposite direction with ,", () => {
+    expect(posAfter(["2fa", ","])).toBe("1:5");
+    expect(posAfter(["$", "2Fa", ","])).toBe("1:16");
+    expect(posAfter(["fa", ";", ",", ";"])).toBe("1:10");
+  });
+});
+
+describe("vim motions: screen positions", () => {
+  it("moves to top, middle and bottom of the screen with H M L", () => {
+    // 120x40 gives a 34-line editor viewport.
+    expect(posAfter(["H"], LONG)).toBe("1:1");
+    expect(posAfter(["M"], LONG)).toBe("17:1");
+    expect(posAfter(["L"], LONG)).toBe("34:1");
+  });
+
+  it("accepts counts for H and L", () => {
+    expect(posAfter(["5H"], LONG)).toBe("5:1");
+    expect(posAfter(["3L"], LONG)).toBe("32:1");
+  });
+});
+
+describe("vim motions: scrolling", () => {
+  function screenAfter(keys, content = LONG) {
+    startVim(content, "long.txt");
+    for (const k of keys) {
+      if (k.startsWith("<")) {
+        tui.press(k.slice(1, -1));
+      } else {
+        tui.type(k);
+      }
+      tui.waitStable(80);
+    }
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+    return snapshots[s];
+  }
+
+  it("scrolls a half page with Ctrl-D and Ctrl-U", () => {
+    const down = screenAfter(["<ctrl+d>"]);
+    expect(pos(down)).toBe("18:1");
+    expect(down).toMatch(/\bline 18\b/);
+    expect(down).not.toMatch(/\bline 17\b/);
+
+    expect(pos(screenAfter(["<ctrl+d>", "<ctrl+u>"]))).toBe("1:1");
+  });
+
+  it("scrolls a full page with Ctrl-F", () => {
+    const down = screenAfter(["<ctrl+f>"]);
+    expect(pos(down)).toBe("35:1");
+    expect(down).toMatch(/\bline 35\b/);
+    expect(down).not.toMatch(/\bline 34\b/);
+  });
+
+  // Ctrl-B is a core force key (sidebar.toggle) and outranks plugin key
+  // interceptors, so PgUp is the reachable equivalent.
+  it("pages with PgDn and PgUp", () => {
+    expect(pos(screenAfter(["<pgdn>"]))).toBe("35:1");
+    expect(pos(screenAfter(["<pgdn>", "<pgup>"]))).toBe("1:1");
+  });
+
+  it("scrolls one line without moving the cursor using Ctrl-Y", () => {
+    const view = screenAfter(["<ctrl+f>", "<ctrl+y>"]);
+    expect(pos(view)).toBe("35:1"); // cursor stayed
+    expect(view).toMatch(/\bline 34\b/); // but the view moved up one
+  });
+
+  it("drags the cursor along with Ctrl-E when it would leave the screen", () => {
+    const view = screenAfter(["<ctrl+e>"]);
+    expect(pos(view)).toBe("2:1");
+    expect(view).not.toMatch(/\bline 1\b/);
+  });
+
+  it("repositions the view around the cursor with zz, zt and zb", () => {
+    const zt = screenAfter(["100G", "zt"]);
+    expect(pos(zt)).toBe("100:1");
+    expect(zt).toMatch(/\bline 100\b/);
+    expect(zt).not.toMatch(/\bline 99\b/);
+
+    const zz = screenAfter(["100G", "zz"]);
+    expect(pos(zz)).toBe("100:1");
+    expect(zz).toMatch(/\bline 83\b/);
+    expect(zz).not.toMatch(/\bline 82\b/);
+
+    const zb = screenAfter(["100G", "zb"]);
+    expect(pos(zb)).toBe("100:1");
+    expect(zb).toMatch(/\bline 67\b/);
+    expect(zb).not.toMatch(/\bline 66\b/);
+  });
+});
+
+describe("vim motions: counts and cursor semantics", () => {
+  it("lands the cursor where the buffer says it should", () => {
+    startVim();
+    tui.type("3wiX");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("alpha beta gamma Xdelta");
+  });
+
+  it("does not leak a count into the following motion", () => {
+    expect(posAfter(["3l", "l"])).toBe("1:5");
+  });
+
+  it("does not treat a leading 0 as a count", () => {
+    expect(posAfter(["5l", "0"])).toBe("1:1");
+  });
+
+  it("clamps the cursor back onto a character when leaving insert mode", () => {
+    // `$` then `i` then Right puts the cursor one past the end (legal in
+    // insert mode); Esc must pull it back onto the last character.
+    startVim();
+    tui.type("$");
+    tui.type("i");
+    tui.press("right");
+    tui.waitStable(100);
+    const insert = tui.snapshot();
+    tui.press("escape");
+    tui.waitStable();
+    const normal = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(pos(snapshots[insert])).toBe("1:23");
+    expect(pos(snapshots[normal])).toBe("1:22");
+  });
+
+  it("does not type motion keys into the buffer", () => {
+    startVim();
+    tui.type("3wbe0$Ggg");
+    tui.waitStable();
+    const s = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s]).toContain("alpha beta gamma delta");
+    expect(snapshots[s]).not.toContain("3wbe");
+  });
+});

--- a/tests/functional/vim-operators.test.js
+++ b/tests/functional/vim-operators.test.js
@@ -1,0 +1,487 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "plugins", "vim", "init.lua");
+
+// Line 1 is three plain words. Line 2 is indented so linewise change can be
+// shown to preserve indentation. Line 3 ends the "paragraph" for { and }.
+const FIXTURE =
+  "alpha beta gamma\n" + "  indented two\n" + "count 41 and 007\n" + "temp -5 degrees\n" + "last line\n";
+
+// Short, unambiguous line markers for the linewise matrix.
+const LINES = "L1\nL2\nL3\nL4\nL5\n";
+
+const PARA = "one\ntwo\n\nthree\nfour\n";
+
+const CODE = "function foo() {\n" + "bar()\n" + "baz()\n" + "}\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content = FIXTURE, name = "test.txt") {
+  dir = createTempDir();
+  const file = createTempFile(dir, name, content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+// The pattern is deliberately strict: Vim scripts contain "<<" and "<G", which
+// a bare startsWith("<") check would swallow as key names.
+const KEY_TOKEN = /^<[a-z0-9+]+>$/i;
+
+function send(keys) {
+  for (const k of keys) {
+    if (KEY_TOKEN.test(k)) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+function screenAfter(keys, content = FIXTURE) {
+  startVim(content);
+  send(keys);
+  tui.waitStable();
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+function posAfter(keys, content = FIXTURE) {
+  return pos(screenAfter(keys, content));
+}
+
+// Assert that a numbered gutter line holds exactly `text`.
+function line(snapshot, n) {
+  const m = snapshot.match(new RegExp(`\\u2502\\s+${n}\\s{2}(.*?)\\s*\\u2502`));
+  return m ? m[1] : null;
+}
+
+describe("vim operators: exclusive vs inclusive motions", () => {
+  // The single most common Vim-emulation bug: dw must not eat the character it
+  // lands on, de must.
+  it("dw is exclusive and de is inclusive", () => {
+    expect(screenAfter(["dw"])).toContain("beta gamma");
+    expect(screenAfter(["de"])).toContain(" beta gamma");
+  });
+
+  it("d$ is inclusive and deletes the last character", () => {
+    const s = screenAfter(["5l", "d$"]);
+    expect(line(s, 1)).toBe("alpha");
+  });
+
+  it("d0 deletes back to the start of the line", () => {
+    expect(line(screenAfter(["6l", "d0"]), 1)).toBe("beta gamma");
+  });
+
+  it("dfx includes the target character, dtx does not", () => {
+    expect(line(screenAfter(["dfb"]), 1)).toBe("eta gamma");
+    expect(line(screenAfter(["dtb"]), 1)).toBe("beta gamma");
+  });
+
+  it("dFx and dTx are exclusive of the character under the cursor", () => {
+    // Cursor on the "g" of gamma (col 12); dFb deletes back to the "b".
+    expect(line(screenAfter(["11l", "dFb"]), 1)).toBe("alpha gamma");
+    expect(line(screenAfter(["11l", "dTb"]), 1)).toBe("alpha bgamma");
+  });
+
+  it("dh and dl work in both directions", () => {
+    expect(line(screenAfter(["dl"]), 1)).toBe("lpha beta gamma");
+    expect(line(screenAfter(["3l", "dh"]), 1)).toBe("alha beta gamma");
+  });
+
+  it("d% is inclusive of both brackets", () => {
+    expect(line(screenAfter(["f(", "d%"], "a (b c) d\n"), 1)).toBe("a  d");
+  });
+});
+
+describe("vim operators: word motions at line ends", () => {
+  // Vim: "the last word moved over is at the end of a line" -> the operated
+  // text stops there instead of swallowing the newline and the next indent.
+  it("dw on the last word of a line stops at the line end", () => {
+    const s = screenAfter(["$", "b", "dw"]);
+    expect(line(s, 1)).toBe("alpha beta");
+    expect(line(s, 2)).toBe("  indented two");
+  });
+
+  it("cw behaves like ce on a non-blank", () => {
+    // Real Vim special case: cw does not reach the start of the next word.
+    expect(line(screenAfter(["cwZZ", "<escape>"]), 1)).toBe("ZZ beta gamma");
+  });
+
+  it("cw on the last word of a line does not join lines", () => {
+    const s = screenAfter(["$", "b", "cwZZ", "<escape>"]);
+    expect(line(s, 1)).toBe("alpha beta ZZ");
+    expect(line(s, 2)).toBe("  indented two");
+  });
+});
+
+describe("vim operators: linewise motions", () => {
+  it("dj and dk take whole lines in both directions", () => {
+    expect(line(screenAfter(["jj", "dj"], LINES), 3)).toBe("L5");
+    const up = screenAfter(["jj", "dk"], LINES);
+    expect(line(up, 1)).toBe("L1");
+    expect(line(up, 2)).toBe("L4");
+  });
+
+  it("d2j takes three lines", () => {
+    const s = screenAfter(["jj", "d2j"], LINES);
+    expect(line(s, 1)).toBe("L1");
+    expect(line(s, 2)).toBe("L2");
+    expect(line(s, 3)).toBe("");
+  });
+
+  it("dG deletes to the end of the buffer", () => {
+    expect(line(screenAfter(["jj", "dG"], LINES), 1)).toBe("L1");
+  });
+
+  it("dgg deletes to the start of the buffer", () => {
+    const s = screenAfter(["jj", "dgg"], LINES);
+    expect(line(s, 1)).toBe("L4");
+  });
+
+  it("d3G deletes from the cursor line through line 3", () => {
+    const s = screenAfter(["d3G"], LINES);
+    expect(line(s, 1)).toBe("L4");
+  });
+
+  it("d} takes the paragraph but leaves the blank line", () => {
+    const s = screenAfter(["d}"], PARA);
+    expect(line(s, 1)).toBe("");
+    expect(line(s, 2)).toBe("three");
+  });
+});
+
+describe("vim operators: doubled linewise forms", () => {
+  it("dd deletes the current line", () => {
+    expect(line(screenAfter(["dd"], LINES), 1)).toBe("L2");
+  });
+
+  it("2dd and d2d delete two lines", () => {
+    expect(line(screenAfter(["2dd"], LINES), 1)).toBe("L3");
+    expect(line(screenAfter(["d2d"], LINES), 1)).toBe("L3");
+  });
+
+  it("dd on the last line leaves no stray blank", () => {
+    // LINES ends with a newline, so line 6 is the empty final line.
+    const s = screenAfter(["G", "k", "dd"], LINES);
+    expect(line(s, 4)).toBe("L4");
+    expect(line(s, 5)).toBe("");
+    expect(line(s, 6)).toBe(null);
+  });
+
+  it("deleting every line leaves one empty line", () => {
+    const s = screenAfter(["10dd"], LINES);
+    expect(line(s, 1)).toBe("");
+    expect(line(s, 2)).toBe(null);
+  });
+
+  it("yy and cc are doubled too", () => {
+    expect(line(screenAfter(["yyp"], LINES), 2)).toBe("L1");
+    expect(line(screenAfter(["ccZZ", "<escape>"], LINES), 1)).toBe("ZZ");
+  });
+
+  it("cc preserves the line's indentation", () => {
+    expect(line(screenAfter(["j", "ccZZ", "<escape>"]), 2)).toBe("  ZZ");
+  });
+
+  it("S is the same operation as cc", () => {
+    expect(line(screenAfter(["j", "SZZ", "<escape>"]), 2)).toBe("  ZZ");
+  });
+});
+
+describe("vim operators: counts multiply", () => {
+  it("2d3w deletes six words", () => {
+    // alpha beta gamma / indented two / count -> leaves "41 and 007".
+    expect(line(screenAfter(["2d3w"]), 1)).toBe("41 and 007");
+  });
+
+  it("3dw and d3w agree", () => {
+    expect(line(screenAfter(["3dw"]), 1)).toBe(line(screenAfter(["d3w"]), 1));
+  });
+
+  it("2d2d deletes four lines", () => {
+    expect(line(screenAfter(["2d2d"], LINES), 1)).toBe("L5");
+  });
+});
+
+describe("vim operators: change", () => {
+  it("c$ changes to the end of the line", () => {
+    expect(line(screenAfter(["5l", "c$ZZ", "<escape>"]), 1)).toBe("alphaZZ");
+  });
+
+  it("c with a linewise motion collapses the lines", () => {
+    const s = screenAfter(["cjZZ", "<escape>"], LINES);
+    expect(line(s, 1)).toBe("ZZ");
+    expect(line(s, 2)).toBe("L3");
+  });
+
+  it("c leaves you in insert mode, d and y do not", () => {
+    startVim();
+    tui.type("cw");
+    tui.waitStable(100);
+    const afterC = tui.snapshot();
+    tui.press("escape");
+    tui.type("dw");
+    tui.waitStable(100);
+    const afterD = tui.snapshot();
+    tui.type("yw");
+    tui.waitStable(100);
+    const afterY = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[afterC]).toContain("-- INSERT --");
+    expect(snapshots[afterD]).toContain("-- NORMAL --");
+    expect(snapshots[afterY]).toContain("-- NORMAL --");
+  });
+});
+
+describe("vim operators: yank and paste", () => {
+  it("yy then p puts the line below", () => {
+    const s = screenAfter(["yyp"], LINES);
+    expect(line(s, 1)).toBe("L1");
+    expect(line(s, 2)).toBe("L1");
+    expect(line(s, 3)).toBe("L2");
+  });
+
+  it("yy then P puts the line above", () => {
+    const s = screenAfter(["j", "yyP"], LINES);
+    expect(line(s, 2)).toBe("L2");
+    expect(line(s, 3)).toBe("L2");
+  });
+
+  it("a linewise paste lands on its own line, not inline", () => {
+    const s = screenAfter(["yy", "j", "p"], LINES);
+    expect(line(s, 2)).toBe("L2");
+    expect(line(s, 3)).toBe("L1");
+  });
+
+  it("yw then P pastes charwise before the cursor", () => {
+    expect(line(screenAfter(["ywP"]), 1)).toBe("alpha alpha beta gamma");
+  });
+
+  it("yw then p pastes charwise after the cursor", () => {
+    expect(line(screenAfter(["yw", "p"]), 1)).toBe("aalpha lpha beta gamma");
+  });
+
+  it("a counted paste repeats the register", () => {
+    const s = screenAfter(["yy", "3p"], LINES);
+    expect(line(s, 2)).toBe("L1");
+    expect(line(s, 3)).toBe("L1");
+    expect(line(s, 4)).toBe("L1");
+    expect(line(s, 5)).toBe("L2");
+  });
+
+  it("dd then p moves a line down", () => {
+    const s = screenAfter(["dd", "p"], LINES);
+    expect(line(s, 1)).toBe("L2");
+    expect(line(s, 2)).toBe("L1");
+  });
+
+  it("x then p transposes two characters", () => {
+    expect(line(screenAfter(["xp"]), 1)).toBe("lapha beta gamma");
+  });
+
+  it("y2j yanks three lines linewise", () => {
+    const s = screenAfter(["y2j", "G", "p"], LINES);
+    expect(line(s, 7)).toBe("L1");
+    expect(line(s, 8)).toBe("L2");
+    expect(line(s, 9)).toBe("L3");
+  });
+
+  it("Y yanks to the end of the line", () => {
+    // ttt follows Neovim's Y = y$ rather than Vim's Y = yy.
+    expect(line(screenAfter(["6l", "YP"]), 1)).toBe("alpha beta gammabeta gamma");
+  });
+
+  it("y leaves the cursor at the start of the range", () => {
+    expect(posAfter(["$", "yb"])).toBe("1:12");
+  });
+});
+
+describe("vim operators: indent", () => {
+  it(">> and >j agree on two lines", () => {
+    const a = screenAfter(["2>>"], LINES);
+    const b = screenAfter([">j"], LINES);
+    expect(line(a, 1)).toBe(line(b, 1));
+    expect(line(a, 2)).toBe(line(b, 2));
+    expect(line(a, 1)).toBe("    L1");
+  });
+
+  it("> with a linewise motion indents the range", () => {
+    const s = screenAfter([">G"], LINES);
+    expect(line(s, 1)).toBe("    L1");
+    expect(line(s, 5)).toBe("    L5");
+  });
+
+  it("< dedents and stops at column 1", () => {
+    const s = screenAfter([">>", ">>", "<<"], LINES);
+    expect(line(s, 1)).toBe("    L1");
+  });
+
+  it("> is always linewise even with a charwise motion", () => {
+    expect(line(screenAfter([">w"], LINES), 1)).toBe("    L1");
+  });
+
+  it("= reindents a range", () => {
+    const s = screenAfter(["j", "=j"], CODE);
+    expect(line(s, 2)).toBe("    bar()");
+    expect(line(s, 3)).toBe("    baz()");
+  });
+});
+
+describe("vim operators: case", () => {
+  it("gUw and guw change case over a word", () => {
+    expect(line(screenAfter(["gUw"]), 1)).toBe("ALPHA beta gamma");
+    expect(line(screenAfter(["gUw", "guw"]), 1)).toBe("alpha beta gamma");
+  });
+
+  it("g~w swaps case", () => {
+    expect(line(screenAfter(["gUw", "g~w"]), 1)).toBe("alpha beta gamma");
+  });
+
+  it("gUU, gUgU and gU$ act on the line", () => {
+    expect(line(screenAfter(["gUU"]), 1)).toBe("ALPHA BETA GAMMA");
+    expect(line(screenAfter(["gUgU"]), 1)).toBe("ALPHA BETA GAMMA");
+    expect(line(screenAfter(["gU$"]), 1)).toBe("ALPHA BETA GAMMA");
+  });
+
+  it("guu and g~~ act on the line", () => {
+    expect(line(screenAfter(["gUU", "guu"]), 1)).toBe("alpha beta gamma");
+    expect(line(screenAfter(["g~~"]), 1)).toBe("ALPHA BETA GAMMA");
+  });
+
+  it("gU with a linewise motion covers every line", () => {
+    const s = screenAfter(["gUj"], LINES);
+    expect(line(s, 1)).toBe("L1");
+    expect(line(s, 2)).toBe("L2");
+    // Already uppercase; use the word fixture for a visible change.
+    const t = screenAfter(["gUj"]);
+    expect(line(t, 1)).toBe("ALPHA BETA GAMMA");
+    expect(line(t, 2)).toBe("  INDENTED TWO");
+  });
+
+  it("2gUU covers two lines", () => {
+    const s = screenAfter(["2gUU"]);
+    expect(line(s, 1)).toBe("ALPHA BETA GAMMA");
+    expect(line(s, 2)).toBe("  INDENTED TWO");
+  });
+});
+
+describe("vim operators: shorthands", () => {
+  it("D deletes to the end of the line", () => {
+    expect(line(screenAfter(["5l", "D"]), 1)).toBe("alpha");
+  });
+
+  it("C changes to the end of the line", () => {
+    expect(line(screenAfter(["5l", "CZZ", "<escape>"]), 1)).toBe("alphaZZ");
+  });
+
+  it("D fills the register", () => {
+    // D from col 6 takes " beta gamma"; Esc-style clamping leaves the cursor on
+    // col 5, so P puts the text back before the final "a".
+    expect(line(screenAfter(["5l", "D", "P"]), 1)).toBe("alph beta gammaa");
+  });
+});
+
+// Every Vim operation must collapse to exactly one undo step.
+describe("vim operators: undo atomicity", () => {
+  const original = "alpha beta gamma";
+
+  it("undoes d with a motion as ONE step", () => {
+    expect(line(screenAfter(["d2w", "u"]), 1)).toBe(original);
+  });
+
+  it("undoes dd as ONE step", () => {
+    expect(line(screenAfter(["dd", "u"], LINES), 1)).toBe("L1");
+  });
+
+  it("undoes a counted dd as ONE step", () => {
+    const s = screenAfter(["3dd", "u"], LINES);
+    expect(line(s, 1)).toBe("L1");
+    expect(line(s, 3)).toBe("L3");
+  });
+
+  it("undoes c plus typing as ONE step", () => {
+    expect(line(screenAfter(["cwZZZ", "<escape>", "u"]), 1)).toBe(original);
+  });
+
+  it("undoes cc plus typing as ONE step", () => {
+    expect(line(screenAfter(["ccZZZ", "<escape>", "u"]), 1)).toBe(original);
+  });
+
+  it("undoes a linewise c plus typing as ONE step", () => {
+    const s = screenAfter(["cjZZZ", "<escape>", "u"], LINES);
+    expect(line(s, 1)).toBe("L1");
+    expect(line(s, 2)).toBe("L2");
+  });
+
+  it("undoes > as ONE step", () => {
+    expect(line(screenAfter([">G", "u"], LINES), 1)).toBe("L1");
+  });
+
+  it("undoes < as ONE step", () => {
+    const s = screenAfter([">G", "<G", "u"], LINES);
+    expect(line(s, 1)).toBe("    L1");
+  });
+
+  it("undoes = as ONE step", () => {
+    expect(line(screenAfter(["j", "=j", "u"], CODE), 2)).toBe("bar()");
+  });
+
+  it("undoes gU as ONE step", () => {
+    expect(line(screenAfter(["gUj", "u"]), 1)).toBe(original);
+  });
+
+  it("undoes gu as ONE step", () => {
+    expect(line(screenAfter(["gUj", "guj", "u"]), 1)).toBe("ALPHA BETA GAMMA");
+  });
+
+  it("undoes g~ as ONE step", () => {
+    expect(line(screenAfter(["g~~", "u"]), 1)).toBe(original);
+  });
+
+  it("undoes p as ONE step", () => {
+    expect(line(screenAfter(["yy", "3p", "u"], LINES), 2)).toBe("L2");
+  });
+
+  it("undoes P as ONE step", () => {
+    expect(line(screenAfter(["ywP", "u"]), 1)).toBe(original);
+  });
+
+  it("y alone pushes nothing onto the undo stack", () => {
+    // The undo after `yw` must reach the earlier `x`, not a no-op yank entry.
+    expect(line(screenAfter(["x", "yw", "u"]), 1)).toBe(original);
+  });
+});
+
+describe("vim operators: pending state", () => {
+  it("Esc cancels a pending operator without editing", () => {
+    expect(line(screenAfter(["d", "<escape>", "w"]), 1)).toBe("alpha beta gamma");
+  });
+
+  it("an operator followed by a meaningless key is a no-op", () => {
+    expect(line(screenAfter(["dz", "w"]), 1)).toBe("alpha beta gamma");
+  });
+
+  it("the operator does not leak into the next keystroke", () => {
+    // d then Esc, then a plain dd must still delete exactly one line.
+    expect(line(screenAfter(["d", "<escape>", "dd"], LINES), 1)).toBe("L2");
+  });
+});

--- a/tests/functional/vim-registers.test.js
+++ b/tests/functional/vim-registers.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "plugins", "vim", "init.lua");
+
+const LINES = "one\ntwo\nthree\nfour\nfive\n";
+const WORDS = "alpha beta gamma\nsecond line here\nthird line\n";
+const GRID = "abcdef\nghijkl\nmnopqr\nstuvwx\n";
+// Deliberately ragged: the last row is too short to reach the paste column.
+const RAGGED = "abcdef\nghijkl\nmn\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content) {
+  dir = createTempDir();
+  const file = createTempFile(dir, "test.txt", content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+// The pattern is deliberately strict: Vim scripts contain "<<" and "<G", which
+// a bare startsWith("<") check would swallow as key names.
+const KEY_TOKEN = /^<[a-z0-9+]+>$/i;
+
+function send(keys) {
+  for (const k of keys) {
+    if (KEY_TOKEN.test(k)) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+function screenAfter(keys, content = LINES) {
+  startVim(content);
+  send(keys);
+  tui.waitStable();
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+// Assert that a numbered gutter line holds exactly `text`.
+function line(snapshot, n) {
+  const m = snapshot.match(new RegExp(`\\u2502\\s+${n}\\s{2}(.*?)\\s*\\u2502`));
+  return m ? m[1] : null;
+}
+
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+describe("vim registers: named registers", () => {
+  it('"ayy then "ap pastes from the named register', () => {
+    const s = screenAfter(['"ayy', "j", '"ap']);
+    expect(line(s, 1)).toBe("one");
+    expect(line(s, 2)).toBe("two");
+    expect(line(s, 3)).toBe("one");
+  });
+
+  it("a named register survives an intervening unnamed delete", () => {
+    const s = screenAfter(['"ayy', "j", "dd", '"ap']);
+    // "two" was deleted; "a still holds "one".
+    expect(line(s, 1)).toBe("one");
+    expect(line(s, 2)).toBe("three");
+    expect(line(s, 3)).toBe("one");
+  });
+
+  it('uppercase "A appends to the named register', () => {
+    // The fixture has a trailing newline, so G lands on the empty line 6.
+    const s = screenAfter(['"ayy', "j", '"Ayy', "G", '"ap']);
+    expect(line(s, 7)).toBe("one");
+    expect(line(s, 8)).toBe("two");
+  });
+
+  it("a named register works with an operator and a count", () => {
+    const s = screenAfter(['"a2dd', "G", '"ap']);
+    expect(line(s, 1)).toBe("three");
+    expect(line(s, 5)).toBe("one");
+    expect(line(s, 6)).toBe("two");
+  });
+
+  it("a named register is charwise when the yank was", () => {
+    const s = screenAfter(['"ayw', "j", '"ap'], WORDS);
+    expect(line(s, 2)).toBe("salpha econd line here");
+  });
+});
+
+describe("vim registers: the yank register and the delete ring", () => {
+  it('"0 keeps the last yank across a delete', () => {
+    const s = screenAfter(["yy", "dd", '"0p']);
+    expect(line(s, 1)).toBe("two");
+    expect(line(s, 2)).toBe("one");
+  });
+
+  it('"1 and "2 rotate as lines are deleted', () => {
+    const s = screenAfter(["dd", "dd", '"1p', '"2p']);
+    expect(line(s, 1)).toBe("three");
+    expect(line(s, 2)).toBe("two");
+    expect(line(s, 3)).toBe("one");
+  });
+
+  it("a small delete does not disturb the ring", () => {
+    const s = screenAfter(["dd", "x", '"1p']);
+    expect(line(s, 1)).toBe("wo");
+    expect(line(s, 2)).toBe("one");
+  });
+});
+
+describe("vim registers: the blackhole register", () => {
+  it('"_dd deletes without touching the unnamed register', () => {
+    const s = screenAfter(["yy", '"_dd', "p"]);
+    expect(line(s, 1)).toBe("two");
+    expect(line(s, 2)).toBe("one");
+  });
+
+  it('"_x does not clobber a yank', () => {
+    const s = screenAfter(["yy", '"_x', "p"]);
+    expect(line(s, 1)).toBe("ne");
+    expect(line(s, 2)).toBe("one");
+  });
+});
+
+describe("vim registers: blockwise", () => {
+  it("a blockwise yank pastes back as a rectangle", () => {
+    const s = screenAfter(["<ctrl+v>", "jl", "y", "3l", "p"], GRID);
+    expect(line(s, 1)).toBe("abcdabef");
+    expect(line(s, 2)).toBe("ghijghkl");
+    expect(line(s, 3)).toBe("mnopqr");
+  });
+
+  it("a blockwise delete pastes back as a rectangle", () => {
+    const s = screenAfter(["<ctrl+v>", "jl", "d", "$", "p"], GRID);
+    expect(line(s, 1)).toBe("cdefab");
+    expect(line(s, 2)).toBe("ijklgh");
+  });
+
+  it("blockwise paste pads a short row out to the paste column", () => {
+    const s = screenAfter(["<ctrl+v>", "jl", "y", "jj", "$", "p"], RAGGED);
+    // Row 3 is "mn"; the block lands after its end, padded with spaces.
+    expect(line(s, 3)).toBe("mnab");
+    expect(line(s, 4)).toBe("  gh");
+  });
+
+  it("blockwise paste appends rows past the end of the buffer", () => {
+    // G lands on the empty line after the fixture's trailing newline, so the
+    // block's second and third rows have to create lines of their own.
+    const s = screenAfter(["<ctrl+v>", "jjl", "y", "G", "p"], GRID);
+    expect(line(s, 5)).toBe("ab");
+    expect(line(s, 6)).toBe("gh");
+    expect(line(s, 7)).toBe("mn");
+  });
+});
+
+describe("vim registers: visual mode", () => {
+  it("a register prefix works in visual mode", () => {
+    const s = screenAfter(["v", "$", '"ay', "j", '"ap'], WORDS);
+    expect(line(s, 2)).toBe("salpha beta gammaecond line here");
+  });
+
+  it("V with a named register yanks linewise", () => {
+    const s = screenAfter(["V", '"ay', "G", '"ap']);
+    expect(line(s, 7)).toBe("one");
+  });
+});
+
+describe("vim registers: system clipboard", () => {
+  // "+ has no Lua binding, so it is routed through editor.copy / editor.paste.
+  // A round trip is the only thing that can be asserted without a real
+  // clipboard tool being present.
+  it('"+y then "+p round-trips through the clipboard', () => {
+    const s = screenAfter(["v", "ll", '"+y', "j", "$", '"+p']);
+    expect(line(s, 1)).toBe("one");
+    expect(line(s, 2)).toBe("twoone");
+  });
+});
+
+describe("vim marks", () => {
+  it("m sets a mark and backtick jumps back to it exactly", () => {
+    const s = screenAfter(["ll", "ma", "jjj", "`a"], WORDS);
+    expect(pos(s)).toBe("1:3");
+  });
+
+  it("' jumps to the first non-blank of the marked line", () => {
+    const s = screenAfter(["j", "ll", "ma", "gg", "'a"], "  indented\nsecond\n");
+    expect(pos(s)).toBe("2:1");
+  });
+
+  it("a mark survives lines being inserted above it", () => {
+    const s = screenAfter(["G", "ma", "gg", "O", "new", "<esc>", "`a"]);
+    expect(pos(s)).toBe("7:1");
+    expect(line(s, 7)).toBe("");
+  });
+
+  it("a mark survives lines being deleted above it", () => {
+    const s = screenAfter(["3j", "ma", "gg", "dd", "`a"]);
+    expect(pos(s)).toBe("3:1");
+    expect(line(s, 3)).toBe("four");
+  });
+
+  it("`` jumps back to the position before the last jump", () => {
+    const s = screenAfter(["jj", "G", "``"]);
+    expect(pos(s)).toBe("3:1");
+  });
+
+  it("`. jumps to the position of the last change", () => {
+    const s = screenAfter(["jj", "x", "G", "`."]);
+    expect(pos(s)).toBe("3:1");
+  });
+
+  it("a mark is a valid operator target", () => {
+    const s = screenAfter(["ma", "3j", "d'a"]);
+    expect(line(s, 1)).toBe("five");
+  });
+
+  it("marks can be set in visual mode", () => {
+    const s = screenAfter(["v", "jj", "<esc>", "gg", "'a"]);
+    // No mark 'a' was set, so nothing moves.
+    expect(pos(s)).toBe("1:1");
+  });
+});

--- a/tests/functional/vim-search.test.js
+++ b/tests/functional/vim-search.test.js
@@ -1,0 +1,239 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "plugins",
+  "vim",
+  "init.lua",
+);
+
+// Four "alpha"s spread over the buffer, so wrapping in both directions is
+// observable, plus a word that only differs by a suffix for whole-word tests.
+const FIXTURE = "alpha one\nbeta two\nalpha three\nalphabet four\nlast alpha\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content = FIXTURE, name = "test.txt") {
+  dir = createTempDir();
+  const file = createTempFile(dir, name, content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+// The pattern is deliberately strict: Vim scripts contain "<<" and "<G", which
+// a bare startsWith("<") check would swallow as key names.
+const KEY_TOKEN = /^<[a-z0-9+]+>$/i;
+
+function send(keys) {
+  for (const k of keys) {
+    if (KEY_TOKEN.test(k)) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+function screenAfter(keys, content = FIXTURE) {
+  startVim(content);
+  send(keys);
+  tui.waitStable(300);
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+// A snapshot taken mid-script, so an incremental preview can be observed while
+// the command line is still open.
+function screensAfter(scripts, content = FIXTURE) {
+  startVim(content);
+  const idx = [];
+  for (const keys of scripts) {
+    send(keys);
+    tui.waitStable(250);
+    idx.push(tui.snapshot());
+  }
+  const { snapshots } = tui.run();
+  return idx.map((i) => snapshots[i]);
+}
+
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+function posAfter(keys, content = FIXTURE) {
+  return pos(screenAfter(keys, content));
+}
+
+// Assert that a numbered gutter line holds exactly `text`.
+function line(snapshot, n) {
+  const m = snapshot.match(new RegExp(`\\u2502\\s+${n}\\s{2}(.*?)\\s*\\u2502`));
+  return m ? m[1] : null;
+}
+
+describe("vim search: / and ?", () => {
+  it("/ jumps forward to the next match on submit", () => {
+    expect(posAfter(["/alpha", "<enter>"])).toBe("3:1");
+  });
+
+  it("? jumps backward to the previous match", () => {
+    expect(posAfter(["G", "?alpha", "<enter>"])).toBe("5:6");
+  });
+
+  it("/ previews the match incrementally, before Enter is pressed", () => {
+    const [typing, submitted] = screensAfter([["/three"], ["<enter>"]]);
+    // The command line is still open here, and the cursor has already moved.
+    expect(typing).toContain("/three");
+    expect(pos(typing)).toBe("3:7");
+    expect(pos(submitted)).toBe("3:7");
+  });
+
+  it("the preview retreats when the pattern stops matching", () => {
+    const [matching, broken] = screensAfter([["/alpha"], ["zzz"]]);
+    expect(pos(matching)).toBe("3:1");
+    // No match for "alphazzz": the cursor falls back to where it started.
+    expect(pos(broken)).toBe("1:1");
+  });
+
+  it("Esc cancels the search and restores the original cursor", () => {
+    expect(posAfter(["2G", "/last", "<esc>"])).toBe("2:1");
+  });
+
+  it("a submitted search with no match leaves the cursor alone", () => {
+    const s = screenAfter(["/nothinghere", "<enter>"]);
+    expect(s).toContain("Pattern not found");
+  });
+
+  it("search is case sensitive by default and \\c makes it insensitive", () => {
+    expect(posAfter(["/ALPHA", "<enter>"], "alpha\nALPHA\n")).toBe("2:1");
+    expect(posAfter(["/ALPHA\\c", "<enter>"], "one\nalpha\n")).toBe("2:1");
+  });
+
+  it("matches a regex subset: . * \\d \\+ and character classes", () => {
+    expect(posAfter(["/b.ta", "<enter>"])).toBe("2:1");
+    expect(posAfter(["/\\d\\+", "<enter>"], "no digits\nx 4711 y\n")).toBe(
+      "2:3",
+    );
+    expect(posAfter(["/[Bb]eta", "<enter>"])).toBe("2:1");
+  });
+
+  it("rejects an unsupported regex construct instead of misreading it", () => {
+    expect(screenAfter(["/a\\|b", "<enter>"])).toContain("alternation");
+  });
+});
+
+describe("vim search: n and N", () => {
+  it("n walks forward through the matches", () => {
+    expect(posAfter(["/alpha", "<enter>", "n"])).toBe("4:1");
+  });
+
+  it("N walks back the other way", () => {
+    expect(posAfter(["/alpha", "<enter>", "n", "n", "N"])).toBe("4:1");
+  });
+
+  it("n wraps past the end of the buffer and says so", () => {
+    const s = screenAfter(["/alpha", "<enter>", "n", "n", "n"]);
+    expect(s).toContain("search hit BOTTOM, continuing at TOP");
+  });
+
+  it("N wraps past the start of the buffer and says so", () => {
+    // Line 1 is a match, so the first N lands there and the second wraps.
+    const s = screenAfter(["/alpha", "<enter>", "N", "N"]);
+    expect(s).toContain("search hit TOP, continuing at BOTTOM");
+  });
+
+  it("n after ? keeps searching backward", () => {
+    expect(posAfter(["G", "?alpha", "<enter>", "n"])).toBe("4:1");
+  });
+
+  it("{count}n skips ahead", () => {
+    expect(posAfter(["/alpha", "<enter>", "2n"])).toBe("5:6");
+  });
+
+  it("n without a previous search reports no pattern", () => {
+    expect(screenAfter(["n"])).toContain("No previous regular expression");
+  });
+});
+
+describe("vim search: * and #", () => {
+  it("* searches forward for the whole word under the cursor", () => {
+    // "alphabet" on line 4 must not match: * is whole-word.
+    expect(posAfter(["*"])).toBe("3:1");
+  });
+
+  it("# searches backward for the whole word under the cursor", () => {
+    // G lands on the empty line after the trailing newline; 5G is the last
+    // line with text on it.
+    expect(posAfter(["5G", "$", "#"])).toBe("3:1");
+  });
+
+  it("* is repeatable with n", () => {
+    expect(posAfter(["*", "n"])).toBe("5:6");
+  });
+
+  it("* skips a substring match", () => {
+    // Only line 3 has a standalone "foo"; line 1 and 2 embed it in a word.
+    expect(posAfter(["*"], "foo\nfoobar\nbarfoo\nfoo\n")).toBe("4:1");
+  });
+});
+
+describe("vim search: as an operator target", () => {
+  it("d/pattern deletes up to the match, exclusive of it", () => {
+    const s = screenAfter(["d/alpha three", "<enter>"]);
+    expect(line(s, 1)).toBe("alpha three");
+  });
+
+  it("c/pattern changes up to the match and enters insert mode", () => {
+    const s = screenAfter(["c/one", "<enter>", "X"]);
+    expect(line(s, 1)).toBe("Xone");
+    expect(s).toContain("-- INSERT --");
+  });
+
+  it("a search landing in column 1 becomes linewise, as in Vim", () => {
+    // Vim's exclusive-motion adjustment: the motion started at the first
+    // non-blank and ends in column 1, so c/ operates on whole lines.
+    const s = screenAfter(["c/beta", "<enter>", "X"]);
+    expect(line(s, 1)).toBe("X");
+    expect(line(s, 2)).toBe("beta two");
+  });
+
+  it("y/pattern yanks up to the match", () => {
+    const s = screenAfter(["y/beta", "<enter>", "P"]);
+    expect(line(s, 1)).toBe("alpha one");
+    expect(line(s, 2)).toBe("alpha one");
+  });
+
+  it("a cancelled search leaves the operator pending state clean", () => {
+    // Esc drops the operator; the following x must delete a single character.
+    const s = screenAfter(["d/alpha", "<esc>", "x"]);
+    expect(line(s, 1)).toBe("lpha one");
+  });
+
+  it("d/pattern is one undo step", () => {
+    const s = screenAfter(["d/alpha three", "<enter>", "u"]);
+    expect(line(s, 1)).toBe("alpha one");
+    expect(line(s, 2)).toBe("beta two");
+    expect(line(s, 3)).toBe("alpha three");
+  });
+
+  it(". repeats d/pattern against the next match", () => {
+    const s = screenAfter(["d/BB", "<enter>", "."], "x1\nBB\nx2\nBB\nx3\n");
+    expect(line(s, 1)).toBe("BB");
+    expect(line(s, 2)).toBe("x3");
+  });
+});

--- a/tests/functional/vim-settings.test.js
+++ b/tests/functional/vim-settings.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+// This test drives the real binary directly (not via tui.js) because it needs
+// to seed a settings.json into the config dir, which the shared tui.js harness
+// creates privately per run and does not expose. Same --exec protocol as tui.js.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..", "..");
+const BINARY = join(ROOT, "bin", "ttt");
+const VIM_PLUGIN = join(ROOT, "plugins", "vim", "init.lua");
+const SEP = "\x1f";
+
+let dir;
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = "";
+});
+
+// Boots ttt with the vim plugin, a seeded settings.json, and the given --exec
+// steps, then returns the resulting screenshot text.
+function runWithSettings(settings, steps) {
+  dir = mkdtempSync(join(tmpdir(), "ttt-vimset-"));
+  const cfg = join(dir, "config");
+  mkdirSync(cfg, { recursive: true });
+  writeFileSync(join(cfg, "settings.json"), JSON.stringify(settings));
+  const file = join(dir, "test.txt");
+  writeFileSync(file, "hello\n");
+  const shot = join(dir, "shot.txt");
+
+  const script = [...steps, `screenshot ${shot}`, "quit"].join(SEP);
+  try {
+    execFileSync(
+      BINARY,
+      ["--size", "100x30", "--exec-split-on", SEP, "--exec", script, "--plugin", VIM_PLUGIN, file],
+      { encoding: "utf8", timeout: 15000, stdio: "pipe", env: { ...process.env, TTT_CONFIG_DIR: cfg } },
+    );
+  } catch {
+    // A non-zero exit (e.g. from quit) is fine.
+  }
+  return readFileSync(shot, "utf8");
+}
+
+describe("vim settings", () => {
+  it("vim.enabled=false starts with vim mode off (keys type into the buffer)", () => {
+    const screen = runWithSettings({ version: 1, vim: { enabled: false } }, ["wait 600", "key x", "wait 150"]);
+    // No modal indicator, and 'x' inserts literally rather than deleting a char.
+    expect(screen).not.toContain("-- NORMAL --");
+    expect(screen).toContain("xhello");
+  });
+
+  it("default (vim.enabled unset) starts in normal mode (load assertion)", () => {
+    const screen = runWithSettings({ version: 1 }, ["wait 600", "key x", "wait 150"]);
+    // Plugin loaded and active: the indicator is present and 'x' deleted the 'h'.
+    expect(screen).toContain("-- NORMAL --");
+    expect(screen).toContain("ello");
+    expect(screen).not.toContain("xhello");
+  });
+});

--- a/tests/functional/vim-textobjects.test.js
+++ b/tests/functional/vim-textobjects.test.js
@@ -1,0 +1,367 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "plugins", "vim", "init.lua");
+
+const WORDS = "alpha beta gamma delta\n" + "foo.bar baz\n";
+
+const QUOTES = "say \"hello there\" now\n" + "call 'one two' end\n" + "tick `a b` done\n";
+
+const BRACKETS = "xs = arr[one two] end\n" + "fn(a, b) tail\n" + "map{k: v} rest\n" + "cmp<T, U> post\n";
+
+const CODE = "function foo(a, b) {\n" + "    bar()\n" + "    baz()\n" + "}\n";
+
+const NESTED = "outer(one, inner(two, three), four)\n";
+
+const HTML = "<div class=\"x\">\n" + "  <p>hello world</p>\n" + "</div>\n";
+
+const PARA = "one\ntwo\n\nthree\nfour\n\nfive\n";
+
+const SENT = "One two. Three four. Five six.\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content, name = "test.txt") {
+  dir = createTempDir();
+  const file = createTempFile(dir, name, content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+// Strict on purpose: text-object scripts contain "<" and ">" as object keys.
+const KEY_TOKEN = /^<[a-z0-9+]+>$/i;
+
+function send(keys) {
+  for (const k of keys) {
+    if (KEY_TOKEN.test(k)) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+function screenAfter(keys, content) {
+  startVim(content);
+  send(keys);
+  tui.waitStable();
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+// Assert on a numbered gutter line's exact content.
+function line(snapshot, n) {
+  const m = snapshot.match(new RegExp(`\\u2502\\s+${n}\\s{2}(.*?)\\s*\\u2502`));
+  return m ? m[1] : null;
+}
+
+// Same, but keeping trailing whitespace out of the picture by matching a prefix.
+function lineOf(keys, content, n = 1) {
+  return line(screenAfter(keys, content), n);
+}
+
+describe("text objects: words", () => {
+  it("diw deletes the word under the cursor", () => {
+    expect(lineOf(["w", "diw"], WORDS)).toBe("alpha  gamma delta");
+  });
+
+  it("daw takes the trailing whitespace too", () => {
+    expect(lineOf(["w", "daw"], WORDS)).toBe("alpha gamma delta");
+  });
+
+  it("daw falls back to leading whitespace at the end of a line", () => {
+    expect(lineOf(["$", "daw"], WORDS)).toBe("alpha beta gamma");
+  });
+
+  it("ciw replaces the word and leaves insert mode clean", () => {
+    expect(lineOf(["w", "ciwZZ", "<escape>"], WORDS)).toBe("alpha ZZ gamma delta");
+  });
+
+  it("diw on punctuation takes only the punctuation run", () => {
+    // Line 2 is "foo.bar baz"; the "." is its own word for iw.
+    expect(lineOf(["j", "3l", "diw"], WORDS, 2)).toBe("foobar baz");
+  });
+
+  it("diW takes the whole WORD including punctuation", () => {
+    expect(lineOf(["j", "diW"], WORDS, 2)).toBe(" baz");
+  });
+
+  it("daW takes the WORD and its trailing space", () => {
+    expect(lineOf(["j", "daW"], WORDS, 2)).toBe("baz");
+  });
+
+  it("d2iw counts chunks, d2aw counts words", () => {
+    // iw chunk 2 is the space after "alpha".
+    expect(lineOf(["d2iw"], WORDS)).toBe("beta gamma delta");
+    expect(lineOf(["d2aw"], WORDS)).toBe("gamma delta");
+  });
+
+  it("yiw then P duplicates a word", () => {
+    expect(lineOf(["w", "yiwP"], WORDS)).toBe("alpha betabeta gamma delta");
+  });
+
+  it("gUiw uppercases a word in place", () => {
+    expect(lineOf(["w", "gUiw"], WORDS)).toBe("alpha BETA gamma delta");
+  });
+});
+
+describe("text objects: quotes", () => {
+  it('di" empties a double-quoted string', () => {
+    expect(lineOf(["f h", "di\""], QUOTES)).toBe('say "" now');
+  });
+
+  it('di" works from the start of the line, searching forward', () => {
+    expect(lineOf(['di"'], QUOTES)).toBe('say "" now');
+  });
+
+  it('da" takes the quotes and the trailing space', () => {
+    expect(lineOf(['da"'], QUOTES)).toBe("say now");
+  });
+
+  it("di' and da' handle single quotes", () => {
+    expect(lineOf(["j", "di'"], QUOTES, 2)).toBe("call '' end");
+    expect(lineOf(["j", "da'"], QUOTES, 2)).toBe("call end");
+  });
+
+  it("di` and da` handle backticks", () => {
+    expect(lineOf(["jj", "di`"], QUOTES, 3)).toBe("tick `` done");
+    expect(lineOf(["jj", "da`"], QUOTES, 3)).toBe("tick done");
+  });
+
+  it('ci" replaces the string contents', () => {
+    expect(lineOf(['ci"ZZ', "<escape>"], QUOTES)).toBe('say "ZZ" now');
+  });
+});
+
+describe("text objects: brackets", () => {
+  it("di( and da( work from inside", () => {
+    expect(lineOf(["j", "f,", "di("], BRACKETS, 2)).toBe("fn() tail");
+    expect(lineOf(["j", "f,", "da("], BRACKETS, 2)).toBe("fn tail");
+  });
+
+  it("dib and dab are synonyms for di( and da(", () => {
+    expect(lineOf(["j", "f,", "dib"], BRACKETS, 2)).toBe("fn() tail");
+    expect(lineOf(["j", "f,", "dab"], BRACKETS, 2)).toBe("fn tail");
+  });
+
+  it("di) closes the same object as di(", () => {
+    expect(lineOf(["j", "f,", "di)"], BRACKETS, 2)).toBe("fn() tail");
+  });
+
+  it("di[ and da[ work on square brackets", () => {
+    expect(lineOf(["fo", "di["], BRACKETS, 1)).toBe("xs = arr[] end");
+    expect(lineOf(["fo", "da["], BRACKETS, 1)).toBe("xs = arr end");
+  });
+
+  it("di] is a synonym for di[", () => {
+    expect(lineOf(["fo", "di]"], BRACKETS, 1)).toBe("xs = arr[] end");
+  });
+
+  it("di{ , di} and diB work on braces", () => {
+    expect(lineOf(["jj", "fk", "di{"], BRACKETS, 3)).toBe("map{} rest");
+    expect(lineOf(["jj", "fk", "di}"], BRACKETS, 3)).toBe("map{} rest");
+    expect(lineOf(["jj", "fk", "diB"], BRACKETS, 3)).toBe("map{} rest");
+    expect(lineOf(["jj", "fk", "da{"], BRACKETS, 3)).toBe("map rest");
+  });
+
+  it("di< and da< work on angle brackets", () => {
+    expect(lineOf(["3j", "fT", "di<"], BRACKETS, 4)).toBe("cmp<> post");
+    expect(lineOf(["3j", "fT", "da<"], BRACKETS, 4)).toBe("cmp post");
+    expect(lineOf(["3j", "fT", "di>"], BRACKETS, 4)).toBe("cmp<> post");
+  });
+
+  it("a count selects the enclosing pair", () => {
+    // "w" only occurs inside inner(...), so fw parks the cursor one level deep.
+    expect(lineOf(["fw", "di("], NESTED)).toBe("outer(one, inner(), four)");
+    expect(lineOf(["fw", "d2i("], NESTED)).toBe("outer()");
+  });
+
+  it("ci( leaves you inside the brackets in insert mode", () => {
+    expect(lineOf(["j", "f,", "ci(ZZ", "<escape>"], BRACKETS, 2)).toBe("fn(ZZ) tail");
+  });
+});
+
+describe("text objects: blocks spanning lines", () => {
+  // Vim turns an inner block into a linewise one when the open brace ends a
+  // line and the close brace starts one -- that is what makes di{ clear a body.
+  it("di{ clears a multi-line block linewise", () => {
+    const s = screenAfter(["3j", "di{"], CODE);
+    expect(line(s, 1)).toBe("function foo(a, b) {");
+    expect(line(s, 2)).toBe("}");
+  });
+
+  it("da{ takes the braces with it", () => {
+    expect(line(screenAfter(["3j", "da{"], CODE), 1)).toBe("function foo(a, b)");
+  });
+
+  it("di{ works from inside the block too", () => {
+    const s = screenAfter(["j", "di{"], CODE);
+    expect(line(s, 1)).toBe("function foo(a, b) {");
+    expect(line(s, 2)).toBe("}");
+  });
+
+  it(">i{ indents the block body", () => {
+    const s = screenAfter(["j", ">i{"], CODE);
+    expect(line(s, 2)).toBe("        bar()");
+    expect(line(s, 3)).toBe("        baz()");
+  });
+
+  it("di( on the signature only touches the signature", () => {
+    const s = screenAfter(["f,", "di("], CODE);
+    expect(line(s, 1)).toBe("function foo() {");
+    expect(line(s, 2)).toBe("    bar()");
+  });
+});
+
+describe("text objects: tags", () => {
+  it("dit empties the tag body", () => {
+    const s = screenAfter(["j", "fh", "dit"], HTML);
+    expect(line(s, 2)).toBe("  <p></p>");
+  });
+
+  it("dat removes the tag as well", () => {
+    const s = screenAfter(["j", "fh", "dat"], HTML);
+    expect(line(s, 2)).toBe("");
+    expect(line(s, 1)).toBe('<div class="x">');
+  });
+
+  it("cit replaces the tag body", () => {
+    const s = screenAfter(["j", "fh", "citZZ", "<escape>"], HTML);
+    expect(line(s, 2)).toBe("  <p>ZZ</p>");
+  });
+
+  it("dit picks the innermost enclosing tag", () => {
+    // On the "p" of <p>, the innermost pair containing the cursor is <p>...</p>.
+    const s = screenAfter(["j", "fp", "dit"], HTML);
+    expect(line(s, 2)).toBe("  <p></p>");
+  });
+});
+
+describe("text objects: paragraphs", () => {
+  it("dip takes the block of non-blank lines", () => {
+    const s = screenAfter(["dip"], PARA);
+    expect(line(s, 1)).toBe("");
+    expect(line(s, 2)).toBe("three");
+  });
+
+  it("dap takes the following blank line too", () => {
+    const s = screenAfter(["dap"], PARA);
+    expect(line(s, 1)).toBe("three");
+    expect(line(s, 2)).toBe("four");
+  });
+
+  it("dap on a later paragraph works the same", () => {
+    const s = screenAfter(["3j", "dap"], PARA);
+    expect(line(s, 1)).toBe("one");
+    expect(line(s, 2)).toBe("two");
+    expect(line(s, 3)).toBe("");
+    expect(line(s, 4)).toBe("five");
+  });
+
+  it("dip on a blank line removes the gap", () => {
+    const s = screenAfter(["jj", "dip"], PARA);
+    expect(line(s, 2)).toBe("two");
+    expect(line(s, 3)).toBe("three");
+  });
+
+  it("yip then P duplicates a paragraph", () => {
+    const s = screenAfter(["yipP"], PARA);
+    expect(line(s, 1)).toBe("one");
+    expect(line(s, 2)).toBe("two");
+    expect(line(s, 3)).toBe("one");
+    expect(line(s, 4)).toBe("two");
+  });
+
+  it("gUip uppercases a paragraph", () => {
+    const s = screenAfter(["gUip"], PARA);
+    expect(line(s, 1)).toBe("ONE");
+    expect(line(s, 2)).toBe("TWO");
+    expect(line(s, 4)).toBe("three");
+  });
+});
+
+describe("text objects: sentences", () => {
+  it("das removes a sentence and its trailing space", () => {
+    expect(lineOf(["das"], SENT)).toBe("Three four. Five six.");
+  });
+
+  it("dis leaves the space that followed the sentence", () => {
+    expect(lineOf(["dis"], SENT)).toBe(" Three four. Five six.");
+  });
+
+  it("das works on a later sentence", () => {
+    expect(lineOf(["fT", "das"], SENT)).toBe("One two. Five six.");
+  });
+
+  it("cis replaces a sentence", () => {
+    expect(lineOf(["cisZZ", "<escape>"], SENT)).toBe("ZZ Three four. Five six.");
+  });
+
+  it("d2as removes two sentences", () => {
+    expect(lineOf(["d2as"], SENT)).toBe("Five six.");
+  });
+});
+
+describe("text objects: undo atomicity", () => {
+  it("undoes diw as ONE step", () => {
+    expect(lineOf(["w", "diw", "u"], WORDS)).toBe("alpha beta gamma delta");
+  });
+
+  it("undoes ciw plus typing as ONE step", () => {
+    expect(lineOf(["w", "ciwZZZ", "<escape>", "u"], WORDS)).toBe("alpha beta gamma delta");
+  });
+
+  it("undoes di{ as ONE step", () => {
+    const s = screenAfter(["3j", "di{", "u"], CODE);
+    expect(line(s, 2)).toBe("    bar()");
+    expect(line(s, 3)).toBe("    baz()");
+  });
+
+  it("undoes dap as ONE step", () => {
+    const s = screenAfter(["dap", "u"], PARA);
+    expect(line(s, 1)).toBe("one");
+    expect(line(s, 3)).toBe("");
+    expect(line(s, 4)).toBe("three");
+  });
+
+  it("undoes dit as ONE step", () => {
+    expect(line(screenAfter(["j", "fh", "dit", "u"], HTML), 2)).toBe("  <p>hello world</p>");
+  });
+
+  it("undoes gUip as ONE step", () => {
+    expect(line(screenAfter(["gUip", "u"], PARA), 1)).toBe("one");
+  });
+});
+
+describe("text objects: no-ops", () => {
+  it("di( with no enclosing parens does nothing", () => {
+    expect(lineOf(["di("], WORDS)).toBe("alpha beta gamma delta");
+  });
+
+  it("dit outside any tag does nothing", () => {
+    expect(lineOf(["dit"], WORDS)).toBe("alpha beta gamma delta");
+  });
+
+  it("an unknown object key cancels the operator", () => {
+    expect(lineOf(["diq"], WORDS)).toBe("alpha beta gamma delta");
+    // ...and the cancelled operator must not swallow the next command.
+    expect(lineOf(["diq", "x"], WORDS)).toBe("lpha beta gamma delta");
+  });
+
+  it("i and a still enter insert mode without a pending operator", () => {
+    expect(lineOf(["iZZ", "<escape>"], WORDS)).toBe("ZZalpha beta gamma delta");
+    expect(lineOf(["aZZ", "<escape>"], WORDS)).toBe("aZZlpha beta gamma delta");
+  });
+});

--- a/tests/functional/vim-visual.test.js
+++ b/tests/functional/vim-visual.test.js
@@ -1,0 +1,477 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Exercise the real shipped plugin, not an inline copy.
+const VIM_PLUGIN = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "plugins",
+  "vim",
+  "init.lua",
+);
+
+// A rectangular grid, so blockwise column ranges are unambiguous.
+const GRID = "abcdef\n" + "ghijkl\n" + "mnopqr\n" + "stuvwx\n";
+
+const WORDS =
+  "alpha beta gamma\n" + "second line here\n" + "third line\n" + "fourth\n";
+
+const RAGGED = "abcdefgh\n" + "ij\n" + "klmnop\n";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function startVim(content, name = "test.txt") {
+  dir = createTempDir();
+  const file = createTempFile(dir, name, content);
+  tui.start("--plugin", VIM_PLUGIN, file);
+  tui.waitStable(300);
+  return file;
+}
+
+// Drive a keystroke script. "<name>" is a key press, everything else is typed.
+// The pattern is deliberately strict: Vim scripts contain "<<" and "<G", which
+// a bare startsWith("<") check would swallow as key names.
+const KEY_TOKEN = /^<[a-z0-9+]+>$/i;
+
+function send(keys) {
+  for (const k of keys) {
+    if (KEY_TOKEN.test(k)) {
+      tui.press(k.slice(1, -1));
+    } else {
+      tui.type(k);
+    }
+  }
+}
+
+function screenAfter(keys, content = GRID) {
+  startVim(content);
+  send(keys);
+  tui.waitStable();
+  const s = tui.snapshot();
+  const { snapshots } = tui.run();
+  return snapshots[s];
+}
+
+// Assert that a numbered gutter line holds exactly `text`.
+function line(snapshot, n) {
+  const m = snapshot.match(new RegExp(`\\u2502\\s+${n}\\s{2}(.*?)\\s*\\u2502`));
+  return m ? m[1] : null;
+}
+
+function pos(snapshot) {
+  const m = snapshot.match(/Ln (\d+), Col (\d+)/);
+  return m ? `${m[1]}:${m[2]}` : "none";
+}
+
+// Lines 1..n of the buffer as an array, for the multi-line assertions.
+function lines(snapshot, n) {
+  const out = [];
+  for (let i = 1; i <= n; i++) out.push(line(snapshot, i));
+  return out;
+}
+
+describe("vim visual: entering, switching and leaving", () => {
+  it("v, V and ctrl+v show their mode indicators", () => {
+    expect(screenAfter(["v"])).toContain("-- VISUAL --");
+    expect(screenAfter(["V"])).toContain("-- VISUAL LINE --");
+    expect(screenAfter(["<ctrl+v>"])).toContain("-- VISUAL BLOCK --");
+  });
+
+  it("re-pressing the same key leaves visual mode", () => {
+    expect(screenAfter(["v", "v"])).toContain("-- NORMAL --");
+    expect(screenAfter(["V", "V"])).toContain("-- NORMAL --");
+    expect(screenAfter(["<ctrl+v>", "<ctrl+v>"])).toContain("-- NORMAL --");
+  });
+
+  it("pressing a different mode key switches without losing the anchor", () => {
+    // v then l then V then d: the anchor is still line 1, so V-d is linewise.
+    const s = screenAfter(["v", "l", "V", "d"]);
+    expect(line(s, 1)).toBe("ghijkl");
+    expect(s).toContain("-- NORMAL --");
+  });
+
+  it("Esc leaves visual mode and keeps the cursor where the motion left it", () => {
+    const s = screenAfter(["v", "ll", "<escape>"]);
+    expect(s).toContain("-- NORMAL --");
+    expect(pos(s)).toBe("1:3");
+  });
+
+  it("leaving visual mode does not modify the buffer", () => {
+    const s = screenAfter(["v", "jl", "<escape>"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "mnopqr", "stuvwx"]);
+  });
+});
+
+describe("vim visual: selection movement", () => {
+  it("charwise d is inclusive of the character under the cursor", () => {
+    // v then two l = 3 characters selected.
+    expect(line(screenAfter(["v", "ll", "d"]), 1)).toBe("def");
+  });
+
+  it("a bare v then d deletes exactly one character", () => {
+    expect(line(screenAfter(["v", "d"]), 1)).toBe("bcdef");
+  });
+
+  it("word motions extend the selection", () => {
+    expect(line(screenAfter(["v", "e", "d"], WORDS), 1)).toBe(" beta gamma");
+    // Visual mode is always inclusive, so `vw` also takes the character it lands on.
+    expect(line(screenAfter(["v", "w", "d"], WORDS), 1)).toBe("eta gamma");
+  });
+
+  it("counts apply to motions inside visual mode", () => {
+    expect(line(screenAfter(["v", "3l", "d"]), 1)).toBe("ef");
+    expect(line(screenAfter(["v", "2e", "d"], WORDS), 1)).toBe(" gamma");
+  });
+
+  it("$ selects to the end of the line inclusively", () => {
+    expect(line(screenAfter(["l", "v", "$", "d"]), 1)).toBe("a");
+  });
+
+  it("f and t motions extend the selection", () => {
+    expect(line(screenAfter(["v", "fd", "d"]), 1)).toBe("ef");
+    expect(line(screenAfter(["v", "td", "d"]), 1)).toBe("def");
+  });
+
+  it("G and gg extend the selection linewise-ish across the buffer", () => {
+    expect(line(screenAfter(["V", "G", "d"]), 1)).toBe("");
+  });
+
+  it("a backward selection includes the anchor character", () => {
+    // Start on "d" (col 4), select back to "b" (col 2): b, c and d all go.
+    expect(line(screenAfter(["3l", "v", "hh", "d"]), 1)).toBe("aef");
+  });
+});
+
+describe("vim visual: o, O and gv", () => {
+  it("o swaps the cursor and the anchor and keeps the same range", () => {
+    const s = screenAfter(["v", "jj", "o", "d"]);
+    expect(line(s, 1)).toBe("nopqr");
+  });
+
+  it("o moves the cursor to the other end", () => {
+    expect(pos(screenAfter(["v", "jj", "o"]))).toBe("1:1");
+  });
+
+  it("O in blockwise swaps the corners horizontally", () => {
+    // Block from 1:1 to 3:3, then O puts the cursor on the left edge and l
+    // widens from the *left*, so the block becomes columns 1..4.
+    const s = screenAfter(["<ctrl+v>", "jj", "ll", "O", "h", "d"]);
+    expect(lines(s, 4)).toEqual(["def", "jkl", "pqr", "stuvwx"]);
+  });
+
+  it("gv reselects the previous visual range", () => {
+    expect(line(screenAfter(["v", "ll", "<escape>", "gv", "d"]), 1)).toBe(
+      "def",
+    );
+  });
+
+  it("gv reselects a linewise range", () => {
+    const s = screenAfter(["V", "j", "<escape>", "gv", "d"]);
+    expect(line(s, 1)).toBe("mnopqr");
+  });
+
+  it("gv after an operator reselects the range that was operated on", () => {
+    // yank two lines, move away, then gv + d removes the same two lines.
+    const s = screenAfter(["V", "j", "y", "G", "gv", "d"]);
+    expect(line(s, 1)).toBe("mnopqr");
+  });
+});
+
+describe("vim visual: operators over a charwise selection", () => {
+  it("d and x both delete the selection", () => {
+    expect(line(screenAfter(["v", "ll", "d"]), 1)).toBe("def");
+    expect(line(screenAfter(["v", "ll", "x"]), 1)).toBe("def");
+  });
+
+  it("c and s delete the selection and enter insert mode", () => {
+    expect(screenAfter(["v", "ll", "c"])).toContain("-- INSERT --");
+    const s = screenAfter(["v", "ll", "c", "ZZ", "<escape>"]);
+    expect(line(s, 1)).toBe("ZZdef");
+    expect(s).toContain("-- NORMAL --");
+    const t = screenAfter(["v", "ll", "s", "Q", "<escape>"]);
+    expect(line(t, 1)).toBe("Qdef");
+  });
+
+  it("y yanks the selection and p pastes it", () => {
+    const s = screenAfter(["v", "ll", "y", "$", "p"]);
+    expect(line(s, 1)).toBe("abcdefabc");
+  });
+
+  it("gu, gU and g~ change case over the selection", () => {
+    expect(line(screenAfter(["v", "ll", "gU"]), 1)).toBe("ABCdef");
+    expect(line(screenAfter(["v", "ll", "gU", "gv", "gu"]), 1)).toBe("abcdef");
+    expect(line(screenAfter(["v", "ll", "g~"]), 1)).toBe("ABCdef");
+  });
+
+  it("u, U and ~ are the visual-mode case shorthands", () => {
+    expect(line(screenAfter(["v", "ll", "U"]), 1)).toBe("ABCdef");
+    expect(line(screenAfter(["v", "ll", "U", "gv", "u"]), 1)).toBe("abcdef");
+    expect(line(screenAfter(["v", "ll", "~"]), 1)).toBe("ABCdef");
+  });
+
+  it("r replaces every selected character", () => {
+    expect(line(screenAfter(["v", "ll", "rZ"]), 1)).toBe("ZZZdef");
+  });
+
+  it("r spans lines in a charwise selection", () => {
+    const s = screenAfter(["v", "jl", "rZ"]);
+    expect(lines(s, 2)).toEqual(["ZZZZZZ", "ZZijkl"]);
+  });
+
+  it("p replaces the selection with the register", () => {
+    // yank "abc" charwise, then select "ghi" and replace it.
+    const s = screenAfter(["v", "ll", "y", "j", "v", "ll", "p"]);
+    expect(lines(s, 2)).toEqual(["abcdef", "abcjkl"]);
+  });
+
+  it("J joins the selected lines", () => {
+    const s = screenAfter(["v", "j", "J"]);
+    expect(line(s, 1)).toBe("abcdef ghijkl");
+    expect(line(s, 2)).toBe("mnopqr");
+  });
+
+  it("> and < shift the lines the selection touches", () => {
+    expect(line(screenAfter(["v", "j", ">"]), 1)).toBe("    abcdef");
+    expect(line(screenAfter(["v", "j", ">"]), 2)).toBe("    ghijkl");
+    expect(line(screenAfter(["v", "j", ">", "gv", "<"]), 1)).toBe("abcdef");
+  });
+
+  it("a count repeats the shift", () => {
+    expect(line(screenAfter(["v", "2>"]), 1)).toBe("        abcdef");
+  });
+
+  it("= reindents the selected lines", () => {
+    const s = screenAfter(["V", "j", "="], "function foo() {\n     bar()\n}\n");
+    expect(line(s, 2)).toBe("    bar()");
+  });
+});
+
+describe("vim visual: operators over a linewise selection", () => {
+  it("V d removes whole lines", () => {
+    expect(lines(screenAfter(["V", "j", "d"]), 2)).toEqual([
+      "mnopqr",
+      "stuvwx",
+    ]);
+  });
+
+  it("V c collapses the lines and inserts", () => {
+    const s = screenAfter(["V", "j", "c", "new", "<escape>"]);
+    expect(lines(s, 2)).toEqual(["new", "mnopqr"]);
+  });
+
+  it("V y yanks linewise so p opens a new line", () => {
+    const s = screenAfter(["V", "y", "j", "p"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "abcdef", "mnopqr"]);
+  });
+
+  it("V p replaces the lines with the register", () => {
+    const s = screenAfter(["V", "y", "j", "V", "p"]);
+    expect(lines(s, 3)).toEqual(["abcdef", "abcdef", "mnopqr"]);
+  });
+
+  it("V gU uppercases whole lines regardless of the cursor column", () => {
+    expect(line(screenAfter(["lll", "V", "gU"]), 1)).toBe("ABCDEF");
+  });
+
+  it("V r fills the lines", () => {
+    expect(lines(screenAfter(["lll", "V", "rZ"]), 2)).toEqual([
+      "ZZZZZZ",
+      "ghijkl",
+    ]);
+  });
+
+  it("X, D, S and C act linewise from a charwise selection", () => {
+    expect(line(screenAfter(["v", "l", "X"]), 1)).toBe("ghijkl");
+    expect(line(screenAfter(["v", "l", "D"]), 1)).toBe("ghijkl");
+    expect(line(screenAfter(["v", "l", "S", "hi", "<escape>"]), 1)).toBe("hi");
+    expect(line(screenAfter(["v", "l", "C", "hi", "<escape>"]), 1)).toBe("hi");
+  });
+});
+
+describe("vim visual: text objects", () => {
+  it("viw selects the word under the cursor", () => {
+    expect(line(screenAfter(["viw", "d"], WORDS), 1)).toBe(" beta gamma");
+  });
+
+  it("vaw takes the trailing whitespace too", () => {
+    expect(line(screenAfter(["vaw", "d"], WORDS), 1)).toBe("beta gamma");
+  });
+
+  it("vi( selects the parenthesised body", () => {
+    expect(line(screenAfter(["f(", "vi(", "d"], "call(a, b) end\n"), 1)).toBe(
+      "call() end",
+    );
+  });
+
+  it("va( includes the brackets", () => {
+    expect(line(screenAfter(["f(", "va(", "d"], "call(a, b) end\n"), 1)).toBe(
+      "call end",
+    );
+  });
+
+  it('vi" selects the quoted body', () => {
+    expect(line(screenAfter(['vi"', "d"], 'x = "hello" ;\n'), 1)).toBe(
+      'x = "" ;',
+    );
+  });
+
+  it("text objects can be changed straight away", () => {
+    const s = screenAfter(["viw", "c", "ZZ", "<escape>"], WORDS);
+    expect(line(s, 1)).toBe("ZZ beta gamma");
+  });
+
+  it("vip selects a paragraph linewise", () => {
+    const s = screenAfter(["vip", "d"], "one\ntwo\n\nthree\n");
+    expect(s).toContain("-- NORMAL --");
+    expect(lines(s, 2)).toEqual(["", "three"]);
+  });
+
+  it("a text object switches the mode indicator to VISUAL LINE when linewise", () => {
+    expect(screenAfter(["vip"], "one\ntwo\n\nthree\n")).toContain(
+      "-- VISUAL LINE --",
+    );
+  });
+
+  it("counted bracket objects reach the enclosing pair", () => {
+    expect(line(screenAfter(["fx", "v2i(", "d"], "a(b(x)c)d\n"), 1)).toBe(
+      "a()d",
+    );
+  });
+});
+
+describe("vim visual block", () => {
+  it("d deletes the column range on every row", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "d"]);
+    expect(lines(s, 4)).toEqual(["cdef", "ijkl", "opqr", "stuvwx"]);
+  });
+
+  it("x is the same as d", () => {
+    const s = screenAfter(["<ctrl+v>", "j", "l", "x"]);
+    expect(lines(s, 3)).toEqual(["cdef", "ijkl", "mnopqr"]);
+  });
+
+  it("y yanks the block and p pastes the rows joined by newlines", () => {
+    // G lands on the trailing empty line, so the two rows paste as new lines.
+    const s = screenAfter(["<ctrl+v>", "j", "l", "y", "G", "p"]);
+    expect(line(s, 5)).toBe("ab");
+    expect(line(s, 6)).toBe("gh");
+  });
+
+  it("c replaces the block and types on every row", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "c", "Z", "<escape>"]);
+    expect(lines(s, 4)).toEqual(["Zcdef", "Zijkl", "Zopqr", "stuvwx"]);
+  });
+
+  it("I inserts at the left edge of every row", () => {
+    const s = screenAfter(["l", "<ctrl+v>", "jj", "I", "X", "<escape>"]);
+    expect(lines(s, 4)).toEqual(["aXbcdef", "gXhijkl", "mXnopqr", "stuvwx"]);
+  });
+
+  it("A appends at the right edge of every row", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "ll", "A", "X", "<escape>"]);
+    expect(lines(s, 4)).toEqual(["abcXdef", "ghiXjkl", "mnoXpqr", "stuvwx"]);
+  });
+
+  it("r fills every cell of the block", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "rZ"]);
+    expect(lines(s, 4)).toEqual(["ZZcdef", "ZZijkl", "ZZopqr", "stuvwx"]);
+  });
+
+  it("gU uppercases the block only", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "gU"]);
+    expect(lines(s, 4)).toEqual(["ABcdef", "GHijkl", "MNopqr", "stuvwx"]);
+  });
+
+  it("$ gives a ragged right edge", () => {
+    const s = screenAfter(["l", "<ctrl+v>", "jj", "$", "d"], RAGGED);
+    expect(lines(s, 3)).toEqual(["a", "i", "k"]);
+  });
+
+  it("$ then A appends at each line's own end", () => {
+    const s = screenAfter(
+      ["l", "<ctrl+v>", "jj", "$", "A", "X", "<escape>"],
+      RAGGED,
+    );
+    expect(lines(s, 3)).toEqual(["abcdefghX", "ijX", "klmnopX"]);
+  });
+
+  it("rows shorter than the block's left edge are left alone", () => {
+    // Block over columns 4..5; line 2 ("ij") has no such columns.
+    const s = screenAfter(["3l", "<ctrl+v>", "jj", "l", "d"], RAGGED);
+    expect(lines(s, 3)).toEqual(["abcfgh", "ij", "klmp"]);
+  });
+
+  it("leaving block mode collapses the extra cursors", () => {
+    // If the block cursors survived, typing "Z" in insert mode would land on
+    // every row instead of just the current one.
+    // Esc leaves the cursor on the row the block ended on, as in Vim.
+    const s = screenAfter(["<ctrl+v>", "jj", "<escape>", "iZ", "<escape>"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "Zmnopqr", "stuvwx"]);
+  });
+});
+
+describe("vim visual: undo atomicity", () => {
+  it("a charwise delete is one undo step", () => {
+    const s = screenAfter(["v", "ll", "d", "u"]);
+    expect(line(s, 1)).toBe("abcdef");
+  });
+
+  it("a linewise delete is one undo step", () => {
+    const s = screenAfter(["V", "jj", "d", "u"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "mnopqr", "stuvwx"]);
+  });
+
+  it("a blockwise delete across three lines is ONE undo step", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "d", "u"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "mnopqr", "stuvwx"]);
+  });
+
+  it("a blockwise r across three lines is one undo step", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "rZ", "u"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "mnopqr", "stuvwx"]);
+  });
+
+  it("a blockwise gU across three lines is one undo step", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "gU", "u"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "mnopqr", "stuvwx"]);
+  });
+
+  it("blockwise I plus typing plus Esc is one undo step", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "I", "XY", "<escape>", "u"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "mnopqr", "stuvwx"]);
+  });
+
+  it("blockwise c plus typing plus Esc is one undo step", () => {
+    const s = screenAfter(["<ctrl+v>", "jj", "l", "c", "Z", "<escape>", "u"]);
+    expect(lines(s, 4)).toEqual(["abcdef", "ghijkl", "mnopqr", "stuvwx"]);
+  });
+
+  it("a visual change is one undo step", () => {
+    const s = screenAfter(["v", "ll", "c", "ZZ", "<escape>", "u"]);
+    expect(line(s, 1)).toBe("abcdef");
+  });
+
+  it("a multi-line visual indent is one undo step", () => {
+    const s = screenAfter(["V", "jj", ">", "u"]);
+    expect(lines(s, 3)).toEqual(["abcdef", "ghijkl", "mnopqr"]);
+  });
+
+  it("a visual J is one undo step", () => {
+    const s = screenAfter(["V", "jj", "J", "u"]);
+    expect(lines(s, 3)).toEqual(["abcdef", "ghijkl", "mnopqr"]);
+  });
+
+  it("a visual p is one undo step", () => {
+    const s = screenAfter(["v", "ll", "y", "j", "v", "ll", "p", "u"]);
+    expect(lines(s, 2)).toEqual(["abcdef", "ghijkl"]);
+  });
+});

--- a/vim.md
+++ b/vim.md
@@ -63,3 +63,18 @@ The core needs several plugin API additions first — all general-purpose, not V
 - `editor.add_cursor(line, col)` — add a cursor at position (1-based). Duplicates ignored. Gated on `editor.write`.
 - `editor.get_cursors()` — returns list of `{line, col}` tables (1-based). Gated on `editor.read`.
 - `editor.clear_cursors()` — collapse back to single cursor. Gated on `editor.write`.
+
+### 8. Key Interceptor Precedence ✅
+
+**Done.** The `KeyInterceptor` hook moved up in `Root.HandleEvent` (`internal/ui/root.go`) so modal plugins can own the keyboard.
+
+- Now runs **above** the Escape branch and `handleChord`, instead of below them. Without this a plugin could never observe Esc, which blocks Insert→Normal.
+- Still runs **below** `ForceKeys` (the terminal-toggle escape hatch must stay unswallowable) and `handleOverlay` (modal dialogs and the command palette keep their keys).
+- Skipped entirely while a chord is in flight (`r.chord != nil`), because a chord's continuation keys are plain runes (`s` of `ctrl+k s`) that a modal plugin would otherwise consume — silently breaking every chord binding.
+- Plugins must return `false` for keys they do not own. In particular, Esc should pass through when the plugin has nothing to cancel, so core `EscapeDismissers` still run.
+
+Covered by `tests/e2e/key_interceptor_test.go`.
+
+### Remaining
+
+**9. Status-line command input** — a Vim-style `:`/`/` prompt on the bottom row, for ex commands and incremental search. Needed by Phase 6 of the plugin; not yet started.


### PR DESCRIPTION
Closes #386.

A full-ish Vim compatibility layer for ttt, built as a single Lua plugin in `plugins/vim/`, plus the core plugin-API work it needed. Requested by @atreus44.

## What you get

Modal editing with genuine Vim semantics, not just hjkl:

- **Modes** — normal / insert / visual / visual-line / visual-block / replace, with a mode indicator in the status bar.
- **Motions** — `hjkl`, word/WORD, `0 ^ $ g_`, `gg G {n}G`, `f F t T ; ,`, `% { }`, `H M L`, `Ctrl-D/U/F/B/E/Y`, `zz zt zb`, all count-aware.
- **Operators × motions × text objects** — `d c y > < = gu gU g~` composed with every motion and count, doubled forms (`dd cc yy`), and text objects (`iw aw i" i( i{ it ip is` …). Exclusive/inclusive boundaries handled correctly (`dw` vs `de`, `dtx` vs `dfx`).
- **Visual modes** — all three, with operators, text objects, `o`/`O`/`gv`, and blockwise `I`/`A`.
- **Registers, marks, macros, dot-repeat** — named/append/numbered/yank/blackhole/clipboard registers, marks that survive edits, `q`/`@`/`@@`, and `.`.
- **Ex & search** — `:` command line and `/`/`?` incremental search on a 3-row framed box above the status bar; `n N * #`, search as an operator target, `:w :q :wq :e :%s/…/…/g` with a documented regex subset.
- **Editor integration** — `]c`/`[c` (changed hunks), `]f`/`[f` (changed files), `za/zR/zM` folds, `gt/gT` tabs.
- **Settings** — `vim.enabled`, `vim.clipboard`.

Every Vim operation is a single undo step.

## Core / plugin-API changes (the reusable part)

This is not just a plugin — it drove several general-purpose additions:

- **Key interceptor precedence** — the plugin `KeyInterceptor` now runs above Escape handling and chords (still below ForceKeys and modal overlays), so a modal plugin can own the keyboard and see Esc. A chord already in flight is exempt so `ctrl+k …` bindings keep working.
- **`ttt.command_line` API** — a Vim-style command line rendered as a modal overlay, reused for `:` and `/`. Because it is modal, the plugin goes silent automatically while it is open.
- **Plugin-namespaced settings** — `config.Settings` no longer drops unknown top-level keys, so `ttt.settings.get/set` works for plugin-owned namespaces. Empty-`Extra` encoding is byte-identical to before.
- **Four diff-navigation commands** — `diff.nextHunk`/`prevHunk`, `changes.nextFile`/`prevFile` (palette-only).
- **`--exec-split-on`** — lets scripted `--exec` runs send a literal `;` (a Vim motion), and the functional harness uses it unconditionally.

Plugin **API bumped to v2** (ttt **1.1.0**). A 1.0.x binary refuses the plugin cleanly via the existing manifest check rather than loading it half-broken; the README also states the requirement in prose.

## Testing

Nine phases, each verified independently against real Vim behavior and committed only when green. **86 functional test files / 653 passing / 27 expected-fail**, plus Go unit/e2e for every core change (command-line widget, interceptor precedence incl. a test pinning that a modal overlay silences the interceptor, settings roundtrip, hunk grouping). ~290 Vim-specific functional tests.

## Notes for review

- The plugin is one large `init.lua` by necessity — the sandbox strips `package.loaders`, so plugins can't span files. Sections use `do…end` blocks to stay under Lua 5.1's 200-live-locals-per-scope limit.
- Surfaced a genuine **gopher-lua codegen bug**: multiple assignment is not simultaneous for *local* variables (`local a,b = b,a` → `b,b`; table fields are fine). Worked around with explicit temporaries throughout.
- **`zo`/`zc` (open/close-only folds) and `Ctrl-W` splits have no core equivalent** in ttt and are documented as unsupported rather than faked.
- Filed #395 separately: plugin load/compile errors are effectively silent today, which made several of these failures hard to diagnose. Worth fixing independently of this PR.
- Intended to move to the `ttt-plugins` repo after 1.1.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qec4jq5DadwW68aJD5qTa