### PR TITLE
feat(plugin): support stdin in sys.exec and sys.exec_async

### DIFF
--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -1628,7 +1628,7 @@ The `ttt.system` module provides command execution and environment variable acce
 local sys = require("ttt.system")
 ```
 
-### `sys.exec(binary, [args])`
+### `sys.exec(binary, [args], [opts])`
 
 Execute a command synchronously. Requires the `system.exec` permission with the binary listed in the allowlist.
 
@@ -1636,6 +1636,13 @@ Execute a command synchronously. Requires the `system.exec` permission with the 
 |-----------|--------|----------|------------------------------------------|
 | `binary`  | string | yes      | Command to execute. Must be in the `system.exec` permission allowlist. |
 | `args`    | table  | no       | Array of string arguments.               |
+| `opts`    | table  | no       | Options table. Only `stdin` is supported. |
+
+**Options:**
+
+| Field   | Type   | Description                                                      |
+|---------|--------|------------------------------------------------------------------|
+| `stdin` | string | Written to the command's standard input. Nothing is written when omitted or empty. |
 
 **Returns** a table:
 
@@ -1652,9 +1659,23 @@ if result.exit_code == 0 then
 end
 ```
 
+Many tools read the text they operate on from standard input rather than from a
+file argument — formatters like `prettier` and `gofmt`, and checkers like
+`aspell`. Pass it with `stdin`:
+
+```lua
+local result = sys.exec("aspell", {"pipe", "--mode=markdown"}, {
+  stdin = "!\n^" .. line .. "\n",
+})
+```
+
+Prefer `stdin` over passing document text as an argument. Arguments are capped
+by the OS (`ARG_MAX`, commonly 2 MB) and are visible to every process on the
+machine via `ps`; standard input has neither limit.
+
 Arguments are validated before execution: shell-injection patterns and dangerous git flags (e.g. `--upload-pack`, `core.fsmonitor`) are rejected.
 
-### `sys.exec_async(binary, [args], callback)`
+### `sys.exec_async(binary, [args], [opts], callback)`
 
 Execute a command asynchronously. The callback receives the same result table and is called on the main thread when the command completes. The UI remains responsive during execution.
 
@@ -1662,6 +1683,7 @@ Execute a command asynchronously. The callback receives the same result table an
 |------------|----------|----------|----------------------------------------------|
 | `binary`   | string   | yes      | Command to execute.                          |
 | `args`     | table    | no       | Array of string arguments. May be omitted — the callback can be the second argument. |
+| `opts`     | table    | no       | Options table, same fields as `sys.exec`. Requires `args` to be passed too. |
 | `callback` | function | yes      | Receives the result table when done.         |
 
 ```lua
@@ -1675,6 +1697,11 @@ end)
 -- Without arguments:
 sys.exec_async("uptime", function(result)
   panel:redraw()
+end)
+
+-- With stdin:
+sys.exec_async("aspell", {"pipe"}, {stdin = text}, function(result)
+  -- parse result.stdout
 end)
 ```
 

--- a/internal/app/plugin_api.go
+++ b/internal/app/plugin_api.go
@@ -408,7 +408,7 @@ func (s *PluginSystemAPI) validateArgs(binary string, args []string) error {
 	return nil
 }
 
-func (s *PluginSystemAPI) Exec(binary string, args []string) (string, string, int, error) {
+func (s *PluginSystemAPI) Exec(binary string, args []string, stdin string) (string, string, int, error) {
 	if err := s.validateArgs(binary, args); err != nil {
 		return "", "", -1, err
 	}
@@ -416,6 +416,9 @@ func (s *PluginSystemAPI) Exec(binary string, args []string) (string, string, in
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
 	err := cmd.Run()
 	exitCode := 0
 	if err != nil {

--- a/internal/app/plugin_api_test.go
+++ b/internal/app/plugin_api_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -247,5 +248,33 @@ func TestPluginSystemAPI_ArgumentInjection(t *testing.T) {
 				t.Errorf("expected argument to be allowed, got: %v", err)
 			}
 		})
+	}
+}
+
+// TestPluginSystemAPI_ExecStdin exercises the real subprocess path. The
+// Lua-level tests in internal/plugin use a mock SystemAPI, so this is the only
+// coverage that stdin actually reaches the child process.
+func TestPluginSystemAPI_ExecStdin(t *testing.T) {
+	if _, err := exec.LookPath("cat"); err != nil {
+		t.Skip("cat not available")
+	}
+	api := NewPluginSystemAPI()
+
+	stdout, _, code, err := api.Exec("cat", nil, "hello from stdin\n")
+	if err != nil || code != 0 {
+		t.Fatalf("exec cat: err=%v code=%d", err, code)
+	}
+	if stdout != "hello from stdin\n" {
+		t.Errorf("stdin not piped to child, got %q", stdout)
+	}
+
+	// With no stdin the child must see EOF immediately. If Stdin were left
+	// attached to the terminal instead, this would block forever.
+	stdout, _, code, err = api.Exec("cat", nil, "")
+	if err != nil || code != 0 {
+		t.Fatalf("exec cat with no stdin: err=%v code=%d", err, code)
+	}
+	if stdout != "" {
+		t.Errorf("expected empty stdout, got %q", stdout)
 	}
 }

