### PR TITLE
Sync open tabs when a file is renamed in the explorer

### DIFF
--- a/internal/app/commands_help.go
+++ b/internal/app/commands_help.go
@@ -13,6 +13,7 @@ var explorerHelpEntries = []widgets.KeyValueEntry{
 	{Key: "Space", Value: "Open file or toggle folder"},
 	{Key: "Shift+Enter", Value: "Open context menu"},
 	{Key: "Menu*", Value: "Open context menu (terminal-dependent)"},
+	{Key: "r", Value: "Refresh explorer"},
 	{Key: "Up / k", Value: "Move up"},
 	{Key: "Down / j", Value: "Move down"},
 	{Key: "Left / h", Value: "Collapse folder"},

--- a/internal/app/explorer.go
+++ b/internal/app/explorer.go
@@ -6,8 +6,11 @@ import (
 	"strings"
 
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/widgets"
+
+	"github.com/gdamore/tcell/v3"
 )
 
 type NavigationPanel struct {
@@ -48,6 +51,14 @@ func NewNavigationPanel(settings config.ExplorerSettings, paths ...string) *Navi
 			if cmd == "activate" && n.OnOpenFile != nil {
 				n.OnOpenFile(node.ID)
 			}
+		},
+		OnKey: func(ev *tcell.EventKey, _ *widgets.TreeNode) bool {
+			switch term.KeyRune(ev) {
+			case 'r', 'R':
+				n.Reload()
+				return true
+			}
+			return false
 		},
 		OnMenu: func(_ []widgets.MenuEntry, node *widgets.TreeNode, sx, sy int) {
 			if n.isRoot(node) {

--- a/internal/app/fileops.go
+++ b/internal/app/fileops.go
@@ -77,6 +77,7 @@ func (a *App) FileOpRename(path string, reload func()) {
 			a.StatusError("Error: " + err.Error())
 			return
 		}
+		a.EditorGroup.RenamePath(path, newPath)
 		reload()
 	})
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -734,6 +734,55 @@ func (g *EditorGroupWidget) SaveAs(path string) {
 	g.syncTabs()
 }
 
+// RenamePath repoints open tabs after a path is renamed on disk. oldPath may be
+// a file, matched exactly, or a folder, in which case every tab beneath it moves
+// with it. Without this a renamed file's tab keeps pointing at the path it no
+// longer occupies, so the next save writes the old name back out as a duplicate.
+//
+// Buffer, cursor, selection and undo history are deliberately preserved: the
+// document did not change, only its name. Path-derived state (the syntax
+// highlighter, and the language server's notion of which document this is) is
+// rebuilt, since a rename can change the extension.
+func (g *EditorGroupWidget) RenamePath(oldPath, newPath string) bool {
+	if oldPath == "" || newPath == "" || oldPath == newPath {
+		return false
+	}
+	prefix := oldPath + string(filepath.Separator)
+	renamed := false
+	for i := range g.tabs {
+		t := &g.tabs[i]
+		if t.Virtual || t.Content != nil || t.Buf == nil {
+			continue
+		}
+		var updated string
+		switch {
+		case t.FilePath == oldPath:
+			updated = newPath
+		case strings.HasPrefix(t.FilePath, prefix):
+			updated = filepath.Join(newPath, strings.TrimPrefix(t.FilePath, prefix))
+		default:
+			continue
+		}
+		if g.OnFileClose != nil && t.Highlighter != nil {
+			g.OnFileClose(t.FilePath, t.Highlighter.Language())
+		}
+		t.FilePath = updated
+		if g.SyntaxHighlight {
+			t.Highlighter = highlight.New(updated)
+		} else {
+			t.Highlighter = nil
+		}
+		if g.OnFileOpen != nil && t.Highlighter != nil {
+			g.OnFileOpen(updated, t.Highlighter.Language(), strings.Join(t.Buf.Lines, "\n"))
+		}
+		renamed = true
+	}
+	if renamed {
+		g.syncTabs()
+	}
+	return renamed
+}
+
 func (g *EditorGroupWidget) ActiveFilePath() string {
 	if t := g.activeTab(); t != nil {
 		return t.FilePath

--- a/internal/ui/editor_group_rename_test.go
+++ b/internal/ui/editor_group_rename_test.go
@@ -1,0 +1,177 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newRenameGroup returns a group with one tab open on a real file at path.
+func newRenameGroup(t *testing.T, path, contents string) *EditorGroupWidget {
+	t.Helper()
+	os.MkdirAll(filepath.Dir(path), 0755)
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+	g.SyntaxHighlight = true
+	g.OpenFile(path)
+	return g
+}
+
+func TestRenamePathUpdatesOpenTab(t *testing.T) {
+	tmp := t.TempDir()
+	old := filepath.Join(tmp, "old.txt")
+	g := newRenameGroup(t, old, "hello\nworld")
+
+	newPath := filepath.Join(tmp, "new.txt")
+	if !g.RenamePath(old, newPath) {
+		t.Fatal("expected RenamePath to report a change")
+	}
+	if got := g.ActiveFilePath(); got != newPath {
+		t.Fatalf("tab path: got %q, want %q", got, newPath)
+	}
+}
+
+// The reported bug: after a rename the tab kept the old path, so saving wrote
+// the buffer back to the name it had been renamed away from, leaving a ghost
+// duplicate on disk alongside the renamed file.
+func TestRenamePathSaveDoesNotRecreateOldFile(t *testing.T) {
+	tmp := t.TempDir()
+	old := filepath.Join(tmp, "old.txt")
+	g := newRenameGroup(t, old, "hello")
+
+	newPath := filepath.Join(tmp, "new.txt")
+	if err := os.Rename(old, newPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	g.RenamePath(old, newPath)
+
+	g.tabs[g.active].Buf.Lines = []string{"edited"}
+	g.tabs[g.active].Buf.Dirty = true
+	if !g.Save() {
+		t.Fatal("expected save to succeed")
+	}
+
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Fatalf("save recreated the old path %s as a ghost duplicate", old)
+	}
+	data, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", newPath, err)
+	}
+	if string(data) != "edited\n" && string(data) != "edited" {
+		t.Fatalf("new path contents: got %q, want edited", string(data))
+	}
+}
+
+func TestRenamePathPreservesBufferAndUndo(t *testing.T) {
+	tmp := t.TempDir()
+	old := filepath.Join(tmp, "old.txt")
+	g := newRenameGroup(t, old, "hello\nworld")
+
+	buf := g.tabs[g.active].Buf
+	undo := g.tabs[g.active].Undo
+
+	g.RenamePath(old, filepath.Join(tmp, "new.txt"))
+
+	if g.tabs[g.active].Buf != buf {
+		t.Error("buffer was replaced; a rename must not reload the document")
+	}
+	if g.tabs[g.active].Undo != undo {
+		t.Error("undo stack was replaced; history must survive a rename")
+	}
+}
+
+func TestRenamePathRedetectsLanguageOnExtensionChange(t *testing.T) {
+	tmp := t.TempDir()
+	old := filepath.Join(tmp, "script.txt")
+	g := newRenameGroup(t, old, "package main")
+
+	newPath := filepath.Join(tmp, "script.go")
+	g.RenamePath(old, newPath)
+
+	h := g.tabs[g.active].Highlighter
+	if h == nil {
+		t.Fatal("expected a highlighter after rename")
+	}
+	if h.Language() != "Go" {
+		t.Fatalf("language after rename to .go: got %q, want Go", h.Language())
+	}
+}
+
+func TestRenamePathFolderMovesNestedTabs(t *testing.T) {
+	tmp := t.TempDir()
+	oldDir := filepath.Join(tmp, "src")
+	nested := filepath.Join(oldDir, "pkg", "a.txt")
+	g := newRenameGroup(t, nested, "a")
+
+	newDir := filepath.Join(tmp, "lib")
+	if !g.RenamePath(oldDir, newDir) {
+		t.Fatal("expected folder rename to move nested tabs")
+	}
+
+	want := filepath.Join(newDir, "pkg", "a.txt")
+	if got := g.ActiveFilePath(); got != want {
+		t.Fatalf("nested tab path: got %q, want %q", got, want)
+	}
+}
+
+func TestRenamePathLeavesUnrelatedTabsAlone(t *testing.T) {
+	tmp := t.TempDir()
+	keep := filepath.Join(tmp, "keep.txt")
+	g := newRenameGroup(t, keep, "keep")
+
+	// A sibling whose name merely shares a prefix must not be dragged along.
+	if g.RenamePath(filepath.Join(tmp, "keep"), filepath.Join(tmp, "moved")) {
+		t.Fatal("prefix-only match should not rename keep.txt")
+	}
+	if got := g.ActiveFilePath(); got != keep {
+		t.Fatalf("unrelated tab changed: got %q, want %q", got, keep)
+	}
+}
+
+func TestRenamePathSkipsVirtualTabs(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+	untitled := g.ActiveFilePath()
+
+	if g.RenamePath(untitled, "renamed") {
+		t.Fatal("virtual tabs have no path on disk and must not be renamed")
+	}
+	if got := g.ActiveFilePath(); got != untitled {
+		t.Fatalf("virtual tab path changed: got %q, want %q", got, untitled)
+	}
+}
+
+func TestRenamePathNotifiesLSPOfMove(t *testing.T) {
+	tmp := t.TempDir()
+	old := filepath.Join(tmp, "old.go")
+	g := newRenameGroup(t, old, "package main")
+
+	var closed, opened string
+	g.OnFileClose = func(path, _ string) { closed = path }
+	g.OnFileOpen = func(path, _, _ string) { opened = path }
+
+	newPath := filepath.Join(tmp, "new.go")
+	g.RenamePath(old, newPath)
+
+	if closed != old {
+		t.Errorf("expected didClose for %q, got %q", old, closed)
+	}
+	if opened != newPath {
+		t.Errorf("expected didOpen for %q, got %q", newPath, opened)
+	}
+}
+
+func TestRenamePathIgnoresNoOp(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "a.txt")
+	g := newRenameGroup(t, path, "a")
+
+	if g.RenamePath(path, path) {
+		t.Error("renaming a path to itself is not a change")
+	}
+	if g.RenamePath("", path) || g.RenamePath(path, "") {
+		t.Error("empty paths must be ignored")
+	}
+}

--- a/tests/e2e/explorer_refresh_test.go
+++ b/tests/e2e/explorer_refresh_test.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The explorer.refresh command existed but had no key binding, so a file
+// created outside the editor could only be surfaced through the context menu
+// or the command palette. `r` matches the changes panel.
+func TestExplorerRefreshKeyPicksUpNewFile(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("sidebar.explorer")
+	h.app.Explorer.Tree.SetSelectedIndex(0)
+	h.redraw()
+
+	before := h.app.Explorer.Tree.ItemCount()
+	if err := os.WriteFile(filepath.Join(h.dir, "created-outside.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h.pressRune('r')
+	h.redraw()
+
+	if got := h.app.Explorer.Tree.ItemCount(); got <= before {
+		t.Fatalf("expected the tree to grow after refresh: had %d, got %d", before, got)
+	}
+	h.assertContains("created-outside.txt")
+}
+
+// Refresh must not eat the key that moves the selection, so `r` sits alongside
+// the tree's own j/k/h/l navigation rather than replacing any of it.
+func TestExplorerRefreshKeyKeepsNavigation(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("sidebar.explorer")
+	if h.app.Explorer.Tree.ItemCount() < 3 {
+		t.Skipf("expected at least 3 explorer items, got %d", h.app.Explorer.Tree.ItemCount())
+	}
+	h.app.Explorer.Tree.SetSelectedIndex(0)
+
+	h.pressRune('j')
+	if got := h.app.Explorer.Tree.SelectedIndex(); got != 1 {
+		t.Fatalf("j should still move down: got index %d, want 1", got)
+	}
+
+	h.pressRune('r')
+	if got := h.app.Explorer.Tree.SelectedIndex(); got != 1 {
+		t.Fatalf("refresh should not move the selection: got index %d, want 1", got)
+	}
+}
+
+// The shortcut is only useful if it is discoverable from the panel's help.
+func TestExplorerHelpListsRefreshKey(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("sidebar.explorer")
+	h.exec("explorer.help")
+	h.redraw()
+
+	h.assertContains("Refresh explorer")
+}

--- a/tests/e2e/explorer_rename_test.go
+++ b/tests/e2e/explorer_rename_test.go
@@ -1,0 +1,100 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+// renameVia drives the explorer rename dialog for the node at path, replacing
+// its name with newName.
+func (h *testHarness) renameVia(path, newName string) {
+	h.t.Helper()
+	h.app.ExplorerContextNode = &widgets.TreeNode{ID: path}
+	h.exec("explorer.rename")
+	h.redraw()
+
+	// The dialog is pre-filled with the current basename and places no
+	// selection, so clear it before typing the replacement.
+	for range filepath.Base(path) {
+		h.pressKey(tcell.KeyBackspace, tcell.ModNone)
+	}
+	h.typeText(newName)
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+	h.redraw()
+}
+
+// Renaming a file in the explorer used to leave the open tab pointing at the
+// old path, so Ctrl+S wrote the buffer back out under the name the file had
+// been renamed away from, leaving a ghost duplicate on disk. Issue #284.
+func TestExplorerRenameUpdatesOpenTabAndSavesToNewPath(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+
+	old := filepath.Join(h.dir, "alpha.txt")
+	h.app.EditorGroup.OpenFile(old)
+	h.redraw()
+
+	h.renameVia(old, "renamed.txt")
+
+	newPath := filepath.Join(h.dir, "renamed.txt")
+	if got := h.app.EditorGroup.ActiveFilePath(); got != newPath {
+		t.Fatalf("tab still points at the old path: got %q, want %q", got, newPath)
+	}
+
+	h.app.EditorGroup.ActiveBuffer().Lines = []string{"edited"}
+	h.app.EditorGroup.ActiveBuffer().Dirty = true
+	h.exec("file.save")
+
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Fatalf("save recreated %s as a ghost duplicate", old)
+	}
+	data, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read renamed file: %v", err)
+	}
+	if got := string(data); got != "edited\n" && got != "edited" {
+		t.Fatalf("renamed file contents: got %q, want edited", got)
+	}
+}
+
+// A folder rename has to carry every tab beneath it, not just an exact match.
+func TestExplorerRenameFolderUpdatesNestedTab(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+
+	nested := filepath.Join(h.dir, "subdir", "nested.txt")
+	h.app.EditorGroup.OpenFile(nested)
+	h.redraw()
+
+	h.renameVia(filepath.Join(h.dir, "subdir"), "renamed-dir")
+
+	want := filepath.Join(h.dir, "renamed-dir", "nested.txt")
+	if got := h.app.EditorGroup.ActiveFilePath(); got != want {
+		t.Fatalf("nested tab path: got %q, want %q", got, want)
+	}
+}
+
+// A file that is not open must still rename cleanly, and must not disturb the
+// tab that is open.
+func TestExplorerRenameLeavesOtherTabsAlone(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+
+	openPath := filepath.Join(h.dir, "alpha.txt")
+	h.app.EditorGroup.OpenFile(openPath)
+	h.redraw()
+
+	h.renameVia(filepath.Join(h.dir, "beta.txt"), "beta-renamed.txt")
+
+	if got := h.app.EditorGroup.ActiveFilePath(); got != openPath {
+		t.Fatalf("unrelated rename moved the open tab: got %q, want %q", got, openPath)
+	}
+	if _, err := os.Stat(filepath.Join(h.dir, "beta-renamed.txt")); err != nil {
+		t.Fatalf("expected beta-renamed.txt on disk: %v", err)
+	}
+}

--- a/tests/functional/explorer-rename.test.js
+++ b/tests/functional/explorer-rename.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import {
+  createTempDir,
+  createTempFile,
+  cleanupDir,
+  fileExists,
+  readFile,
+} from "./helpers.js";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+// The rename dialog is pre-filled with the current basename and places no
+// selection, so the old name has to be cleared before typing the new one.
+function renameSelectedTo(oldName, newName) {
+  tui.exec("Explorer: Rename");
+  tui.waitStable();
+  for (let i = 0; i < oldName.length; i++) tui.press("backspace");
+  tui.type(newName);
+  tui.press("enter");
+  tui.waitStable();
+}
+
+describe("explorer rename", () => {
+  it("should retitle the open tab when its file is renamed", () => {
+    dir = createTempDir();
+    createTempFile(dir, "alpha.txt", "ALPHA CONTENT");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.press("ctrl+0");
+    tui.waitStable();
+    tui.press("arrow_down");
+    tui.press("enter");
+    tui.waitStable();
+
+    renameSelectedTo("alpha.txt", "renamed.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("renamed.txt");
+    expect(snapshots[s0]).not.toContain("alpha.txt");
+  });
+
+  // Issue #284: the tab kept the old path, so saving wrote the buffer back out
+  // under the name the file had been renamed away from.
+  it("should save to the new path without recreating the old file", () => {
+    dir = createTempDir();
+    createTempFile(dir, "alpha.txt", "ALPHA CONTENT");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.press("ctrl+0");
+    tui.waitStable();
+    tui.press("arrow_down");
+    tui.press("enter");
+    tui.waitStable();
+
+    renameSelectedTo("alpha.txt", "renamed.txt");
+
+    tui.type("EDITED ");
+    tui.exec("Save File");
+    tui.waitStable();
+    tui.run();
+
+    expect(fileExists(join(dir, "alpha.txt"))).toBe(false);
+    expect(fileExists(join(dir, "renamed.txt"))).toBe(true);
+    expect(readFile(join(dir, "renamed.txt"))).toContain("EDITED");
+  });
+
+  it("should keep editing the same buffer after a rename", () => {
+    dir = createTempDir();
+    createTempFile(dir, "alpha.txt", "ORIGINAL LINE");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.press("ctrl+0");
+    tui.waitStable();
+    tui.press("arrow_down");
+    tui.press("enter");
+    tui.waitStable();
+
+    renameSelectedTo("alpha.txt", "renamed.txt");
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("ORIGINAL LINE");
+  });
+});
+
+describe("explorer refresh", () => {
+  it("should pick up a file created outside the editor when r is pressed", () => {
+    dir = createTempDir();
+    createTempFile(dir, "alpha.txt", "alpha");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+
+    tui.press("ctrl+0");
+    tui.waitStable();
+
+    // The explorer has already listed the directory; add a file behind its back.
+    writeFileSync(join(dir, "created-outside.txt"), "outside");
+
+    tui.press("r");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[s0]).toContain("created-outside.txt");
+  });
+});


### PR DESCRIPTION
Fixes the file-rename desync reported as item 1 of #284, and adds the explorer refresh key.

## The bug

Renaming a file in the explorer renamed it on disk and reloaded the tree, but nothing touched open tabs. The tab kept pointing at the path its file no longer occupied, so `Ctrl+S` wrote the buffer back out under the old name — leaving a ghost duplicate alongside the renamed file.

`FileOpRename` (`internal/app/fileops.go`) called `os.Rename` and then only `reload()`, which refreshes the explorer tree.

## The fix

`EditorGroupWidget.RenamePath(oldPath, newPath)` repoints every affected tab. It follows the shape of the existing `SaveAs`, which already had to handle "this tab's path changed":

- Matches a file exactly, and a **folder** by prefix, so renaming a directory carries every tab beneath it.
- Preserves buffer, cursor, selection and undo history — the document didn't change, only its name.
- Rebuilds the syntax highlighter, since a rename can change the extension.
- Fires `OnFileClose`/`OnFileOpen` so the language server learns the document moved rather than tracking a URI that no longer exists.
- Skips virtual and content tabs.

## Explorer refresh key

`explorer.refresh` already existed as a command and a context-menu entry — it just had no key binding and no help line. Bound `r`/`R` via the explorer's `TreeConfig.OnKey`, matching the changes panel's existing `'r', 'R'` handler, and added the entry to `explorerHelpEntries`.

`r` was free: `TreeWidget` only claims `j`/`k`/`h`/`l`, space, and node action icons. This is a panel-local key rather than a global binding, so `DefaultKeybindings()` and its generated mirror are unaffected — and like the changes panel's `a`/`u`/`d`/`r`, the help dialog is the only place it's documented.

## Tests

- **Unit** (`internal/ui/editor_group_rename_test.go`) — 9 tests: exact file match, folder prefix match, buffer/undo preserved, language re-detection on extension change, prefix-only siblings left alone, virtual tabs skipped, LSP move notification, no-op guards.
- **E2E** (`tests/e2e/explorer_rename_test.go`, `explorer_refresh_test.go`) — 6 tests driving the real rename dialog and the `r` key, including that refresh doesn't move the selection and that help lists the shortcut.
- **Functional** (`tests/functional/explorer-rename.test.js`) — 4 tests against the compiled binary.

Verified the tests actually catch the regression rather than passing vacuously: with the `RenamePath` call commented out, two e2e and two functional tests fail — including the ghost-duplicate assertion — and pass again once restored.

`make test` and the full functional suite (79 files, 258 passed, 27 expected-fail) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
