### PR TITLE
docs: highlight the Vim Mode plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,9 @@ TTT supports Lua plugins that add sidebar panels, bottom panel tabs, commands, a
 
 #### Vim Mode
 
-Prefer modal editing? Install the [Vim Mode](https://github.com/eugenioenko/ttt-vim) plugin for a Vim compatibility layer: Normal, Insert and Visual modes, motions, operators, text objects, registers, marks and macros. It is built entirely on the public plugin API, so it needs no special core support and stays enabled or disabled like any other plugin.
+Prefer modal editing? Install the [Vim Mode](https://github.com/eugenioenko/ttt-vim) plugin for a Vim compatibility layer: Normal, Insert and Visual modes, the operator/motion/text-object grammar, registers, marks, macros, dot-repeat, a `:` command line and `/` search. It is a single Lua plugin with no core changes of its own, and it enables or disables like any other plugin.
+
+It does rely on plugin API additions that landed in ttt 1.1.0 (the key interceptor's precedence over Escape, needed to leave Insert mode, and the command-line API for `:` and `/`), so it requires ttt 1.1.0 or newer. Its manifest declares `api: 2`, so an older editor refuses to load it rather than running it half-broken.
 
 Install it from the **Plugins** sidebar tab by searching for "vim", or run **Plugins: Install from URL** with `https://github.com/eugenioenko/ttt-vim`.
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,12 @@ To use your terminal's native colors instead of the theme's, set foreground/back
 
 TTT supports Lua plugins that add sidebar panels, bottom panel tabs, commands, and keybindings. Plugins run in a sandboxed Lua VM with a permission system — users approve each plugin's capabilities on first load.
 
+#### Vim Mode
+
+Prefer modal editing? Install the [Vim Mode](https://github.com/eugenioenko/ttt-vim) plugin for a Vim compatibility layer: Normal, Insert and Visual modes, motions, operators, text objects, registers, marks and macros. It is built entirely on the public plugin API, so it needs no special core support and stays enabled or disabled like any other plugin.
+
+Install it from the **Plugins** sidebar tab by searching for "vim", or run **Plugins: Install from URL** with `https://github.com/eugenioenko/ttt-vim`.
+
 #### Installing Plugins
 
 Open the **Plugins** sidebar tab to browse and install from the community registry, or use **Plugins: Install from URL** from the command palette to install from any git repository.

--- a/docs-web/src/content/docs/guides/plugins.md
+++ b/docs-web/src/content/docs/guides/plugins.md
@@ -7,7 +7,9 @@ TTT supports Lua plugins that add panels, commands, and keybindings to the edito
 
 ## Vim Mode
 
-If you prefer modal editing, the [Vim Mode](https://github.com/eugenioenko/ttt-vim) plugin adds a Vim compatibility layer on top of TTT: Normal, Insert and Visual modes, motions, operators, text objects, registers, marks and macros. It is written entirely against the public plugin API (key interception, status bar segments, multi cursor, undo grouping), so it requires no special core support and can be enabled or disabled like any other plugin.
+If you prefer modal editing, the [Vim Mode](https://github.com/eugenioenko/ttt-vim) plugin adds a Vim compatibility layer on top of TTT: Normal, Insert and Visual modes, the operator/motion/text-object grammar, registers, marks, macros, dot-repeat, a `:` command line and `/` search. It is a single Lua plugin written against the public plugin API (key interception, status bar segments, multi cursor, undo grouping).
+
+Because it depends on plugin API additions from ttt 1.1.0 (the key interceptor's precedence over Escape, needed to leave Insert mode, and the command-line API for `:` and `/`), it requires ttt 1.1.0 or newer. Its manifest declares `api: 2`, so an older editor declines to load it instead of running it half-broken.
 
 Install it from the **Plugins** sidebar tab by searching for "vim", or run **Plugins: Install from URL** with `https://github.com/eugenioenko/ttt-vim`. Once loaded it starts in Normal mode and shows the current mode in the status bar.
 

--- a/docs-web/src/content/docs/guides/plugins.md
+++ b/docs-web/src/content/docs/guides/plugins.md
@@ -5,6 +5,12 @@ description: Install, manage, and configure plugins in TTT.
 
 TTT supports Lua plugins that add panels, commands, and keybindings to the editor. Plugins run in a sandboxed Lua VM with a permission system — no plugin can access your filesystem, run commands, or make network requests without your explicit approval.
 
+## Vim Mode
+
+If you prefer modal editing, the [Vim Mode](https://github.com/eugenioenko/ttt-vim) plugin adds a Vim compatibility layer on top of TTT: Normal, Insert and Visual modes, motions, operators, text objects, registers, marks and macros. It is written entirely against the public plugin API (key interception, status bar segments, multi cursor, undo grouping), so it requires no special core support and can be enabled or disabled like any other plugin.
+
+Install it from the **Plugins** sidebar tab by searching for "vim", or run **Plugins: Install from URL** with `https://github.com/eugenioenko/ttt-vim`. Once loaded it starts in Normal mode and shows the current mode in the status bar.
+
 ## Installing Plugins
 
 ### From the Plugins Panel


### PR DESCRIPTION
Highlights the [ttt-vim](https://github.com/eugenioenko/ttt-vim) plugin so users can discover modal editing. It is a standalone community plugin (already in `community-plugins.json`, so it shows in the built-in browser), but nothing in the README or docs pointed at it.

## Changes

- **README** `### Plugins`: a `#### Vim Mode` callout above "Installing Plugins" with the feature list, the version requirement, and install instructions.
- **docs-web** `guides/plugins.md`: a `## Vim Mode` section above "Installing Plugins" covering the same, plus what to expect on first load.

## Verified against the ttt-vim source

Every claim was checked against the plugin's `init.lua` and manifest, not written from assumption:

- **Starts in Normal mode and shows the mode in the status bar** - confirmed (`state.mode = "normal"` default, `set_status_item("left", "mode", ...)`).
- **Requires ttt 1.1.0 (manifest `api: 2`)** - it depends on the key interceptor's precedence over Escape (to leave Insert mode) and the `ttt.command_line` API (for `:` and `/`), both core additions in 1.1.0. An earlier draft wrongly said it needed no core support; corrected.
- **Feature list** - modal editing, operator/motion/text-object grammar, registers, marks, macros, dot-repeat, `:` command line and `/` search all present. The APIs named in the docs (key interception, status segments, multi cursor, undo grouping) are all genuinely used.

## Notes

- Docs-only. `npm run build` in `docs-web` passes.
- No em or en dashes in the added text, per request.
- Not added to the README "Available Plugins" table, which lists the `ttt-plugins` monorepo; ttt-vim is a separate repo.
- The docs state "requires ttt 1.1.0 or newer." Current tags top out at `v1.0.1`, so this should land with or after the 1.1.0 release, not ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WG4WkHnWZZi5hEPSnrZpfj
