### PR TITLE
fix: highlight multiline block comments

### DIFF
--- a/internal/core/highlight/highlighter.go
+++ b/internal/core/highlight/highlighter.go
@@ -34,6 +34,11 @@ type Highlighter struct {
 
 	// states[i] reports whether line i starts inside a block comment.
 	states []bool
+	// stateSrc[i] is the text of line i that produced states[i+1], so an edit
+	// can be located by comparison instead of discarding the whole table.
+	stateSrc []string
+	// Set by ClearCache; the table is revalidated on the next lookup.
+	statesDirty bool
 }
 
 func New(filename string) *Highlighter {
@@ -67,7 +72,7 @@ func (h *Highlighter) HighlightLineAt(lines []string, idx int) []Span {
 
 func (h *Highlighter) ClearCache() {
 	h.cache = make(map[spanKey][]Span)
-	h.states = nil
+	h.statesDirty = true
 }
 
 func (h *Highlighter) highlight(line string, inBlock bool) []Span {
@@ -151,17 +156,39 @@ func (h *Highlighter) stateAt(lines []string, idx int) bool {
 	if h.blockOpen == "" || idx <= 0 {
 		return false
 	}
+	if h.statesDirty {
+		h.statesDirty = false
+		h.truncateToEdit(lines)
+	}
 	if len(h.states) == 0 {
 		h.states = append(h.states, false)
 	}
 	for len(h.states) <= idx && len(h.states) <= len(lines) {
 		i := len(h.states) - 1
 		h.states = append(h.states, h.nextState(lines[i], h.states[i]))
+		h.stateSrc = append(h.stateSrc, lines[i])
 	}
 	if idx < len(h.states) {
 		return h.states[idx]
 	}
 	return false
+}
+
+// truncateToEdit drops the state table from the first line whose text changed,
+// keeping everything above it. Comparing strings that were never rewritten hits
+// Go's identical-pointer fast path, so unchanged lines cost no scanning.
+func (h *Highlighter) truncateToEdit(lines []string) {
+	keep := min(len(h.stateSrc), len(lines))
+	for i := 0; i < keep; i++ {
+		if h.stateSrc[i] != lines[i] {
+			keep = i
+			break
+		}
+	}
+	h.stateSrc = h.stateSrc[:keep]
+	if len(h.states) > keep+1 {
+		h.states = h.states[:keep+1]
+	}
 }
 
 // nextState advances block comment state across one line.

--- a/internal/core/highlight/highlighter.go
+++ b/internal/core/highlight/highlighter.go
@@ -14,9 +14,26 @@ type Span struct {
 	Style term.Style
 }
 
+// spanKey keys the span cache; the same text differs by incoming state.
+type spanKey struct {
+	line    string
+	inBlock bool
+}
+
 type Highlighter struct {
 	lexer chroma.Lexer
-	cache map[string][]Span
+	cache map[spanKey][]Span
+
+	// Empty when the language has no block comment; state tracking is then skipped.
+	blockOpen  string
+	blockClose string
+
+	// Rune index where a line opens an unclosed block comment, -1 for none.
+	// Pure function of the text, so it survives ClearCache.
+	opens map[string]int
+
+	// states[i] reports whether line i starts inside a block comment.
+	states []bool
 }
 
 func New(filename string) *Highlighter {
@@ -25,19 +42,83 @@ func New(filename string) *Highlighter {
 		return nil
 	}
 	lexer = chroma.Coalesce(lexer)
-	return &Highlighter{lexer: lexer}
+	h := &Highlighter{lexer: lexer}
+	h.blockOpen, h.blockClose = detectBlockComment(lexer)
+	return h
 }
 
 func (h *Highlighter) Language() string {
 	return h.lexer.Config().Name
 }
 
+// HighlightLine highlights a line in isolation, ignoring multiline comments.
 func (h *Highlighter) HighlightLine(line string) []Span {
+	return h.highlight(line, false)
+}
+
+// HighlightLineAt highlights lines[idx], carrying block comment state down
+// from the top of the buffer.
+func (h *Highlighter) HighlightLineAt(lines []string, idx int) []Span {
+	if idx < 0 || idx >= len(lines) {
+		return nil
+	}
+	return h.highlight(lines[idx], h.stateAt(lines, idx))
+}
+
+func (h *Highlighter) ClearCache() {
+	h.cache = make(map[spanKey][]Span)
+	h.states = nil
+}
+
+func (h *Highlighter) highlight(line string, inBlock bool) []Span {
+	key := spanKey{line: line, inBlock: inBlock}
 	if h.cache != nil {
-		if cached, ok := h.cache[line]; ok {
+		if cached, ok := h.cache[key]; ok {
 			return cached
 		}
 	}
+	spans := h.computeSpans(line, inBlock)
+	if h.cache == nil {
+		h.cache = make(map[spanKey][]Span)
+	}
+	h.cache[key] = spans
+	return spans
+}
+
+func (h *Highlighter) computeSpans(line string, inBlock bool) []Span {
+	if inBlock {
+		end := h.closesAt(line)
+		if end < 0 {
+			if line == "" {
+				return nil
+			}
+			return []Span{{Start: 0, End: len([]rune(line)), Style: term.StyleSyntaxComment}}
+		}
+		spans := []Span{{Start: 0, End: end, Style: term.StyleSyntaxComment}}
+		for _, s := range h.computeSpans(string([]rune(line)[end:]), false) {
+			spans = append(spans, Span{Start: s.Start + end, End: s.End + end, Style: s.Style})
+		}
+		return spans
+	}
+
+	spans := h.lexLine(line)
+	open := h.opensAt(line)
+	if open < 0 {
+		return spans
+	}
+	// Comment opens here and runs past end of line. Fresh slice: spans is cached.
+	out := make([]Span, 0, len(spans)+1)
+	for _, s := range spans {
+		if s.End <= open {
+			out = append(out, s)
+		} else if s.Start < open {
+			out = append(out, Span{Start: s.Start, End: open, Style: s.Style})
+		}
+	}
+	return append(out, Span{Start: open, End: len([]rune(line)), Style: term.StyleSyntaxComment})
+}
+
+func (h *Highlighter) lexLine(line string) []Span {
 	iter, err := h.lexer.Tokenise(nil, line+"\n")
 	if err != nil {
 		return nil
@@ -60,15 +141,125 @@ func (h *Highlighter) HighlightLine(line string) []Span {
 		}
 		pos += runeLen
 	}
-	if h.cache == nil {
-		h.cache = make(map[string][]Span)
-	}
-	h.cache[line] = spans
 	return spans
 }
 
-func (h *Highlighter) ClearCache() {
-	h.cache = make(map[string][]Span)
+// stateAt reports whether lines[idx] starts inside a block comment, extending
+// the state table as needed. Transitions are memoized, so this is a map lookup
+// per line rather than a re-lex.
+func (h *Highlighter) stateAt(lines []string, idx int) bool {
+	if h.blockOpen == "" || idx <= 0 {
+		return false
+	}
+	if len(h.states) == 0 {
+		h.states = append(h.states, false)
+	}
+	for len(h.states) <= idx && len(h.states) <= len(lines) {
+		i := len(h.states) - 1
+		h.states = append(h.states, h.nextState(lines[i], h.states[i]))
+	}
+	if idx < len(h.states) {
+		return h.states[idx]
+	}
+	return false
+}
+
+// nextState advances block comment state across one line.
+func (h *Highlighter) nextState(line string, inBlock bool) bool {
+	for inBlock {
+		end := h.closesAt(line)
+		if end < 0 {
+			return true
+		}
+		line = string([]rune(line)[end:])
+		inBlock = false
+	}
+	return h.opensAt(line) >= 0
+}
+
+// closesAt returns the rune index just past the closing delimiter, or -1.
+// A plain search is correct: nothing is special inside a block comment.
+func (h *Highlighter) closesAt(line string) int {
+	if h.blockClose == "" {
+		return -1
+	}
+	i := strings.Index(line, h.blockClose)
+	if i < 0 {
+		return -1
+	}
+	return len([]rune(line[:i+len(h.blockClose)]))
+}
+
+// opensAt returns the rune index where line opens an unclosed block comment,
+// or -1. Appending the closer makes the comment well formed, so chroma's own
+// rules decide: an opener inside a string or after a line comment is ignored.
+func (h *Highlighter) opensAt(line string) int {
+	if h.blockOpen == "" || !strings.Contains(line, h.blockOpen) {
+		return -1
+	}
+	if idx, ok := h.opens[line]; ok {
+		return idx
+	}
+	idx := h.computeOpensAt(line)
+	if h.opens == nil {
+		h.opens = make(map[string]int)
+	}
+	h.opens[line] = idx
+	return idx
+}
+
+func (h *Highlighter) computeOpensAt(line string) int {
+	iter, err := h.lexer.Tokenise(nil, line+h.blockClose)
+	if err != nil {
+		return -1
+	}
+	pos, start := 0, -1
+	for _, tok := range iter.Tokens() {
+		switch {
+		case isCommentToken(tok.Type) && strings.HasPrefix(tok.Value, h.blockOpen):
+			start = pos
+		case !isCommentToken(tok.Type):
+			start = -1
+		}
+		pos += len([]rune(tok.Value))
+	}
+	return start
+}
+
+// Probed in order to discover the language's block comment delimiters.
+var blockCommentCandidates = [][2]string{
+	{"/*", "*/"},
+	{"<!--", "-->"},
+	{"{-", "-}"},
+	{"(*", "*)"},
+	{"--[[", "]]"},
+	{"<#", "#>"},
+}
+
+// detectBlockComment finds which candidate pair the lexer honours. Chroma's
+// comment rules vary too much in shape to read delimiters off directly.
+// The probe spans two lines because a line comment cannot, which stops
+// Haskell's "--" from matching the "--[[" candidate.
+func detectBlockComment(lx chroma.Lexer) (string, string) {
+	for _, c := range blockCommentCandidates {
+		probe := c[0] + " a\nb " + c[1]
+		iter, err := lx.Tokenise(nil, probe)
+		if err != nil {
+			continue
+		}
+		toks := iter.Tokens()
+		if len(toks) == 0 {
+			continue
+		}
+		if isCommentToken(toks[0].Type) && len([]rune(toks[0].Value)) >= len([]rune(probe)) {
+			return c[0], c[1]
+		}
+	}
+	return "", ""
+}
+
+func isCommentToken(t chroma.TokenType) bool {
+	return t == chroma.Comment || t.InSubCategory(chroma.Comment)
 }
 
 func mapTokenType(t chroma.TokenType) term.Style {

--- a/internal/core/highlight/highlighter_test.go
+++ b/internal/core/highlight/highlighter_test.go
@@ -112,3 +112,171 @@ func TestHighlightJSON(t *testing.T) {
 		t.Error("expected spans for JSON")
 	}
 }
+
+// styleAt returns the style covering rune index col, or StyleDefault.
+func styleAt(spans []Span, col int) term.Style {
+	for _, s := range spans {
+		if col >= s.Start && col < s.End {
+			return s.Style
+		}
+	}
+	return term.StyleDefault
+}
+
+func allComment(t *testing.T, spans []Span, line string, ctx string) {
+	t.Helper()
+	for i := range []rune(line) {
+		if styleAt(spans, i) != term.StyleSyntaxComment {
+			t.Errorf("%s: rune %d of %q not styled as comment", ctx, i, line)
+			return
+		}
+	}
+}
+
+func TestMultilineBlockComment(t *testing.T) {
+	lines := []string{
+		"const a = 1;",
+		"/*",
+		"   still inside",
+		"*/",
+		"const b = 2;",
+	}
+	h := New("test.js")
+	if h == nil {
+		t.Fatal("expected highlighter for .js")
+	}
+	for _, i := range []int{1, 2, 3} {
+		allComment(t, h.HighlightLineAt(lines, i), lines[i], "js")
+	}
+	// code after the comment closes is highlighted normally again
+	if styleAt(h.HighlightLineAt(lines, 4), 0) != term.StyleSyntaxKeyword {
+		t.Error("expected keyword on line after comment close")
+	}
+}
+
+func TestMultilineBlockCommentGo(t *testing.T) {
+	lines := []string{"package main", "/*", "doc", "*/", "func main() {}"}
+	h := New("main.go")
+	for _, i := range []int{1, 2, 3} {
+		allComment(t, h.HighlightLineAt(lines, i), lines[i], "go")
+	}
+	if styleAt(h.HighlightLineAt(lines, 4), 0) != term.StyleSyntaxKeyword {
+		t.Error("expected keyword after comment close")
+	}
+}
+
+func TestOpenerInStringDoesNotStartComment(t *testing.T) {
+	lines := []string{`const s = "/*";`, "const b = 2;"}
+	h := New("test.js")
+	if got := styleAt(h.HighlightLineAt(lines, 1), 0); got != term.StyleSyntaxKeyword {
+		t.Errorf("line after string containing /* should be normal code, got %v", got)
+	}
+}
+
+func TestOpenerInLineCommentDoesNotStartComment(t *testing.T) {
+	lines := []string{"// note /*", "const b = 2;"}
+	h := New("test.js")
+	if got := styleAt(h.HighlightLineAt(lines, 1), 0); got != term.StyleSyntaxKeyword {
+		t.Errorf("line after // containing /* should be normal code, got %v", got)
+	}
+}
+
+func TestInlineBlockCommentDoesNotLeak(t *testing.T) {
+	lines := []string{"/* inline */ const a = 1;", "const b = 2;"}
+	h := New("test.js")
+	if got := styleAt(h.HighlightLineAt(lines, 1), 0); got != term.StyleSyntaxKeyword {
+		t.Errorf("closed inline comment must not leak to next line, got %v", got)
+	}
+}
+
+func TestCodeBeforeAndAfterBlockComment(t *testing.T) {
+	lines := []string{"const a = 1; /* open", "*/ const b = 2;"}
+	h := New("test.js")
+	first := h.HighlightLineAt(lines, 0)
+	if styleAt(first, 0) != term.StyleSyntaxKeyword {
+		t.Error("code before the opener should stay highlighted")
+	}
+	if styleAt(first, 13) != term.StyleSyntaxComment {
+		t.Error("opener onwards should be comment")
+	}
+	second := h.HighlightLineAt(lines, 1)
+	if styleAt(second, 0) != term.StyleSyntaxComment {
+		t.Error("closer should be comment")
+	}
+	if styleAt(second, 3) != term.StyleSyntaxKeyword {
+		t.Error("code after the closer should be highlighted")
+	}
+}
+
+func TestUnclosedCommentRunsToEndOfBuffer(t *testing.T) {
+	lines := []string{"code();", "/* never closed", "a", "b"}
+	h := New("test.js")
+	for _, i := range []int{2, 3} {
+		allComment(t, h.HighlightLineAt(lines, i), lines[i], "unclosed")
+	}
+}
+
+func TestHTMLBlockComment(t *testing.T) {
+	lines := []string{"<p>hi</p>", "<!--", "hidden", "-->"}
+	h := New("index.html")
+	for _, i := range []int{1, 2, 3} {
+		allComment(t, h.HighlightLineAt(lines, i), lines[i], "html")
+	}
+}
+
+func TestNoBlockCommentLanguageUnaffected(t *testing.T) {
+	h := New("script.py")
+	if h.blockOpen != "" {
+		t.Errorf("python should have no block comment delimiters, got %q", h.blockOpen)
+	}
+	lines := []string{"x = 1", "y = 2"}
+	if styleAt(h.HighlightLineAt(lines, 1), 0) == term.StyleSyntaxComment {
+		t.Error("python line should not be a comment")
+	}
+}
+
+func TestDetectBlockCommentDelimiters(t *testing.T) {
+	cases := []struct{ file, open, close string }{
+		{"a.go", "/*", "*/"},
+		{"a.js", "/*", "*/"},
+		{"a.rs", "/*", "*/"},
+		{"a.css", "/*", "*/"},
+		{"a.html", "<!--", "-->"},
+		{"a.hs", "{-", "-}"},
+		{"a.py", "", ""},
+		{"a.json", "", ""},
+	}
+	for _, c := range cases {
+		h := New(c.file)
+		if h == nil {
+			t.Fatalf("no highlighter for %s", c.file)
+		}
+		if h.blockOpen != c.open || h.blockClose != c.close {
+			t.Errorf("%s: got %q/%q want %q/%q", c.file, h.blockOpen, h.blockClose, c.open, c.close)
+		}
+	}
+}
+
+func TestStateSurvivesClearCache(t *testing.T) {
+	lines := []string{"/*", "inside", "*/"}
+	h := New("test.js")
+	allComment(t, h.HighlightLineAt(lines, 1), lines[1], "before clear")
+	h.ClearCache()
+	allComment(t, h.HighlightLineAt(lines, 1), lines[1], "after clear")
+}
+
+// The span cache must not be corrupted by the truncation done when a comment
+// opens mid-line: the same text is requested both with and without state.
+func TestCacheNotAliasedAcrossStates(t *testing.T) {
+	h := New("test.js")
+	line := "const a = 1; /* open"
+	plain := h.HighlightLineAt([]string{line}, 0)
+	if styleAt(plain, 0) != term.StyleSyntaxKeyword {
+		t.Fatal("expected keyword at start")
+	}
+	// request the same text again; a mutated cache entry would lose the keyword
+	again := h.HighlightLineAt([]string{line}, 0)
+	if styleAt(again, 0) != term.StyleSyntaxKeyword {
+		t.Error("cached spans were mutated in place")
+	}
+}

--- a/internal/core/highlight/highlighter_test.go
+++ b/internal/core/highlight/highlighter_test.go
@@ -280,3 +280,73 @@ func TestCacheNotAliasedAcrossStates(t *testing.T) {
 		t.Error("cached spans were mutated in place")
 	}
 }
+
+func TestInvalidationEditAboveViewport(t *testing.T) {
+	lines := []string{"const a = 1;", "const b = 2;", "const c = 3;", "const d = 4;"}
+	h := New("test.js")
+	if styleAt(h.HighlightLineAt(lines, 3), 0) != term.StyleSyntaxKeyword {
+		t.Fatal("precondition: last line should be code")
+	}
+	// Edit line 0 to open a comment; everything below must become comment.
+	lines[0] = "/* now open"
+	h.ClearCache()
+	allComment(t, h.HighlightLineAt(lines, 3), lines[3], "after opening edit")
+
+	// Close it again; the tail must go back to code.
+	lines[0] = "const a = 1;"
+	h.ClearCache()
+	if styleAt(h.HighlightLineAt(lines, 3), 0) != term.StyleSyntaxKeyword {
+		t.Error("closing the comment again should restore code styling")
+	}
+}
+
+// A whole-buffer rewrite (format, sort, replace-all) touches lines far from the
+// cursor. Content-based invalidation must still catch it.
+func TestInvalidationWholeBufferRewrite(t *testing.T) {
+	lines := []string{"const a = 1;", "const b = 2;", "const c = 3;"}
+	h := New("test.js")
+	h.HighlightLineAt(lines, 2)
+
+	rewritten := []string{"/* header", "   rewritten", "*/"}
+	copy(lines, rewritten)
+	h.ClearCache()
+	for i := range lines {
+		allComment(t, h.HighlightLineAt(lines, i), lines[i], "whole-buffer rewrite")
+	}
+}
+
+func TestInvalidationBufferShrinks(t *testing.T) {
+	lines := []string{"/* open", "inside", "*/", "const a = 1;"}
+	h := New("test.js")
+	h.HighlightLineAt(lines, 3)
+
+	// Delete the closer line.
+	lines = []string{"/* open", "inside", "const a = 1;"}
+	h.ClearCache()
+	allComment(t, h.HighlightLineAt(lines, 2), lines[2], "after shrink")
+}
+
+func TestInvalidationBufferGrows(t *testing.T) {
+	lines := []string{"const a = 1;", "const b = 2;"}
+	h := New("test.js")
+	h.HighlightLineAt(lines, 1)
+
+	lines = append(lines, "/* open", "inside")
+	h.ClearCache()
+	allComment(t, h.HighlightLineAt(lines, 3), lines[3], "after growth")
+}
+
+func TestInvalidationUnchangedBufferKeepsTable(t *testing.T) {
+	lines := []string{"/* open", "inside", "*/", "const a = 1;"}
+	h := New("test.js")
+	h.HighlightLineAt(lines, 3)
+	before := len(h.stateSrc)
+	h.ClearCache()
+	h.HighlightLineAt(lines, 3)
+	if len(h.stateSrc) != before {
+		t.Errorf("unchanged buffer should keep the state table: %d -> %d", before, len(h.stateSrc))
+	}
+	if styleAt(h.HighlightLineAt(lines, 3), 0) != term.StyleSyntaxKeyword {
+		t.Error("styling changed after a no-op edit")
+	}
+}

--- a/internal/ui/editor_widget_render.go
+++ b/internal/ui/editor_widget_render.go
@@ -185,7 +185,7 @@ func (e *EditorPaneWidget) Render(surface Surface) {
 			line := []rune(e.Buf.Lines[lineIdx])
 			var syntaxSpans []highlight.Span
 			if e.Highlighter != nil {
-				syntaxSpans = e.Highlighter.HighlightLine(e.Buf.Lines[lineIdx])
+				syntaxSpans = e.Highlighter.HighlightLineAt(e.Buf.Lines, lineIdx)
 			}
 
 			isCollapsedLine := e.Folds != nil && e.Folds.IsCollapsed(lineIdx)

--- a/tests/e2e/multiline_comment_test.go
+++ b/tests/e2e/multiline_comment_test.go
@@ -1,0 +1,168 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+// findRow returns the screen row whose text contains want, or -1.
+func findRow(h *testHarness, want string) int {
+	_, _, ht := h.screen.GetContents()
+	for y := 0; y < ht; y++ {
+		if containsSubstring(h.screenRow(y), want) {
+			return y
+		}
+	}
+	return -1
+}
+
+func containsSubstring(s, sub string) bool {
+	if len(sub) > len(s) {
+		return false
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// styleOfRune returns the style of the first cell on row y holding r.
+func styleOfRune(h *testHarness, y int, r rune) (tcell.Style, bool) {
+	cells, w, _ := h.screen.GetContents()
+	for x := 0; x < w; x++ {
+		if runeAt(cells, y*w+x) == r {
+			return cells[y*w+x].Style, true
+		}
+	}
+	return tcell.StyleDefault, false
+}
+
+// TestMultilineCommentIsStyledAcrossLines is the regression test for multiline
+// block comments being ignored: only the line holding the opener was styled as
+// a comment, because each line was lexed in isolation.
+func TestMultilineCommentIsStyledAcrossLines(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+
+	fp := filepath.Join(h.dir, "sample.js")
+	content := `const before = 1;
+/* opener
+   MIDDLEWORD
+*/
+const after = 2;
+`
+	if err := os.WriteFile(fp, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(fp)
+	h.redraw()
+
+	h.assertContains("MIDDLEWORD")
+
+	// Reference: the styling of the opener line, which worked before the fix.
+	openRow := findRow(h, "/* opener")
+	if openRow < 0 {
+		t.Fatal("opener line not on screen")
+	}
+	commentStyle, ok := styleOfRune(h, openRow, 'p') // from "opener"
+	if !ok {
+		t.Fatal("could not sample opener line style")
+	}
+
+	// The interior line must carry that same comment style.
+	midRow := findRow(h, "MIDDLEWORD")
+	if midRow < 0 {
+		t.Fatal("interior line not on screen")
+	}
+	midStyle, ok := styleOfRune(h, midRow, 'W')
+	if !ok {
+		t.Fatal("could not sample interior line style")
+	}
+	if midStyle != commentStyle {
+		t.Errorf("interior comment line not styled as a comment: got %v want %v", midStyle, commentStyle)
+	}
+
+	// The closer line too.
+	closeRow := findRow(h, "*/")
+	if closeRow < 0 {
+		t.Fatal("closer line not on screen")
+	}
+	closeStyle, ok := styleOfRune(h, closeRow, '/')
+	if !ok {
+		t.Fatal("could not sample closer line style")
+	}
+	if closeStyle != commentStyle {
+		t.Errorf("closer line not styled as a comment: got %v want %v", closeStyle, commentStyle)
+	}
+
+	// Code after the comment closes must NOT be comment styled.
+	afterRow := findRow(h, "const after")
+	if afterRow < 0 {
+		t.Fatal("trailing code line not on screen")
+	}
+	afterStyle, ok := styleOfRune(h, afterRow, 'c')
+	if !ok {
+		t.Fatal("could not sample trailing code style")
+	}
+	if afterStyle == commentStyle {
+		t.Error("code after the comment closed is still styled as a comment")
+	}
+}
+
+// TestCommentStateUpdatesAfterEdit checks the state table is rebuilt when the
+// buffer changes: deleting the closer should extend the comment downward.
+func TestCommentStateUpdatesAfterEdit(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+
+	fp := filepath.Join(h.dir, "edit.js")
+	content := `/* opener
+*/
+const TAILWORD = 2;
+`
+	if err := os.WriteFile(fp, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.EditorGroup.OpenFile(fp)
+	h.redraw()
+
+	openRow := findRow(h, "/* opener")
+	commentStyle, ok := styleOfRune(h, openRow, 'p')
+	if !ok {
+		t.Fatal("could not sample comment style")
+	}
+
+	tailRow := findRow(h, "TAILWORD")
+	before, ok := styleOfRune(h, tailRow, 'T')
+	if !ok {
+		t.Fatal("could not sample tail style")
+	}
+	if before == commentStyle {
+		t.Fatal("precondition: tail should not start as a comment")
+	}
+
+	// Delete the closer line so the comment never closes.
+	ed := h.app.EditorGroup.Editor
+	ed.Cursor.Line = 1
+	ed.Cursor.Col = 0
+	h.exec("editor.deleteLine")
+	h.flushOnChange()
+	h.redraw()
+
+	tailRow = findRow(h, "TAILWORD")
+	if tailRow < 0 {
+		t.Fatal("tail line not on screen after edit")
+	}
+	after, ok := styleOfRune(h, tailRow, 'T')
+	if !ok {
+		t.Fatal("could not sample tail style after edit")
+	}
+	if after != commentStyle {
+		t.Errorf("removing the closer should extend the comment: got %v want %v", after, commentStyle)
+	}
+}


### PR DESCRIPTION
## Problem

`HighlightLine` lexed each line with a fresh chroma lexer, so an opener and its closer were never in the same input and chroma's multiline comment rule could never match. Only the line holding the opener was styled.

```js
// this comment works          ✓
/* this comment works */       ✓
/*
   this one doesn't            ✗
*/
```

## Why not the two earlier attempts

Both #439 and #440 were closed as too complicated. Measuring all three implementations on the same machine explains why neither shape was right. Scenario is typing: one line edited per keystroke, viewport at the end of the file, 40 rows drawn. Absolute figures below come from a synthetic buffer with repeating line patterns, which flatters every variant that has a span cache (this PR and #440) — see the note under State invalidation for distinct-line numbers.

| File size | main | #439 full-buffer | #440 hand-rolled | this PR |
|---|---|---|---|---|
| 1k | ~148µs | 68ms | ~115µs | 138µs |
| 10k | ~168µs | 670ms | ~400µs | 203µs |
| 50k | ~171µs | 3.26s | 1.59ms | 248µs |

**#439** re-tokenized the buffer on every edit. Chroma lexes at ~95µs/line, so that is 68ms at 1k lines and over three seconds at 50k — every keypress. Its `lineSpans` cache is keyed on line count alone, so it can only stay correct by being dropped on each change, which is exactly what makes it slow.

**#440** had the right instinct (per-line plus carried state) but used *two different detectors*: chroma-aware for visible lines, naive string matching for the pre-scan. They disagree, so highlighting depended on scroll position:

```
per-line path says line 0 opens a comment:  false   <- correct, it is a glob in a string
prescan says line 3 is inside a comment:    true    <- wrong
```

It also hardcoded `/* */` and applied it to every language, so a shell script greyed out from its first glob:

```
rm -rf build/*     commented=true
echo "done"        commented=true
exit 0             commented=true
```

## Approach

**Opener detection is delegated to chroma, not string matching.** Appending the closing delimiter makes the comment well-formed, so the lexer's own rules decide. Naive matching is wrong on 5 of 8 realistic JS lines:

| line | naive | chroma |
|---|---|---|
| `const files = glob("src/*");` | opens comment | no |
| `app.use("/api/*", handler);` | opens comment | no |
| `const p = path.join(dir, "/*");` | opens comment | no |
| `const re = /a\/*b/;` | opens comment | no |
| `// see docs at src/*` | opens comment | no |

Chroma's own signal for an unterminated opener can't be used directly: it emits `Error` in JS/TS, `CommentMultiline` in C/Rust/HTML, and nothing at all in Go, Java and CSS.

**Delimiters are probed from the lexer**, so there is no per-language table — `/* */`, `<!-- -->`, `{- -}`, `(* *)`, `--[[ ]]`, `<# #>` are tried against a two-line probe (a line comment can't span one, which stops Haskell's `--` from matching `--[[`). Verified on 24 languages. Languages with no block comment (Python, Bash, JSON, YAML) probe empty and keep the previous behaviour exactly — which is why the shell case above is not a problem here.

**One detector.** `opensAt` serves both the state walk and rendering, so the two cannot disagree by construction.

## State invalidation

The state table is not discarded on edit. `ClearCache` marks it dirty and `truncateToEdit` drops it from the first line whose text changed, keeping everything above. Unchanged lines were never rewritten, so comparing them hits Go's identical-pointer fast path and costs no scanning.

The value is that it removes *growth with file size*, rather than a large constant speedup. On a buffer of distinct lines (no span-cache hits, the realistic case):

| File size | without | with |
|---|---|---|
| 1k | 2.95ms | 3.02ms |
| 10k | 3.46ms | 3.36ms |
| 50k | 4.09ms | 3.11ms |

Without it, cost climbs with file size because every keystroke rescans from line 0; with it, cost is flat. On a buffer with many repeating lines the same comparison reads 932µs → 248µs at 50k, because the span cache absorbs most of the per-line lexing. Real files sit between the two, nearer the distinct-line end since the 40 visible lines are usually distinct.

The dominant remaining cost is chroma itself at ~78µs/line, not the state tracking.

Located by content comparison rather than an invalidate-from-line call, because `EditCommand` exposes only `Apply`/`Undo`; taking the line from the cursor would go stale on multicursor edits, format-document and replace-all — the same scroll-dependent staleness that made #440 wrong.

**Cost:** ~19 bytes per line for the line headers used to locate the edit (0.3MB at 10k lines, 3.7MB at 200k). Line text is shared with the buffer, not copied.

**Total cost of this PR vs main**, on distinct lines (2 runs averaged):

| File size | main | this PR |
|---|---|---|
| 1k | 2.83ms | 2.92ms (+3%) |
| 10k | 3.08ms | 3.19ms (+3%) |
| 50k | 2.86ms | 3.08ms (+7%) |

On realistic content the whole feature costs 3–7%, because lexing the 40 visible lines through chroma (~78µs/line) dominates and the state tracking is noise against it. Both main and this PR are flat in file size; only the intermediate version without invalidation grew (2.95 → 3.46 → 4.09ms).

It is still O(scroll depth), since the edit has to be located by comparison; going fully O(1) would need `Buffer` to report its own dirty line.

### Comparison with micro

micro solves the same problem by storing the open region on each line and having the buffer report its modified range (`MarkModified(start, end)` → `ReHighlightStates`), which early-exits as soon as a line's end state stops changing — O(edit region) rather than O(scroll depth), with no per-line change-detection array.

| | micro | this PR |
|---|---|---|
| keystroke, 50k | 2.23ms | 3.11ms |
| file open, 50k | 2.74s (async, full-buffer pass) | 6.9ms (lazy, visible lines only) |

micro is ~1.4× faster per keystroke, purely because its regex engine runs ~50µs/line against chroma's ~78µs/line. It affords O(edit region) invalidation by paying a full-buffer pass on open; ttt stays lazy. Adopting micro's model here would mean threading a modified-line range from `Buffer`/`EditCommand` to the highlighter — worth a follow-up issue, out of scope for this PR.

## Two bugs from #440 avoided

- The span cache was keyed on line text alone, but the same text renders differently depending on incoming state — state is now part of the cache key.
- `filtered := spans[:0]` reused the cached slice's backing array, mutating the cache entry in place. Covered by `TestCacheNotAliasedAcrossStates`.

## Changes

- `internal/core/highlight/highlighter.go` — state tracking, chroma-delegated opener detection, delimiter probing, content-based invalidation
- `internal/ui/editor_widget_render.go` — one line, `HighlightLine` → `HighlightLineAt`
- `internal/core/highlight/highlighter_test.go` — 17 unit tests
- `tests/e2e/multiline_comment_test.go` — 2 e2e tests asserting rendered cell styles

## Testing

Full Go suite and functional suite (258 passed, 27 expected-fail) green. Both e2e tests were verified to **fail** on the old code, so they are real regression tests. They assert styles via `GetContents()` rather than screenshots, since text snapshots carry no colour.

## Known gaps (not in this PR)

- `internal/markdown/markdown.go` still uses the stateless `HighlightLine`, so multiline comments inside markdown code fences have the same bug. One-line fix, left out to keep this focused.
- The diff view is also stateless. Harder: it interleaves two documents row by row and elides context between hunks, so state at a hunk boundary isn't derivable from what's displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
