### PR TITLE
Fix panic in Copy on non-editor tabs (chaos monkey, #414)

### DIFF
--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1296,6 +1296,10 @@ func (g *EditorGroupWidget) Copy() {
 		}
 		return
 	}
+	if t.Content != nil {
+		// Non-editor tab (settings UI, plugin panel, ...): no buffer to copy from.
+		return
+	}
 	if t.Sel == nil || !t.Sel.Active {
 		// No selection: copy the whole current line, including a trailing
 		// newline so a paste inserts it as a full line.

--- a/tests/e2e/content_tab_commands_test.go
+++ b/tests/e2e/content_tab_commands_test.go
@@ -1,0 +1,53 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+// Regression test for issue #414: pressing Ctrl+C (editor.copy) while a
+// non-editor content tab (the Settings UI) was active panicked with a nil
+// dereference, because such tabs have no cursor/buffer/selection.
+func TestCopyOnSettingsTabDoesNotPanic(t *testing.T) {
+	h := openSettings(t)
+
+	h.pressKey(tcell.KeyCtrlC, tcell.ModCtrl)
+
+	// The app must still be responsive and the settings tab still rendered.
+	if screen := h.screenText(); !strings.Contains(screen, "Settings") {
+		t.Errorf("settings view no longer rendered after ctrl+c:\n%s", screen)
+	}
+}
+
+// Sibling editor commands routed through global keybindings or the palette
+// must be safe no-ops while a content tab (settings) is active.
+func TestEditorCommandsOnSettingsTabAreSafeNoOps(t *testing.T) {
+	h := openSettings(t)
+
+	for _, cmd := range []string{
+		"editor.copy", "editor.cut", "editor.paste", "editor.selectAll",
+		"editor.undo", "editor.redo",
+		"editor.moveLineUp", "editor.moveLineDown", "editor.duplicateLine",
+		"editor.deleteLine", "editor.joinLines",
+		"editor.insertLineBelow", "editor.insertLineAbove",
+		"editor.toggleComment",
+		"editor.sortLinesAsc", "editor.sortLinesDesc",
+		"editor.reverseLines", "editor.uniqueLines",
+		"editor.upperCase", "editor.lowerCase", "editor.titleCase",
+		"editor.goToMatchingBracket",
+		"multicursor.selectNext", "multicursor.selectAll", "multicursor.undoCursor",
+		"editor.splitSelectionToLines",
+		"editor.moveWordLeft", "editor.moveWordRight",
+		"editor.deleteWordLeft", "editor.deleteWordRight",
+		"fold.toggle", "fold.collapseAll", "fold.expandAll",
+		"diff.nextHunk", "diff.prevHunk",
+	} {
+		h.exec(cmd)
+	}
+
+	if screen := h.screenText(); !strings.Contains(screen, "Settings") {
+		t.Errorf("settings view no longer rendered after editor commands:\n%s", h.screenText())
+	}
+}

--- a/tests/functional/settings-ui.test.js
+++ b/tests/functional/settings-ui.test.js
@@ -111,6 +111,30 @@ describe("settings editor", () => {
     expect(tabBar.match(/Settings x/g)).toHaveLength(1);
   });
 
+  // Regression for issue #414: Ctrl+C (editor.copy) while the settings tab was
+  // active crashed with a nil dereference — settings tabs have no buffer,
+  // cursor, or selection. The copy must be a safe no-op and the app must keep
+  // rendering the settings UI.
+  it("survives editor clipboard keys while the settings tab is active", () => {
+    openEditor();
+
+    tui.exec("Settings: Open Editor Settings");
+    tui.waitStable();
+    tui.press("ctrl+c");
+    tui.press("ctrl+x");
+    tui.press("ctrl+v");
+    tui.press("ctrl+a");
+    tui.waitStable();
+    const s0 = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    // A crash would leave an empty/errored snapshot; the settings UI must
+    // still be on screen and intact.
+    expect(snapshots[s0]).toContain("Settings");
+    expect(snapshots[s0]).toContain("Word wrap");
+    expect(snapshots[s0]).toContain("Apply");
+  });
+
   it("still offers the raw JSON path", () => {
     openEditor();
 


### PR DESCRIPTION
Closes #414. Stacked on #415 (tcell v3 migration) — merge that first.

## Fix

`EditorGroupWidget.Copy()` special-cased DiffView tabs but fell through for every other widget tab (settings UI, plugin panels), dereferencing the nil cursor/buffer when the global Ctrl+C binding fired. Now guards with `t.Content != nil`, matching `Cut()`'s existing style (`Paste()` already guards via `IsEditorActive()`).

## Audit

Swept `editor_group.go` and all app-level command handlers for the same pattern: every other `t.Cur`/`t.Buf`/`t.Sel` deref is already guarded, and the `g.Editor` pane fields are never nil by construction. Empirically probed ~55 palette commands (clipboard, line ops, transforms, multicursor, folds, hunks, save, LSP) against the settings tab via `--exec` — no other crash paths. Two behavioral warts noted for follow-up issues, not fixed here: `file.save` on a settings tab opens a Save As dialog, and some panel-driven commands operate on the previously active editor's buffer while a widget tab is shown.

## Tests

- E2E: `TestCopyOnSettingsTabDoesNotPanic` (verified to panic with the guard reverted) and a 35-command sweep `TestEditorCommandsOnSettingsTabAreSafeNoOps` (`tests/e2e/content_tab_commands_test.go`)
- Functional: real-binary test pressing ctrl+c/x/v/a on the settings tab (`tests/functional/settings-ui.test.js`)
- Chaos in Docker: the exact 1000-seed sweep that crashed 14/1000 iterations on the parent branch now passes clean (500k events, no panics, base seed `1784763281967644816`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HooAN2Adh4ALuX8H4rBWS5