### PR TITLE
fix: classify symlinked directories as expandable in explorer

### DIFF
--- a/internal/ui/dirloader.go
+++ b/internal/ui/dirloader.go
@@ -46,14 +46,21 @@ func LoadDirEntries(dirPath string, settings config.ExplorerSettings) []DirEntry
 			continue
 		}
 
+		isDir := entry.IsDir()
+		if entry.Type()&os.ModeSymlink != 0 {
+			if info, err := os.Stat(childPath); err == nil {
+				isDir = info.IsDir()
+			}
+		}
+
 		de := DirEntry{
 			Name:       name,
 			Path:       childPath,
-			IsDir:      entry.IsDir(),
+			IsDir:      isDir,
 			GitIgnored: isIgnored,
 		}
 
-		if entry.IsDir() {
+		if isDir {
 			dirs = append(dirs, de)
 		} else {
 			files = append(files, de)

--- a/internal/ui/dirloader_test.go
+++ b/internal/ui/dirloader_test.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+)
+
+func TestLoadDirEntriesClassifiesSymlinkDirectory(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	for _, entry := range LoadDirEntries(root, config.DefaultExplorerSettings()) {
+		if entry.Name == "linked" {
+			if !entry.IsDir {
+				t.Fatal("symlinked directory is not expandable")
+			}
+			if entry.Path != link {
+				t.Fatalf("path = %q, want %q", entry.Path, link)
+			}
+			return
+		}
+	}
+	t.Fatal("symlink entry missing")
+}
+
+func TestLoadDirEntriesKeepsSymlinkFileAsFile(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "linked.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	for _, entry := range LoadDirEntries(root, config.DefaultExplorerSettings()) {
+		if entry.Name == "linked.txt" {
+			if entry.IsDir {
+				t.Fatal("symlinked file was classified as a directory")
+			}
+			return
+		}
+	}
+	t.Fatal("symlink entry missing")
+}


### PR DESCRIPTION
This is @choephix's fix, cherry-picked from their fork with authorship preserved: I didn't write it.

**The bug:** `os.ReadDir` returns lstat-based entries, so a symlink pointing at a directory reports `IsDir() == false`. The explorer classified those as files; they sorted with files, drew a file icon, and couldn't be expanded.

**The fix:** when an entry is a symlink, `os.Stat` through it to get the real type. Broken links and symlink loops return an error and fall back to being treated as files, so nothing regresses.

Includes a test (`internal/ui/dirloader_test.go`). I confirmed it fails on `main` with `symlinked directory is not expandable` and passes here.

---

@choephix, I came across your fork while looking at how people are using ttt, and found this sitting on your `mine` branch. It's a real bug I still had, so rather than reimplementing it I've opened your commit as-is, with you as the author.

Are you okay with this being merged? Happy to drop it if you'd rather I didn't. If I don't hear back I'll plan to merge in a week or two: either way the commit stays under your name.

Thanks for it, and for `remote-open`. That one surfaced a few gaps in the plugin API that I'm filing separately.

