### PR TITLE
fix: undo cursor position after delete selection

### DIFF
--- a/internal/core/undo/undo.go
+++ b/internal/core/undo/undo.go
@@ -167,7 +167,7 @@ func cursorAfterUndo(cmd EditCommand) *CursorPos {
 	case *JoinNextLineCommand:
 		return &CursorPos{c.Line, c.JoinCol}
 	case *DeleteSelectionCommand:
-		return &CursorPos{c.EndLine, c.EndCol}
+		return &CursorPos{c.StartLine, c.StartCol}
 	case *PasteCommand:
 		return &CursorPos{c.Line, c.Col}
 	case *BatchCommand:

--- a/internal/core/undo/undo_test.go
+++ b/internal/core/undo/undo_test.go
@@ -807,3 +807,18 @@ func TestEndTransactionWithoutBegin(t *testing.T) {
 	s := &UndoStack{}
 	s.EndTransaction()
 }
+
+func TestDeleteSelectionCursorAfterUndoReturnsStart(t *testing.T) {
+	cmd := &DeleteSelectionCommand{
+		StartLine: 0, StartCol: 3,
+		EndLine: 0, EndCol: 8,
+		Deleted: "hello",
+	}
+	pos := cursorAfterUndo(cmd)
+	if pos == nil {
+		t.Fatal("expected non-nil cursor position")
+	}
+	if pos.Line != 0 || pos.Col != 3 {
+		t.Errorf("expected cursor at (0, 3), got (%d, %d)", pos.Line, pos.Col)
+	}
+}


### PR DESCRIPTION
## Summary

- `cursorAfterUndo` for `DeleteSelectionCommand` returned `{EndLine, EndCol}`, placing the cursor at the end of the deleted range after undo. This caused sequences like `dwu` to leave the cursor on the wrong character.
- Fix: return `{StartLine, StartCol}` instead, matching Vim's behavior.
- Found by the ttt-vim differential fuzzer (bug B6 in eugenioenko/ttt-vim#2).

## Test plan

- [x] New unit test `TestDeleteSelectionCursorAfterUndoReturnsStart`
- [x] `make test` — all Go unit + e2e tests pass
- [x] ttt-vim test suite (462 tests) passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qec4jq5DadwW68aJD5qTa