### PR TITLE
feat(plugin): add on_key to the command line

### DIFF
--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -362,6 +362,29 @@ Open the command line and move focus to it. If one is already open, it is replac
 | `on_change` | function | Called with the full text after every edit. Use for incremental search. |
 | `on_submit` | function | Called with the full text when Enter is pressed. The command line closes first. |
 | `on_cancel` | function | Called when Escape is pressed. The command line closes first.      |
+| `on_key`    | function | Called with a key event **before** the input handles it. Return `true` to consume the key, `false` to let it through. |
+
+##### `on_key`: driving the prompt yourself
+
+`on_change` and `on_submit` are enough for a "type a string, press Enter" prompt. They are not enough when the *keys themselves* are the interface — an Emacs-style incremental search binds `Ctrl+S` to "next match", `Ctrl+G` to "abort back to where I started", and Backspace to "undo the last search step, not the last character". None of those are recoverable from watching the text change.
+
+`on_key` receives the same event table as a [`key.press`](#keypress) listener — `{ type, key, rune, mod }` — so whatever key-normalisation a plugin already has works unchanged in both places. It sees **every** key including Enter and Escape, so it can preempt `on_submit` and `on_cancel`.
+
+```lua
+ttt.command_line.show({
+  prefix = "I-search: ",
+  on_key = function(ev)
+    if ev.key == "Ctrl-S" then
+      next_match()
+      return true            -- consumed; the input never sees it
+    end
+    return false             -- fall through to normal editing
+  end,
+  on_change = function(text) search(text) end,
+})
+```
+
+An `on_key` that raises an error declines the key rather than consuming it, so a broken hook cannot wedge the prompt with no way to type or cancel.
 
 ```lua
 local ttt = require("ttt")

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -389,10 +389,14 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	p.ExecCommand = func(id string) bool {
 		return a.Reg.Execute(id)
 	}
-	p.ShowCommandLine = func(prefix, text string, onChange, onSubmit func(string), onCancel func()) {
-		w := a.ShowCommandLine(prefix, onChange, onSubmit, onCancel)
-		if w != nil && text != "" {
-			w.SetText(text)
+	p.ShowCommandLine = func(opts plugin.CommandLineOptions) {
+		w := a.ShowCommandLine(opts.Prefix, opts.OnChange, opts.OnSubmit, opts.OnCancel)
+		if w == nil {
+			return
+		}
+		w.OnKey = opts.OnKey
+		if opts.Text != "" {
+			w.SetText(opts.Text)
 		}
 	}
 	p.HideCommandLine = func() {

--- a/internal/plugin/lua_commandline.go
+++ b/internal/plugin/lua_commandline.go
@@ -1,8 +1,24 @@
 package plugin
 
 import (
+	"github.com/gdamore/tcell/v3"
 	lua "github.com/yuin/gopher-lua"
 )
+
+// CommandLineOptions is what a plugin asked the command line to be. Grouped
+// rather than passed positionally because the set grows: on_key was added for
+// incremental search, and completion candidates are the obvious next one.
+type CommandLineOptions struct {
+	Prefix   string
+	Text     string
+	OnChange func(text string)
+	OnSubmit func(text string)
+	OnCancel func()
+
+	// OnKey is offered every key before the input handles it, so a plugin can
+	// drive the prompt live. Returning true consumes the key.
+	OnKey func(ev *tcell.EventKey) bool
+}
 
 // newCommandLineModule builds the `ttt.command_line` table.
 //
@@ -40,8 +56,38 @@ func newCommandLineModule(L *lua.LState, p *Plugin) *lua.LTable {
 			}
 		}
 
+		var onKey func(*tcell.EventKey) bool
+		if fn, ok := L.GetField(opts, "on_key").(*lua.LFunction); ok {
+			onKey = func(ev *tcell.EventKey) bool {
+				if p.State == nil {
+					return false
+				}
+				// Same event shape as the key.press listener, so a plugin's
+				// existing key normalisation works unchanged here.
+				err := p.State.CallByParam(lua.P{
+					Fn:      fn,
+					NRet:    1,
+					Protect: true,
+				}, keyEventToLua(p.State, ev))
+				if err != nil {
+					p.logError("command_line.on_key", err)
+					return false
+				}
+				ret := p.State.Get(-1)
+				p.State.Pop(1)
+				return lua.LVAsBool(ret)
+			}
+		}
+
 		if p.ShowCommandLine != nil {
-			p.ShowCommandLine(prefix, text, onChange, onSubmit, onCancel)
+			p.ShowCommandLine(CommandLineOptions{
+				Prefix:   prefix,
+				Text:     text,
+				OnChange: onChange,
+				OnSubmit: onSubmit,
+				OnCancel: onCancel,
+				OnKey:    onKey,
+			})
 		}
 		return 0
 	}))

--- a/internal/plugin/lua_commandline_test.go
+++ b/internal/plugin/lua_commandline_test.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"strings"
 	"testing"
+
+	"github.com/gdamore/tcell/v3"
 )
 
 type commandLineRecorder struct {
@@ -14,19 +16,21 @@ type commandLineRecorder struct {
 	onChange func(string)
 	onSubmit func(string)
 	onCancel func()
+	onKey    func(*tcell.EventKey) bool
 }
 
 func setupCommandLinePlugin(t *testing.T, perms PermissionSet) (*Plugin, *commandLineRecorder, func()) {
 	t.Helper()
 	p, cleanup := newTestPluginBase(perms)
 	rec := &commandLineRecorder{}
-	p.ShowCommandLine = func(prefix, text string, onChange, onSubmit func(string), onCancel func()) {
+	p.ShowCommandLine = func(opts CommandLineOptions) {
 		rec.shown = true
-		rec.prefix = prefix
-		rec.text = text
-		rec.onChange = onChange
-		rec.onSubmit = onSubmit
-		rec.onCancel = onCancel
+		rec.prefix = opts.Prefix
+		rec.text = opts.Text
+		rec.onChange = opts.OnChange
+		rec.onSubmit = opts.OnSubmit
+		rec.onCancel = opts.OnCancel
+		rec.onKey = opts.OnKey
 		rec.active = true
 	}
 	p.HideCommandLine = func() {
@@ -202,5 +206,72 @@ func TestCommandLinePermissionDenied(t *testing.T) {
 			t.Errorf("%s: host callback must not run without permission", snippet)
 		}
 		cleanup()
+	}
+}
+
+// on_key is what makes an incremental search possible: the plugin has to see
+// C-s, C-g and DEL as they arrive, not just the final text on submit.
+func TestCommandLineOnKeyConsumes(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		seen = {}
+		ttt.command_line.show({ on_key = function(ev)
+			seen[#seen + 1] = ev.key .. "/" .. tostring(ev.mod)
+			return ev.key == "Ctrl-S"
+		end })
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if rec.onKey == nil {
+		t.Fatal("expected on_key to be wired through")
+	}
+
+	if got := rec.onKey(tcell.NewEventKey(tcell.KeyCtrlS, "", tcell.ModCtrl)); !got {
+		t.Error("expected ctrl+s to be consumed")
+	}
+	if got := rec.onKey(tcell.NewEventKey(tcell.KeyRune, "a", tcell.ModNone)); got {
+		t.Error("expected a declined key to fall through")
+	}
+
+	// The event shape must match key.press so a plugin's key normalisation works
+	// unchanged in both places.
+	if err := p.State.DoString(`
+		assert(seen[1] == "Ctrl-S/ctrl", "got " .. tostring(seen[1]))
+		assert(seen[2] == "a/nil", "got " .. tostring(seen[2]))
+	`); err != nil {
+		t.Fatalf("event shape: %v", err)
+	}
+}
+
+func TestCommandLineOnKeyAbsentIsNil(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	if err := p.State.DoString(`require("ttt").command_line.show({})`); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if rec.onKey != nil {
+		t.Fatal("expected on_key to stay nil when not supplied")
+	}
+}
+
+func TestCommandLineOnKeyErrorDeclines(t *testing.T) {
+	p, rec, cleanup := setupCommandLinePlugin(t, PermissionSet{Keybindings: true})
+	defer cleanup()
+
+	err := p.State.DoString(`
+		require("ttt").command_line.show({ on_key = function() error("boom") end })
+	`)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	// A throwing hook must not consume the key, or a broken plugin would wedge
+	// the prompt with no way to type or cancel.
+	if rec.onKey(tcell.NewEventKey(tcell.KeyRune, "x", tcell.ModNone)) {
+		t.Error("expected a failing on_key to decline the key")
 	}
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -88,7 +88,7 @@ type Plugin struct {
 	PublishDiagnostics func(path string, items []DiagnosticItem)
 	ClearDiagnostics   func(path string)
 
-	ShowCommandLine    func(prefix, text string, onChange, onSubmit func(string), onCancel func())
+	ShowCommandLine    func(CommandLineOptions)
 	HideCommandLine    func()
 	SetCommandLineText func(text string)
 	CommandLineActive  func() bool

--- a/internal/ui/commandline_widget.go
+++ b/internal/ui/commandline_widget.go
@@ -29,6 +29,10 @@ type CommandLineWidget struct {
 	OnSubmit func(text string)
 	OnCancel func()
 
+	// OnKey, when set, is offered every key before the widget handles it.
+	// Returning true consumes the key.
+	OnKey func(ev *tcell.EventKey) bool
+
 	input *widgets.InputWidget
 
 	// Layout computed by Render and reused by event handlers, so clicks and the
@@ -125,6 +129,13 @@ func (c *CommandLineWidget) HandleEvent(ev tcell.Event) EventResult {
 }
 
 func (c *CommandLineWidget) handleKey(kev *tcell.EventKey) EventResult {
+	// OnKey sees every key first, including Enter and Escape, so a caller can
+	// drive the prompt itself -- an incremental search needs the keystrokes as
+	// they arrive, not just the final text. Declining falls through to the
+	// normal handling below.
+	if c.OnKey != nil && c.OnKey(kev) {
+		return EventConsumed
+	}
 	switch kev.Key() {
 	case tcell.KeyEnter:
 		// The overlay sits above Root's Escape handling, so submit/cancel are

--- a/internal/ui/commandline_widget_test.go
+++ b/internal/ui/commandline_widget_test.go
@@ -190,3 +190,62 @@ func TestCommandLineDefaultPrefix(t *testing.T) {
 		t.Fatalf("expected default prefix %q, got %q", ":", c.Prefix)
 	}
 }
+
+// OnKey must see Enter and Escape too. An incremental search binds RET to
+// "exit at the match" and C-g to "abort to origin", so a hook that only got
+// ordinary keys could not implement either.
+func TestCommandLineOnKeyPreemptsSubmitAndCancel(t *testing.T) {
+	w := NewCommandLineWidget("/")
+
+	submitted, cancelled := 0, 0
+	w.OnSubmit = func(string) { submitted++ }
+	w.OnCancel = func() { cancelled++ }
+
+	var seen []tcell.Key
+	w.OnKey = func(ev *tcell.EventKey) bool {
+		seen = append(seen, ev.Key())
+		return true
+	}
+
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEscape, "", tcell.ModNone))
+
+	if len(seen) != 2 {
+		t.Fatalf("expected OnKey to see both keys, got %d", len(seen))
+	}
+	if submitted != 0 || cancelled != 0 {
+		t.Fatalf("expected OnKey to preempt submit/cancel, got %d/%d", submitted, cancelled)
+	}
+}
+
+func TestCommandLineOnKeyDeclineFallsThrough(t *testing.T) {
+	w := NewCommandLineWidget("/")
+
+	submitted := 0
+	w.OnSubmit = func(string) { submitted++ }
+	w.OnKey = func(*tcell.EventKey) bool { return false }
+
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "a", tcell.ModNone))
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+
+	if submitted != 1 {
+		t.Fatalf("expected declined keys to fall through to normal handling, got %d submits", submitted)
+	}
+	if got := w.Text(); got != "a" {
+		t.Fatalf("expected the declined rune to reach the input, got %q", got)
+	}
+}
+
+func TestCommandLineWithoutOnKeyIsUnchanged(t *testing.T) {
+	w := NewCommandLineWidget("/")
+
+	submitted := 0
+	w.OnSubmit = func(string) { submitted++ }
+
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "x", tcell.ModNone))
+	w.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+
+	if submitted != 1 || w.Text() != "x" {
+		t.Fatalf("expected unchanged behaviour with no hook, got %d submits and %q", submitted, w.Text())
+	}
+}


### PR DESCRIPTION
## Problem

`ttt.command_line` gives plugins `on_change`, `on_submit` and `on_cancel`. That is enough for a *"type a string, press Enter"* prompt — which is exactly what Vim's `:` and `/` are, and why the current API has served ttt-vim fine.

It cannot express a prompt where the **keys themselves are the interface**. An Emacs incremental search binds:

- `Ctrl+S` → next match
- `Ctrl+R` → flip direction
- `Ctrl+G` → abort back to where the search started
- Backspace → undo the last *search step*, not the last character

None of those are recoverable from watching text change in `on_change`. Backspace is the clearest case: `C-s beta C-s DEL` returns to the *first* match of "beta" — it does not become a search for "bet".

The command line is a modal overlay, and `Root.handleOverlay` runs above the plugin key interceptor (there is an existing test pinning this, `TestKeyInterceptorNotCalledForOverlays`). So a plugin currently goes **completely silent** while it is open. That is deliberate and good for Vim — the widget comment says so — but it left ttt-emacs rendering its isearch prompt into the **status bar**, which is the wrong line: ttt's status bar is the equivalent of Emacs's *mode line*, not its *minibuffer*.

## Change

`on_key` is offered every key — including Enter and Escape — before the input handles it. Returning `true` consumes it; returning `false` falls through to existing behaviour.

The event table is the **same shape `key.press` delivers** (`{type, key, rune, mod}`), so a plugin's existing key normalisation works unchanged in both places rather than needing a second vocabulary.

A hook that raises **declines** the key rather than consuming it, so a broken plugin cannot wedge the prompt with no way to type or cancel.

`Plugin.ShowCommandLine` becomes an options struct instead of gaining a sixth positional parameter, since this set will grow — completion candidates are the obvious next addition, and would unblock a real `M-x`.

## Also unblocks

Three gaps documented in ttt-vim's own REFERENCE have this exact cause, and become implementable:

- Tab-completion of `:` commands
- `Ctrl+R` register insertion
- `Ctrl+N` command history

It would also let the `:s///c` confirm prompt be written properly, instead of the current workaround that sniffs `text:sub(1,1)` inside `on_change` and immediately calls `hide()`.

## Tests

`internal/ui/commandline_widget_test.go`:
- `on_key` preempts both submit and cancel (the load-bearing case — `RET` and `C-g` must be claimable)
- a declining hook falls through to normal editing and still submits
- with no hook set, behaviour is byte-for-byte unchanged

`internal/plugin/lua_commandline_test.go`:
- the hook is wired through and consumes selectively
- the Lua event shape matches `key.press` exactly
- absent `on_key` stays nil
- a raising hook declines rather than consuming

Docs updated in `docs-web` plugin-authoring guide with the rationale and an isearch example.

`make test` green, and `tests/functional` green at 232 passed / 27 expected fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V2yCew6ocjCHAoTwKuSqQ