### PR TITLE
feat: list ttt-emacs in the community plugin registry

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -108,6 +108,15 @@
     "tags": ["vim", "keybindings", "modal", "editor"]
   },
   {
+    "name": "emacs",
+    "displayName": "Emacs Mode",
+    "author": "eugenioenko",
+    "description": "Emacs compatibility layer: prefix keymaps, kill ring, mark and region, incremental search, universal argument and keyboard macros",
+    "repo": "https://github.com/eugenioenko/ttt-emacs",
+    "version": "0.1.0",
+    "tags": ["emacs", "keybindings", "editor"]
+  },
+  {
     "name": "formatter-gofmt",
     "displayName": "gofmt Formatter",
     "author": "eugenioenko",


### PR DESCRIPTION
Adds [ttt-emacs](https://github.com/eugenioenko/ttt-emacs) to `community-plugins.json`, so it appears in the Plugins sidebar browser alongside Vim Mode.

An Emacs compatibility layer as a single-file Lua plugin: prefix keymaps (`C-x`, `C-x r`, `C-h`), the mark and region, the kill ring with `M-y` yank-pop, incremental search, the universal argument and keyboard macros.

Behaviour is pinned against **real GNU Emacs** in `fundamental-mode` by a differential fuzzer that drives `emacs -Q --batch` headlessly and compares buffer text, point *and* mark — a stronger check than the Vim fuzzer, which can only compare the saved file and is structurally blind to cursor position.

Entry follows the standalone-repo shape used by the `vim` entry (no `path` field). JSON validated; the diff is the 9 added lines only.
