### PR TITLE
fix: gate multi-cursor Enter auto-indent on editor.autoIndent

### DIFF
--- a/internal/ui/autoindent_test.go
+++ b/internal/ui/autoindent_test.go
@@ -189,3 +189,24 @@ func TestAutoIndentDisabledNoSmartIndentAfterBrace(t *testing.T) {
 		t.Fatalf("expected no shiftwidth after opener with AutoIndent off, got %q", e.Buf.Lines[1])
 	}
 }
+
+func TestAutoIndentDisabledInMultiCursor(t *testing.T) {
+	e := newEditorWithLines("    foo", "    bar")
+	e.AutoIndent = false
+	e.Cursor.Line, e.Cursor.Col = 0, 7
+	e.ensureMulti()
+	e.Multi.Add(1, 7)
+	e.syncFromMulti()
+	if !e.isMultiActive() {
+		t.Fatal("expected multi-cursor mode to be active")
+	}
+
+	e.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, 0, 0))
+
+	// Both split lines should open at column 1 with AutoIndent off.
+	for _, ln := range []int{1, 3} {
+		if e.Buf.Lines[ln] != "" {
+			t.Fatalf("expected column-1 line at %d with AutoIndent off, got %q", ln, e.Buf.Lines[ln])
+		}
+	}
+}

--- a/internal/ui/editor_widget_multicursor.go
+++ b/internal/ui/editor_widget_multicursor.go
@@ -229,7 +229,10 @@ func (e *EditorPaneWidget) multiExecEnter() {
 			e.adjustLaterCursors(i, start, end)
 		}
 		cs.Line = e.Buf.ClampLine(cs.Line)
-		indent := leadingWhitespace(e.Buf.Lines[cs.Line])
+		indent := ""
+		if e.AutoIndent {
+			indent = leadingWhitespace(e.Buf.Lines[cs.Line])
+		}
 		cmd := &undo.SplitLineCommand{Line: cs.Line, Col: cs.Col}
 		cmd.Apply(e.Buf)
 		cmds = append(cmds, cmd)


### PR DESCRIPTION
## What

Follow-up to #399. The new `editor.autoIndent` setting gated the **single-cursor** Enter path (`execEnter`) but missed the **multi-cursor** one (`multiExecEnter`). So with `autoIndent: false`:

- single-cursor Enter → opens at column 1 ✓
- multi-cursor Enter → still inherited the previous line's indent ✗

This gates `multiExecEnter`'s indent inheritance on the same `e.AutoIndent` flag, so both cursor modes agree.

## Tests

- `internal/ui/autoindent_test.go` — `TestAutoIndentDisabledInMultiCursor`: with the setting off, both split lines from a two-cursor Enter open at column 1.
- The existing `TestEnterIndentConsistentAcrossCursorModes` still guards the default-on case (single and multi agree).
- Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qec4jq5DadwW68aJD5qTa