### PR TITLE
feat(plugin): add editor.set_search / editor.clear_search API

### DIFF
--- a/internal/app/plugin_api.go
+++ b/internal/app/plugin_api.go
@@ -298,6 +298,23 @@ func (e *PluginEditorAPI) ClearCursors() {
 	e.eg.CollapseMultiCursor()
 }
 
+func (e *PluginEditorAPI) SetSearch(pattern string, useRegex bool) {
+	if !e.eg.IsEditorActive() {
+		return
+	}
+	buf := e.eg.ActiveBuffer()
+	if buf == nil {
+		return
+	}
+	opts := ui.SearchOptions{UseRegex: useRegex, CaseSensitive: true}
+	matches, _ := ui.FindInLines(buf.Lines, pattern, opts)
+	e.eg.SetSearch(pattern, matches)
+}
+
+func (e *PluginEditorAPI) ClearSearch() {
+	e.eg.ClearSearch()
+}
+
 // PluginFilesystemAPI implements plugin.FilesystemAPI with path restrictions.
 type PluginFilesystemAPI struct {
 	allowedRoots []string

--- a/internal/plugin/api.go
+++ b/internal/plugin/api.go
@@ -55,6 +55,9 @@ type EditorAPI interface {
 	AddCursor(line, col int)
 	GetCursors() []CursorPosition
 	ClearCursors()
+
+	SetSearch(pattern string, useRegex bool)
+	ClearSearch()
 }
 
 type CursorPosition struct {

--- a/internal/plugin/lua_editor.go
+++ b/internal/plugin/lua_editor.go
@@ -43,6 +43,8 @@ func setupEditorModule(L *lua.LState, p *Plugin) {
 			L.SetField(mod, "end_undo_group", L.NewFunction(editorEndUndoGroup(p)))
 			L.SetField(mod, "add_cursor", L.NewFunction(editorAddCursor(p)))
 			L.SetField(mod, "clear_cursors", L.NewFunction(editorClearCursors(p)))
+			L.SetField(mod, "set_search", L.NewFunction(editorSetSearch(p)))
+			L.SetField(mod, "clear_search", L.NewFunction(editorClearSearch(p)))
 		}
 
 		L.Push(mod)
@@ -515,6 +517,31 @@ func editorClearCursors(p *Plugin) lua.LGFunction {
 			return 0
 		}
 		p.Editor.ClearCursors()
+		return 0
+	}
+}
+
+func editorSetSearch(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		pattern := L.CheckString(1)
+		useRegex := false
+		if L.GetTop() >= 2 {
+			useRegex = L.OptBool(2, false)
+		}
+		p.Editor.SetSearch(pattern, useRegex)
+		return 0
+	}
+}
+
+func editorClearSearch(p *Plugin) lua.LGFunction {
+	return func(L *lua.LState) int {
+		if p.Editor == nil {
+			return 0
+		}
+		p.Editor.ClearSearch()
 		return 0
 	}
 }

--- a/internal/plugin/lua_editor_test.go
+++ b/internal/plugin/lua_editor_test.go
@@ -40,6 +40,10 @@ type mockEditorAPI struct {
 
 	selCleared   bool
 	extraCursors []CursorPosition
+
+	searchPattern string
+	searchRegex   bool
+	searchCleared bool
 }
 
 func (m *mockEditorAPI) BufferText() string { return m.bufText }
@@ -111,6 +115,13 @@ func (m *mockEditorAPI) GetCursors() []CursorPosition {
 }
 func (m *mockEditorAPI) ClearCursors() {
 	m.extraCursors = nil
+}
+func (m *mockEditorAPI) SetSearch(pattern string, useRegex bool) {
+	m.searchPattern = pattern
+	m.searchRegex = useRegex
+}
+func (m *mockEditorAPI) ClearSearch() {
+	m.searchCleared = true
 }
 
 func setupTestPluginWithEditor(perms PermissionSet, editor *mockEditorAPI) (*Plugin, func()) {
@@ -318,5 +329,62 @@ func TestEditorSelection(t *testing.T) {
 	}
 	if p.State.GetGlobal("text").String() != "selected text" {
 		t.Errorf("expected 'selected text', got %q", p.State.GetGlobal("text").String())
+	}
+}
+
+func TestEditorSetSearch(t *testing.T) {
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorWrite: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.set_search("hello")
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.searchPattern != "hello" {
+		t.Errorf("expected pattern 'hello', got %q", mock.searchPattern)
+	}
+	if mock.searchRegex {
+		t.Error("expected useRegex false")
+	}
+}
+
+func TestEditorSetSearchRegex(t *testing.T) {
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorWrite: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.set_search("\\bfoo\\b", true)
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if mock.searchPattern != `\bfoo\b` {
+		t.Errorf("expected pattern '\\bfoo\\b', got %q", mock.searchPattern)
+	}
+	if !mock.searchRegex {
+		t.Error("expected useRegex true")
+	}
+}
+
+func TestEditorClearSearch(t *testing.T) {
+	mock := &mockEditorAPI{}
+	p, cleanup := setupTestPluginWithEditor(PermissionSet{EditorWrite: true}, mock)
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local editor = require("ttt.editor")
+		editor.clear_search()
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !mock.searchCleared {
+		t.Error("expected ClearSearch to be called")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `editor.set_search(pattern, use_regex)` to highlight all matches of a pattern in the active editor
- Adds `editor.clear_search()` to remove search highlights
- Gated on `editor.write` permission
- Enables plugins (e.g. ttt-vim) to implement Vim-style `hlsearch`

## Test plan
- [x] Unit tests for `set_search`, `set_search` with regex, and `clear_search`
- [x] All existing tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qec4jq5DadwW68aJD5qTa