### PR TITLE
feat(explorer): add "Reveal in File Manager"

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -534,6 +534,8 @@ func registerWidgetCallbacks(app *App) {
 			{Label: "Copy Absolute Path", Command: "explorer.copyAbsolutePath"},
 			{Label: "Copy Relative Path", Command: "explorer.copyRelativePath"},
 			ui.MenuSep(),
+			{Label: "Reveal in File Manager", Command: "explorer.reveal"},
+			ui.MenuSep(),
 			{Label: "Rename", Command: "explorer.rename"},
 			{Label: "Delete", Command: "explorer.delete"},
 		}

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -61,6 +61,12 @@ func (a *App) ExplorerCopyRelativePath() {
 	a.FileOpCopyRelativePath(path)
 }
 
+func (a *App) ExplorerReveal() {
+	path := a.explorerNodePath()
+	a.ExplorerContextNode = nil
+	a.FileOpReveal(path)
+}
+
 func (a *App) ExplorerRemoveRoot() {
 	path := a.explorerNodePath()
 	a.ExplorerContextNode = nil
@@ -155,6 +161,12 @@ func registerExplorerCommands(app *App) {
 		ID: "file.copyRelativePath", Title: "File: Copy Relative Path",
 		Keywords: []string{"file", "path", "copy", "clipboard", "relative"},
 		Handler:  app.CopyRelativePath,
+	})
+
+	reg.Register(command.Command{
+		ID: "explorer.reveal", Title: "Explorer: Reveal in File Manager",
+		Keywords: []string{"explorer", "file", "reveal", "manager", "folder", "finder", "open"},
+		Handler:  app.ExplorerReveal,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/fileops.go
+++ b/internal/app/fileops.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
 )
@@ -107,6 +109,51 @@ func (a *App) FileOpCopyAbsolutePath(path string) {
 	}
 	clipboard.Set(path)
 	a.StatusNotify("Absolute path copied to clipboard")
+}
+
+func (a *App) FileOpReveal(path string) {
+	if path == "" {
+		a.StatusWarn("No file selected")
+		return
+	}
+	if err := revealInFileManager(path); err != nil {
+		a.StatusError("Could not reveal in file manager")
+		return
+	}
+	a.StatusNotify("Revealed in file manager")
+}
+
+// revealInFileManager opens the OS file manager showing path, highlighting the
+// item where the platform supports it. On Linux it falls back to opening the
+// containing folder (no highlight) when the FileManager1 D-Bus service is
+// unavailable.
+func revealInFileManager(path string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", "-R", path).Start()
+	case "windows":
+		return exec.Command("explorer", "/select,"+path).Start()
+	default:
+		uri := "file://" + path
+		dbus := exec.Command("dbus-send", "--session",
+			"--dest=org.freedesktop.FileManager1", "--type=method_call",
+			"/org/freedesktop/FileManager1",
+			"org.freedesktop.FileManager1.ShowItems",
+			"array:string:"+uri, "string:")
+		if err := dbus.Run(); err == nil {
+			return nil
+		}
+		return exec.Command("xdg-open", containingFolder(path)).Start()
+	}
+}
+
+// containingFolder returns the folder to open for a fallback reveal: the path
+// itself if it is a directory, otherwise its parent directory.
+func containingFolder(path string) string {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return path
+	}
+	return filepath.Dir(path)
 }
 
 func (a *App) FileOpCopyRelativePath(path string) {

--- a/internal/app/fileops_test.go
+++ b/internal/app/fileops_test.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestContainingFolder(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "note.txt")
+	if err := os.WriteFile(file, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := containingFolder(file); got != dir {
+		t.Errorf("file: got %q, want %q", got, dir)
+	}
+	if got := containingFolder(dir); got != dir {
+		t.Errorf("dir: got %q, want %q", got, dir)
+	}
+
+	// Non-existent path falls back to filepath.Dir.
+	missing := filepath.Join(dir, "sub", "gone.txt")
+	if got := containingFolder(missing); got != filepath.Dir(missing) {
+		t.Errorf("missing: got %q, want %q", got, filepath.Dir(missing))
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **"Reveal in File Manager"** entry to the file explorer's right-click context menu (and command palette), resolving #412.

Right-clicking a file/folder now offers an option that opens the OS file manager showing that item — matching what most IDEs provide.

## Behavior

| OS | Command | Highlights the item? |
|---|---|---|
| macOS | `open -R <path>` | ✅ yes |
| Windows | `explorer /select,<path>` | ✅ yes |
| Linux | `FileManager1.ShowItems` via D-Bus | ✅ yes (Nautilus, Dolphin, Nemo, …) |
| Linux (fallback) | `xdg-open <containing-folder>` | ❌ opens the folder, no highlight |

The Linux fallback opens the containing folder when the FileManager1 D-Bus service isn't available — good enough per the issue discussion.

## Implementation

- `revealInFileManager(path)` + `containingFolder(path)` helpers and `FileOpReveal` in `internal/app/fileops.go`
- `ExplorerReveal` handler + `explorer.reveal` command registration in `internal/app/commands_explorer.go`
- Menu entry wired in the explorer `OnRightClick` context menu (`internal/app/callbacks.go`)

## Tests

- Unit test for `containingFolder` (file / directory / missing-path cases). The shell-out itself isn't tested since running it would launch a real file manager.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WG4WkHnWZZi5hEPSnrZpfj