### PR TITLE
perf: fix quadratic bracket matching on large JSON files

### DIFF
--- a/internal/ui/editor_widget.go
+++ b/internal/ui/editor_widget.go
@@ -66,6 +66,8 @@ type EditorPaneWidget struct {
 	LineChanges             []diff.LineChangeKind
 	bracketColorCache       bracketColorMap
 	bracketColorDirty       bool
+	bracketMatchCache       bracketMatch
+	bracketGen              int
 	wrapMap                 []wrapEntry
 	wrapTopOffset           int
 }
@@ -83,6 +85,7 @@ func NewEditorPaneWidget(buf *buffer.Buffer, cur *cursor.Cursor, vp *view.Viewpo
 
 func (e *EditorPaneWidget) InvalidateBracketColors() {
 	e.bracketColorDirty = true
+	e.bracketGen++
 }
 
 func (e *EditorPaneWidget) Focusable() bool { return true }
@@ -226,6 +229,7 @@ func (e *EditorPaneWidget) FlushOnChange() {
 		e.bufferDirty = false
 		e.maxWidthSeen = 0
 		e.bracketColorDirty = true
+		e.bracketGen++
 		if e.Highlighter != nil {
 			e.Highlighter.ClearCache()
 		}

--- a/internal/ui/editor_widget_brackets.go
+++ b/internal/ui/editor_widget_brackets.go
@@ -12,7 +12,40 @@ var closingBrackets = map[rune]bool{')': true, ']': true, '}': true}
 
 var indentOpeners = map[rune]bool{'{': true, '(': true, '[': true, ':': true}
 
+// bracketMatch caches one matching-bracket scan, keyed on the cursor position
+// and the buffer generation that produced it.
+type bracketMatch struct {
+	valid     bool
+	keyLine   int
+	keyCol    int
+	keyGen    int
+	line, col int
+	ok        bool
+}
+
+// findMatchingBracket returns the position of the bracket paired with the one
+// under the cursor. The render path calls this every frame, but the scan only
+// runs when the cursor or the buffer actually changed — a cursor parked on a
+// brace in a bracket-dense file would otherwise rescan the buffer per frame.
 func (e *EditorPaneWidget) findMatchingBracket() (int, int, bool) {
+	c := &e.bracketMatchCache
+	if c.valid && c.keyLine == e.Cursor.Line && c.keyCol == e.Cursor.Col && c.keyGen == e.bracketGen {
+		return c.line, c.col, c.ok
+	}
+	line, col, ok := e.scanMatchingBracket()
+	*c = bracketMatch{
+		valid:   true,
+		keyLine: e.Cursor.Line,
+		keyCol:  e.Cursor.Col,
+		keyGen:  e.bracketGen,
+		line:    line,
+		col:     col,
+		ok:      ok,
+	}
+	return line, col, ok
+}
+
+func (e *EditorPaneWidget) scanMatchingBracket() (int, int, bool) {
 	if e.Cursor.Line < 0 || e.Cursor.Line >= len(e.Buf.Lines) {
 		return 0, 0, false
 	}
@@ -31,9 +64,11 @@ func (e *EditorPaneWidget) findMatchingBracket() (int, int, bool) {
 	}
 	depth := 1
 	line, col := e.Cursor.Line, e.Cursor.Col
+	// lr always holds the runes of `line`; decoding it per stepped character
+	// instead of per line makes the scan quadratic in line length.
+	lr := runes
 	for {
 		col += dir
-		lr := []rune(e.Buf.Lines[line])
 		if col < 0 {
 			line--
 			if line < 0 {

--- a/internal/ui/editor_widget_brackets_test.go
+++ b/internal/ui/editor_widget_brackets_test.go
@@ -1,0 +1,154 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/buffer"
+	"github.com/eugenioenko/ttt/internal/core/cursor"
+	"github.com/eugenioenko/ttt/internal/view"
+)
+
+func bracketEditor(lines []string, line, col int) *EditorPaneWidget {
+	buf := &buffer.Buffer{Lines: lines}
+	cur := &cursor.Cursor{Line: line, Col: col}
+	vp := &view.Viewport{TopLine: 0, LeftCol: 0, Width: 40, Height: 10}
+	return NewEditorPaneWidget(buf, cur, vp)
+}
+
+func TestFindMatchingBracket(t *testing.T) {
+	tests := []struct {
+		name              string
+		lines             []string
+		line, col         int
+		wantLine, wantCol int
+		wantOK            bool
+	}{
+		{
+			name:  "same line forward",
+			lines: []string{"foo(bar)"},
+			line:  0, col: 3,
+			wantLine: 0, wantCol: 7, wantOK: true,
+		},
+		{
+			name:  "same line backward from closer",
+			lines: []string{"foo(bar)"},
+			line:  0, col: 7,
+			wantLine: 0, wantCol: 3, wantOK: true,
+		},
+		{
+			name:  "multiline nested",
+			lines: []string{"{", "  {", "  }", "}"},
+			line:  0, col: 0,
+			wantLine: 3, wantCol: 0, wantOK: true,
+		},
+		{
+			name:  "skips over nested pair",
+			lines: []string{"[[]]"},
+			line:  0, col: 0,
+			wantLine: 0, wantCol: 3, wantOK: true,
+		},
+		{
+			name:  "unmatched returns false",
+			lines: []string{"{ no closer"},
+			line:  0, col: 0,
+			wantOK: false,
+		},
+		{
+			name:  "cursor not on a bracket",
+			lines: []string{"plain text"},
+			line:  0, col: 2,
+			wantOK: false,
+		},
+		{
+			name:  "spans blank lines",
+			lines: []string{"(", "", "", ")"},
+			line:  0, col: 0,
+			wantLine: 3, wantCol: 0, wantOK: true,
+		},
+		{
+			name:  "backward across blank lines",
+			lines: []string{"(", "", "", ")"},
+			line:  3, col: 0,
+			wantLine: 0, wantCol: 0, wantOK: true,
+		},
+		{
+			name:  "fullwidth runes counted as rune indices",
+			lines: []string{"（｛[日本語]｝）"},
+			line:  0, col: 2,
+			wantLine: 0, wantCol: 6, wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := bracketEditor(tt.lines, tt.line, tt.col)
+			gotLine, gotCol, gotOK := e.findMatchingBracket()
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if gotLine != tt.wantLine || gotCol != tt.wantCol {
+				t.Errorf("match = (%d,%d), want (%d,%d)", gotLine, gotCol, tt.wantLine, tt.wantCol)
+			}
+		})
+	}
+}
+
+// The cached result must not outlive the cursor move or the edit that
+// invalidates it.
+func TestFindMatchingBracketCacheInvalidation(t *testing.T) {
+	e := bracketEditor([]string{"(a)", "[b]"}, 0, 0)
+
+	if _, col, ok := e.findMatchingBracket(); !ok || col != 2 {
+		t.Fatalf("initial scan = (%d, %v), want (2, true)", col, ok)
+	}
+
+	// Moving the cursor re-keys the cache.
+	e.Cursor.Line, e.Cursor.Col = 1, 0
+	line, col, ok := e.findMatchingBracket()
+	if !ok || line != 1 || col != 2 {
+		t.Fatalf("after cursor move = (%d,%d,%v), want (1,2,true)", line, col, ok)
+	}
+
+	// Editing the buffer under a stationary cursor must invalidate too.
+	e.Buf.Lines[1] = "[bbbb]"
+	e.bufferDirty = true
+	e.FlushOnChange()
+	if _, col, ok = e.findMatchingBracket(); !ok || col != 5 {
+		t.Fatalf("after edit = (%d, %v), want (5, true)", col, ok)
+	}
+
+	// InvalidateBracketColors is the other invalidation hook (tab switch,
+	// settings change) and must drop the match cache as well.
+	e.Buf.Lines[1] = "[b]"
+	e.InvalidateBracketColors()
+	if _, col, ok = e.findMatchingBracket(); !ok || col != 2 {
+		t.Fatalf("after invalidate = (%d, %v), want (2, true)", col, ok)
+	}
+}
+
+// Guards the regression from issue #444: the scan must be linear in the
+// characters it steps over, not in characters times line length.
+func BenchmarkFindMatchingBracketLargeJSON(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString("{\n")
+	for i := 0; i < 8000; i++ {
+		sb.WriteString(`  "node_modules/some-package-name": { "version": "1.0.0", "resolved": "https://registry.npmjs.org/some/-/some-1.0.0.tgz" },`)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("}")
+	lines := strings.Split(sb.String(), "\n")
+
+	e := bracketEditor(lines, 0, 0)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.bracketGen++ // defeat the cache so the scan itself is measured
+		if _, _, ok := e.findMatchingBracket(); !ok {
+			b.Fatal("expected a match")
+		}
+	}
+}


### PR DESCRIPTION
Fixes #444.

## The bug

`findMatchingBracket` converted the current line to a `[]rune` **inside** its scan loop:

```go
for {
    col += dir
    lr := []rune(e.Buf.Lines[line])   // re-decodes the whole line, per character
```

So stepping across a 120-character line decoded that line 120 times — the scan is quadratic in line length. It's called from the render path (`editor_widget_render.go:85`) on **every frame**, with no cache and no bound, and from a top-level brace it scans to EOF.

`package-lock.json` is the worst case: the cursor sits on `{` `}` `[` `]` constantly. On a 7,704-line lockfile a single scan cost **35.5ms and allocated 68MB** — every frame. In a CPU profile of a live typing session, 42% went to the scan and another ~29% to GC cleaning up after it.

This is also why the issue reports `pnpm-lock.yaml` as fine: YAML has no brackets, so the function returns at the `bracketPairs[ch]` lookup before scanning anything.

Worth noting `computeBracketColors` right below it does a similar whole-buffer walk but was already protected by a dirty-flag cache and a 10k-line cap. The always-on match highlight never got the same treatment — and it isn't gated by `bracketPairColorization` (default `false`), so this cost was paid even with that feature off.

## The fix

1. **Hoist the conversion out of the loop.** The invariant is now "`lr` holds the runes of `line`", maintained at the three points where `line` changes. The two existing in-branch conversions are unchanged. This is the actual fix.
2. **Cache the result** on `(cursor line, cursor col, buffer generation)`, so the scan runs on cursor move or edit rather than per frame. Invalidation reuses the two hooks bracket colorization already relies on (`FlushOnChange`, `InvalidateBracketColors`), so both bracket caches share one lifecycle.

**No behavior change**: no scan bound, no new setting, distant pairs still match, and `editor.goToMatchingBracket` (`ctrl+k m`) shares the same function.

## Results

Same scenario in both profiles — open the lockfile, jump to line 4000, type 36 characters:

| | before | after |
|---|---|---|
| per scan | 35.5 ms | 1.1 ms |
| per scan allocated | 68 MB | 1.2 MB |
| session CPU | 620 ms | 90 ms |
| session allocated | 562 MB | 65 MB |

`findMatchingBracket` no longer appears in the CPU profile at all.

## Tests

New `internal/ui/editor_widget_brackets_test.go`:

- 9 matcher cases — same-line forward/backward, multiline, nested-pair skipping, unmatched, cursor-not-on-bracket, blank-line spans in both directions, and fullwidth runes (rune indices, not columns)
- cache invalidation across cursor move, buffer edit, and `InvalidateBracketColors` (tab switch / settings change)
- a benchmark on a synthetic 8k-line lockfile guarding the regression

`go test ./...` passes; functional suite passes (258 tests / 79 files).

## Not included

The fold path also showed up while profiling — `ComputeIndentRanges` re-runs on every edit and `FoldAt`/`ContainingFold` are O(ranges) linear scans, about 0.9ms per edit on a 7.7k-line file. Real but unrelated to this bug; happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)