### PR TITLE
feat: make Output a core log panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ The codebase follows a strict layered architecture: **core → view → render �
 - The diff view layers syntax highlighting on top of diff background colors using `BgStyle` layering.
 - **RawKeyConsumer interface**: when the integrated terminal is focused, all key events are routed directly to the PTY. Only force-keys (Ctrl+`) bypass this to allow toggling the terminal panel.
 - Async PTY output wakes the event loop via `PostEvent`/`EventInterrupt`.
+- **Output panel** (`internal/app/output.go`) is a core surface, not a plugin console. Producers are plugin `ttt.log`, language servers (`lsp:<server>`), and every status bar notification (`notice`). Append via `App.LogOutput` on the main thread, or `App.LogOutputAsync` from a background goroutine — it routes through `OutputLineResult` on the event loop, because widget state must not be mutated off the main thread. `LogOutput` also mirrors to `slog`, so `ttt.log` (debug builds) stays a superset of the panel. The panel is capped at `outputMaxLines` and trims in chunks; append with `TreeWidget.AppendItem`, never by rebuilding the slice for `SetItems`.
 - **Global search** (`search_widget.go`) shells out to `rg` (ripgrep) with debounced input (`search.debounce` in settings.json, default 350ms). Uses a generation counter and mutex to prevent concurrent searches from racing. Editor search highlights are tied to the search panel lifecycle — cleared when switching away, re-applied from existing results when switching back.
 
 ### Keybinding System & tcell Key Mapping

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -2072,11 +2072,13 @@ ttt.log("error", "failed to connect to service")
 | `warn`  | Warning color (yellow)           |
 | `error` | Danger color (red)               |
 
-Messages appear in the OUTPUT panel with a timestamp and plugin name prefix: `15:04:05 [my-plugin] message`. Open the OUTPUT panel via the bottom panel tabs.
+Messages appear in the OUTPUT panel with a timestamp and source prefix: `15:04:05 [my-plugin] message`. Open the OUTPUT panel via the bottom panel tabs or **Output: Show Panel** from the command palette.
+
+The OUTPUT panel is shared with the editor itself, so your plugin's lines are interleaved with core sources — language servers log as `[lsp:<server>]` and status bar notifications as `[notice]`.
 
 Plugin errors (init failures, render crashes, callback errors) are automatically routed to the OUTPUT panel as error-level messages, so you don't need to wrap everything in `pcall` for visibility.
 
-Use **Plugins: Clear Output** from the command palette to clear the OUTPUT panel.
+Use **Output: Clear** from the command palette to clear the OUTPUT panel, and **Output: Copy Selected Line** (or `Ctrl+C` while the panel is focused) to copy a line.
 
 ## Error Handling and Debugging
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -462,6 +462,10 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		}
 	}
 
+	lspManager.OnLog = func(server, level, message string) {
+		a.LogOutputAsync(level, "lsp:"+server, message)
+	}
+
 	lspManager.OnDiagnostics = func(params lsp.PublishDiagnosticsParams) {
 		path := URIToPath(params.URI)
 		diags := LspToUIDiagnostics(params.Diagnostics)
@@ -475,6 +479,7 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 
 func (a *App) statusMessage(msg string, level view.NotifyLevel) {
 	a.Status.SetNotification(msg, level, 5*time.Second)
+	a.LogOutput(outputLevelForNotify(level), "notice", msg)
 	time.AfterFunc(5*time.Second, func() {
 		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
 	})

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -21,6 +21,7 @@ func RegisterCommands(app *App) {
 	registerOptionsCommands(app)
 	registerSettingsCommands(app)
 	registerPluginCommands(app)
+	registerOutputCommands(app)
 	registerDebugCommands(app)
 	registerWidgetCallbacks(app)
 	RegisterEscapeDismissers(app)

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -83,12 +83,6 @@ func registerPluginCommands(app *App) {
 		Handler:  func() { app.pluginReloadAll() },
 	})
 
-	reg.Register(command.Command{
-		ID:       "plugin.clearOutput",
-		Title:    "Plugins: Clear Output",
-		Keywords: []string{"plugin", "output", "clear", "log"},
-		Handler:  func() { app.Output.Clear() },
-	})
 }
 
 func (a *App) showPluginList() {

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -345,6 +345,8 @@ func RunEventLoop(
 				// SetDiagnostics routes through the "lsp" source and fires
 				// OnDiagnosticsChanged, which rebuilds the Diagnostics panel.
 				app.EditorGroup.SetDiagnostics(v.Path, v.Diagnostics)
+			case *OutputLineResult:
+				app.LogOutput(v.Level, v.Source, v.Message)
 			case *FileChangedResult:
 				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -1,0 +1,103 @@
+package app
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/view"
+	"github.com/gdamore/tcell/v3"
+)
+
+func registerOutputCommands(app *App) {
+	reg := app.Reg
+	reg.Register(command.Command{
+		ID:       "output.clear",
+		Title:    "Output: Clear",
+		Keywords: []string{"output", "clear", "log", "plugin", "lsp"},
+		Handler:  func() { app.Output.Clear() },
+	})
+	reg.Register(command.Command{
+		ID:       "output.show",
+		Title:    "Output: Show Panel",
+		Keywords: []string{"output", "log", "panel", "show", "lsp"},
+		Handler:  func() { app.ShowOutputPanel() },
+	})
+	reg.Register(command.Command{
+		ID:       "output.copyLine",
+		Title:    "Output: Copy Selected Line",
+		Keywords: []string{"output", "copy", "log", "line"},
+		Handler:  func() { app.OutputCopyLine() },
+	})
+}
+
+// ShowOutputPanel reveals the bottom panel on the Output tab and focuses it.
+func (a *App) ShowOutputPanel() {
+	a.BottomPanel.SetActivePanel("output")
+	a.FocusPanel()
+}
+
+// OutputCopyLine copies the selected Output line, mirroring what Ctrl+C does
+// while the panel has focus.
+func (a *App) OutputCopyLine() {
+	if a.Output == nil || !a.Output.CopySelected() {
+		return
+	}
+	a.StatusNotify("Output line copied to clipboard")
+}
+
+// OutputLineResult carries a log line from a background goroutine to the event
+// loop. Widget state must only be mutated on the main thread.
+type OutputLineResult struct {
+	Source  string
+	Level   string
+	Message string
+}
+
+// LogOutput appends a line to the Output panel and mirrors it to slog, so the
+// debug log file stays a superset of what the panel shows. Main thread only —
+// background goroutines must use LogOutputAsync.
+func (a *App) LogOutput(level, source, message string) {
+	if a.Output == nil {
+		return
+	}
+	a.Output.AddLine(ui.OutputLine{
+		Time:       time.Now().Format("15:04:05"),
+		PluginName: source,
+		Level:      level,
+		Message:    message,
+	})
+	switch level {
+	case "error":
+		slog.Error(message, "source", source)
+	case "warn":
+		slog.Warn(message, "source", source)
+	default:
+		slog.Info(message, "source", source)
+	}
+}
+
+// LogOutputAsync routes a log line through the event loop so it lands on the
+// main thread.
+func (a *App) LogOutputAsync(level, source, message string) {
+	if a.Screen == nil {
+		return
+	}
+	a.Screen.PostEvent(tcell.NewEventInterrupt(&OutputLineResult{
+		Source:  source,
+		Level:   level,
+		Message: message,
+	}))
+}
+
+func outputLevelForNotify(level view.NotifyLevel) string {
+	switch level {
+	case view.NotifyWarning:
+		return "warn"
+	case view.NotifyError:
+		return "error"
+	default:
+		return "info"
+	}
+}

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -1,13 +1,17 @@
 package lsp
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -18,15 +22,18 @@ type Client struct {
 	pending map[int]chan Response
 	mu      sync.Mutex
 	done    chan struct{}
+	closing atomic.Bool
 
 	completionTriggers  []string
 	signatureTriggers   []string
 	signatureRetriggers []string
 
+	onLog func(level, message string)
+
 	OnDiagnostics func(params PublishDiagnosticsParams)
 }
 
-func NewClient(command []string, workDir string) (*Client, error) {
+func NewClient(command []string, workDir string, onLog func(level, message string)) (*Client, error) {
 	if len(command) == 0 {
 		return nil, fmt.Errorf("empty command")
 	}
@@ -41,6 +48,10 @@ func NewClient(command []string, workDir string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("stdout pipe: %w", err)
 	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start %s: %w", command[0], err)
@@ -52,9 +63,32 @@ func NewClient(command []string, workDir string) (*Client, error) {
 		nextID:  1,
 		pending: make(map[int]chan Response),
 		done:    make(chan struct{}),
+		onLog:   onLog,
 	}
+	go c.drainStderr(stderr)
 	go c.readLoop()
 	return c, nil
+}
+
+func (c *Client) log(level, message string) {
+	if c.onLog != nil {
+		c.onLog(level, message)
+	}
+}
+
+// drainStderr surfaces what a server reports about itself. A server that fails
+// to start, crashes, or rejects its config explains why on stderr and nowhere
+// else, so without this the user sees only silent absence of LSP features.
+// Level is "info" because servers vary in how much routine chatter they emit
+// here; genuine failures are reported by the exit path in readLoop.
+func (c *Client) drainStderr(r io.ReadCloser) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if line := strings.TrimSpace(scanner.Text()); line != "" {
+			c.log("info", line)
+		}
+	}
 }
 
 func (c *Client) readLoop() {
@@ -63,6 +97,9 @@ func (c *Client) readLoop() {
 		resp, err := c.codec.Receive()
 		if err != nil {
 			slog.Debug("lsp read loop exit", "err", err)
+			if !c.closing.Load() {
+				c.log("error", "server exited unexpectedly: "+err.Error())
+			}
 			c.mu.Lock()
 			for _, ch := range c.pending {
 				close(ch)
@@ -486,6 +523,7 @@ func (c *Client) RangeFormatting(uri string, r Range, tabSize int, insertSpaces 
 }
 
 func (c *Client) Shutdown() error {
+	c.closing.Store(true)
 	_, err := c.call("shutdown", nil)
 	if err != nil {
 		return err
@@ -496,6 +534,7 @@ func (c *Client) Shutdown() error {
 }
 
 func (c *Client) Close() {
+	c.closing.Store(true)
 	c.cmd.Process.Kill()
 	c.cmd.Wait()
 }

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -80,6 +80,7 @@ func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 	}
 
 	m.servers[key] = client
+	m.log(key, "info", "ready")
 	return client, nil
 }
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -16,12 +16,22 @@ type Manager struct {
 	config        *config.LSPSettings
 	mu            sync.Mutex
 	OnDiagnostics func(params PublishDiagnosticsParams)
+
+	// OnLog receives server-reported messages. Called from the client's stderr
+	// and read-loop goroutines, so the handler must be goroutine-safe.
+	OnLog func(server, level, message string)
 }
 
 func NewManager(cfg *config.LSPSettings) *Manager {
 	return &Manager{
 		servers: make(map[string]*Client),
 		config:  cfg,
+	}
+}
+
+func (m *Manager) log(server, level, message string) {
+	if m.OnLog != nil {
+		m.OnLog(server, level, message)
 	}
 }
 
@@ -51,8 +61,13 @@ func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 	}
 
 	slog.Info("lsp starting server", "language", lang, "command", serverCfg.Command)
-	client, err := NewClient(serverCfg.Command, workDir)
+	m.log(key, "info", "starting "+strings.Join(serverCfg.Command, " "))
+
+	client, err := NewClient(serverCfg.Command, workDir, func(level, message string) {
+		m.log(key, level, message)
+	})
 	if err != nil {
+		m.log(key, "error", err.Error())
 		return nil, fmt.Errorf("start LSP for %s: %w", lang, err)
 	}
 	client.OnDiagnostics = m.OnDiagnostics
@@ -60,6 +75,7 @@ func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 	rootURI := "file://" + workDir
 	if err := client.Initialize(rootURI); err != nil {
 		client.Close()
+		m.log(key, "error", "initialize failed: "+err.Error())
 		return nil, fmt.Errorf("initialize LSP for %s: %w", lang, err)
 	}
 

--- a/internal/ui/output_widget.go
+++ b/internal/ui/output_widget.go
@@ -127,15 +127,21 @@ func (o *OutputWidget) renderItem(surface widgets.Surface, idx, y, w int, select
 		surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
 	}
 
-	levelStyle := style
-	switch line.Level {
-	case "error":
-		levelStyle = term.StyleDanger
-	case "warn":
-		levelStyle = term.StyleWarning
+	// Selection owns the whole row: a style carries its own background, so
+	// keeping the muted prefix or the level color on a selected line would
+	// punch holes in the selection bar.
+	prefixStyle, levelStyle := style, style
+	if !selected {
+		prefixStyle = term.StyleMuted
+		switch line.Level {
+		case "error":
+			levelStyle = term.StyleDanger
+		case "warn":
+			levelStyle = term.StyleWarning
+		}
 	}
 
 	prefix := fmt.Sprintf("%s [%s]", line.Time, line.PluginName)
-	x := surface.DrawText(1, y, prefix, w, term.StyleMuted)
+	x := surface.DrawText(1, y, prefix, w, prefixStyle)
 	surface.DrawText(x+1, y, line.Message, w, levelStyle)
 }

--- a/internal/ui/output_widget.go
+++ b/internal/ui/output_widget.go
@@ -3,9 +3,18 @@ package ui
 import (
 	"fmt"
 
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
+)
+
+// A chatty producer (an LSP server dumping stderr) would otherwise grow the log
+// without bound. Lines are dropped in chunks so the O(n) rebuild that a trim
+// forces is amortised across outputTrimChunk appends.
+const (
+	outputMaxLines  = 5000
+	outputTrimChunk = 500
 )
 
 type OutputLine struct {
@@ -17,6 +26,8 @@ type OutputLine struct {
 
 type OutputWidget struct {
 	Lines      []OutputLine
+	nodes      []*widgets.TreeNode
+	seq        int
 	autoScroll bool
 	tree       *widgets.TreeWidget
 }
@@ -43,6 +54,12 @@ func (o *OutputWidget) SetBoxModel(bm widgets.BoxModel) { o.tree.SetBoxModel(bm)
 func (o *OutputWidget) Render(surface Surface)          { o.tree.Render(surface) }
 
 func (o *OutputWidget) HandleEvent(ev tcell.Event) EventResult {
+	if kev, ok := ev.(*tcell.EventKey); ok && kev.Key() == tcell.KeyCtrlC {
+		if o.CopySelected() {
+			return EventConsumed
+		}
+	}
+
 	prevSel := o.tree.SelectedIndex()
 	result := EventResult(o.tree.HandleEvent(ev))
 	if result != EventIgnored && o.tree.SelectedIndex() != prevSel {
@@ -55,16 +72,34 @@ func (o *OutputWidget) HandleEvent(ev tcell.Event) EventResult {
 	return result
 }
 
+// CopySelected puts the selected line on the clipboard as it reads on screen.
+func (o *OutputWidget) CopySelected() bool {
+	idx := o.tree.SelectedIndex()
+	if idx < 0 || idx >= len(o.Lines) {
+		return false
+	}
+	line := o.Lines[idx]
+	clipboard.Set(fmt.Sprintf("%s [%s] %s", line.Time, line.PluginName, line.Message))
+	return true
+}
+
 func (o *OutputWidget) AddLine(line OutputLine) {
 	o.Lines = append(o.Lines, line)
-	nodes := make([]*widgets.TreeNode, len(o.Lines))
-	for i, l := range o.Lines {
-		nodes[i] = &widgets.TreeNode{
-			ID:    fmt.Sprintf("output-%d", i),
-			Label: l.Message,
-		}
+	o.nodes = append(o.nodes, &widgets.TreeNode{
+		ID:    fmt.Sprintf("output-%d", o.seq),
+		Label: line.Message,
+	})
+	o.seq++
+
+	if len(o.Lines) > outputMaxLines {
+		drop := len(o.Lines) - (outputMaxLines - outputTrimChunk)
+		o.Lines = append([]OutputLine(nil), o.Lines[drop:]...)
+		o.nodes = append([]*widgets.TreeNode(nil), o.nodes[drop:]...)
+		o.tree.SetItems(o.nodes)
+	} else {
+		o.tree.AppendItem(o.nodes[len(o.nodes)-1])
 	}
-	o.tree.SetItems(nodes)
+
 	if o.autoScroll {
 		o.tree.SetSelectedIndex(len(o.Lines) - 1)
 	}
@@ -72,6 +107,7 @@ func (o *OutputWidget) AddLine(line OutputLine) {
 
 func (o *OutputWidget) Clear() {
 	o.Lines = nil
+	o.nodes = nil
 	o.tree.SetItems(nil)
 	o.autoScroll = true
 }
@@ -91,8 +127,6 @@ func (o *OutputWidget) renderItem(surface widgets.Surface, idx, y, w int, select
 		surface.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
 	}
 
-	x := 1
-
 	levelStyle := style
 	switch line.Level {
 	case "error":
@@ -102,20 +136,6 @@ func (o *OutputWidget) renderItem(surface widgets.Surface, idx, y, w int, select
 	}
 
 	prefix := fmt.Sprintf("%s [%s]", line.Time, line.PluginName)
-	for _, ch := range prefix {
-		if x >= w {
-			break
-		}
-		surface.SetCell(x, y, term.Cell{Ch: ch, Style: term.StyleMuted})
-		x++
-	}
-	x++
-
-	for _, ch := range line.Message {
-		if x >= w {
-			break
-		}
-		surface.SetCell(x, y, term.Cell{Ch: ch, Style: levelStyle})
-		x++
-	}
+	x := surface.DrawText(1, y, prefix, w, term.StyleMuted)
+	surface.DrawText(x+1, y, line.Message, w, levelStyle)
 }

--- a/internal/ui/output_widget_test.go
+++ b/internal/ui/output_widget_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
+	"github.com/eugenioenko/ttt/internal/term"
 )
 
 func addLines(o *OutputWidget, n int) {
@@ -106,6 +107,40 @@ func TestOutputRenderFullwidthMessage(t *testing.T) {
 	}
 	if grid[0][msgX+2].Ch != 'b' {
 		t.Errorf("grid[0][%d] = %q, want 'b' two columns after the fullwidth rune", msgX+2, grid[0][msgX+2].Ch)
+	}
+}
+
+// A style carries its own background, so a selected row that kept the muted
+// prefix or the level color would show gaps in the selection bar.
+func TestOutputSelectedRowUsesOneStyle(t *testing.T) {
+	o := NewOutputWidget()
+	o.AddLine(OutputLine{Time: "12:00:00", PluginName: "p", Level: "error", Message: "boom"})
+
+	grid := makeGrid(40, 1)
+	s := NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 40, H: 1})
+	o.renderItem(s, 0, 0, 40, true)
+
+	for x := 0; x < 40; x++ {
+		if got := grid[0][x].Style; got != term.StyleSidebarSelected {
+			t.Fatalf("column %d has style %d, want StyleSidebarSelected", x, got)
+		}
+	}
+}
+
+func TestOutputUnselectedRowKeepsLevelColor(t *testing.T) {
+	o := NewOutputWidget()
+	o.AddLine(OutputLine{Time: "12:00:00", PluginName: "p", Level: "error", Message: "boom"})
+
+	grid := makeGrid(40, 1)
+	s := NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 40, H: 1})
+	o.renderItem(s, 0, 0, 40, false)
+
+	if got := grid[0][1].Style; got != term.StyleMuted {
+		t.Errorf("prefix style = %d, want StyleMuted", got)
+	}
+	// 1 (left pad) + len("12:00:00 [p]") + 1 (gap) = 14
+	if got := grid[0][14].Style; got != term.StyleDanger {
+		t.Errorf("message style = %d, want StyleDanger", got)
 	}
 }
 

--- a/internal/ui/output_widget_test.go
+++ b/internal/ui/output_widget_test.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
+)
+
+func addLines(o *OutputWidget, n int) {
+	for i := 0; i < n; i++ {
+		o.AddLine(OutputLine{
+			Time:       "12:00:00",
+			PluginName: "test",
+			Level:      "info",
+			Message:    fmt.Sprintf("line %d", i),
+		})
+	}
+}
+
+func TestOutputAddLineKeepsTreeInSync(t *testing.T) {
+	o := NewOutputWidget()
+	addLines(o, 5)
+
+	if got := o.tree.ItemCount(); got != 5 {
+		t.Fatalf("expected 5 tree items, got %d", got)
+	}
+	if got := o.tree.FlatList()[4].Label; got != "line 4" {
+		t.Errorf("expected last item %q, got %q", "line 4", got)
+	}
+}
+
+func TestOutputTrimsToCapKeepingNewest(t *testing.T) {
+	o := NewOutputWidget()
+	addLines(o, outputMaxLines+1)
+
+	want := outputMaxLines - outputTrimChunk
+	if len(o.Lines) != want {
+		t.Fatalf("expected %d lines after trim, got %d", want, len(o.Lines))
+	}
+	if o.tree.ItemCount() != want {
+		t.Fatalf("expected %d tree items after trim, got %d", want, o.tree.ItemCount())
+	}
+
+	// The newest line must survive; the oldest must not.
+	last := fmt.Sprintf("line %d", outputMaxLines)
+	if got := o.Lines[len(o.Lines)-1].Message; got != last {
+		t.Errorf("expected newest line %q, got %q", last, got)
+	}
+	if got := o.Lines[0].Message; got == "line 0" {
+		t.Error("expected oldest line to be dropped")
+	}
+
+	// Lines and tree nodes must stay index-aligned, since renderItem indexes
+	// Lines by the tree's flat index.
+	for i, node := range o.tree.FlatList() {
+		if node.Label != o.Lines[i].Message {
+			t.Fatalf("index %d out of sync: node %q vs line %q", i, node.Label, o.Lines[i].Message)
+		}
+	}
+}
+
+func TestOutputTrimKeepsUniqueNodeIDs(t *testing.T) {
+	o := NewOutputWidget()
+	addLines(o, outputMaxLines+outputTrimChunk+10)
+
+	seen := map[string]bool{}
+	for _, node := range o.tree.FlatList() {
+		if seen[node.ID] {
+			t.Fatalf("duplicate node ID %q after trim", node.ID)
+		}
+		seen[node.ID] = true
+	}
+}
+
+func TestOutputClearResetsState(t *testing.T) {
+	o := NewOutputWidget()
+	addLines(o, 10)
+	o.Clear()
+
+	if len(o.Lines) != 0 || o.tree.ItemCount() != 0 {
+		t.Fatalf("expected empty after Clear, got %d lines / %d items", len(o.Lines), o.tree.ItemCount())
+	}
+
+	addLines(o, 1)
+	if o.tree.ItemCount() != 1 {
+		t.Errorf("expected 1 item after re-adding, got %d", o.tree.ItemCount())
+	}
+}
+
+// A fullwidth rune in a log message advances two terminal columns. Measuring the
+// message by rune count instead would put the rest of the line one column left of
+// where the terminal actually draws it (issue #434).
+func TestOutputRenderFullwidthMessage(t *testing.T) {
+	o := NewOutputWidget()
+	o.AddLine(OutputLine{Time: "12:00:00", PluginName: "p", Level: "info", Message: "가b"})
+
+	grid := makeGrid(40, 1)
+	s := NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 40, H: 1})
+	o.renderItem(s, 0, 0, 40, false)
+
+	// 1 (left pad) + len("12:00:00 [p]") + 1 (gap) = 14
+	const msgX = 14
+	if grid[0][msgX].Ch != '가' {
+		t.Fatalf("grid[0][%d] = %q, want '가'", msgX, grid[0][msgX].Ch)
+	}
+	if grid[0][msgX+2].Ch != 'b' {
+		t.Errorf("grid[0][%d] = %q, want 'b' two columns after the fullwidth rune", msgX+2, grid[0][msgX+2].Ch)
+	}
+}
+
+func TestOutputCopySelected(t *testing.T) {
+	clipboard.DisableSystem()
+	o := NewOutputWidget()
+
+	if o.CopySelected() {
+		t.Error("expected CopySelected to report false on an empty panel")
+	}
+
+	o.AddLine(OutputLine{Time: "12:00:00", PluginName: "lsp:go", Level: "error", Message: "boom"})
+	if !o.CopySelected() {
+		t.Fatal("expected CopySelected to report true")
+	}
+	if got := clipboard.Get(); got != "12:00:00 [lsp:go] boom" {
+		t.Errorf("unexpected clipboard contents: %q", got)
+	}
+}

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -112,6 +112,15 @@ func (t *TreeWidget) SetItems(items []*TreeNode) {
 	t.clampSelected()
 }
 
+// AppendItem adds a root node and flattens only that node. Callers appending to
+// a long list must use this instead of rebuilding the slice for SetItems, which
+// re-flattens every item and turns an append loop into O(n²).
+func (t *TreeWidget) AppendItem(item *TreeNode) {
+	t.Config.Items = append(t.Config.Items, item)
+	t.flattenNode(item, 0)
+	t.clampSelected()
+}
+
 func (t *TreeWidget) SetActiveID(id string) {
 	t.Config.ActiveID = id
 }

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -1472,3 +1472,38 @@ func TestTreeRenderItemCallback(t *testing.T) {
 		t.Errorf("RenderItem should be called for each visible item, got %v", rendered)
 	}
 }
+
+func TestTreeAppendItem(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{Items: makeTreeItems("a", "b")})
+
+	tree.AppendItem(&TreeNode{ID: "c", Label: "c"})
+
+	if got := tree.ItemCount(); got != 3 {
+		t.Fatalf("ItemCount = %d, want 3", got)
+	}
+	flat := tree.FlatList()
+	if flat[2].ID != "c" {
+		t.Errorf("appended node at index 2 = %q, want %q", flat[2].ID, "c")
+	}
+	// The appended node must be reachable through Config.Items too, so a later
+	// SetItems/flatten round-trip does not lose it.
+	if len(tree.Config.Items) != 3 || tree.Config.Items[2].ID != "c" {
+		t.Error("appended node missing from Config.Items")
+	}
+}
+
+func TestTreeAppendItemFlattensChildren(t *testing.T) {
+	tree := NewTreeWidget(TreeConfig{Items: makeTreeItems("a")})
+
+	tree.AppendItem(&TreeNode{
+		ID: "b", Label: "b", Expanded: true,
+		Children: []*TreeNode{{ID: "b1", Label: "b1"}},
+	})
+
+	if got := tree.ItemCount(); got != 3 {
+		t.Fatalf("ItemCount = %d, want 3 (a, b, b1)", got)
+	}
+	if got := tree.FlatList()[2].ID; got != "b1" {
+		t.Errorf("child at index 2 = %q, want %q", got, "b1")
+	}
+}

--- a/tests/functional/output-panel.test.js
+++ b/tests/functional/output-panel.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("output panel", () => {
+  it("should log status notifications", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello world\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    // Any command that reports through the status bar should leave a trail.
+    tui.exec("File: Copy Absolute Path");
+    tui.waitStable();
+
+    tui.exec("Output: Show Panel");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("[notice]");
+    expect(snapshots[s0]).toContain("Absolute path copied to clipboard");
+  });
+
+  it("should clear logged lines", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello world\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.exec("File: Copy Absolute Path");
+    tui.waitStable();
+    tui.exec("Output: Show Panel");
+    tui.waitStable();
+
+    const before = tui.snapshot();
+
+    tui.exec("Output: Clear");
+    tui.waitStable();
+
+    const after = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    // Assert on the panel's own line format: the status bar still shows the
+    // notification text for a few seconds after the panel has been cleared.
+    expect(snapshots[before]).toContain("[notice]");
+    expect(snapshots[after]).not.toContain("[notice]");
+    expect(snapshots[after]).toContain("No output");
+  });
+
+  it("should copy the selected line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello world\n");
+
+    tui.start(file);
+    tui.waitFor("hello");
+
+    tui.exec("File: Copy Absolute Path");
+    tui.waitStable();
+    tui.exec("Output: Show Panel");
+    tui.waitStable();
+
+    tui.exec("Output: Copy Selected Line");
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Output line copied to clipboard");
+  });
+});


### PR DESCRIPTION
## Motivation

The Output panel held a permanent slot in the bottom tab bar but only ever showed plugin logs — empty for anyone without plugins. Meanwhile the editor's own diagnostics went nowhere the user could see:

- LSP errors reached `slog`, which is `io.Discard` outside `--debug`. `NewClient` never even captured stderr, so a server that failed to start produced total silence.
- Status bar notifications vanished after 5s with no history.

## PR Changes

Three core producers now feed the panel:

- **Language servers** — stderr is captured and the read loop reports unexpected exits, prefixed `[lsp:<server>]`.
- **Status bar notifications** — mirrored as `[notice]` so a message that flashed past can still be read.
- **Plugin logs** — unchanged.

`LogOutput` mirrors to `slog`, so the debug log file stays a superset of the panel. Background producers use `LogOutputAsync`, which routes through the event loop instead of mutating widget state off the main thread.

Perf: `AddLine` rebuilt the full `[]*TreeNode` and re-flattened on every line — O(n²) over an append loop, which a chatty server would have made visible. Adds `TreeWidget.AppendItem` and caps the panel at 5000 lines, trimming in chunks.

Also fixes `renderItem` measuring the message by rune count instead of display width (#434 pattern), and adds Ctrl+C to copy the selected line.

Commands: `plugin.clearOutput` → `output.clear` now that the panel is not plugin-specific; `output.show` and `output.copyLine` are new.

Verified against a failing server and a healthy `gopls` — the failure path shows the start command, both stderr lines, the unexpected exit and the initialize failure; a healthy server logs one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)