### PR TITLE
Render fullwidth CJK characters correctly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ The codebase follows a strict layered architecture: **core → view → render �
 
 - **`internal/ui/`** — Window manager and pane system. `Window` binds a `Rect`, `Viewport`, and `Buffer` together. `WindowManager` tracks focus across windows. Also contains `terminal_widget.go` (renders vt10x grid as direct-color cells, handles key-to-VT translation), `root.go` (ForceKeys and RawKeyConsumer interface for terminal key routing), and `content_split.go` (OnTopClick/OnBottomClick for focus routing between editor and bottom panel).
 
+- **`internal/textwidth/`** — Display-width measurement (`Rune`, `String`, `Runes`). The single source of truth for how many terminal columns text occupies. Wraps `clipperhouse/displaywidth` with the same options tcell v3 uses internally, including the `RUNEWIDTH_EASTASIAN` toggle, so ttt's layout always matches what tcell draws.
+
 - **`internal/workspace/`** — Multi-folder workspace management. `Folder` and `Workspace` types track one or more project roots, with `IsRepo` git-detection, `FolderForFile` lookup (longest-prefix match), and JSON-based workspace file loading/saving (`.ttt` files). The editor falls back to `cwd` when no folders are explicitly provided.
 
 - **`cmd/ttt/main.go`** — Entry point with event loop. Wires all components together, handles key dispatch, viewport scrolling, and redraw. Accepts a `--workspace <file>` flag to open a saved workspace, or folder/file paths as positional arguments.
@@ -56,7 +58,12 @@ The codebase follows a strict layered architecture: **core → view → render �
 
 ### Key Design Constraints
 
-- Cursor `Col` is a visual column (rune-based), not a byte index — all line-length calculations use `[]rune()`.
+- Cursor `Col` is a rune index, not a byte index — all line-length calculations use `[]rune()`. It is **not** a terminal column: a fullwidth rune advances `Col` by 1 and the screen by 2.
+- **Never compute display width by hand.** No `len([]rune(s))`, `visCol++`, or `x++` as a stand-in for terminal columns — use `textwidth.String`/`textwidth.Rune`. Fullwidth East Asian runes occupy two columns, and tcell advances the terminal cursor by the rune's width when it draws: a layout that assumes one column per rune writes the next character into a cell the terminal never displays, so it vanishes (issue #434). Three distinct quantities must not be conflated:
+  - **byte offset** ↔ **rune index** — `editor.byte_to_col`/`col_to_byte` in the Lua API (`internal/plugin/lua_editor.go`); no width involved.
+  - **rune index** ↔ **terminal column** — `bufColToVisualCol`/`visualColToBufCol` (`internal/ui/editor_widget_utils.go`); width-aware.
+  - A widget that draws left to right should take its width from what `DrawText` returns rather than measuring the same string a second time.
+- A fullwidth rune must never be drawn in the last column of a clip region: the terminal paints it across two columns regardless of clipping, so it bleeds over the border or scrollbar to its right. `DrawText` substitutes a space in that case.
 - The renderer uses double-buffering (prev/curr cell grids) to minimize terminal writes.
 - `Screen` interface keeps tcell isolated — the rest of the codebase never imports tcell directly (except `cmd/ttt/main.go` for event types).
 - **Never hardcode colors.** All colors must go through the theme system (`internal/config/theme.go` → `StyleDef` → `term.Style` constants → `buildStyleMap`). Add a new `StyleDef` field to `ThemeConfig`, a `term.Style` constant, and wire it in `buildStyleMap()`. Widgets reference `term.Style*` constants, never color values. The one exception is the integrated terminal, which uses direct RGB color rendering via `DirectColor`/`CellAttr` to support 256-color output.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/alecthomas/chroma/v2 v2.24.1
 	github.com/aymanbagabas/go-pty v0.2.3
