### PR TITLE
feat: add editor.undoDeleteCursorStart setting

### DIFF
--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -34,6 +34,8 @@ func (a *App) ApplySettings(s config.Settings) {
 	a.EditorGroup.TrimTrailingWhitespace = s.Editor.TrimTrailingWhitespace
 	a.EditorGroup.WordWrap = s.Editor.WordWrap
 	a.EditorGroup.BracketPairColorization = s.Editor.BracketPairColorization
+	a.EditorGroup.UndoDeleteCursorStart = s.Editor.UndoDeleteCursorStart
+	a.EditorGroup.ApplyUndoDeleteCursorStart(s.Editor.UndoDeleteCursorStart)
 
 	if a.EditorGroup.Editor != nil {
 		a.EditorGroup.Editor.TabSize = s.Editor.TabSize

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -91,6 +91,7 @@ type EditorSettings struct {
 	BorderStyle             string `json:"borderStyle,omitempty"`
 	BracketPairColorization bool   `json:"bracketPairColorization"`
 	ShowTrailingNewline     *bool  `json:"showTrailingNewline,omitempty"`
+	UndoDeleteCursorStart  bool   `json:"undoDeleteCursorStart,omitempty"`
 }
 
 func (e EditorSettings) IsShowTrailingNewlineEnabled() bool {

--- a/internal/core/undo/undo.go
+++ b/internal/core/undo/undo.go
@@ -22,6 +22,10 @@ type UndoStack struct {
 	savePoint      int
 	inTransaction  bool
 	transactionIdx int
+	// DeleteCursorStart controls where the cursor lands after undoing a
+	// DeleteSelectionCommand. When true, cursor goes to the start of the
+	// restored text (Emacs convention); when false, to the end (default).
+	DeleteCursorStart bool
 }
 
 func (s *UndoStack) BeginTransaction() {
@@ -136,7 +140,7 @@ func (s *UndoStack) Undo(b *buffer.Buffer) *CursorPos {
 	s.undo = s.undo[:len(s.undo)-1]
 	cmd.Undo(b)
 	s.redo = append(s.redo, cmd)
-	return cursorAfterUndo(cmd)
+	return s.cursorAfterUndo(cmd)
 }
 
 // Redo re-applies the last undone command and returns where the cursor should be placed.
@@ -152,7 +156,7 @@ func (s *UndoStack) Redo(b *buffer.Buffer) *CursorPos {
 	return cursorAfterRedo(cmd)
 }
 
-func cursorAfterUndo(cmd EditCommand) *CursorPos {
+func (s *UndoStack) cursorAfterUndo(cmd EditCommand) *CursorPos {
 	switch c := cmd.(type) {
 	case *InsertRuneCommand:
 		return &CursorPos{c.Line, c.Col}
@@ -167,12 +171,15 @@ func cursorAfterUndo(cmd EditCommand) *CursorPos {
 	case *JoinNextLineCommand:
 		return &CursorPos{c.Line, c.JoinCol}
 	case *DeleteSelectionCommand:
+		if s.DeleteCursorStart {
+			return &CursorPos{c.StartLine, c.StartCol}
+		}
 		return &CursorPos{c.EndLine, c.EndCol}
 	case *PasteCommand:
 		return &CursorPos{c.Line, c.Col}
 	case *BatchCommand:
 		if len(c.Commands) > 0 {
-			return cursorAfterUndo(c.Commands[0])
+			return s.cursorAfterUndo(c.Commands[0])
 		}
 	}
 	return nil

--- a/internal/core/undo/undo_test.go
+++ b/internal/core/undo/undo_test.go
@@ -76,6 +76,24 @@ func TestDeleteSelectionCommand(t *testing.T) {
 	}
 }
 
+func TestDeleteSelectionUndoCursorPosition(t *testing.T) {
+	cmd := &DeleteSelectionCommand{StartLine: 0, StartCol: 3, EndLine: 1, EndCol: 2}
+
+	// Default: cursor at end of restored text
+	s := &UndoStack{}
+	pos := s.cursorAfterUndo(cmd)
+	if pos.Line != 1 || pos.Col != 2 {
+		t.Errorf("default: want {1,2}, got {%d,%d}", pos.Line, pos.Col)
+	}
+
+	// DeleteCursorStart: cursor at start of restored text
+	s.DeleteCursorStart = true
+	pos = s.cursorAfterUndo(cmd)
+	if pos.Line != 0 || pos.Col != 3 {
+		t.Errorf("DeleteCursorStart: want {0,3}, got {%d,%d}", pos.Line, pos.Col)
+	}
+}
+
 func TestBatchCommand(t *testing.T) {
 	b := &buffer.Buffer{Lines: []string{"abc"}}
 	batch := &BatchCommand{
@@ -267,7 +285,7 @@ func TestDeleteRuneCommandLastChar(t *testing.T) {
 }
 
 func TestDeleteRuneCommandCursorPositions(t *testing.T) {
-	undoPos := cursorAfterUndo(&DeleteRuneCommand{Line: 2, Col: 5})
+	undoPos := (&UndoStack{}).cursorAfterUndo(&DeleteRuneCommand{Line: 2, Col: 5})
 	if undoPos == nil || undoPos.Line != 2 || undoPos.Col != 6 {
 		t.Errorf("expected undo cursor {2, 6}, got %+v", undoPos)
 	}
@@ -344,7 +362,7 @@ func TestSplitLineCommandMiddleOfBuffer(t *testing.T) {
 }
 
 func TestSplitLineCommandCursorPositions(t *testing.T) {
-	undoPos := cursorAfterUndo(&SplitLineCommand{Line: 3, Col: 7})
+	undoPos := (&UndoStack{}).cursorAfterUndo(&SplitLineCommand{Line: 3, Col: 7})
 	if undoPos == nil || undoPos.Line != 3 || undoPos.Col != 7 {
 		t.Errorf("expected undo cursor {3, 7}, got %+v", undoPos)
 	}
@@ -407,7 +425,7 @@ func TestJoinLineCommandEmptyFirstLine(t *testing.T) {
 func TestJoinLineCommandCursorPositions(t *testing.T) {
 	cmd := &JoinLineCommand{Line: 2, PrevLen: 5}
 	cmd.PrevLen = 5 // simulate what Apply would set
-	undoPos := cursorAfterUndo(cmd)
+	undoPos := (&UndoStack{}).cursorAfterUndo(cmd)
 	if undoPos == nil || undoPos.Line != 1 || undoPos.Col != 5 {
 		t.Errorf("expected undo cursor {1, 5}, got %+v", undoPos)
 	}
@@ -495,7 +513,7 @@ func TestJoinNextLineCommandWhitespaceOnlyNextLine(t *testing.T) {
 
 func TestJoinNextLineCommandCursorPositions(t *testing.T) {
 	cmd := &JoinNextLineCommand{Line: 3, JoinCol: 10}
-	undoPos := cursorAfterUndo(cmd)
+	undoPos := (&UndoStack{}).cursorAfterUndo(cmd)
 	if undoPos == nil || undoPos.Line != 3 || undoPos.Col != 10 {
 		t.Errorf("expected undo cursor {3, 10}, got %+v", undoPos)
 	}
@@ -648,7 +666,7 @@ func TestInsertStringCommandTabSpaces(t *testing.T) {
 }
 
 func TestInsertStringCommandCursorPositions(t *testing.T) {
-	undoPos := cursorAfterUndo(&InsertStringCommand{Line: 1, Col: 3, Text: "abc"})
+	undoPos := (&UndoStack{}).cursorAfterUndo(&InsertStringCommand{Line: 1, Col: 3, Text: "abc"})
 	if undoPos == nil || undoPos.Line != 1 || undoPos.Col != 3 {
 		t.Errorf("expected undo cursor {1, 3}, got %+v", undoPos)
 	}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -84,6 +84,7 @@ type EditorGroupWidget struct {
 	InsertFinalNewline      bool
 	ShowTrailingNewline     bool
 	TrimTrailingWhitespace  bool
+	UndoDeleteCursorStart   bool
 	Borders                 *term.BorderSet
 	OnFileOpen              func(path, lang, text string)
 	OnFileChange            func(path, lang, text string)
@@ -129,7 +130,7 @@ func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool
 	tabBar.OnNextTab = func() { g.NextTab() }
 	tabBar.OnPrevTab = func() { g.PrevTab() }
 	tabBar.OnDoubleClick = func() { g.NewFile() }
-	undoStack := &undo.UndoStack{}
+	undoStack := g.newUndoStack()
 	sel := &selection.Selection{}
 	editor.Undo = undoStack
 	editor.Selection = sel
@@ -144,6 +145,18 @@ func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool
 	}}
 	g.syncTabs()
 	return g
+}
+
+func (g *EditorGroupWidget) newUndoStack() *undo.UndoStack {
+	return &undo.UndoStack{DeleteCursorStart: g.UndoDeleteCursorStart}
+}
+
+func (g *EditorGroupWidget) ApplyUndoDeleteCursorStart(v bool) {
+	for i := range g.tabs {
+		if g.tabs[i].Undo != nil {
+			g.tabs[i].Undo.DeleteCursorStart = v
+		}
+	}
 }
 
 func (g *EditorGroupWidget) Focusable() bool { return true }
@@ -244,7 +257,7 @@ func (g *EditorGroupWidget) OpenFile(path string) {
 		Buf:      newBuf,
 		Cur:      &cursor.Cursor{},
 		Vp:       &view.Viewport{},
-		Undo:     &undo.UndoStack{},
+		Undo:     g.newUndoStack(),
 		Sel:      &selection.Selection{},
 		Folds:    folds,
 		TabSize:  tabSize,
@@ -272,7 +285,7 @@ func (g *EditorGroupWidget) NewFile() {
 		Buf:      &buffer.Buffer{Lines: []string{""}},
 		Cur:      &cursor.Cursor{},
 		Vp:       &view.Viewport{},
-		Undo:     &undo.UndoStack{},
+		Undo:     g.newUndoStack(),
 		Sel:      &selection.Selection{},
 		Virtual:  true,
 	})
@@ -354,7 +367,7 @@ func (g *EditorGroupWidget) ClosePluginTab(id string) {
 					Buf:      &buffer.Buffer{Lines: []string{""}},
 					Cur:      &cursor.Cursor{},
 					Vp:       &view.Viewport{},
-					Undo:     &undo.UndoStack{},
+					Undo:     g.newUndoStack(),
 					Sel:      &selection.Selection{},
 					Virtual:  true,
 				}}
@@ -373,7 +386,7 @@ func (g *EditorGroupWidget) ReloadFile(path string) {
 		if g.tabs[i].FilePath == path && g.tabs[i].Buf != nil {
 			g.tabs[i].Buf.LoadFile(path)
 			g.tabs[i].Buf.Dirty = false
-			g.tabs[i].Undo = &undo.UndoStack{}
+			g.tabs[i].Undo = g.newUndoStack()
 			if g.tabs[i].Folds != nil {
 				g.tabs[i].Folds.SetRanges(fold.ComputeIndentRanges(g.tabs[i].Buf.Lines))
 			}
@@ -577,7 +590,7 @@ func (g *EditorGroupWidget) CloseTab() {
 			Buf:      &buffer.Buffer{Lines: []string{""}},
 			Cur:      &cursor.Cursor{},
 			Vp:       &view.Viewport{},
-			Undo:     &undo.UndoStack{},
+			Undo:     g.newUndoStack(),
 			Sel:      &selection.Selection{},
 			Virtual:  true,
 		}}
@@ -646,7 +659,7 @@ func (g *EditorGroupWidget) CloseAllTabs() {
 		Buf:      &buffer.Buffer{Lines: []string{""}},
 		Cur:      &cursor.Cursor{},
 		Vp:       &view.Viewport{},
-		Undo:     &undo.UndoStack{},
+		Undo:     g.newUndoStack(),
 		Sel:      &selection.Selection{},
 		Virtual:  true,
 	}}


### PR DESCRIPTION
## Summary
- Adds `editor.undoDeleteCursorStart` setting (default `false`)
- When `true`, undoing a delete-selection places cursor at the **start** of restored text (Emacs convention)
- When `false`, cursor goes to the **end** (VSCode convention, current behavior)
- Propagates to all existing undo stacks when changed via settings

## Test plan
- [x] Unit test covering both modes (`TestDeleteSelectionUndoCursorPosition`)
- [x] `make test` passes
- [x] Functional suite passes (232 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V2yCew6ocjCHAoTwKuSqQ