### PR TITLE
Rename Review PR to Open PR Diff and add it to the Changes panel menu

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -50,6 +50,8 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			{Label: "Push", Command: "git.push"},
 			{Label: "Sync", Command: "git.sync"},
 			ui.MenuSep(),
+			{Label: "Open PR Diff", Command: "pr.openDiff"},
+			ui.MenuSep(),
 			{Label: "Help", Command: "changes.help"},
 		}
 	case "outline":

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -142,7 +142,7 @@ func (a *App) OpenPullRequestDialog() {
 		a.StatusError("GitHub CLI (gh) is required. Install from https://cli.github.com/")
 		return
 	}
-	a.ShowInputDialogEx("Review PR", "https://github.com/owner/repo/pull/123", "", "Review", func(url string) {
+	a.ShowInputDialogEx("Open PR Diff", "https://github.com/owner/repo/pull/123", "", "Open", func(url string) {
 		a.FetchAndOpenPR(url)
 	})
 }
@@ -367,7 +367,7 @@ func registerPRCommands(app *App) {
 	reg := app.Reg
 
 	reg.Register(command.Command{
-		ID: "pr.review", Title: "Git: Review PR",
+		ID: "pr.openDiff", Title: "Git: Open PR Diff",
 		Keywords: []string{"git", "pull request", "github"},
 		Handler:  app.OpenPullRequestDialog,
 	})

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -27,7 +27,7 @@ var menuBarMenus = [][]ui.ContextMenuItem{
 		{Label: "Open Workspace", Command: "workspace.open"},
 		{Label: "Save Workspace", Command: "workspace.save"},
 		ui.MenuSep(),
-		{Label: "Review PR", Command: "pr.review"},
+		{Label: "Open PR Diff", Command: "pr.openDiff"},
 		ui.MenuSep(),
 		{Label: "Quit", Command: "editor.quit"},
 	},


### PR DESCRIPTION
The `pr.review` command downloads and displays a PR's diff. "Review PR" implied a review workflow (comments, approvals) that doesn't exist, and "Open PR" read like creating one — putting "Diff" in the name removes the ambiguity.

- Renamed everywhere users see it: File menu entry, palette title (`Git: Open PR Diff`), input dialog title and button
- Renamed the command ID `pr.review` → `pr.openDiff` (matches `domain.verbNoun`; no default keybinding, docs, or tests referenced the old ID — only risk is user configs, worth a release-note line)
- Added `Open PR Diff` to the Changes sidebar panel ⋮ menu (between Sync and Help) — the contextual home for Git actions; deliberately not added to the per-repo group menu, whose commands are all repo-scoped while this one is global
- File menu entry kept (renamed): it does open a diff view, and the name no longer suggests scope confusion

If real review actions (comments/approve) ever land, the `pr.review` name is now free for them.

Verified with `--exec` screenshots (palette command opens the retitled dialog; panel menu shows the new entry) and the e2e suite.