+	github.com/clipperhouse/displaywidth v0.11.0
 	github.com/eugenioenko/vt10x v0.0.0-20260723044012-f8bf2a92fc22
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gdamore/tcell/v3 v3.4.1
@@ -13,7 +14,6 @@ require (
 )
 
 require (
-	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect

--- a/internal/textwidth/textwidth.go
+++ b/internal/textwidth/textwidth.go
@@ -1,0 +1,64 @@
+// Package textwidth measures how many terminal columns text occupies.
+//
+// It is the single source of truth for display width in ttt. Nothing else may
+// compute width by hand: a rune count is a buffer index, not a screen width,
+// and two disagreeing measurements are what makes fullwidth characters render
+// on top of each other.
+package textwidth
+
+import (
+	"os"
+	"strings"
+
+	"github.com/clipperhouse/displaywidth"
+)
+
+// options mirrors tcell's own width configuration (its internal
+// widthutil.Options). tcell measures every cell it draws with displaywidth
+// using these options and advances the terminal cursor by that width, so ttt
+// must measure with identical settings — where the two disagree, our layout and
+// what the terminal actually shows drift apart.
+var options = eastAsianOptions(os.Getenv("RUNEWIDTH_EASTASIAN"))
+
+func eastAsianOptions(env string) displaywidth.Options {
+	switch strings.ToLower(env) {
+	case "1", "true", "yes":
+		return displaywidth.Options{EastAsianWidth: true}
+	}
+	return displaywidth.Options{}
+}
+
+// Rune returns the number of terminal columns r occupies: 2 for East Asian wide
+// and fullwidth runes, 1 for everything else.
+//
+// Zero-width runes (control characters, combining marks) report 1 rather than
+// 0: ttt renders one cell per rune and never folds a rune into the preceding
+// cell, so a 0 here would stall column advance and overwrite the previous cell.
+func Rune(r rune) int {
+	if options.Rune(r) > 1 {
+		return 2
+	}
+	return 1
+}
+
+// String returns the number of terminal columns s occupies.
+//
+// It sums Rune rather than calling displaywidth.String because ttt draws text
+// rune by rune into its own cell grid; measuring by grapheme cluster would
+// report a width the renderer never produces.
+func String(s string) int {
+	w := 0
+	for _, r := range s {
+		w += Rune(r)
+	}
+	return w
+}
+
+// Runes returns the number of terminal columns runes occupy.
+func Runes(runes []rune) int {
+	w := 0
+	for _, r := range runes {
+		w += Rune(r)
+	}
+	return w
+}

--- a/internal/textwidth/textwidth_test.go
+++ b/internal/textwidth/textwidth_test.go
@@ -1,0 +1,88 @@
+package textwidth
+
+import (
+	"testing"
+
+	"github.com/clipperhouse/displaywidth"
+)
+
+func TestRuneWidth(t *testing.T) {
+	cases := []struct {
+		name string
+		r    rune
+		want int
+	}{
+		{"ascii letter", 'a', 1},
+		{"ascii digit", '7', 1},
+		{"space", ' ', 1},
+		{"cyrillic is multi-byte but narrow", 'п', 1},
+		{"greek", 'λ', 1},
+		{"box drawing", '─', 1},
+		{"ellipsis", '…', 1},
+		{"korean syllable", '가', 2},
+		{"chinese han", '你', 2},
+		{"japanese hiragana", 'こ', 2},
+		{"japanese katakana", 'ア', 2},
+		{"fullwidth latin", 'Ａ', 2},
+		{"halfwidth katakana", 'ｱ', 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Rune(tc.r); got != tc.want {
+				t.Errorf("Rune(%q) = %d, want %d", tc.r, got, tc.want)
+			}
+		})
+	}
+}
+
+// Zero-width runes must still advance one column: ttt draws one cell per rune,
+// so a 0 would stall the layout and overwrite the previous cell.
+func TestRuneWidthNeverZero(t *testing.T) {
+	for _, r := range []rune{'\x00', '\x01', '\x7f', '́', '​'} {
+		if got := Rune(r); got != 1 {
+			t.Errorf("Rune(%U) = %d, want 1", r, got)
+		}
+	}
+}
+
+func TestStringWidth(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"hello", 5},
+		{"привет", 6},
+		{"가나다라마바사", 14},
+		{"你好世界", 8},
+		{"가a나b다", 8},
+		{"hello가", 7},
+	}
+	for _, tc := range cases {
+		if got := String(tc.in); got != tc.want {
+			t.Errorf("String(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+		if got := Runes([]rune(tc.in)); got != tc.want {
+			t.Errorf("Runes(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The RUNEWIDTH_EASTASIAN toggle must be read the same way tcell reads it
+// (its internal widthutil.Options), or ambiguous-width runes get laid out at
+// one width and drawn at another.
+func TestEastAsianOptions(t *testing.T) {
+	wide := displaywidth.Options{EastAsianWidth: true}
+	narrow := displaywidth.Options{}
+
+	for _, env := range []string{"1", "true", "yes", "TRUE", "Yes"} {
+		if got := eastAsianOptions(env); got != wide {
+			t.Errorf("eastAsianOptions(%q) = %+v, want east asian width", env, got)
+		}
+	}
+	for _, env := range []string{"", "0", "false", "no", "maybe"} {
+		if got := eastAsianOptions(env); got != narrow {
+			t.Errorf("eastAsianOptions(%q) = %+v, want narrow", env, got)
+		}
+	}
+}

--- a/internal/ui/editor_widget_render.go
+++ b/internal/ui/editor_widget_render.go
@@ -8,6 +8,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/core/highlight"
 	"github.com/eugenioenko/ttt/internal/core/multicursor"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 )
 
 func (e *EditorPaneWidget) Render(surface Surface) {
@@ -413,11 +414,21 @@ func (e *EditorPaneWidget) renderLineToScreen(line []rune, spans []highlight.Spa
 				visCol++
 			}
 		} else {
+			cw := textwidth.Rune(ch)
 			sx := visCol - leftCol
 			if sx >= 0 && sx < width {
-				cells[sx] = screenCell{ch: ch, style: style, bufCol: bufCol}
+				if cw > 1 && sx == width-1 {
+					// The rune's second column falls outside the pane; drawing
+					// it would bleed over the scrollbar or border, so pad.
+					cells[sx] = screenCell{ch: ' ', style: style, bufCol: bufCol}
+				} else {
+					cells[sx] = screenCell{ch: ch, style: style, bufCol: bufCol}
+				}
 			}
-			visCol++
+			// A fullwidth rune's second column keeps the blank the cell array
+			// was initialised with. The terminal never draws that cell — the
+			// rune itself covers it — so it needs no content of its own.
+			visCol += cw
 		}
 		if visCol-leftCol >= width {
 			break

--- a/internal/ui/editor_widget_utils.go
+++ b/internal/ui/editor_widget_utils.go
@@ -1,6 +1,10 @@
 package ui
 
-import "unicode"
+import (
+	"unicode"
+
+	"github.com/eugenioenko/ttt/internal/textwidth"
+)
 
 // wordAt returns the maximal run of word characters (letters, digits, or '_')
 // surrounding col in lineText, or "" if col is not on a word character.
@@ -49,6 +53,8 @@ func leadingWhitespace(s string) string {
 	return s
 }
 
+// bufColToVisualCol converts a rune index into the terminal column it starts
+// at, accounting for tab stops and for fullwidth runes that occupy two columns.
 func bufColToVisualCol(line string, bufCol, tabW int) int {
 	visCol := 0
 	ri := 0
@@ -59,13 +65,17 @@ func bufColToVisualCol(line string, bufCol, tabW int) int {
 		if ch == '\t' {
 			visCol = ((visCol / tabW) + 1) * tabW
 		} else {
-			visCol++
+			visCol += textwidth.Rune(ch)
 		}
 		ri++
 	}
 	return visCol
 }
 
+// visualColToBufCol converts a terminal column into a rune index. A column
+// inside a multi-column rune (a tab's whitespace or the second half of a
+// fullwidth rune) resolves to that rune's index, matching how a click lands on
+// the character the user pointed at.
 func visualColToBufCol(line string, targetVisCol, tabW int) int {
 	visCol := 0
 	ri := 0
@@ -80,7 +90,11 @@ func visualColToBufCol(line string, targetVisCol, tabW int) int {
 			}
 			visCol = nextStop
 		} else {
-			visCol++
+			w := textwidth.Rune(ch)
+			if targetVisCol < visCol+w {
+				return ri
+			}
+			visCol += w
 		}
 		ri++
 	}

--- a/internal/ui/fullwidth_test.go
+++ b/internal/ui/fullwidth_test.go
@@ -1,0 +1,156 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+)
+
+// Each fullwidth rune must land two columns apart, leaving the column it covers
+// untouched. Writing into that column is what made the terminal swallow the
+// following character (issue #434).
+func TestDrawTextFullwidthAdvancesTwoColumns(t *testing.T) {
+	grid := makeGrid(20, 3)
+	s := NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 20, H: 3})
+
+	endX := s.DrawText(0, 0, "가a나", 0, term.StyleDefault)
+	if endX != 5 {
+		t.Fatalf("endX = %d, want 5", endX)
+	}
+	want := map[int]rune{0: '가', 2: 'a', 3: '나'}
+	for x, ch := range want {
+		if grid[0][x].Ch != ch {
+			t.Errorf("grid[0][%d] = %q, want %q", x, grid[0][x].Ch, ch)
+		}
+	}
+}
+
+// A fullwidth rune is painted across two columns by the terminal no matter what
+// the clip says, so one that would straddle the limit must not be drawn at all.
+func TestDrawTextFullwidthStraddlingLimit(t *testing.T) {
+	grid := makeGrid(20, 3)
+	s := NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 20, H: 3})
+
+	s.DrawText(0, 0, "a가", 2, term.StyleDefault)
+	if grid[0][0].Ch != 'a' {
+		t.Fatalf("grid[0][0] = %q, want 'a'", grid[0][0].Ch)
+	}
+	if grid[0][1].Ch == '가' {
+		t.Error("fullwidth rune drawn at the clip edge would bleed past it")
+	}
+}
+
+func TestDrawTextFullwidthStopsAtSurfaceEdge(t *testing.T) {
+	grid := makeGrid(20, 3)
+	s := NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 3, H: 3})
+
+	s.DrawText(0, 0, "a가", 0, term.StyleDefault)
+	if grid[0][2].Ch == '가' {
+		t.Error("fullwidth rune drawn in the last column would bleed outside the surface")
+	}
+	if grid[0][3].Ch != '.' {
+		t.Error("drawing escaped the surface")
+	}
+}
+
+// 가나다 occupies 6 terminal columns: 가=[0,1] 나=[2,3] 다=[4,5].
+func TestBufColToVisualColFullwidth(t *testing.T) {
+	cases := []struct {
+		name   string
+		line   string
+		bufCol int
+		want   int
+	}{
+		{"start of line", "가나다", 0, 0},
+		{"after one fullwidth rune", "가나다", 1, 2},
+		{"after two", "가나다", 2, 4},
+		{"end of line", "가나다", 3, 6},
+		{"ascii is unaffected", "abc", 2, 2},
+		{"mixed ascii and fullwidth", "가a나b다", 3, 5},
+		{"cyrillic stays narrow", "привет", 6, 6},
+		{"tab then fullwidth", "\t가", 2, 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bufColToVisualCol(tc.line, tc.bufCol, 4); got != tc.want {
+				t.Errorf("bufColToVisualCol(%q, %d) = %d, want %d", tc.line, tc.bufCol, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVisualColToBufColFullwidth(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string
+		visCol  int
+		want    int
+		comment string
+	}{
+		{name: "column 0", line: "가나다", visCol: 0, want: 0},
+		{name: "second column of first rune", line: "가나다", visCol: 1, want: 0,
+			comment: "clicking either half of a fullwidth rune selects that rune"},
+		{name: "first column of second rune", line: "가나다", visCol: 2, want: 1},
+		{name: "second column of second rune", line: "가나다", visCol: 3, want: 1},
+		{name: "first column of third rune", line: "가나다", visCol: 4, want: 2},
+		{name: "past the end clamps", line: "가나다", visCol: 99, want: 3},
+		{name: "ascii is unaffected", line: "abc", visCol: 2, want: 2},
+		{name: "ascii after fullwidth", line: "가a나", visCol: 2, want: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := visualColToBufCol(tc.line, tc.visCol, 4); got != tc.want {
+				t.Errorf("visualColToBufCol(%q, %d) = %d, want %d", tc.line, tc.visCol, got, tc.want)
+			}
+		})
+	}
+}
+
+// Round-tripping a rune index through its visual column must return the same
+// index — otherwise the cursor drifts every time it is converted for drawing.
+func TestVisualColRoundTrip(t *testing.T) {
+	for _, line := range []string{"가나다라마바사", "가a나b다", "hello가", "\t가나", "привет"} {
+		for i := range []rune(line) {
+			vis := bufColToVisualCol(line, i, 4)
+			if got := visualColToBufCol(line, vis, 4); got != i {
+				t.Errorf("%q: rune %d -> col %d -> rune %d", line, i, vis, got)
+			}
+		}
+	}
+}
+
+func TestWrapLineSegmentsFullwidth(t *testing.T) {
+	// Width 6 fits exactly three fullwidth runes per visual row.
+	segments := wrapLineSegments([]rune("가나다라마바"), 6, 4)
+	want := []int{0, 3}
+	if len(segments) != len(want) {
+		t.Fatalf("segments = %v, want %v", segments, want)
+	}
+	for i := range want {
+		if segments[i] != want[i] {
+			t.Fatalf("segments = %v, want %v", segments, want)
+		}
+	}
+}
+
+// A fullwidth rune must never be split across two visual rows: with an odd
+// width the last column of the row stays empty instead.
+func TestWrapLineSegmentsNeverSplitsFullwidthRune(t *testing.T) {
+	segments := wrapLineSegments([]rune("가나다라"), 5, 4)
+	if len(segments) != 2 || segments[1] != 2 {
+		t.Fatalf("segments = %v, want [0 2] (two runes fit in 5 columns)", segments)
+	}
+}
+
+func TestBufferPosToWrapScreenPosFullwidth(t *testing.T) {
+	lines := []string{"가나다라마바"}
+	_, screenCol := bufferPosToWrapScreenPos(lines, 0, 2, 6, 4)
+	if screenCol != 4 {
+		t.Errorf("screenCol = %d, want 4", screenCol)
+	}
+	// The fourth rune starts the second visual row.
+	row, screenCol := bufferPosToWrapScreenPos(lines, 0, 3, 6, 4)
+	if row != 1 || screenCol != 0 {
+		t.Errorf("row, col = %d, %d; want 1, 0", row, screenCol)
+	}
+}

--- a/internal/ui/input_widget.go
+++ b/internal/ui/input_widget.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -80,26 +81,34 @@ func (inp *InputWidget) deleteSelection() {
 
 func (inp *InputWidget) Render(surface Surface, x, y, w int) {
 	actionsW := inp.actionsWidth()
-	prefixRunes := []rune(inp.Prefix)
-	prefixW := len(prefixRunes)
+	prefixW := textwidth.String(inp.Prefix)
 	textW := w - actionsW - prefixW
 
 	ox, oy := surface.Origin()
 	inp.renderX = ox + x + prefixW
 	inp.renderY = oy + y
-	for i, ch := range prefixRunes {
-		surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: inp.Style})
+	px := x
+	for _, ch := range inp.Prefix {
+		surface.SetCell(px, y, term.Cell{Ch: ch, Style: inp.Style})
+		px += textwidth.Rune(ch)
 	}
 
 	if textW > 0 {
 		textRunes := []rune(inp.Text)
 		showPlaceholder := len(textRunes) == 0 && inp.Placeholder != ""
 
+		// The visible window is textW columns wide, which holds fewer fullwidth
+		// runes than narrow ones — scroll by column, not by rune index.
 		if inp.CursorPos < inp.scrollOffset {
 			inp.scrollOffset = inp.CursorPos
 		}
-		if inp.CursorPos >= inp.scrollOffset+textW {
-			inp.scrollOffset = inp.CursorPos - textW + 1
+		// Walk the runes once to find the new offset rather than re-measuring
+		// the whole visible range per step — pasted text can be long.
+		if over := inp.visualOffset(textRunes, inp.CursorPos) - textW + 1; over > 0 {
+			for i := inp.scrollOffset; i < inp.CursorPos && over > 0; i++ {
+				over -= textwidth.Rune(textRunes[i])
+				inp.scrollOffset = i + 1
+			}
 		}
 
 		selLo, selHi := -1, -1
@@ -108,27 +117,16 @@ func (inp *InputWidget) Render(surface Surface, x, y, w int) {
 		}
 
 		if showPlaceholder {
-			phRunes := []rune(inp.Placeholder)
-			for i := 0; i < textW; i++ {
-				ch := ' '
-				if i < len(phRunes) {
-					ch = phRunes[i]
-				}
-				surface.SetCell(x+prefixW+i, y, term.Cell{Ch: ch, Style: term.StyleInputPlaceholder})
-			}
+			drawInputRunes(surface, x+prefixW, y, textW, []rune(inp.Placeholder), 0, func(int) term.Style {
+				return term.StyleInputPlaceholder
+			})
 		} else {
-			for i := 0; i < textW; i++ {
-				ch := ' '
-				ri := inp.scrollOffset + i
-				if ri < len(textRunes) {
-					ch = textRunes[ri]
-				}
-				style := inp.Style
+			drawInputRunes(surface, x+prefixW, y, textW, textRunes, inp.scrollOffset, func(ri int) term.Style {
 				if selLo >= 0 && ri >= selLo && ri < selHi {
-					style = term.StyleSelection
+					return term.StyleSelection
 				}
-				surface.SetCell(x+prefixW+i, y, term.Cell{Ch: ch, Style: style})
-			}
+				return inp.Style
+			})
 		}
 	}
 
@@ -139,12 +137,13 @@ func (inp *InputWidget) Render(surface Surface, x, y, w int) {
 		if action.Active {
 			style = term.StyleDefault
 		}
-		labelW := len([]rune(action.Label))
+		labelW := textwidth.String(action.Label)
 		inp.ActionHits = append(inp.ActionHits, HitRegion{X: ox + ax, Y: inp.renderY, W: labelW})
 		for _, ch := range action.Label {
-			if ax < x+w {
+			cw := textwidth.Rune(ch)
+			if ax+cw <= x+w {
 				surface.SetCell(ax, y, term.Cell{Ch: ch, Style: style})
-				ax++
+				ax += cw
 			}
 		}
 		if ax < x+w {
@@ -154,19 +153,74 @@ func (inp *InputWidget) Render(surface Surface, x, y, w int) {
 	}
 }
 
+// drawInputRunes fills textW columns starting at x with runes from index
+// `from`, advancing by display width and padding the rest with spaces so the
+// field keeps a solid background. A fullwidth rune that does not fit in the
+// remaining columns is dropped rather than drawn half outside the field.
+func drawInputRunes(surface Surface, x, y, textW int, runes []rune, from int, styleAt func(ri int) term.Style) {
+	col := 0
+	ri := from
+	for col < textW {
+		ch := ' '
+		style := styleAt(ri)
+		w := 1
+		if ri >= 0 && ri < len(runes) {
+			ch = runes[ri]
+			w = textwidth.Rune(ch)
+			if col+w > textW {
+				ch, w = ' ', 1
+				ri = len(runes)
+			}
+		}
+		surface.SetCell(x+col, y, term.Cell{Ch: ch, Style: style})
+		if w > 1 {
+			// The terminal covers this column with the rune itself; the cell
+			// only needs to carry the matching background.
+			surface.SetCell(x+col+1, y, term.Cell{Ch: ' ', Style: style})
+		}
+		col += w
+		ri++
+	}
+}
+
+// visualOffset returns how many columns the rune at index pos sits to the right
+// of the first visible rune. Fullwidth runes count as two.
+func (inp *InputWidget) visualOffset(runes []rune, pos int) int {
+	lo := max(min(inp.scrollOffset, len(runes)), 0)
+	hi := max(min(pos, len(runes)), lo)
+	return textwidth.Runes(runes[lo:hi])
+}
+
+// posAtColumn maps a column offset from the start of the visible text to a rune
+// index. A click on the second column of a fullwidth rune selects that rune.
+func (inp *InputWidget) posAtColumn(runes []rune, col int) int {
+	if col <= 0 {
+		return max(min(inp.scrollOffset, len(runes)), 0)
+	}
+	used := 0
+	for i := max(inp.scrollOffset, 0); i < len(runes); i++ {
+		w := textwidth.Rune(runes[i])
+		if col < used+w {
+			return i
+		}
+		used += w
+	}
+	return len(runes)
+}
+
 func (inp *InputWidget) actionsWidth() int {
 	if len(inp.Actions) == 0 {
 		return 0
 	}
 	w := 0
 	for _, a := range inp.Actions {
-		w += len([]rune(a.Label)) + 1
+		w += textwidth.String(a.Label) + 1
 	}
 	return w
 }
 
 func (inp *InputWidget) CursorX(x int) int {
-	return x + len([]rune(inp.Prefix)) + inp.CursorPos - inp.scrollOffset
+	return x + textwidth.String(inp.Prefix) + inp.visualOffset([]rune(inp.Text), inp.CursorPos)
 }
 
 func (inp *InputWidget) ResetScroll() {
@@ -428,14 +482,8 @@ func (inp *InputWidget) HandleClick(screenX, screenY int) bool {
 		return false
 	}
 
-	pos := inp.scrollOffset + (screenX - inp.renderX)
 	runes := []rune(inp.Text)
-	if pos < 0 {
-		pos = 0
-	}
-	if pos > len(runes) {
-		pos = len(runes)
-	}
+	pos := inp.posAtColumn(runes, screenX-inp.renderX)
 
 	now := time.Now().UnixMilli()
 	if now-inp.lastClickTime < DoubleClickMs && pos == inp.lastClickPos {

--- a/internal/ui/statusbar_widget.go
+++ b/internal/ui/statusbar_widget.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/eugenioenko/ttt/internal/view"
 
 	"github.com/gdamore/tcell/v3"
@@ -62,11 +63,13 @@ func (s *StatusBarWidget) Render(surface Surface) {
 		if style == 0 {
 			style = term.StyleStatusBar
 		}
-		textLen := len([]rune(seg.Text))
-		if seg.OnClick != nil {
-			s.spans = append(s.spans, statusBarSpan{r.X + x, r.X + x + textLen, seg.OnClick})
-		}
+		start := x
 		x += s.drawText(surface, x, seg.Text, style)
+		if seg.OnClick != nil {
+			// The span comes from what was drawn, not a second measurement, so
+			// a clipped segment can never claim columns it does not occupy.
+			s.spans = append(s.spans, statusBarSpan{r.X + start, r.X + x, seg.OnClick})
+		}
 		x += s.drawText(surface, x, "  ", term.StyleStatusBar)
 	}
 
@@ -80,7 +83,7 @@ func (s *StatusBarWidget) Render(surface Surface) {
 	}
 	rightStr += " "
 
-	rx := w - len([]rune(rightStr))
+	rx := w - textwidth.String(rightStr)
 	if rx > x {
 		pos := rx
 		for i, seg := range rightSegs {
@@ -92,12 +95,11 @@ func (s *StatusBarWidget) Render(surface Surface) {
 			if style == 0 {
 				style = term.StyleStatusBar
 			}
-			segLen := len([]rune(seg.Text))
+			start := pos
+			pos += s.drawText(surface, pos, seg.Text, style)
 			if seg.OnClick != nil {
-				s.spans = append(s.spans, statusBarSpan{r.X + pos, r.X + pos + segLen, seg.OnClick})
+				s.spans = append(s.spans, statusBarSpan{r.X + start, r.X + pos, seg.OnClick})
 			}
-			s.drawText(surface, pos, seg.Text, style)
-			pos += segLen
 		}
 	}
 }
@@ -121,32 +123,29 @@ func (s *StatusBarWidget) renderNotification(surface Surface, w int) {
 
 	if s.Status.ActionLabel != "" && s.Status.NotifyAction != nil {
 		actionLabel := " [" + s.Status.ActionLabel + "] "
-		actionX := rightX - len([]rune(actionLabel))
+		actionW := textwidth.String(actionLabel)
+		actionX := rightX - actionW
 		if actionX > x+2 {
-			s.actionSpan = statusBarSpan{r.X + actionX, r.X + actionX + len([]rune(actionLabel)), nil}
-			for i, ch := range actionLabel {
-				surface.SetCell(actionX+i, 0, term.Cell{Ch: ch, Style: style})
-			}
+			s.actionSpan = statusBarSpan{r.X + actionX, r.X + actionX + actionW, nil}
+			s.drawText(surface, actionX, actionLabel, style)
 			rightX = actionX
 		}
 		if s.Status.SecondaryLabel != "" && s.Status.SecondaryAction != nil {
 			secLabel := " [" + s.Status.SecondaryLabel + "] "
-			secX := rightX - len([]rune(secLabel))
+			secW := textwidth.String(secLabel)
+			secX := rightX - secW
 			if secX > x+2 {
-				s.secondarySpan = statusBarSpan{r.X + secX, r.X + secX + len([]rune(secLabel)), nil}
-				for i, ch := range secLabel {
-					surface.SetCell(secX+i, 0, term.Cell{Ch: ch, Style: style})
-				}
+				s.secondarySpan = statusBarSpan{r.X + secX, r.X + secX + secW, nil}
+				s.drawText(surface, secX, secLabel, style)
 			}
 		}
 	} else {
 		okLabel := " [OK] "
-		okX := rightX - len([]rune(okLabel))
+		okW := textwidth.String(okLabel)
+		okX := rightX - okW
 		if okX > x+2 {
-			s.okSpan = statusBarSpan{r.X + okX, r.X + okX + len([]rune(okLabel)), nil}
-			for i, ch := range okLabel {
-				surface.SetCell(okX+i, 0, term.Cell{Ch: ch, Style: style})
-			}
+			s.okSpan = statusBarSpan{r.X + okX, r.X + okX + okW, nil}
+			s.drawText(surface, okX, okLabel, style)
 		}
 	}
 }
@@ -194,15 +193,18 @@ func (s *StatusBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	return EventIgnored
 }
 
+// drawText draws text at x and returns the number of columns consumed, which is
+// more than the rune count when the text contains fullwidth characters.
 func (s *StatusBarWidget) drawText(surface Surface, x int, text string, style term.Style) int {
 	w, _ := surface.Size()
 	n := 0
 	for _, ch := range text {
-		if x+n >= w {
+		cw := textwidth.Rune(ch)
+		if x+n+cw > w {
 			break
 		}
 		surface.SetCell(x+n, 0, term.Cell{Ch: ch, Style: style})
-		n++
+		n += cw
 	}
 	return n
 }

--- a/internal/ui/surface.go
+++ b/internal/ui/surface.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/eugenioenko/ttt/internal/widgets"
 )
 
@@ -48,13 +49,28 @@ func (s *RenderSurface) Fill(c term.Cell) {
 	}
 }
 
+// DrawText draws text starting at x, advancing by each rune's display width.
+// maxW is an absolute column limit (0 means "the surface edge"). A fullwidth
+// rune that would straddle the limit is replaced by a space: the terminal paints
+// such a rune across two columns regardless of clipping, so drawing it would
+// bleed into whatever is rendered to the right.
 func (s *RenderSurface) DrawText(x, y int, text string, maxW int, style term.Style) int {
+	limit := s.clip.W
+	if maxW > 0 && maxW < limit {
+		limit = maxW
+	}
 	for _, ch := range text {
-		if maxW > 0 && x >= maxW {
+		if x >= limit {
+			break
+		}
+		w := textwidth.Rune(ch)
+		if x+w > limit {
+			s.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+			x++
 			break
 		}
 		s.SetCell(x, y, term.Cell{Ch: ch, Style: style})
-		x++
+		x += w
 	}
 	return x
 }

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -68,6 +69,23 @@ func (t *TabBarWidget) tabLabel(tab Tab) string {
 	return label
 }
 
+// drawTabLabel draws a tab label from x, advancing by each rune's display width
+// and clipping to the scrollable inner zone. The dirty marker keeps its own
+// style so it stays visible against the tab background.
+func drawTabLabel(surface Surface, x, innerLeft, innerRight int, label string, dirty bool, style term.Style) {
+	for _, ch := range label {
+		chStyle := style
+		if dirty && ch == '●' {
+			chStyle = term.StyleWarning
+		}
+		w := textwidth.Rune(ch)
+		if x >= innerLeft && x+w <= innerRight {
+			surface.SetCell(x, 1, term.Cell{Ch: ch, Style: chStyle})
+		}
+		x += w
+	}
+}
+
 func (t *TabBarWidget) Render(surface Surface) {
 	w, _ := surface.Size()
 
@@ -83,7 +101,7 @@ func (t *TabBarWidget) Render(surface Surface) {
 	activeIdx := -1
 	for i, tab := range t.Tabs {
 		label := t.tabLabel(tab)
-		labelW := len([]rune(label))
+		labelW := textwidth.String(label)
 		spanW := labelW
 		if tab.Active {
 			spanW += 2
@@ -173,30 +191,12 @@ func (t *TabBarWidget) Render(surface Surface) {
 			if sx >= innerLeft && sx < innerRight {
 				surface.SetCell(sx, 1, term.Cell{Ch: b.Vertical, Style: bs})
 			}
-			for ci, ch := range []rune(s.label) {
-				style := term.StyleActiveTab
-				if dirty && ch == '●' {
-					style = term.StyleWarning
-				}
-				x := sx + 1 + ci
-				if x >= innerLeft && x < innerRight {
-					surface.SetCell(x, 1, term.Cell{Ch: ch, Style: style})
-				}
-			}
+			drawTabLabel(surface, sx+1, innerLeft, innerRight, s.label, dirty, term.StyleActiveTab)
 			if ex-1 >= innerLeft && ex-1 < innerRight {
 				surface.SetCell(ex-1, 1, term.Cell{Ch: b.Vertical, Style: bs})
 			}
 		} else {
-			for ci, ch := range []rune(s.label) {
-				style := term.StyleInactiveTab
-				if dirty && ch == '●' {
-					style = term.StyleWarning
-				}
-				x := sx + ci
-				if x >= innerLeft && x < innerRight {
-					surface.SetCell(x, 1, term.Cell{Ch: ch, Style: style})
-				}
-			}
+			drawTabLabel(surface, sx, innerLeft, innerRight, s.label, dirty, term.StyleInactiveTab)
 		}
 	}
 

--- a/internal/ui/word_wrap.go
+++ b/internal/ui/word_wrap.go
@@ -1,5 +1,9 @@
 package ui
 
+import (
+	"github.com/eugenioenko/ttt/internal/textwidth"
+)
+
 type wrapEntry struct {
 	bufLine  int
 	startCol int
@@ -56,7 +60,7 @@ func wrapLineSegments(runes []rune, width, tabW int) []int {
 		if ch == '\t' {
 			advance = ((visCol/tabW)+1)*tabW - visCol
 		} else {
-			advance = 1
+			advance = textwidth.Rune(ch)
 		}
 		if visCol+advance > width && visCol > 0 {
 			segments = append(segments, i)
@@ -117,7 +121,7 @@ func bufferPosToWrapScreenPos(lines []string, line, col, width, tabW int) (visua
 		if runes[i] == '\t' {
 			screenCol = ((screenCol / tabW) + 1) * tabW
 		} else {
-			screenCol++
+			screenCol += textwidth.Rune(runes[i])
 		}
 	}
 

--- a/internal/widgets/fullwidth_test.go
+++ b/internal/widgets/fullwidth_test.go
@@ -1,0 +1,150 @@
+package widgets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+	"github.com/gdamore/tcell/v3"
+)
+
+// rowText reads a surface row back the way the terminal displays it: the column
+// covered by a fullwidth rune is skipped, since the terminal paints it from the
+// rune itself and never draws whatever the cell holds. This mirrors what
+// app.Screenshot does with tcell's GetContent.
+func rowText(s *testSurface, y int) string {
+	var b strings.Builder
+	for x := 0; x < s.w; x++ {
+		ch := s.cells[y][x].Ch
+		if ch == 0 {
+			ch = ' '
+		}
+		b.WriteRune(ch)
+		if textwidth.Rune(ch) > 1 {
+			x++
+		}
+	}
+	return strings.TrimRight(b.String(), " ")
+}
+
+// defaultPrefixW is the width of the " ❯ " prefix NewInputWidget applies to
+// borderless inputs.
+const defaultPrefixW = 3
+
+func TestDrawRunesClippedFullwidth(t *testing.T) {
+	s := newTestSurface(20, 1)
+	end := drawRunesClipped(s, 0, 0, 20, []rune("가a나"), term.StyleDefault)
+	if end != 5 {
+		t.Fatalf("end = %d, want 5", end)
+	}
+	for x, want := range map[int]rune{0: '가', 2: 'a', 3: '나'} {
+		if s.cells[0][x].Ch != want {
+			t.Errorf("cell %d = %q, want %q", x, s.cells[0][x].Ch, want)
+		}
+	}
+}
+
+func TestDrawRunesClippedFullwidthEllipsis(t *testing.T) {
+	s := newTestSurface(20, 1)
+	// 가나다 needs 6 columns but only 4 are available.
+	drawRunesClipped(s, 0, 0, 4, []rune("가나다"), term.StyleDefault)
+	if s.cells[0][0].Ch != '가' {
+		t.Errorf("cell 0 = %q, want 가", s.cells[0][0].Ch)
+	}
+	if s.cells[0][2].Ch != '…' {
+		t.Errorf("cell 2 = %q, want an ellipsis", s.cells[0][2].Ch)
+	}
+	if s.cells[0][4].Ch != 0 {
+		t.Error("drawing ran past maxX")
+	}
+}
+
+func TestTruncateRunesLeftFullwidth(t *testing.T) {
+	// 5 columns available: the ellipsis takes 1, leaving 4 for two runes.
+	got := string(truncateRunesLeft([]rune("가나다라"), 5))
+	if got != "…다라" {
+		t.Errorf("got %q, want %q", got, "…다라")
+	}
+	// Fits already: returned unchanged.
+	if got := string(truncateRunesLeft([]rune("가나"), 4)); got != "가나" {
+		t.Errorf("got %q, want %q", got, "가나")
+	}
+}
+
+func TestInputRendersFullwidthText(t *testing.T) {
+	s := newTestSurface(20, 1)
+	inp := NewInputWidget(InputConfig{})
+	inp.SetRect(Rect{X: 0, Y: 0, W: 20, H: 1})
+	inp.SetText("가나다")
+	inp.Render(s)
+
+	if got := rowText(s, 0); !strings.Contains(got, "가나다") {
+		t.Errorf("row = %q, want it to contain 가나다", got)
+	}
+}
+
+// The caret sits after the text in columns, not in runes: three fullwidth runes
+// are six columns wide, not three.
+func TestInputCursorPositionFullwidth(t *testing.T) {
+	inp := NewInputWidget(InputConfig{})
+	inp.SetRect(Rect{X: 0, Y: 0, W: 20, H: 1})
+	inp.SetFocused(true)
+	inp.SetText("가나다")
+
+	x, _, visible := inp.CursorPosition()
+	if !visible {
+		t.Fatal("cursor should be visible when focused")
+	}
+	if want := defaultPrefixW + 6; x != want {
+		t.Errorf("cursor x = %d, want %d", x, want)
+	}
+}
+
+func TestInputClickMapsColumnToRune(t *testing.T) {
+	cases := []struct {
+		col  int
+		want int
+	}{
+		{0, 0}, // first half of 가
+		{1, 0}, // second half of 가 selects the same rune
+		{2, 1}, // first half of 나
+		{3, 1},
+		{4, 2},
+		{9, 3}, // past the end clamps to the rune count
+	}
+	for _, tc := range cases {
+		inp := NewInputWidget(InputConfig{})
+		inp.SetRect(Rect{X: 0, Y: 0, W: 20, H: 1})
+		inp.SetFocused(true)
+		inp.SetText("가나다")
+
+		ev := tcell.NewEventMouse(defaultPrefixW+tc.col, 0, tcell.Button1, 0)
+		if res := inp.HandleEvent(ev); res != EventConsumed {
+			t.Fatalf("column %d: click not consumed", tc.col)
+		}
+		if inp.cursorPos != tc.want {
+			t.Errorf("click at column %d put the cursor at rune %d, want %d", tc.col, inp.cursorPos, tc.want)
+		}
+	}
+}
+
+// A field narrower than its text must scroll by columns; a fullwidth rune that
+// does not fit in the remaining columns is dropped rather than half-drawn.
+func TestInputScrollsByColumns(t *testing.T) {
+	// The widget fills the surface it is handed: prefix plus 6 columns of text,
+	// which the 8-column string cannot fit.
+	s := newTestSurface(defaultPrefixW+6, 1)
+	inp := NewInputWidget(InputConfig{})
+	inp.SetRect(Rect{X: 0, Y: 0, W: defaultPrefixW + 6, H: 1})
+	inp.SetText("가나다라")
+	inp.Render(s)
+
+	row := rowText(s, 0)
+	if strings.Contains(row, "가") {
+		t.Errorf("row = %q: the field should have scrolled past the first rune", row)
+	}
+	if !strings.Contains(row, "라") {
+		t.Errorf("row = %q, want the rune at the cursor to stay visible", row)
+	}
+}

--- a/internal/widgets/input.go
+++ b/internal/widgets/input.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -69,9 +70,17 @@ func (inp *InputWidget) CursorPosition() (int, int, bool) {
 		textX += 2
 		textY += 1
 	} else {
-		textX += len([]rune(inp.Config.Prefix))
+		textX += textwidth.String(inp.Config.Prefix)
 	}
-	return textX + inp.cursorPos - inp.scrollOffset, textY, true
+	return textX + inp.visualOffset([]rune(inp.text), inp.cursorPos), textY, true
+}
+
+// visualOffset returns how many columns the rune at index pos sits to the right
+// of the first visible rune. Fullwidth runes count as two.
+func (inp *InputWidget) visualOffset(runes []rune, pos int) int {
+	lo := max(min(inp.scrollOffset, len(runes)), 0)
+	hi := max(min(pos, len(runes)), lo)
+	return textwidth.Runes(runes[lo:hi])
 }
 
 func (inp *InputWidget) Text() string { return inp.text }
@@ -147,17 +156,19 @@ func (inp *InputWidget) renderBorderless(surface Surface) {
 	}
 
 	prefixRunes := []rune(inp.Config.Prefix)
-	prefixW := len(prefixRunes)
+	prefixW := textwidth.Runes(prefixRunes)
 
 	prefixStyle := term.StyleBorder
 	if inp.focused {
 		prefixStyle = term.StyleBorderActive
 	}
 
-	for i, ch := range prefixRunes {
-		if i < w {
-			inner.SetCell(i, 0, term.Cell{Ch: ch, Style: prefixStyle})
+	px := 0
+	for _, ch := range prefixRunes {
+		if px < w {
+			inner.SetCell(px, 0, term.Cell{Ch: ch, Style: prefixStyle})
 		}
+		px += textwidth.Rune(ch)
 	}
 
 	inp.renderText(inner, prefixW, 0, w-prefixW)
@@ -175,29 +186,27 @@ func (inp *InputWidget) renderText(surface Surface, x, y, textW int) {
 
 	textRunes := []rune(inp.text)
 
-	maxOffset := len(textRunes) - textW
-	if maxOffset < 0 {
-		maxOffset = 0
-	}
-	if inp.scrollOffset > maxOffset {
+	// Scrolling is measured in columns, not runes: a window of textW columns
+	// holds fewer fullwidth runes than narrow ones.
+	if maxOffset := lastOffsetFitting(textRunes, textW); inp.scrollOffset > maxOffset {
 		inp.scrollOffset = maxOffset
 	}
 	if inp.cursorPos < inp.scrollOffset {
 		inp.scrollOffset = inp.cursorPos
 	}
-	if inp.cursorPos >= inp.scrollOffset+textW {
-		inp.scrollOffset = inp.cursorPos - textW + 1
+	// Walk the runes once to find the new offset rather than re-measuring the
+	// whole visible range per step — pasted text can be long.
+	if over := inp.visualOffset(textRunes, inp.cursorPos) - textW + 1; over > 0 {
+		for i := inp.scrollOffset; i < inp.cursorPos && over > 0; i++ {
+			over -= textwidth.Rune(textRunes[i])
+			inp.scrollOffset = i + 1
+		}
 	}
 
 	if len(textRunes) == 0 && inp.Config.Placeholder != "" {
-		phRunes := []rune(inp.Config.Placeholder)
-		for i := range textW {
-			ch := ' '
-			if i < len(phRunes) {
-				ch = phRunes[i]
-			}
-			surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: term.StyleInputPlaceholder})
-		}
+		inp.drawRunes(surface, x, y, textW, []rune(inp.Config.Placeholder), 0, func(int) term.Style {
+			return term.StyleInputPlaceholder
+		})
 		return
 	}
 
@@ -206,18 +215,78 @@ func (inp *InputWidget) renderText(surface Surface, x, y, textW int) {
 		selLo, selHi = inp.selRange()
 	}
 
-	for i := range textW {
-		ch := ' '
-		ri := inp.scrollOffset + i
-		if ri < len(textRunes) {
-			ch = textRunes[ri]
-		}
-		s := style
+	inp.drawRunes(surface, x, y, textW, textRunes, inp.scrollOffset, func(ri int) term.Style {
 		if selLo >= 0 && ri >= selLo && ri < selHi {
-			s = term.StyleSelection
+			return term.StyleSelection
 		}
-		surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: s})
+		return style
+	})
+}
+
+// drawRunes fills textW columns starting at x with runes from index `from`,
+// advancing by display width and padding the remainder with spaces so the input
+// keeps a solid background. A fullwidth rune that would not fit in the
+// remaining columns is dropped rather than drawn half-outside the field.
+func (inp *InputWidget) drawRunes(surface Surface, x, y, textW int, runes []rune, from int, styleAt func(ri int) term.Style) {
+	col := 0
+	ri := from
+	for col < textW {
+		ch := ' '
+		s := styleAt(ri)
+		w := 1
+		if ri < len(runes) {
+			ch = runes[ri]
+			w = textwidth.Rune(ch)
+			if col+w > textW {
+				ch, w = ' ', 1
+				ri = len(runes)
+			}
+		}
+		surface.SetCell(x+col, y, term.Cell{Ch: ch, Style: s})
+		if w > 1 {
+			// The terminal covers this column with the rune itself; the cell
+			// only needs to carry the matching background.
+			surface.SetCell(x+col+1, y, term.Cell{Ch: ' ', Style: s})
+		}
+		col += w
+		ri++
 	}
+}
+
+// posAtColumn maps a column offset from the start of the visible text to a rune
+// index. A click on the second column of a fullwidth rune selects that rune.
+func (inp *InputWidget) posAtColumn(runes []rune, col int) int {
+	if col <= 0 {
+		return max(min(inp.scrollOffset, len(runes)), 0)
+	}
+	used := 0
+	for i := inp.scrollOffset; i < len(runes); i++ {
+		if i < 0 {
+			continue
+		}
+		w := textwidth.Rune(runes[i])
+		if col < used+w {
+			return i
+		}
+		used += w
+	}
+	return len(runes)
+}
+
+// lastOffsetFitting returns the largest starting rune index whose tail still
+// fills a window of w columns, so the field never scrolls past its own text.
+func lastOffsetFitting(runes []rune, w int) int {
+	used := 0
+	i := len(runes)
+	for i > 0 {
+		rw := textwidth.Rune(runes[i-1])
+		if used+rw > w {
+			break
+		}
+		used += rw
+		i--
+	}
+	return i
 }
 
 func (inp *InputWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -367,18 +436,12 @@ func (inp *InputWidget) handleMouse(ev *tcell.EventMouse) EventResult {
 		return EventIgnored
 	}
 
-	textX := r.X + inp.Box.MarginLeft + inp.Box.PaddingLeft + len([]rune(inp.Config.Prefix))
+	textX := r.X + inp.Box.MarginLeft + inp.Box.PaddingLeft + textwidth.String(inp.Config.Prefix)
 	if inp.Config.Bordered {
 		textX = r.X + inp.Box.MarginLeft + inp.Box.PaddingLeft + 2
 	}
-	pos := inp.scrollOffset + (mx - textX)
 	runes := []rune(inp.text)
-	if pos < 0 {
-		pos = 0
-	}
-	if pos > len(runes) {
-		pos = len(runes)
-	}
+	pos := inp.posAtColumn(runes, mx-textX)
 
 	now := time.Now().UnixMilli()
 	if now-inp.lastClickTime < 400 && pos == inp.lastClickPos {

--- a/internal/widgets/table.go
+++ b/internal/widgets/table.go
@@ -2,6 +2,7 @@ package widgets
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -236,46 +237,28 @@ func (t *TableWidget) renderCell(surface Surface, text string, col TableColumn, 
 		return
 	}
 
-	if len(runes) > colW {
-		// Truncate with ellipsis
-		for i := 0; i < colW-1 && x+i < t.contentW; i++ {
-			surface.SetCell(x+i, y, term.Cell{Ch: runes[i], Style: style})
-		}
-		if x+colW-1 < t.contentW {
-			surface.SetCell(x+colW-1, y, term.Cell{Ch: '…', Style: style})
-		}
+	maxX := min(x+colW, t.contentW)
+	textW := textwidth.Runes(runes)
+	if textW > colW {
+		drawRunesClipped(surface, x, y, maxX, runes, style)
 		return
 	}
 
-	padding := colW - len(runes)
+	padding := colW - textW
 	switch col.Align {
 	case "right":
 		for i := 0; i < padding && x+i < t.contentW; i++ {
 			surface.SetCell(x+i, y, term.Cell{Ch: ' ', Style: style})
 		}
-		for i, ch := range runes {
-			px := x + padding + i
-			if px < t.contentW {
-				surface.SetCell(px, y, term.Cell{Ch: ch, Style: style})
-			}
-		}
+		drawRunesClipped(surface, x+padding, y, maxX, runes, style)
 	case "center":
 		leftPad := padding / 2
 		for i := 0; i < leftPad && x+i < t.contentW; i++ {
 			surface.SetCell(x+i, y, term.Cell{Ch: ' ', Style: style})
 		}
-		for i, ch := range runes {
-			px := x + leftPad + i
-			if px < t.contentW {
-				surface.SetCell(px, y, term.Cell{Ch: ch, Style: style})
-			}
-		}
+		drawRunesClipped(surface, x+leftPad, y, maxX, runes, style)
 	default: // left
-		for i, ch := range runes {
-			if x+i < t.contentW {
-				surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: style})
-			}
-		}
+		drawRunesClipped(surface, x, y, maxX, runes, style)
 	}
 }
 

--- a/internal/widgets/text.go
+++ b/internal/widgets/text.go
@@ -1,0 +1,71 @@
+package widgets
+
+import (
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+)
+
+// drawTextWidthAware draws text starting at x, advancing by each rune's display
+// width. maxW is an absolute column limit (0 means "the surface edge"). A
+// fullwidth rune that would straddle the limit is replaced by a space, because
+// the terminal paints such a rune across two columns regardless of clipping.
+func drawTextWidthAware(surface Surface, x, y int, text string, maxW, surfaceW int, style term.Style) int {
+	limit := surfaceW
+	if maxW > 0 && maxW < limit {
+		limit = maxW
+	}
+	for _, ch := range text {
+		if x >= limit {
+			break
+		}
+		w := textwidth.Rune(ch)
+		if x+w > limit {
+			surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+			x++
+			break
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: style})
+		x += w
+	}
+	return x
+}
+
+// drawRunesClipped draws runes from x up to (but not including) maxX, advancing
+// by display width. When the runes do not fit, the last column that would be
+// drawn becomes an ellipsis. Returns the column after the last one written.
+func drawRunesClipped(surface Surface, x, y, maxX int, runes []rune, style term.Style) int {
+	fits := x+textwidth.Runes(runes) <= maxX
+	for i, ch := range runes {
+		w := textwidth.Rune(ch)
+		if x+w > maxX {
+			break
+		}
+		if !fits && x+w >= maxX && i < len(runes)-1 {
+			surface.SetCell(x, y, term.Cell{Ch: '…', Style: style})
+			return x + 1
+		}
+		surface.SetCell(x, y, term.Cell{Ch: ch, Style: style})
+		x += w
+	}
+	return x
+}
+
+// truncateRunesLeft keeps the tail of runes that fits in avail columns,
+// prefixed with an ellipsis. Used where the end of a label (a filename, a path
+// segment) matters more than its beginning.
+func truncateRunesLeft(runes []rune, avail int) []rune {
+	if avail <= 0 || textwidth.Runes(runes) <= avail {
+		return runes
+	}
+	tailW := 0
+	i := len(runes)
+	for i > 0 {
+		w := textwidth.Rune(runes[i-1])
+		if tailW+w > avail-1 {
+			break
+		}
+		tailW += w
+		i--
+	}
+	return append([]rune{'…'}, runes[i:]...)
+}

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -2,6 +2,7 @@ package widgets
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -295,7 +296,7 @@ func (t *TreeWidget) menuIconWidth() int {
 func (t *TreeWidget) rightSideWidth(node *TreeNode) int {
 	rw := t.menuIconWidth()
 	for i, action := range node.Actions {
-		rw += len([]rune(action.Icon))
+		rw += textwidth.String(action.Icon)
 		if i > 0 {
 			rw++
 		}
@@ -348,20 +349,7 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		if idx == t.selected {
 			iconStyle = style
 		}
-		iconRunes := []rune(node.Icon)
-		iconFits := x+len(iconRunes) <= maxX
-		for i, ch := range iconRunes {
-			if x >= maxX {
-				break
-			}
-			if !iconFits && x == maxX-1 && i < len(iconRunes)-1 {
-				surface.SetCell(x, y, term.Cell{Ch: '…', Style: iconStyle})
-				x++
-				break
-			}
-			surface.SetCell(x, y, term.Cell{Ch: ch, Style: iconStyle})
-			x++
-		}
+		x = drawRunesClipped(surface, x, y, maxX, []rune(node.Icon), iconStyle)
 		if x < maxX {
 			surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
 			x++
@@ -374,25 +362,9 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 	}
 	labelRunes := []rune(node.Label)
 	if t.Config.TruncateLeft {
-		if avail := maxX - x; avail > 0 && len(labelRunes) > avail {
-			// Keep the tail visible: leading … then the last avail-1 runes.
-			tail := labelRunes[len(labelRunes)-(avail-1):]
-			labelRunes = append([]rune{'…'}, tail...)
-		}
+		labelRunes = truncateRunesLeft(labelRunes, maxX-x)
 	}
-	labelFits := x+len(labelRunes) <= maxX
-	for i, ch := range labelRunes {
-		if x >= maxX {
-			break
-		}
-		if !labelFits && x == maxX-1 && i < len(labelRunes)-1 {
-			surface.SetCell(x, y, term.Cell{Ch: '…', Style: labelStyle})
-			x++
-			break
-		}
-		surface.SetCell(x, y, term.Cell{Ch: ch, Style: labelStyle})
-		x++
-	}
+	x = drawRunesClipped(surface, x, y, maxX, labelRunes, labelStyle)
 
 	if node.Badge != "" {
 		badgeStyle := node.BadgeStyle
@@ -403,20 +375,7 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 			badgeStyle = style
 		}
 		x++
-		badgeRunes := []rune(node.Badge)
-		badgeFits := x+len(badgeRunes) <= maxX
-		for i, ch := range badgeRunes {
-			if x >= maxX {
-				break
-			}
-			if !badgeFits && x == maxX-1 && i < len(badgeRunes)-1 {
-				surface.SetCell(x, y, term.Cell{Ch: '…', Style: badgeStyle})
-				x++
-				break
-			}
-			surface.SetCell(x, y, term.Cell{Ch: ch, Style: badgeStyle})
-			x++
-		}
+		drawRunesClipped(surface, x, y, maxX, []rune(node.Badge), badgeStyle)
 	}
 
 	rightX := w - 2
@@ -459,10 +418,14 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		action := node.Actions[i]
 		iconRunes := []rune(action.Icon)
 		for j := len(iconRunes) - 1; j >= 0; j-- {
-			if rightX >= 0 && rightX < w {
-				surface.SetCell(rightX, y, term.Cell{Ch: iconRunes[j], Style: actionStyle})
+			cw := textwidth.Rune(iconRunes[j])
+			// Icons are laid out right to left, so a fullwidth rune starts one
+			// column further left than the cursor.
+			startX := rightX - cw + 1
+			if startX >= 0 && startX < w {
+				surface.SetCell(startX, y, term.Cell{Ch: iconRunes[j], Style: actionStyle})
 			}
-			rightX--
+			rightX -= cw
 		}
 		if i > 0 {
 			if rightX >= 0 && rightX < w {
@@ -553,7 +516,7 @@ func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {
 		rightX := t.contentX + t.contentW - 2 - t.menuIconWidth()
 		for i := len(node.Actions) - 1; i >= 0; i-- {
 			action := node.Actions[i]
-			iconW := len([]rune(action.Icon))
+			iconW := textwidth.String(action.Icon)
 			actionX := rightX - iconW + 1
 			if mx >= actionX && mx <= rightX {
 				if t.Config.OnCommand != nil {

--- a/internal/widgets/virtual_surface.go
+++ b/internal/widgets/virtual_surface.go
@@ -29,14 +29,7 @@ func (v *virtualSurface) SetCell(x, y int, c term.Cell) {
 }
 
 func (v *virtualSurface) DrawText(x, y int, text string, maxW int, style term.Style) int {
-	for _, ch := range text {
-		if maxW > 0 && x >= maxW {
-			break
-		}
-		v.SetCell(x, y, term.Cell{Ch: ch, Style: style})
-		x++
-	}
-	return x
+	return drawTextWidthAware(v, x, y, text, maxW, v.w, style)
 }
 
 func (v *virtualSurface) DrawBorder(x, y, w, h int, b term.BorderSet, style term.Style) {
@@ -95,14 +88,7 @@ func (s *subVirtualSurface) SetCell(x, y int, c term.Cell) {
 }
 
 func (s *subVirtualSurface) DrawText(x, y int, text string, maxW int, style term.Style) int {
-	for _, ch := range text {
-		if maxW > 0 && x >= maxW {
-			break
-		}
-		s.SetCell(x, y, term.Cell{Ch: ch, Style: style})
-		x++
-	}
-	return x
+	return drawTextWidthAware(s, x, y, text, maxW, s.w, style)
 }
 
 func (s *subVirtualSurface) DrawBorder(x, y, w, h int, b term.BorderSet, style term.Style) {

--- a/tests/e2e/fullwidth_test.go
+++ b/tests/e2e/fullwidth_test.go
@@ -1,0 +1,171 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+// openFullwidth writes a file of fullwidth text and opens it.
+func openFullwidth(t *testing.T, h *testHarness, name, content string) {
+	t.Helper()
+	f := filepath.Join(h.dir, name)
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+}
+
+// Every syllable must reach the screen. Before the fix the terminal swallowed
+// the character following each fullwidth rune, rendering 가다마사 (issue #434).
+func TestFullwidthLineRendersEveryRune(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	openFullwidth(t, h, "hangul.txt", "가나다라마바사\n")
+	h.assertContains("가나다라마바사")
+}
+
+func TestFullwidthMixedWithASCIIRenders(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	openFullwidth(t, h, "mixed.txt", "가a나b다\n")
+	h.assertContains("가a나b다")
+}
+
+// Arrow keys move one rune at a time; the reported column is a character index,
+// not a screen column.
+func TestFullwidthCursorMovesByRune(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	openFullwidth(t, h, "hangul.txt", "가나다라\n")
+
+	ed := h.app.EditorGroup.Editor
+	for i := 1; i <= 4; i++ {
+		h.pressKey(tcell.KeyRight, tcell.ModNone)
+		if ed.Cursor.Col != i {
+			t.Fatalf("after %d right presses, cursor col = %d, want %d", i, ed.Cursor.Col, i)
+		}
+	}
+	// Past the last rune the cursor wraps to the next line, as it does for
+	// ASCII text.
+	h.pressKey(tcell.KeyRight, tcell.ModNone)
+	if ed.Cursor.Line != 1 || ed.Cursor.Col != 0 {
+		t.Errorf("cursor = (%d,%d), want (1,0)", ed.Cursor.Line, ed.Cursor.Col)
+	}
+}
+
+func TestFullwidthHomeEnd(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	openFullwidth(t, h, "hangul.txt", "가나다라\n")
+	ed := h.app.EditorGroup.Editor
+
+	h.pressKey(tcell.KeyEnd, tcell.ModNone)
+	if ed.Cursor.Col != 4 {
+		t.Errorf("End put the cursor at col %d, want 4", ed.Cursor.Col)
+	}
+	h.pressKey(tcell.KeyHome, tcell.ModNone)
+	if ed.Cursor.Col != 0 {
+		t.Errorf("Home put the cursor at col %d, want 0", ed.Cursor.Col)
+	}
+}
+
+// Clicking either column of a fullwidth rune puts the cursor on that rune.
+func TestFullwidthClickMapsToRune(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	openFullwidth(t, h, "hangul.txt", "가나다라\n")
+	ed := h.app.EditorGroup.Editor
+
+	textX, textY := fullwidthTextOrigin(t, h, '가')
+
+	cases := []struct {
+		dx   int
+		want int
+	}{
+		{0, 0}, {1, 0}, // 가
+		{2, 1}, {3, 1}, // 나
+		{4, 2}, {5, 2}, // 다
+		{6, 3}, {7, 3}, // 라
+	}
+	for _, tc := range cases {
+		// Both halves of a rune resolve to the same buffer column, so two
+		// clicks in a row would register as a double click and select a word.
+		// Park the cursor on the empty line below to break the streak.
+		h.click(textX, textY+1)
+
+		h.click(textX+tc.dx, textY)
+		if ed.Cursor.Col != tc.want {
+			t.Errorf("click %d columns into the line put the cursor at rune %d, want %d",
+				tc.dx, ed.Cursor.Col, tc.want)
+		}
+	}
+}
+
+// Selecting two fullwidth runes must yield those runes, not the columns they
+// span.
+func TestFullwidthSelectionSpansRunes(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	openFullwidth(t, h, "hangul.txt", "가나다라\n")
+	ed := h.app.EditorGroup.Editor
+
+	h.pressKey(tcell.KeyHome, tcell.ModNone)
+	h.pressKey(tcell.KeyRight, tcell.ModShift)
+	h.pressKey(tcell.KeyRight, tcell.ModShift)
+
+	if !ed.Selection.Active {
+		t.Fatal("shift+right should start a selection")
+	}
+	if got := ed.Cursor.Col; got != 2 {
+		t.Errorf("cursor col = %d, want 2", got)
+	}
+	start, end := ed.Selection.Range(ed.Cursor.Line, ed.Cursor.Col)
+	if start.Line != 0 || end.Line != 0 || start.Col != 0 || end.Col != 2 {
+		t.Errorf("selection = (%d,%d)-(%d,%d), want (0,0)-(0,2)",
+			start.Line, start.Col, end.Line, end.Col)
+	}
+}
+
+// A line of fullwidth text must wrap on a rune boundary, never mid-rune.
+func TestFullwidthWordWrapKeepsRunesIntact(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	openFullwidth(t, h, "wrap.txt", strings.Repeat("가", 60)+"\n")
+	h.exec("options.toggleWordWrap")
+	h.redraw()
+
+	// Whatever the wrap width works out to, every rendered row must contain
+	// only whole runes — a split rune shows up as a missing glyph.
+	text := h.screenText()
+	if !strings.Contains(text, "가가가") {
+		t.Errorf("wrapped fullwidth text did not render:\n%s", text)
+	}
+}
+
+// fullwidthTextOrigin finds where the given rune first appears on screen, so
+// click tests do not hard-code the gutter width.
+func fullwidthTextOrigin(t *testing.T, h *testHarness, r rune) (x, y int) {
+	t.Helper()
+	cells, w, ht := h.screen.GetContents()
+	for cy := 0; cy < ht; cy++ {
+		for cx := 0; cx < w; cx++ {
+			if cells[cy*w+cx].Str == string(r) {
+				return cx, cy
+			}
+		}
+	}
+	t.Fatalf("rune %q not found on screen:\n%s", r, h.screenText())
+	return 0, 0
+}

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/render"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/workspace"
 
@@ -159,31 +160,30 @@ func (h *testHarness) screenText() string {
 	cells, w, ht := h.screen.GetContents()
 	var lines []string
 	for y := 0; y < ht; y++ {
-		var line strings.Builder
-		for x := 0; x < w; x++ {
-			sc := cells[y*w+x]
-			if sc.Str != "" {
-				line.WriteString(sc.Str)
-			} else {
-				// wide-rune continuation cell or blank
-				line.WriteRune(' ')
-			}
-		}
-		lines = append(lines, line.String())
+		lines = append(lines, rowString(cells[y*w:(y+1)*w]))
 	}
 	return strings.Join(lines, "\n")
 }
 
 func (h *testHarness) screenRow(y int) string {
 	cells, w, _ := h.screen.GetContents()
+	return rowString(cells[y*w : (y+1)*w])
+}
+
+// rowString reassembles a row the way the terminal displays it. A wide rune
+// already accounts for the column it covers, so the continuation cell that
+// follows it contributes nothing; every other empty cell is a blank column.
+func rowString(cells []term.SimCell) string {
 	var line strings.Builder
-	for x := 0; x < w; x++ {
-		sc := cells[y*w+x]
-		if sc.Str != "" {
-			line.WriteString(sc.Str)
-		} else {
-			// wide-rune continuation cell or blank
+	for x := 0; x < len(cells); x++ {
+		sc := cells[x]
+		if sc.Str == "" {
 			line.WriteRune(' ')
+			continue
+		}
+		line.WriteString(sc.Str)
+		if textwidth.String(sc.Str) > 1 {
+			x++
 		}
 	}
 	return line.String()

--- a/tests/functional/cyrillic-cursor.test.js
+++ b/tests/functional/cyrillic-cursor.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("cursor position with multi-byte UTF-8 characters", () => {
+  it("cursor column is correct after typing Cyrillic", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "cyrillic.txt", "");
+
+    tui.start(file);
+    tui.waitStable();
+
+    // Type 6 Cyrillic characters: привет
+    tui.type("привет");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // 6 runes typed; cursor should be at column 7 (1-indexed, after last char).
+    // If using byte length, it would show Col 13 (6 × 2 bytes + 1).
+    expect(snapshots[s0]).toContain("Col 7");
+  });
+
+  it("cursor column advances correctly mixing ASCII and Cyrillic", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "mixed2.txt", "");
+
+    tui.start(file);
+    tui.waitStable();
+
+    // Type: hiпривет (2 ASCII + 6 Cyrillic = 8 runes)
+    tui.type("hiпривет");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // 8 runes typed; cursor should be at column 9.
+    expect(snapshots[s0]).toContain("Col 9");
+  });
+
+  it("cursor stays after last Cyrillic character when navigating", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "nav.txt", "привет\n");
+
+    tui.start(file);
+    tui.waitStable();
+
+    // Move to end of line
+    tui.press("end");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // End of "привет" (6 runes) should be Col 7.
+    expect(snapshots[s0]).toContain("Col 7");
+  });
+
+  it("home/end work correctly with Cyrillic line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "cyrline.txt", "привет\n");
+
+    tui.start(file);
+    tui.waitStable();
+
+    // Start at Col 1
+    const s0 = tui.snapshot();
+
+    tui.press("end");
+    tui.waitStable();
+    const s1 = tui.snapshot();
+
+    tui.press("home");
+    tui.waitStable();
+    const s2 = tui.snapshot();
+
+    const { snapshots } = tui.run();
+
+    // Home should be Col 1
+    expect(snapshots[s0]).toContain("Col 1");
+    // End should be Col 7 (after 6 runes)
+    expect(snapshots[s1]).toContain("Col 7");
+    // Home again should be Col 1
+    expect(snapshots[s2]).toContain("Col 1");
+  });
+});

--- a/tests/functional/fullwidth-render.test.js
+++ b/tests/functional/fullwidth-render.test.js
@@ -1,0 +1,228 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+// Fullwidth East Asian characters occupy two terminal columns. Everything that
+// maps text to columns — drawing, the cursor, clicks, truncation — has to agree
+// with that, or the terminal swallows the character after each wide one.
+// See https://github.com/eugenioenko/ttt/issues/434
+describe("fullwidth CJK rendering", () => {
+  it("should render all Korean syllables, not every other one", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "hangul.txt", "가나다라마바사\n");
+
+    tui.start(file);
+    tui.waitFor("hangul.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // The issue: fullwidth characters cause the next character to be swallowed.
+    // 가나다라마바사 (7 syllables) renders as 가다마사 (only indices 0,2,4,6).
+    // All 7 should be visible.
+    expect(snapshots[s0]).toContain("가나다라마바사");
+  });
+
+  it("should render all Chinese characters, not every other one", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "chinese.txt", "你好世界\n");
+
+    tui.start(file);
+    tui.waitFor("chinese.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // 你好世界 (4 chars) should all be visible, not just 你世.
+    expect(snapshots[s0]).toContain("你好世界");
+  });
+
+  it("should render all Japanese kana, not every other one", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "japanese.txt", "こんにちは\n");
+
+    tui.start(file);
+    tui.waitFor("japanese.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // こんにちは (5 chars) should all be visible, not just こには.
+    expect(snapshots[s0]).toContain("こんにちは");
+  });
+
+  it("should render mixed fullwidth and ASCII without swallowing", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "mixed.txt", "가a나b다\n");
+
+    tui.start(file);
+    tui.waitFor("mixed.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // ASCII chars following fullwidth chars should not be swallowed.
+    // 가a나b다 should show all 5 runes, not just 가나다.
+    expect(snapshots[s0]).toContain("가a나b다");
+  });
+
+  it("fullwidth last on line should render correctly (trailing padding ok)", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "trailing.txt", "hello가\n");
+
+    tui.start(file);
+    tui.waitFor("trailing.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // A line ending with a fullwidth char — the swallowed cell is trailing
+    // padding, so it looks fine. But verify the whole line renders.
+    expect(snapshots[s0]).toContain("hello가");
+  });
+
+  it("should type fullwidth text into the buffer", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "typing.txt", "\n");
+
+    tui.start(file);
+    tui.waitFor("typing.txt");
+    tui.type("가나다");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("가나다");
+  });
+});
+
+describe("fullwidth CJK cursor and columns", () => {
+  it("should report a character column, not a screen column", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "hangul.txt", "가나다라\n");
+
+    tui.start(file);
+    tui.waitFor("hangul.txt");
+    tui.press("end");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Four runes: the cursor sits at character 5, not column 9.
+    expect(snapshots[s0]).toContain("Ln 1, Col 5");
+  });
+
+  it("should move one rune per arrow key", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "hangul.txt", "가나다라\n");
+
+    tui.start(file);
+    tui.waitFor("hangul.txt");
+    tui.press("right");
+    tui.press("right");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("Ln 1, Col 3");
+  });
+
+  it("should keep the line intact when scrolled horizontally", () => {
+    dir = createTempDir();
+    // Wider than the editor pane, forcing horizontal scroll.
+    const file = createTempFile(dir, "wide.txt", "가".repeat(120) + "END\n");
+
+    tui.start(file);
+    tui.setSize(80, 24);
+    tui.waitFor("wide.txt");
+    tui.press("end");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Scrolled to the end of the line: the tail must render whole.
+    expect(snapshots[s0]).toContain("가가가가");
+    expect(snapshots[s0]).toContain("END");
+  });
+
+  it("should not let a fullwidth rune bleed over the pane border", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "edge.txt", "가".repeat(200) + "\n");
+
+    tui.start(file);
+    tui.setSize(80, 24);
+    tui.waitFor("edge.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Every row of the editor frame keeps its right border: a fullwidth rune
+    // drawn in the last column would paint over it.
+    const rows = snapshots[s0].split("\n").filter((r) => r.includes("가"));
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.trimEnd().endsWith("│")).toBe(true);
+    }
+  });
+});
+
+describe("fullwidth CJK outside the editor", () => {
+  it("should render a CJK filename in the explorer and tab bar", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "한국어파일.txt", "hello\n");
+
+    tui.start(dir, file);
+    tui.waitFor("한국어파일.txt");
+    tui.wait(400);
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Once in the explorer tree, once in the tab bar — neither may drop runes.
+    const matches = snapshots[s0].split("한국어파일.txt").length - 1;
+    expect(matches).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should render fullwidth text typed into the find bar", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "search.txt", "가나다라\n");
+
+    tui.start(file);
+    tui.waitFor("search.txt");
+    tui.press("ctrl+f");
+    tui.wait(200);
+    tui.type("가나다");
+    tui.wait(300);
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // The query renders in full, and matches the buffer text.
+    expect(snapshots[s0]).toContain("가나다");
+    expect(snapshots[s0]).toContain("1/1");
+  });
+
+  it("should render fullwidth text typed into the command palette", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "palette.txt", "hello\n");
+
+    tui.start(file);
+    tui.waitFor("palette.txt");
+    tui.press("ctrl+p");
+    tui.wait(200);
+    tui.type("한국");
+    tui.wait(300);
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("한국");
+  });
+});


### PR DESCRIPTION
Fixes #434.

## The bug

ttt assumed **one terminal column per rune**. Fullwidth East Asian runes occupy two, and tcell advances the terminal cursor by the rune's width when it draws (`tscreen.go` skips the column a wide rune covers). So the character ttt placed in that column was never displayed — in a run of CJK text, every second character vanished.

| Input | Before | After |
|---|---|---|
| `가나다라마바사` | `가다마사` | `가나다라마바사` |
| `你好世界` | `你世` | `你好世界` |
| `가a나b다` | `가나다` | `가a나b다` |

It was never editor-only. A file named `한국어파일.txt` rendered as `한어일txt` in the explorer and tab bar, and typing Korean into the find bar dropped every second character *and* drifted the caret while you typed.

## The fix

**`internal/textwidth`** — new leaf package, the single source of truth for display width. It wraps `clipperhouse/displaywidth` with the same options tcell v3 uses internally (`internal/widthutil`), including the `RUNEWIDTH_EASTASIAN` toggle, so ttt's layout always agrees with what tcell draws. Measuring with a *different* library (e.g. `mattn/go-runewidth`) would reintroduce this exact class of bug wherever the two disagree — tcell v3 no longer uses it.

Column arithmetic is now width-aware everywhere text meets the screen:

- **editor** — `renderLineToScreen`, `bufColToVisualCol`, `visualColToBufCol`, `wrapLineSegments`, `bufferPosToWrapScreenPos`: drawing, cursor, clicks, horizontal scroll and word wrap all agree
- **`DrawText`** on both surfaces — covers the command palette, dialogs, labels and plugin panels for free
- **both `InputWidget`s** (`internal/ui` for find bar/palette, `internal/widgets` for plugin and dialog inputs) — caret position, column-based scrolling, click-to-rune mapping
- **tree/list rows, table cells, tab labels, status bar segments** — including truncation and click hit-regions

Two behaviours worth calling out:

- A fullwidth rune is **never drawn in the last column of a clip region**. The terminal paints it across two columns regardless of clipping, so it would bleed over the border or scrollbar to its right; a space goes there instead.
- **Clicking either column of a wide rune selects that rune**, matching how clicking anywhere inside a tab's whitespace already behaves. Cursor `Col` remains a character index (VS Code semantics), not a screen column.

Where a widget draws left to right, the hit-region now comes from what `DrawText` actually consumed rather than a second measurement of the same string — one oracle, not two.

## Tests

- `internal/textwidth` — width tables, the never-zero rule for control/combining runes, and that the `RUNEWIDTH_EASTASIAN` parsing matches tcell's
- `internal/ui` — rune↔column mapping incl. a round-trip property, wrap segmentation (a rune is never split across rows), `DrawText` clip-edge behaviour
- `internal/widgets` — clipped drawing, left-truncation, input caret/scroll/click
- `tests/e2e` — rendering, arrow/Home/End, click→rune for both halves of every rune, selection extents, word wrap
- `tests/functional` — the 5 original repro cases plus typing, cursor column, horizontal scroll, border bleed, explorer + tab bar, find bar, command palette

**10 of the 13 functional tests fail on `main`** (verified by stashing the fix and rebuilding); the 3 that pass are the trailing-fullwidth case and the two column-reporting ones, which were already correct.

The e2e harness reassembled rows by turning every empty cell into a space, which split wide runes apart in assertions. It now skips the column a wide rune covers, mirroring `app.Screenshot`.

Full suite: `go test ./...` green, `tests/functional` 78 files / 254 tests green (27 pre-existing expected failures unchanged).

## Follow-ups (not in this PR)

- The integrated terminal widget makes the same one-rune-one-column assumption on the vt10x grid — CJK output from a shell command in the bottom panel is still broken. Needs its own wide-cell model.
- Worth asking tcell upstream to export its width function; consumers currently have to reconstruct it (and the env toggle) with no compile-time guarantee they stay in sync.
- Grapheme clusters (emoji ZWJ sequences, combining marks) remain measured per rune. That is consistent with ttt drawing one cell per rune, but it is not what tcell measures for multi-rune clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)