### PR TITLE
fix: apply undoDeleteCursorStart at widget init

### DIFF
--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -135,6 +135,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.Editor.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.Editor.AutoDedent = cfg.Settings.Editor.IsAutoDedentEnabled()
 	editorGroup.Editor.AutoIndent = cfg.Settings.Editor.IsAutoIndentEnabled()
+	editorGroup.UndoDeleteCursorStart = cfg.Settings.Editor.UndoDeleteCursorStart
 	editorGroup.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.Editor.BracketPairColorization = cfg.Settings.Editor.BracketPairColorization
 	editorGroup.BracketColorStyles = bracketStyles


### PR DESCRIPTION
## Summary
- Sets `UndoDeleteCursorStart` on the editor group during widget init in `widgets.go`
- Without this, the setting from `settings.json` only takes effect via `ApplySettings`, which runs after `NewEditorGroupWidget` creates the initial undo stack
- File-open stacks were already correct (they call `g.newUndoStack()` after the field is set)

Companion to #430.

## Test plan
- [x] `make test` passes
- [x] Verified via `--exec` that `M-d C-/` places cursor at col 0 with the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V2yCew6ocjCHAoTwKuSqQ