--- a/internal/plugin/api.go
+++ b/internal/plugin/api.go
@@ -75,7 +75,9 @@ type FilesystemAPI interface {
 }
 
 type SystemAPI interface {
-	Exec(binary string, args []string) (stdout, stderr string, exitCode int, err error)
+	// Exec runs binary with args, writing stdin to the child's standard input
+	// (nothing is written when stdin is empty).
+	Exec(binary string, args []string, stdin string) (stdout, stderr string, exitCode int, err error)
 	Env(name string) string
 }
 

--- a/internal/plugin/lua_system.go
+++ b/internal/plugin/lua_system.go
@@ -27,6 +27,23 @@ func setupSystemModule(L *lua.LState, p *Plugin) {
 	L.PreloadModule("ttt.system", loader)
 }
 
+// parseExecArgs reads the optional argv array and options table that follow the
+// binary name, starting at stack index start. The only option is stdin, whose
+// contents are written to the child's standard input.
+func parseExecArgs(L *lua.LState, start int) (args []string, stdin string) {
+	if argsTbl, ok := L.Get(start).(*lua.LTable); ok {
+		argsTbl.ForEach(func(_, v lua.LValue) {
+			args = append(args, v.String())
+		})
+	}
+	if optsTbl, ok := L.Get(start + 1).(*lua.LTable); ok {
+		if s, ok := L.GetField(optsTbl, "stdin").(lua.LString); ok {
+			stdin = string(s)
+		}
+	}
+	return args, stdin
+}
+
 func sysExec(p *Plugin) lua.LGFunction {
 	return func(L *lua.LState) int {
 		if p.System == nil {
@@ -41,15 +58,10 @@ func sysExec(p *Plugin) lua.LGFunction {
 			return 2
 		}
 
-		var args []string
-		if argsTbl, ok := L.Get(2).(*lua.LTable); ok {
-			argsTbl.ForEach(func(_, v lua.LValue) {
-				args = append(args, v.String())
-			})
-		}
+		args, stdin := parseExecArgs(L, 2)
 
 		tbl := L.NewTable()
-		stdout, stderr, exitCode, err := p.System.Exec(binary, args)
+		stdout, stderr, exitCode, err := p.System.Exec(binary, args, stdin)
 		if err != nil {
 			L.SetField(tbl, "stdout", lua.LString(""))
 			L.SetField(tbl, "stderr", lua.LString(err.Error()))
@@ -79,20 +91,21 @@ func sysExecAsync(p *Plugin) lua.LGFunction {
 		}
 
 		var args []string
+		var stdin string
 		var callback *lua.LFunction
 		if fn, ok := L.Get(2).(*lua.LFunction); ok {
 			callback = fn
 		} else {
-			if argsTbl, ok := L.Get(2).(*lua.LTable); ok {
-				argsTbl.ForEach(func(_, v lua.LValue) {
-					args = append(args, v.String())
-				})
+			args, stdin = parseExecArgs(L, 2)
+			if fn, ok := L.Get(3).(*lua.LFunction); ok {
+				callback = fn
+			} else {
+				callback = L.CheckFunction(4)
 			}
-			callback = L.CheckFunction(3)
 		}
 
 		go func() {
-			stdout, stderr, exitCode, err := p.System.Exec(binary, args)
+			stdout, stderr, exitCode, err := p.System.Exec(binary, args, stdin)
 			resultFn := func() {
 				if p.State == nil {
 					return

--- a/internal/plugin/lua_system_test.go
+++ b/internal/plugin/lua_system_test.go
@@ -13,11 +13,13 @@ type mockSystemAPI struct {
 	exitCode   int
 	execErr    error
 	envVars    map[string]string
+	execStdin  string
 }
 
-func (m *mockSystemAPI) Exec(binary string, args []string) (string, string, int, error) {
+func (m *mockSystemAPI) Exec(binary string, args []string, stdin string) (string, string, int, error) {
 	m.execBinary = binary
 	m.execArgs = args
+	m.execStdin = stdin
 	return m.stdout, m.stderr, m.exitCode, m.execErr
 }
 
@@ -236,4 +238,83 @@ func TestSystemExecAsyncNilStateSafety(t *testing.T) {
 	p.Destroy()
 
 	capturedCallback()
+}
+
+func TestSystemExecStdin(t *testing.T) {
+	mock := &mockSystemAPI{stdout: "& helllo 3 1: hello, hell, he'll\n"}
+	p, cleanup := setupTestPluginWithSystem(
+		PermissionSet{SystemExec: []string{"aspell"}},
+		mock,
+	)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		local result = sys.exec("aspell", {"pipe"}, {stdin = "!\n^helllo\n"})
+		_G.stdout = result.stdout
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.execStdin != "!\n^helllo\n" {
+		t.Errorf("stdin not forwarded, got %q", mock.execStdin)
+	}
+	if len(mock.execArgs) != 1 || mock.execArgs[0] != "pipe" {
+		t.Errorf("opts table leaked into args: %v", mock.execArgs)
+	}
+}
+
+func TestSystemExecWithoutStdin(t *testing.T) {
+	mock := &mockSystemAPI{stdout: "ok"}
+	p, cleanup := setupTestPluginWithSystem(
+		PermissionSet{SystemExec: []string{"echo"}},
+		mock,
+	)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		sys.exec("echo", {"hi"})
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.execStdin != "" {
+		t.Errorf("expected empty stdin, got %q", mock.execStdin)
+	}
+}
+
+func TestSystemExecAsyncStdin(t *testing.T) {
+	mock := &mockSystemAPI{stdout: "piped"}
+
+	ch := make(chan func(), 1)
+	p, cleanup := setupTestPluginWithSystem(
+		PermissionSet{SystemExec: []string{"aspell"}},
+		mock,
+	)
+	defer cleanup()
+
+	p.PostAsync = func(result *PluginAsyncResult) {
+		ch <- result.Callback
+	}
+
+	err := p.State.DoString(`
+		local sys = require("ttt.system")
+		sys.exec_async("aspell", {"pipe"}, {stdin = "^word\n"}, function(result)
+			_G.got_stdout = result.stdout
+		end)
+	`)
+	if err != nil {
+		t.Fatalf("exec_async with stdin failed: %v", err)
+	}
+
+	callback := <-ch
+	callback()
+
+	if mock.execStdin != "^word\n" {
+		t.Errorf("stdin not forwarded, got %q", mock.execStdin)
+	}
+	if p.State.GetGlobal("got_stdout").String() != "piped" {
+		t.Errorf("expected stdout 'piped', got %q", p.State.GetGlobal("got_stdout").String())
+	}
 }


### PR DESCRIPTION
Adds an optional `stdin` to the plugin system API so plugins can drive tools that read their input from standard input.

## Why

`sys.exec` could only pass argv, which put a whole class of tools out of reach of plugins. Formatters (`prettier`, `gofmt`, `black`) and checkers (`aspell`) all read the text they operate on from stdin — several have no file-argument mode at all. `aspell` is the extreme case: its positional argument is a *command* (`pipe`, `list`, `check`), never text, so there was no way to spell-check a buffer from a plugin.

Passing document text as an argument is not a workable substitute:

- **Offsets.** aspell's pipe protocol reports results per *input line*; flattening a document into one argument throws away the line structure a checker's results are indexed by.
- **Size.** argv is capped by `ARG_MAX` (2 MB on a typical Linux box, shared with the environment), so large files would fail intermittently.
- **Privacy.** argv is world-readable via `ps`; stdin is private to the child.

## API

```lua
sys.exec("aspell", {"pipe", "--mode=markdown"}, {stdin = text})
sys.exec_async("aspell", {"pipe"}, {stdin = text}, function(result) end)
```

`opts` is a table whose only field is `stdin`. Existing call forms are unchanged — `exec(bin)`, `exec(bin, args)`, `exec_async(bin, cb)` and `exec_async(bin, args, cb)` all behave exactly as before.

## Implementation

- `SystemAPI.Exec` gains a `stdin` parameter (`internal/plugin/api.go`).
- `PluginSystemAPI.Exec` wires it to `cmd.Stdin`, left `nil` when empty so the child sees EOF immediately rather than inheriting the terminal (`internal/app/plugin_api.go`).
- `parseExecArgs` shares argv/opts parsing between the sync and async bindings (`internal/plugin/lua_system.go`).
- Argument validation is untouched and still applies.

## Tests

- Three Lua-level tests covering stdin forwarding for `exec` and `exec_async`, that the opts table does not leak into argv, and that omitting it yields empty stdin.
- `TestPluginSystemAPI_ExecStdin` in `internal/app` runs a real `cat` subprocess — the only coverage that stdin reaches an actual process, since the Lua tests use a mock. It also asserts the empty-stdin case terminates rather than hanging.
- Existing `sys.exec` tests pass unchanged, covering backward compatibility.

`go test ./...` is green.

## Docs

`plugin-authoring.md` documents `opts`/`stdin` on both functions, with an aspell example and a note on why stdin is preferred over argv for document text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)