### PR TITLE
feat(plugin): expose checkbox widget to the Lua plugin API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ Lua plugins render UI in sidebar panels, bottom-panel tabs, drawers, and editor 
 | `p:tree({...})` | `items`, `indent` (default 2), `on_select`, `on_expand`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Expandable tree view. Items are `{id, label, icon, badge, muted, expandable, expanded, children}` tables. `key_commands` maps single chars to commands via `on_command`. `truncate_left` truncates overflowing labels from the left (`…tail`) so the end stays visible. |
 | `p:list({...})` | `items`, `on_select`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Flat list (backed by TreeWidget, no indentation). `truncate_left` keeps label tails visible on overflow. |
 | `p:button({...})` | `label`, `on_click` | Clickable button. Label is immutable after creation (accelerator parsing). |
+| `p:checkbox({...})` | `label`, `checked`, `style`, `on_change(checked)` | Boolean toggle. Renders `[x]`/`[ ]` with focus styling on brackets. Supports box model. |
 | `p:input({...})` | `placeholder`, `prefix`, `clear_on_submit`, `on_change(text)`, `on_submit(text)` | Text input field. `clear_on_submit` (bool) clears text after submit. |
 | `p:vstack({...})` | `render(child_panel)`, `gap` | Vertical stack container. The `render` function receives a child panel proxy to emit nested widgets. |
 | `p:keyvalue({{key,value}, ...})` | array of `{key, value}` tables | Key-value list. The argument table IS the entries array (not an `entries` field); box model fields go on the same table. |

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -824,6 +824,30 @@ panel:button({
 | `label`    | string   | yes      | Button text. Use `&` for an accelerator: `"&Save"` underlines S. |
 | `on_click` | function | no       | Callback when the button is pressed.           |
 
+### Checkbox
+
+Boolean toggle that renders `[x]` / `[ ]` with focus styling on the brackets. Responds to Enter, Space, and mouse click.
+
+```lua
+panel:checkbox({
+  label = "Word wrap",
+  checked = true,
+  style = "muted",
+  on_change = function(checked)
+    -- called with the new boolean value
+  end,
+})
+```
+
+**Checkbox config fields:**
+
+| Field       | Type     | Default | Description                                    |
+|-------------|----------|---------|------------------------------------------------|
+| `label`     | string   | `""`    | Text displayed next to the checkbox.           |
+| `checked`   | boolean  | `false` | Whether the checkbox is checked.               |
+| `style`     | string   | default | Named style (e.g. `"muted"`, `"bold"`).        |
+| `on_change` | function | nil     | Called when toggled. Receives the new checked state (boolean). |
+
 ### Input
 
 Single-line text input with placeholder text and optional prefix.
@@ -1318,7 +1342,7 @@ The widget system uses a **reconciliation** algorithm to preserve interactive st
 
 The plugin panel manages its own focus system. When the plugin panel is focused:
 
-- **Tab** / **Shift+Tab** cycles focus between focusable widgets (trees, lists, tables, inputs, buttons, dropdowns).
+- **Tab** / **Shift+Tab** cycles focus between focusable widgets (trees, lists, tables, inputs, buttons, checkboxes, dropdowns).
 - **Arrow keys** navigate within the focused widget (e.g., up/down in a tree).
 - **Enter** / **Space** activate the focused widget (select tree node, press button, submit input).
 - **Shift+Enter** opens the context menu on the selected tree/list node (if `node_menu` is defined).

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -26,6 +26,15 @@ func (pp *PanelProxy) wrapSimpleCallback(fn *lua.LFunction) func() {
 	}
 }
 
+func (pp *PanelProxy) wrapBoolCallback(fn *lua.LFunction) func(bool) {
+	p := pp.plugin
+	return func(b bool) {
+		if p.State != nil {
+			p.CallLuaFunc(fn, lua.LBool(b))
+		}
+	}
+}
+
 func (pp *PanelProxy) wrapStringCallback(fn *lua.LFunction) func(string) {
 	p := pp.plugin
 	return func(s string) {
@@ -98,6 +107,7 @@ func RegisterPanelType(L *lua.LState) {
 		"divider":    panelDividerWidget,
 		"progress":   panelProgressWidget,
 		"table":      panelTableWidget,
+		"checkbox":   panelCheckboxWidget,
 		"redraw":     panelRedraw,
 		"markdown":   panelMarkdownWidget,
 	}))
@@ -413,6 +423,33 @@ func panelButtonWidget(L *lua.LState) int {
 
 	parseBoxModel(L, tbl, &desc)
 	proxy.appendDesc(WidgetButton, desc)
+	return 0
+}
+
+func panelCheckboxWidget(L *lua.LState) int {
+	proxy := checkPanelProxy(L)
+	if proxy == nil {
+		return 0
+	}
+
+	tbl := L.CheckTable(2)
+	desc := WidgetDesc{}
+
+	if v := L.GetField(tbl, "label"); v != lua.LNil {
+		desc.Label = v.String()
+	}
+	if v := L.GetField(tbl, "checked"); v != lua.LNil {
+		desc.Checked = lua.LVAsBool(v)
+	}
+	if v := L.GetField(tbl, "style"); v != lua.LNil {
+		desc.StyleName = v.String()
+	}
+	if fn, ok := L.GetField(tbl, "on_change").(*lua.LFunction); ok {
+		desc.OnChangeBool = proxy.wrapBoolCallback(fn)
+	}
+
+	parseBoxModel(L, tbl, &desc)
+	proxy.appendDesc(WidgetCheckbox, desc)
 	return 0
 }
 

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -81,6 +81,8 @@ func createWidget(desc WidgetDesc, p *Plugin) widgets.Widget {
 		return createTableWidget(desc, p)
 	case WidgetMarkdown:
 		return createMarkdownWidget(desc, p)
+	case WidgetCheckbox:
+		return createCheckboxWidget(desc, p)
 	}
 	return widgets.NewLabelWidget(widgets.LabelConfig{Text: "unknown widget"})
 }
