### PR TITLE
fix: restore search error messages lost in streaming rewrite

### DIFF
--- a/internal/ui/search_widget.go
+++ b/internal/ui/search_widget.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +20,7 @@ type SearchBatch struct {
 	Gen    uint64
 	Groups []SearchFileGroup
 	Done   bool
+	Error  string
 }
 
 type SearchMatch struct {
@@ -219,6 +221,7 @@ func (s *SearchWidget) scheduleSearch() {
 	s.FlatList = nil
 	s.Selected = 0
 	s.ScrollTop = 0
+	s.Error = ""
 	s.stopSearch()
 	s.searchGen++
 	gen := s.searchGen
@@ -234,6 +237,7 @@ func (s *SearchWidget) scheduleSearch() {
 
 func (s *SearchWidget) runSearchSync() {
 	s.cancelSearch()
+	s.Error = ""
 	if s.Input.Text == "" {
 		s.Groups = nil
 		s.FlatList = nil
@@ -250,6 +254,14 @@ func (s *SearchWidget) runSearchSync() {
 }
 
 func (s *SearchWidget) streamSearch(ctx context.Context, gen uint64) {
+	// streamSearch runs on its own goroutine, where an unrecovered panic would
+	// take down the editor rather than just the search.
+	defer func() {
+		if r := recover(); r != nil {
+			s.sendBatch(&SearchBatch{Gen: gen, Done: true, Error: fmt.Sprintf("search failed: %v", r)})
+		}
+	}()
+
 	var groups []SearchFileGroup
 
 	if s.DiffSources != nil {
@@ -301,12 +313,13 @@ func (s *SearchWidget) ApplyBatch(batch *SearchBatch) {
 	s.flatten()
 	if batch.Done {
 		s.Searching = false
+		s.Error = batch.Error
 	}
 }
 
 func (s *SearchWidget) streamFiles(ctx context.Context, gen uint64, groups *[]SearchFileGroup) {
 	if _, err := exec.LookPath("rg"); err != nil {
-		s.sendBatch(&SearchBatch{Gen: gen, Done: true})
+		s.sendBatch(&SearchBatch{Gen: gen, Done: true, Error: "ripgrep (rg) not found"})
 		return
 	}
 
@@ -338,11 +351,11 @@ func (s *SearchWidget) streamFiles(ctx context.Context, gen uint64, groups *[]Se
 	cmd := exec.CommandContext(ctx, "rg", args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		s.sendBatch(&SearchBatch{Gen: gen, Done: true})
+		s.sendBatch(&SearchBatch{Gen: gen, Done: true, Error: "search failed: " + err.Error()})
 		return
 	}
 	if err := cmd.Start(); err != nil {
-		s.sendBatch(&SearchBatch{Gen: gen, Done: true})
+		s.sendBatch(&SearchBatch{Gen: gen, Done: true, Error: "search failed: " + err.Error()})
 		return
 	}
 
@@ -427,14 +440,27 @@ func (s *SearchWidget) streamFiles(ctx context.Context, gen uint64, groups *[]Se
 	if scanner.Err() != nil {
 		cmd.Process.Kill()
 	}
-	cmd.Wait()
+	waitErr := cmd.Wait()
 	if ctx.Err() != nil {
 		return
 	}
 
 	snapshot := make([]SearchFileGroup, len(*groups))
 	copy(snapshot, *groups)
-	s.sendBatch(&SearchBatch{Gen: gen, Groups: snapshot, Done: true})
+	s.sendBatch(&SearchBatch{Gen: gen, Groups: snapshot, Done: true, Error: rgFailure(waitErr)})
+}
+
+// rgFailure reports a message for a ripgrep run that failed. Exit code 1 means
+// "no matches", which is a normal empty result, not a failure.
+func rgFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return ""
+	}
+	return "search failed: " + err.Error()
 }
 
 type rgMessage struct {

--- a/internal/ui/search_widget_test.go
+++ b/internal/ui/search_widget_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestRgFailureIgnoresNoMatches(t *testing.T) {
+	// rg exits 1 when it finds nothing, which is an empty result, not a failure.
+	err := exec.Command("sh", "-c", "exit 1").Run()
+	if err == nil {
+		t.Fatal("expected a non-nil error from exit 1")
+	}
+	if got := rgFailure(err); got != "" {
+		t.Errorf("rgFailure(exit 1) = %q, want empty", got)
+	}
+}
+
+func TestRgFailureReportsRealFailures(t *testing.T) {
+	err := exec.Command("sh", "-c", "exit 2").Run()
+	if err == nil {
+		t.Fatal("expected a non-nil error from exit 2")
+	}
+	if got := rgFailure(err); got == "" {
+		t.Error("rgFailure(exit 2) = empty, want a message")
+	}
+
+	if got := rgFailure(errors.New("boom")); got != "search failed: boom" {
+		t.Errorf("rgFailure(boom) = %q", got)
+	}
+	if got := rgFailure(nil); got != "" {
+		t.Errorf("rgFailure(nil) = %q, want empty", got)
+	}
+}
+
+func TestApplyBatchSurfacesError(t *testing.T) {
+	s := NewSearchWidget()
+	s.searchGen = 7
+
+	s.ApplyBatch(&SearchBatch{Gen: 7, Done: true, Error: "ripgrep (rg) not found"})
+	if s.Error != "ripgrep (rg) not found" {
+		t.Fatalf("Error = %q, want the rg message", s.Error)
+	}
+	if s.Searching {
+		t.Error("expected Searching to be cleared")
+	}
+}
+
+func TestApplyBatchIgnoresStaleGeneration(t *testing.T) {
+	s := NewSearchWidget()
+	s.searchGen = 8
+
+	s.ApplyBatch(&SearchBatch{Gen: 7, Done: true, Error: "stale"})
+	if s.Error != "" {
+		t.Errorf("Error = %q, want empty for a stale batch", s.Error)
+	}
+}
+
+// A partial batch must not wipe a message set by the run that follows it.
+func TestApplyBatchKeepsErrorUntilDone(t *testing.T) {
+	s := NewSearchWidget()
+	s.searchGen = 3
+	s.Error = "previous"
+
+	s.ApplyBatch(&SearchBatch{Gen: 3})
+	if s.Error != "previous" {
+		t.Errorf("Error = %q, want it untouched by a partial batch", s.Error)
+	}
+
+	s.ApplyBatch(&SearchBatch{Gen: 3, Done: true})
+	if s.Error != "" {
+		t.Errorf("Error = %q, want cleared by a successful final batch", s.Error)
+	}
+}
+
+func TestSearchStartClearsError(t *testing.T) {
+	s := NewSearchWidget()
+	s.Error = "ripgrep (rg) not found"
+	s.Input.Text = ""
+
+	s.runSearchSync()
+	if s.Error != "" {
+		t.Errorf("Error = %q, want cleared when a new search starts", s.Error)
+	}
+}


### PR DESCRIPTION
## Motivation

`ce0948c` (PR #43, 2026-06-08) moved global search onto a goroutine and removed every assignment to `SearchWidget.Error`, while keeping the branch that renders it (`search_widget.go:539`). The field has been declared and unused since.

Three failures regressed into a plausible-looking empty result:

- ripgrep not on PATH — `streamFiles` returned an empty completed batch
- rg failing for any reason other than "no matches"
- a panic during the search — previously recovered, since then unrecovered on a goroutine, which takes down the editor

All three rendered as `No results`, indistinguishable from a search that genuinely matched nothing.

Before / after, with `rg` off PATH:

```
│ ❯ streamFiles          Aa .* │        │ ❯ streamFiles          Aa .* │
│─────────────────────────── ▼ │        │─────────────────────────── ▼ │
│No results                    │        │ripgrep (rg) not found        │
```

## PR Changes

- `SearchBatch` carries an `Error`, applied by `ApplyBatch` on the final batch — the search no longer runs on the main thread, so it cannot write the field directly.
- `rgFailure` treats exit code 1 as an empty result, not a failure, matching the pre-regression behaviour.
- `Error` is cleared when a search starts, and a partial batch leaves it untouched.
- Restores the panic guard on `streamSearch`.

Six unit tests cover the exit-code split, stale-generation batches, partial batches and the clear-on-start path. Verified end to end against a PATH without ripgrep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)