### PR TITLE
feat: add spell plugin to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -80,6 +80,15 @@
     "tags": ["notes", "scratchpad", "productivity", "utility"]
   },
   {
+    "name": "spell",
+    "displayName": "Spell Check",
+    "author": "eugenioenko",
+    "description": "Spell checking for prose files via aspell, with inline squiggles and corrections",
+    "repo": "https://github.com/eugenioenko/ttt-spell",
+    "version": "0.1.0",
+    "tags": ["spelling", "aspell", "prose", "writing", "markdown"]
+  },
+  {
     "name": "todo-scanner",
     "displayName": "TODO Scanner",
     "author": "eugenioenko",


### PR DESCRIPTION
Registers the [spell](https://github.com/eugenioenko/ttt-spell) plugin in `community-plugins.json`.

Spell checking for prose files (Markdown, HTML, XML, TeX, reStructuredText, Org Mode, and plain files such as `COMMIT_EDITMSG`) backed by aspell. Misspellings render as curly underlines and appear in the Diagnostics panel; corrections come from the right-click menu or the command palette, and words can be added to the personal aspell dictionary. Source files are skipped, and within Markdown the aspell filter keeps code spans and URLs out of the results.

## Note on the entry shape

Unlike the existing entries, this one omits `path`: the plugin lives at the root of its own repository rather than in a subdirectory of `ttt-plugins`. `Manager.Update` (`internal/plugin/manager.go:490`) already handles this — an empty `Path` skips `updateFromSubdir` and takes the plain `git pull` route.

## Requires

The plugin depends on `sys.exec` stdin support (#405), since aspell reads the text to check from standard input and has no file-argument mode. Worth merging that first.

Users must install aspell and a dictionary themselves; the plugin's manifest allowlists exactly one binary (`"system.exec": ["aspell"]`) and stays inert with a single status-bar warning when aspell is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)