@@ -207,6 +209,16 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 				md.SetContent(desc.MarkdownContent)
 			}
 		}
+	case WidgetCheckbox:
+		if cw, ok := w.(*widgets.CheckboxWidget); ok {
+			cw.Config.Label = desc.Label
+			cw.Config.Checked = desc.Checked
+			wireCheckboxCallback(cw, desc, p)
+			if desc.StyleName != "" {
+				cw.Config.Style = resolveStyleName(desc.StyleName)
+			}
+			applyBoxModel(&cw.Box, desc)
+		}
 	}
 }
 
@@ -256,6 +268,9 @@ func widgetMatchesKind(w widgets.Widget, kind WidgetKind) bool {
 		return ok
 	case WidgetMarkdown:
 		_, ok := w.(*widgets.ScrollViewWidget)
+		return ok
+	case WidgetCheckbox:
+		_, ok := w.(*widgets.CheckboxWidget)
 		return ok
 	}
 	return false
@@ -505,6 +520,25 @@ func createButtonWidget(desc WidgetDesc, p *Plugin) *widgets.ButtonWidget {
 func wireButtonCallback(bw *widgets.ButtonWidget, desc WidgetDesc, _ *Plugin) {
 	if desc.OnClick != nil {
 		bw.Config.OnClick = desc.OnClick
+	}
+}
+
+func createCheckboxWidget(desc WidgetDesc, p *Plugin) *widgets.CheckboxWidget {
+	cw := widgets.NewCheckboxWidget(widgets.CheckboxConfig{
+		Label:   desc.Label,
+		Checked: desc.Checked,
+	})
+	if desc.StyleName != "" {
+		cw.Config.Style = resolveStyleName(desc.StyleName)
+	}
+	wireCheckboxCallback(cw, desc, p)
+	applyBoxModel(&cw.Box, desc)
+	return cw
+}
+
+func wireCheckboxCallback(cw *widgets.CheckboxWidget, desc WidgetDesc, _ *Plugin) {
+	if desc.OnChangeBool != nil {
+		cw.Config.OnChange = desc.OnChangeBool
 	}
 }
 

--- a/internal/plugin/widget_desc.go
+++ b/internal/plugin/widget_desc.go
@@ -23,6 +23,7 @@ const (
 	WidgetProgress
 	WidgetTable
 	WidgetMarkdown
+	WidgetCheckbox
 )
 
 func (k WidgetKind) String() string {
@@ -59,6 +60,8 @@ func (k WidgetKind) String() string {
 		return "table"
 	case WidgetMarkdown:
 		return "markdown"
+	case WidgetCheckbox:
+		return "checkbox"
 	}
 	return "unknown"
 }
@@ -92,8 +95,10 @@ type WidgetDesc struct {
 	NodeMenu      []widgets.MenuEntry
 	KeyCommands   map[rune]string
 
-	Label   string
-	OnClick func()
+	Label        string
+	OnClick      func()
+	Checked      bool
+	OnChangeBool func(bool)
 
 	Placeholder   string
 	Prefix        string


### PR DESCRIPTION
## Summary
- Expose the existing `CheckboxWidget` to the Lua plugin API as `p:checkbox({ label, checked, style, on_change })`
- Add `wrapBoolCallback` helper, `WidgetCheckbox` enum, create/update/match wiring in the widget builder
- Update CLAUDE.md widget table and plugin authoring guide in docs-web

Closes #387

## Test plan
- [ ] Build passes (`make build`)
- [ ] All tests pass (`make test`)
- [ ] Create a test plugin using `p:checkbox` and verify it renders, toggles, and fires `on_change`
- [ ] Verify checkbox reconciliation (checked state updates on re-render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)