### PR TITLE
fix: highlight multiline block comments by tokenizing full buffer

### DIFF
--- a/internal/core/highlight/highlighter.go
+++ b/internal/core/highlight/highlighter.go
@@ -15,8 +15,9 @@ type Span struct {
 }
 
 type Highlighter struct {
-	lexer chroma.Lexer
-	cache map[string][]Span
+	lexer     chroma.Lexer
+	cache     map[string][]Span
+	lineSpans [][]Span
 }
 
 func New(filename string) *Highlighter {
@@ -30,6 +31,70 @@ func New(filename string) *Highlighter {
 
 func (h *Highlighter) Language() string {
 	return h.lexer.Config().Name
+}
+
+// HighlightAll tokenizes all lines at once so that multiline constructs
+// (block comments, heredocs, etc.) are correctly recognized. The result is
+// cached and reused until ClearCache is called.
+func (h *Highlighter) HighlightAll(lines []string) [][]Span {
+	if h.lineSpans != nil && len(h.lineSpans) == len(lines) {
+		return h.lineSpans
+	}
+
+	text := strings.Join(lines, "\n") + "\n"
+	iter, err := h.lexer.Tokenise(nil, text)
+	if err != nil {
+		return nil
+	}
+
+	h.lineSpans = make([][]Span, len(lines))
+	lineIdx := 0
+	col := 0
+
+	for tok := iter(); tok != chroma.EOF; tok = iter() {
+		value := tok.Value
+		for {
+			nlIdx := strings.Index(value, "\n")
+			if nlIdx < 0 {
+				part := value
+				runeLen := len([]rune(part))
+				if runeLen > 0 {
+					style := mapTokenType(tok.Type)
+					if style != term.StyleDefault {
+						h.lineSpans[lineIdx] = append(h.lineSpans[lineIdx], Span{
+							Start: col,
+							End:   col + runeLen,
+							Style: style,
+						})
+					}
+				}
+				col += runeLen
+				break
+			}
+
+			part := value[:nlIdx]
+			runeLen := len([]rune(part))
+			if runeLen > 0 {
+				style := mapTokenType(tok.Type)
+				if style != term.StyleDefault {
+					h.lineSpans[lineIdx] = append(h.lineSpans[lineIdx], Span{
+						Start: col,
+						End:   col + runeLen,
+						Style: style,
+					})
+				}
+			}
+
+			lineIdx++
+			if lineIdx >= len(lines) {
+				return h.lineSpans
+			}
+			col = 0
+			value = value[nlIdx+1:]
+		}
+	}
+
+	return h.lineSpans
 }
 
 func (h *Highlighter) HighlightLine(line string) []Span {
@@ -69,6 +134,7 @@ func (h *Highlighter) HighlightLine(line string) []Span {
 
 func (h *Highlighter) ClearCache() {
 	h.cache = make(map[string][]Span)
+	h.lineSpans = nil
 }
 
 func mapTokenType(t chroma.TokenType) term.Style {

--- a/internal/core/highlight/highlighter_test.go
+++ b/internal/core/highlight/highlighter_test.go
@@ -112,3 +112,80 @@ func TestHighlightJSON(t *testing.T) {
 		t.Error("expected spans for JSON")
 	}
 }
+
+func TestHighlightAll_MultilineComment(t *testing.T) {
+	h := New("test.js")
+	if h == nil {
+		t.Fatal("expected highlighter for .js files")
+	}
+
+	lines := []string{
+		`import { foo } from "bar";`,
+		`// single line comment`,
+		`/* inline block */`,
+		`/*`,
+		`   multiline comment`,
+		`*/`,
+		`var x = 1;`,
+	}
+
+	allSpans := h.HighlightAll(lines)
+
+	// Line 1: single-line comment should be Comment style
+	assertLineHasStyle(t, allSpans[1], term.StyleSyntaxComment)
+
+	// Line 2: inline block comment should be Comment style
+	assertLineHasStyle(t, allSpans[2], term.StyleSyntaxComment)
+
+	// Lines 3-5: multiline comment — all should be Comment style
+	assertLineHasStyle(t, allSpans[3], term.StyleSyntaxComment)
+	assertLineHasStyle(t, allSpans[4], term.StyleSyntaxComment)
+	assertLineHasStyle(t, allSpans[5], term.StyleSyntaxComment)
+
+	// Line 6: normal code, should NOT be comment
+	for _, s := range allSpans[6] {
+		if s.Style == term.StyleSyntaxComment {
+			t.Errorf("line 6 should not have comment spans, got %v", s)
+		}
+	}
+
+	// Verify that HighlightLine (the old per-line API) does NOT highlight
+	// multiline comments correctly — this is the known limitation.
+	spans := h.HighlightLine("   multiline comment")
+	for _, s := range spans {
+		if s.Style == term.StyleSyntaxComment {
+			t.Error("HighlightLine should NOT highlight orphan comment text (no delimiters on line)")
+		}
+	}
+}
+
+func TestHighlightAll_CacheReuse(t *testing.T) {
+	h := New("test.js")
+	if h == nil {
+		t.Fatal("expected highlighter for .js files")
+	}
+
+	lines := []string{"// comment", "code"}
+	first := h.HighlightAll(lines)
+	second := h.HighlightAll(lines)
+
+	if len(first) != len(second) {
+		t.Error("cached result should have same length")
+	}
+
+	h.ClearCache()
+	third := h.HighlightAll(lines)
+	if len(third) != len(first) {
+		t.Error("result after ClearCache should have same length")
+	}
+}
+
+func assertLineHasStyle(t *testing.T, spans []Span, style term.Style) {
+	t.Helper()
+	for _, s := range spans {
+		if s.Style == style {
+			return
+		}
+	}
+	t.Errorf("expected style %v in spans, got %v", style, spans)
+}

--- a/internal/ui/editor_widget_render.go
+++ b/internal/ui/editor_widget_render.go
@@ -103,6 +103,11 @@ func (e *EditorPaneWidget) Render(surface Surface) {
 		e.wrapMap = nil
 	}
 
+	var allSpans [][]highlight.Span
+	if e.Highlighter != nil {
+		allSpans = e.Highlighter.HighlightAll(e.Buf.Lines)
+	}
+
 	for y := 0; y < h; y++ {
 		var lineIdx int
 		var segStartCol int
@@ -184,8 +189,8 @@ func (e *EditorPaneWidget) Render(surface Surface) {
 		if lineIdx < totalLines {
 			line := []rune(e.Buf.Lines[lineIdx])
 			var syntaxSpans []highlight.Span
-			if e.Highlighter != nil {
-				syntaxSpans = e.Highlighter.HighlightLine(e.Buf.Lines[lineIdx])
+			if allSpans != nil && lineIdx < len(allSpans) {
+				syntaxSpans = allSpans[lineIdx]
 			}
 
 			isCollapsedLine := e.Folds != nil && e.Folds.IsCollapsed(lineIdx)


### PR DESCRIPTION
## Problem

Chroma's `HighlightLine` tokenized each line in isolation with a fresh lexer state, so the JS block-comment regex (`/\*.*?\*/` with `dot_all`) could never match across line boundaries — the opener and closer were never in the same input.

- `// this comment` — worked ✓
- `/* inline comment */` — worked ✓
- `/*` / `   multiline` / `*/` — **broken** ✗

## Fix

Added `HighlightAll(lines []string) [][]Span` which joins all lines and tokenizes the full buffer in one chroma call, then splits the resulting tokens back into per-line spans. The result is cached and invalidated on `ClearCache()` (which the editor already calls on buffer changes), so there's no per-frame cost — re-tokenization only happens when the buffer actually changes.

## Changes

- `internal/core/highlight/highlighter.go` — added `HighlightAll` method with caching
- `internal/ui/editor_widget_render.go` — precomputes all spans before the render loop
- `internal/core/highlight/highlighter_test.go` — tests for multiline comments and cache reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)