### PR TITLE
Add EchoText to status bar for plugin prompts

### DIFF
--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -386,6 +386,9 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	p.RemoveStatusItem = func(id string) {
 		a.Status.RemoveSegment(id)
 	}
+	p.SetEcho = func(text string) {
+		a.Status.EchoText = text
+	}
 	p.ExecCommand = func(id string) bool {
 		return a.Reg.Execute(id)
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -83,6 +83,7 @@ type Plugin struct {
 	Notify             func(message, level string)
 	SetStatusItem      func(side, id, text string, priority int, onClick func())
 	RemoveStatusItem   func(id string)
+	SetEcho            func(text string) // status bar shows only this text when non-empty
 	ExecCommand        func(id string) bool
 	ListCommands       func() []CommandInfo
 	PublishDiagnostics func(path string, items []DiagnosticItem)
@@ -254,6 +255,7 @@ func (p *Plugin) Destroy() {
 	p.Notify = nil
 	p.SetStatusItem = nil
 	p.RemoveStatusItem = nil
+	p.SetEcho = nil
 	p.ExecCommand = nil
 	p.ListCommands = nil
 	p.PublishDiagnostics = nil

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -294,6 +294,21 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 0
 		}))
 
+		L.SetField(mod, "set_echo", L.NewFunction(func(L *lua.LState) int {
+			text := L.CheckString(1)
+			if p.SetEcho != nil {
+				p.SetEcho(text)
+			}
+			return 0
+		}))
+
+		L.SetField(mod, "clear_echo", L.NewFunction(func(L *lua.LState) int {
+			if p.SetEcho != nil {
+				p.SetEcho("")
+			}
+			return 0
+		}))
+
 		L.SetField(mod, "exec_command", L.NewFunction(func(L *lua.LState) int {
 			if err := p.Granted.Check("commands"); err != nil {
 				L.ArgError(1, "commands permission not granted")

--- a/internal/ui/statusbar_widget.go
+++ b/internal/ui/statusbar_widget.go
@@ -35,6 +35,13 @@ func (s *StatusBarWidget) Render(surface Surface) {
 		surface.SetCell(x, 0, term.Cell{Ch: ' ', Style: term.StyleStatusBar})
 	}
 
+	// EchoText takes over the entire status bar — used by plugins for
+	// prompts (isearch, query-replace) that need the full row.
+	if st.EchoText != "" {
+		s.drawText(surface, 1, st.EchoText, term.StyleStatusBar)
+		return
+	}
+
 	if st.IsNotificationActive() {
 		s.renderNotification(surface, w)
 		return

--- a/internal/view/statusbar.go
+++ b/internal/view/statusbar.go
@@ -47,6 +47,10 @@ type StatusBar struct {
 	ActionLabel     string
 	SecondaryAction func()
 	SecondaryLabel  string
+	// EchoText, when non-empty, is rendered as the sole content of the status
+	// bar. Used by plugins to display prompts (isearch, query-replace) without
+	// competing with core mode-line segments for space.
+	EchoText string
 }
 
 func NewStatusBar() *StatusBar {


### PR DESCRIPTION
When `StatusBar.EchoText` is non-empty, the status bar renders ONLY that text — no segments, no notifications. This lets plugins display prompts (isearch, query-replace) that take over the full status bar row without competing with core mode-line segments.

**Changes:**
- `internal/view/statusbar.go` — add `EchoText` field
- `internal/ui/statusbar_widget.go` — `Render()` checks EchoText first, draws only it when set
- `internal/plugin/plugin.go` — add `SetEcho` callback
- `internal/plugin/sandbox.go` — expose `ttt.set_echo(text)` and `ttt.clear_echo()` to Lua plugins
- `internal/app/commands_plugin.go` — wire SetEcho to StatusBar.EchoText

**How plugins use it:**
```lua
ttt.set_echo("I-search: foo")   -- status bar shows only this
ttt.clear_echo()                -- back to normal
```

**Before vs After:**
- Before: isearch prompt competes with branch/position/encoding on the same row
- After: isearch prompt has the full status bar to itself, matching Emacs's echo area

Companion PR in ttt-emacs: updates the emacs plugin to use this API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)