### PR TITLE
feat: add j/k/h/l navigation to tree widgets

### DIFF
--- a/internal/app/commands_help.go
+++ b/internal/app/commands_help.go
@@ -13,14 +13,16 @@ var explorerHelpEntries = []widgets.KeyValueEntry{
 	{Key: "Space", Value: "Open file or toggle folder"},
 	{Key: "Shift+Enter", Value: "Open context menu"},
 	{Key: "Menu*", Value: "Open context menu (terminal-dependent)"},
-	{Key: "Left", Value: "Collapse folder"},
-	{Key: "Right", Value: "Expand folder"},
-	{Key: "Up / Down", Value: "Navigate items"},
+	{Key: "Up / k", Value: "Move up"},
+	{Key: "Down / j", Value: "Move down"},
+	{Key: "Left / h", Value: "Collapse folder"},
+	{Key: "Right / l", Value: "Expand folder"},
 }
 
 var searchHelpEntries = []widgets.KeyValueEntry{
 	{Key: "Enter", Value: "Activate selected result"},
-	{Key: "Up / Down", Value: "Navigate results"},
+	{Key: "Up / k", Value: "Move up"},
+	{Key: "Down / j", Value: "Move down"},
 	{Key: "Tab", Value: "Next input field"},
 	{Key: "Shift+Tab", Value: "Previous input field"},
 	{Key: "Alt+c", Value: "Toggle case sensitivity"},
@@ -38,7 +40,8 @@ var changesHelpEntries = []widgets.KeyValueEntry{
 	{Key: "c", Value: "Open compact diff"},
 	{Key: "e", Value: "Open extended diff"},
 	{Key: "Enter", Value: "Open compact diff"},
-	{Key: "Up / Down", Value: "Navigate files"},
+	{Key: "Up / k", Value: "Move up"},
+	{Key: "Down / j", Value: "Move down"},
 }
 
 func (a *App) ShowPanelHelp(title string, entries []widgets.KeyValueEntry, description ...string) {

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -230,7 +230,8 @@ func (a *App) ShowKeybindings() {
 			{Key: "Enter", Value: "Edit selected shortcut"},
 			{Key: "Backspace", Value: "Reset to default"},
 			{Key: "Delete", Value: "Clear shortcut"},
-			{Key: "Up/Down", Value: "Navigate list"},
+			{Key: "Up / k", Value: "Move up"},
+			{Key: "Down / j", Value: "Move down"},
 			{Key: "Esc", Value: "Close"},
 		})
 		dialog := widgets.NewDialogWidget(50)

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -607,6 +607,24 @@ func (t *TreeWidget) handleKey(ev *tcell.EventKey) EventResult {
 		if t.Config.OnKey != nil && t.Config.OnKey(ev, t.Selected()) {
 			return EventConsumed
 		}
+		switch ev.Rune() {
+		case 'j':
+			if t.selected < len(t.flatList)-1 {
+				t.selected++
+			}
+			return EventConsumed
+		case 'k':
+			if t.selected > 0 {
+				t.selected--
+			}
+			return EventConsumed
+		case 'l':
+			t.expandOrChild()
+			return EventConsumed
+		case 'h':
+			t.collapseOrParent()
+			return EventConsumed
+		}
 		if ev.Rune() == ' ' {
 			t.ActivateSelected()
 			return EventConsumed

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -361,6 +361,35 @@ func TestTreeKeyUpDown(t *testing.T) {
 	}
 }
 
+func TestTreeJKHL(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{
+			{ID: "a", Label: "A", Expandable: true, Children: []*TreeNode{
+				{ID: "a1", Label: "A1"},
+			}},
+			{ID: "b", Label: "B"},
+		},
+	})
+	renderWidget(tree, 0, 0, 20, 10)
+
+	pressRune(tree, 'j')
+	if tree.SelectedIndex() != 1 {
+		t.Errorf("j should move down to 1, got %d", tree.SelectedIndex())
+	}
+	pressRune(tree, 'k')
+	if tree.SelectedIndex() != 0 {
+		t.Errorf("k should move up to 0, got %d", tree.SelectedIndex())
+	}
+	pressRune(tree, 'l')
+	if !tree.flatList[0].Expanded {
+		t.Error("l should expand node A")
+	}
+	pressRune(tree, 'h')
+	if tree.flatList[0].Expanded {
+		t.Error("h should collapse node A")
+	}
+}
+
 func TestTreeKeyLeftCollapse(t *testing.T) {
 	tree := NewTreeWidget(TreeConfig{
 		Items: []*TreeNode{


### PR DESCRIPTION
## Summary
- Tree widgets now support `j`/`k` for up/down and `h`/`l` for collapse/expand, alongside arrow keys
- Help dialogs (explorer, search, changes, keybindings) updated to show both arrow keys and hjkl alternatives as separate entries
- Unit test added for j/k/h/l tree navigation

## Test plan
- [x] Unit test `TestTreeJKHL` verifies j moves down, k moves up, l expands, h collapses
- [x] All existing tests pass (`make test`)
- [ ] Manual: open explorer, use j/k to navigate and h/l to collapse/expand folders
- [ ] Manual: open help dialogs to verify updated key listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qec4jq5DadwW68aJD5qTa