### PR TITLE
fix: report real language server state in the status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ You can also add custom servers manually in `~/.config/ttt/settings.json`. See t
 
 To disable LSP entirely: `"lsp": { "enabled": false }` in settings.
 
+#### Server Status
+
+The language segment in the status bar shows the state of the server for the current file: `◉` connected, `◌` starting or not yet launched, `⚠` failed to start or exited, and no indicator when no server is configured. Click it to open the OUTPUT panel, where each server logs its startup command, stderr and any failures under `lsp:<server>`.
+
 #### Supported Features
 
 | Feature | Keybinding | Description |

--- a/docs-web/src/content/docs/guides/lsp.md
+++ b/docs-web/src/content/docs/guides/lsp.md
@@ -254,6 +254,19 @@ The optional `languages` field is for servers that handle multiple file types re
 
 The server is started lazily on first use and shut down when the editor exits.
 
+## Server Status
+
+The language segment on the right of the status bar shows the state of the server for the current file:
+
+| Indicator | Meaning |
+|-----------|---------|
+| `Go ◉` | Connected and initialized |
+| `Go ◌` | Starting, or not launched yet — servers start on first use |
+| `Go ⚠` | Failed to start, exited, or the binary is not installed |
+| `Go` | No server configured for this language |
+
+Click the segment to open the OUTPUT panel, where each server logs its startup command, its own stderr, initialization failures and unexpected exits under the `lsp:<server>` prefix. That is the place to look when a feature silently does nothing.
+
 ## Supported Features
 
 | Feature | Keybinding | Description |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -466,6 +466,12 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		a.LogOutputAsync(level, "lsp:"+server, message)
 	}
 
+	// A server can die at any time; waking the loop redraws the status bar so
+	// the indicator does not keep claiming the server is up.
+	lspManager.OnStateChange = func() {
+		screen.PostEvent(tcell.NewEventInterrupt(&LSPStateChanged{}))
+	}
+
 	lspManager.OnDiagnostics = func(params lsp.PublishDiagnosticsParams) {
 		path := URIToPath(params.URI)
 		diags := LspToUIDiagnostics(params.Diagnostics)

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"log/slog"
-	"os/exec"
 
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/plugin"
@@ -85,24 +84,7 @@ func RunEventLoop(
 		}
 		app.Status.SetSegment(view.StatusSegment{ID: "indent", Side: "right", Priority: 200, Text: fmt.Sprintf("%s: %d", indentLabel, tabSize)})
 
-		if app.EditorGroup.Editor != nil && app.EditorGroup.Editor.Highlighter != nil {
-			lang := app.EditorGroup.Editor.Highlighter.Language()
-			serverKey, _, lspOk := app.lspResolve(filePath, lang)
-			if lspOk {
-				serverCfg := app.LspManager.ServerConfig(serverKey)
-				if len(serverCfg.Command) > 0 {
-					_, err := exec.LookPath(serverCfg.Command[0])
-					lspOk = err == nil
-				}
-			}
-			langText := lang
-			if lspOk {
-				langText += " ⊕"
-			}
-			app.Status.SetSegment(view.StatusSegment{ID: "language", Side: "right", Priority: 500, Text: langText})
-		} else {
-			app.Status.SetSegment(view.StatusSegment{ID: "language", Side: "right", Priority: 500, Text: ""})
-		}
+		app.SyncLanguageSegment()
 
 		repoDir := ""
 		if filePath != "" && !app.EditorGroup.IsActiveVirtual() {
@@ -347,6 +329,8 @@ func RunEventLoop(
 				app.EditorGroup.SetDiagnostics(v.Path, v.Diagnostics)
 			case *OutputLineResult:
 				app.LogOutput(v.Level, v.Source, v.Message)
+			case *LSPStateChanged:
+				app.SyncLanguageSegment()
 			case *FileChangedResult:
 				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:

--- a/internal/app/lsp_status.go
+++ b/internal/app/lsp_status.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"os/exec"
+
+	"github.com/eugenioenko/ttt/internal/lsp"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/view"
+)
+
+// SyncLanguageSegment refreshes the language status bar segment. It is separate
+// from syncStatus so a language server changing state asynchronously can update
+// the indicator without the full status sync, which the event loop runs only on
+// user input.
+func (a *App) SyncLanguageSegment() {
+	if a.EditorGroup.Editor == nil || a.EditorGroup.Editor.Highlighter == nil {
+		a.Status.SetSegment(view.StatusSegment{ID: "language", Side: "right", Priority: 500, Text: ""})
+		return
+	}
+
+	lang := a.EditorGroup.Editor.Highlighter.Language()
+	icon, iconStyle := a.lspStatusIcon(a.EditorGroup.ActiveFilePath(), lang)
+	text := lang
+	if icon != "" {
+		text += " " + icon
+	}
+	a.Status.SetSegment(view.StatusSegment{
+		ID: "language", Side: "right", Priority: 500,
+		Text:    text,
+		Style:   iconStyle,
+		OnClick: a.ShowOutputPanel,
+	})
+}
+
+// lspStatusIcon reports the language server indicator for the status bar.
+func (a *App) lspStatusIcon(filePath, lang string) (string, term.Style) {
+	serverKey, _, configured := a.lspResolve(filePath, lang)
+	if !configured {
+		return "", 0
+	}
+
+	// The status bar syncs on every keystroke, so only stat the binary when its
+	// presence is what the icon actually turns on.
+	state := a.LspManager.State(serverKey)
+	binaryOK := true
+	if state == lsp.ServerStopped {
+		if cfg := a.LspManager.ServerConfig(serverKey); len(cfg.Command) > 0 {
+			_, err := exec.LookPath(cfg.Command[0])
+			binaryOK = err == nil
+		}
+	}
+	return lspIcon(state, binaryOK)
+}
+
+// lspIcon maps a server state to its indicator. Every icon is single-width
+// under both normal and East Asian width rules, so the segment does not shift
+// as the state changes — ⊕, ● and ○ are ambiguous width and would.
+func lspIcon(state lsp.ServerState, binaryOK bool) (string, term.Style) {
+	switch state {
+	case lsp.ServerReady:
+		return "◉", 0
+	case lsp.ServerStarting:
+		return "◌", 0
+	case lsp.ServerFailed:
+		return "⚠", term.StyleDanger
+	}
+
+	// Not started — servers launch lazily on the first request. A missing
+	// binary is the one failure knowable before then, and ttt never even tries.
+	if !binaryOK {
+		return "⚠", term.StyleDanger
+	}
+	return "◌", 0
+}
+
+// LSPStateChanged tells the event loop a language server changed state.
+type LSPStateChanged struct{}

--- a/internal/app/lsp_status_test.go
+++ b/internal/app/lsp_status_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/lsp"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+)
+
+func TestLspIcon(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     lsp.ServerState
+		binaryOK  bool
+		wantIcon  string
+		wantStyle term.Style
+	}{
+		{"ready", lsp.ServerReady, true, "◉", 0},
+		{"starting", lsp.ServerStarting, true, "◌", 0},
+		{"failed", lsp.ServerFailed, true, "⚠", term.StyleDanger},
+		{"not started, binary present", lsp.ServerStopped, true, "◌", 0},
+		{"not started, binary missing", lsp.ServerStopped, false, "⚠", term.StyleDanger},
+		// A crashed server reports failed regardless of the binary still being
+		// on disk — presence on disk says nothing about the process.
+		{"failed with binary present", lsp.ServerFailed, true, "⚠", term.StyleDanger},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			icon, style := lspIcon(tt.state, tt.binaryOK)
+			if icon != tt.wantIcon {
+				t.Errorf("icon = %q, want %q", icon, tt.wantIcon)
+			}
+			if style != tt.wantStyle {
+				t.Errorf("style = %d, want %d", style, tt.wantStyle)
+			}
+		})
+	}
+}
+
+// The indicator must not resize as the state changes, or the whole right-hand
+// side of the status bar shifts. ⊕, ● and ○ are ambiguous width and would.
+func TestLspIconsAreSingleWidth(t *testing.T) {
+	for _, state := range []lsp.ServerState{lsp.ServerStopped, lsp.ServerStarting, lsp.ServerReady, lsp.ServerFailed} {
+		for _, binaryOK := range []bool{true, false} {
+			icon, _ := lspIcon(state, binaryOK)
+			if w := textwidth.String(icon); w != 1 {
+				t.Errorf("icon %q for state %v has width %d, want 1", icon, state, w)
+			}
+		}
+	}
+}

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -2,12 +2,9 @@ package app
 
 import (
 	"log/slog"
-	"os/exec"
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/command"
-	"github.com/eugenioenko/ttt/internal/lsp"
-	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/view"
 	"github.com/gdamore/tcell/v3"
@@ -35,67 +32,6 @@ func registerOutputCommands(app *App) {
 	})
 }
 
-// SyncLanguageSegment refreshes the language status bar segment. It is separate
-// from syncStatus so a language server changing state asynchronously can update
-// the indicator without the full status sync, which the event loop runs only on
-// user input.
-func (a *App) SyncLanguageSegment() {
-	if a.EditorGroup.Editor == nil || a.EditorGroup.Editor.Highlighter == nil {
-		a.Status.SetSegment(view.StatusSegment{ID: "language", Side: "right", Priority: 500, Text: ""})
-		return
-	}
-
-	lang := a.EditorGroup.Editor.Highlighter.Language()
-	icon, iconStyle := a.lspStatusIcon(a.EditorGroup.ActiveFilePath(), lang)
-	text := lang
-	if icon != "" {
-		text += " " + icon
-	}
-	a.Status.SetSegment(view.StatusSegment{
-		ID: "language", Side: "right", Priority: 500,
-		Text:    text,
-		Style:   iconStyle,
-		OnClick: a.ShowOutputPanel,
-	})
-}
-
-// lspStatusIcon reports the language server indicator for the status bar.
-//
-// The icons are all single-width under both normal and East Asian width rules,
-// so the segment does not shift as the state changes. ⊕, ● and ○ are ambiguous
-// width and would.
-func (a *App) lspStatusIcon(filePath, lang string) (string, term.Style) {
-	serverKey, _, configured := a.lspResolve(filePath, lang)
-	if !configured {
-		return "", 0
-	}
-
-	binaryOK := true
-	if cfg := a.LspManager.ServerConfig(serverKey); len(cfg.Command) > 0 {
-		_, err := exec.LookPath(cfg.Command[0])
-		binaryOK = err == nil
-	}
-	return lspIcon(a.LspManager.State(serverKey), binaryOK)
-}
-
-func lspIcon(state lsp.ServerState, binaryOK bool) (string, term.Style) {
-	switch state {
-	case lsp.ServerReady:
-		return "◉", 0
-	case lsp.ServerStarting:
-		return "◌", 0
-	case lsp.ServerFailed:
-		return "⚠", term.StyleDanger
-	}
-
-	// Not started — servers launch lazily on the first request. A missing
-	// binary is the one failure knowable before then, and ttt never even tries.
-	if !binaryOK {
-		return "⚠", term.StyleDanger
-	}
-	return "◌", 0
-}
-
 // ShowOutputPanel reveals the bottom panel on the Output tab and focuses it.
 func (a *App) ShowOutputPanel() {
 	a.BottomPanel.SetActivePanel("output")
@@ -110,9 +46,6 @@ func (a *App) OutputCopyLine() {
 	}
 	a.StatusNotify("Output line copied to clipboard")
 }
-
-// LSPStateChanged tells the event loop a language server changed state.
-type LSPStateChanged struct{}
 
 // OutputLineResult carries a log line from a background goroutine to the event
 // loop. Widget state must only be mutated on the main thread.

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -2,9 +2,12 @@ package app
 
 import (
 	"log/slog"
+	"os/exec"
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/lsp"
+	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/view"
 	"github.com/gdamore/tcell/v3"
@@ -32,6 +35,67 @@ func registerOutputCommands(app *App) {
 	})
 }
 
+// SyncLanguageSegment refreshes the language status bar segment. It is separate
+// from syncStatus so a language server changing state asynchronously can update
+// the indicator without the full status sync, which the event loop runs only on
+// user input.
+func (a *App) SyncLanguageSegment() {
+	if a.EditorGroup.Editor == nil || a.EditorGroup.Editor.Highlighter == nil {
+		a.Status.SetSegment(view.StatusSegment{ID: "language", Side: "right", Priority: 500, Text: ""})
+		return
+	}
+
+	lang := a.EditorGroup.Editor.Highlighter.Language()
+	icon, iconStyle := a.lspStatusIcon(a.EditorGroup.ActiveFilePath(), lang)
+	text := lang
+	if icon != "" {
+		text += " " + icon
+	}
+	a.Status.SetSegment(view.StatusSegment{
+		ID: "language", Side: "right", Priority: 500,
+		Text:    text,
+		Style:   iconStyle,
+		OnClick: a.ShowOutputPanel,
+	})
+}
+
+// lspStatusIcon reports the language server indicator for the status bar.
+//
+// The icons are all single-width under both normal and East Asian width rules,
+// so the segment does not shift as the state changes. ⊕, ● and ○ are ambiguous
+// width and would.
+func (a *App) lspStatusIcon(filePath, lang string) (string, term.Style) {
+	serverKey, _, configured := a.lspResolve(filePath, lang)
+	if !configured {
+		return "", 0
+	}
+
+	binaryOK := true
+	if cfg := a.LspManager.ServerConfig(serverKey); len(cfg.Command) > 0 {
+		_, err := exec.LookPath(cfg.Command[0])
+		binaryOK = err == nil
+	}
+	return lspIcon(a.LspManager.State(serverKey), binaryOK)
+}
+
+func lspIcon(state lsp.ServerState, binaryOK bool) (string, term.Style) {
+	switch state {
+	case lsp.ServerReady:
+		return "◉", 0
+	case lsp.ServerStarting:
+		return "◌", 0
+	case lsp.ServerFailed:
+		return "⚠", term.StyleDanger
+	}
+
+	// Not started — servers launch lazily on the first request. A missing
+	// binary is the one failure knowable before then, and ttt never even tries.
+	if !binaryOK {
+		return "⚠", term.StyleDanger
+	}
+	return "◌", 0
+}
+
 // ShowOutputPanel reveals the bottom panel on the Output tab and focuses it.
 func (a *App) ShowOutputPanel() {
 	a.BottomPanel.SetActivePanel("output")
@@ -46,6 +110,9 @@ func (a *App) OutputCopyLine() {
 	}
 	a.StatusNotify("Output line copied to clipboard")
 }
+
+// LSPStateChanged tells the event loop a language server changed state.
+type LSPStateChanged struct{}
 
 // OutputLineResult carries a log line from a background goroutine to the event
 // loop. Widget state must only be mutated on the main thread.

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -28,12 +28,23 @@ type Client struct {
 	signatureTriggers   []string
 	signatureRetriggers []string
 
-	onLog func(level, message string)
+	hooks ClientHooks
 
 	OnDiagnostics func(params PublishDiagnosticsParams)
 }
 
-func NewClient(command []string, workDir string, onLog func(level, message string)) (*Client, error) {
+// ClientHooks are passed to NewClient rather than assigned afterwards: the
+// stderr and read-loop goroutines start inside NewClient, and a server that
+// dies immediately would otherwise report its exit before the caller had a
+// chance to install the handler.
+type ClientHooks struct {
+	// OnLog receives server-reported messages.
+	OnLog func(level, message string)
+	// OnExit fires when the server goes away without ttt asking it to.
+	OnExit func()
+}
+
+func NewClient(command []string, workDir string, hooks ClientHooks) (*Client, error) {
 	if len(command) == 0 {
 		return nil, fmt.Errorf("empty command")
 	}
@@ -63,7 +74,7 @@ func NewClient(command []string, workDir string, onLog func(level, message strin
 		nextID:  1,
 		pending: make(map[int]chan Response),
 		done:    make(chan struct{}),
-		onLog:   onLog,
+		hooks:   hooks,
 	}
 	go c.drainStderr(stderr)
 	go c.readLoop()
@@ -71,8 +82,8 @@ func NewClient(command []string, workDir string, onLog func(level, message strin
 }
 
 func (c *Client) log(level, message string) {
-	if c.onLog != nil {
-		c.onLog(level, message)
+	if c.hooks.OnLog != nil {
+		c.hooks.OnLog(level, message)
 	}
 }
 
@@ -97,15 +108,24 @@ func (c *Client) readLoop() {
 		resp, err := c.codec.Receive()
 		if err != nil {
 			slog.Debug("lsp read loop exit", "err", err)
-			if !c.closing.Load() {
-				c.log("error", "server exited unexpectedly: "+err.Error())
-			}
+
+			// Release in-flight callers before notifying. OnExit may block on a
+			// lock held by whoever is waiting on this server — Initialize, for
+			// one — and that caller cannot make progress until its request is
+			// released here.
 			c.mu.Lock()
 			for _, ch := range c.pending {
 				close(ch)
 			}
 			c.pending = make(map[int]chan Response)
 			c.mu.Unlock()
+
+			if !c.closing.Load() {
+				c.log("error", "server exited unexpectedly: "+err.Error())
+				if c.hooks.OnExit != nil {
+					c.hooks.OnExit()
+				}
+			}
 			return
 		}
 		if resp.IsNotification() {
@@ -157,6 +177,14 @@ func (c *Client) call(method string, params any) (json.RawMessage, error) {
 	var ok bool
 	select {
 	case resp, ok = <-ch:
+	case <-c.done:
+		// The read loop empties the pending map when it exits, so a request
+		// registered after that point would otherwise wait out the full
+		// timeout for a reply that can never arrive.
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, fmt.Errorf("connection closed")
 	case <-time.After(10 * time.Second):
 		c.mu.Lock()
 		delete(c.pending, id)

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -11,21 +11,61 @@ import (
 	"github.com/eugenioenko/ttt/internal/config"
 )
 
+// ServerState is what the editor can honestly say about a language server.
+// Anything derived from the config alone (the binary exists on disk) is not a
+// state: it says nothing about whether the server started or is still alive.
+type ServerState int
+
+const (
+	ServerStopped ServerState = iota
+	ServerStarting
+	ServerReady
+	ServerFailed
+)
+
 type Manager struct {
-	servers       map[string]*Client
-	config        *config.LSPSettings
-	mu            sync.Mutex
+	servers map[string]*Client
+	config  *config.LSPSettings
+	mu      sync.Mutex
+
+	// states has its own lock: ClientForLanguage holds mu for its whole body
+	// and records state transitions as it goes, and sync.Mutex is not reentrant.
+	states  map[string]ServerState
+	stateMu sync.Mutex
+
 	OnDiagnostics func(params PublishDiagnosticsParams)
 
 	// OnLog receives server-reported messages. Called from the client's stderr
 	// and read-loop goroutines, so the handler must be goroutine-safe.
 	OnLog func(server, level, message string)
+
+	// OnStateChange fires when a server's state changes, so the UI can refresh
+	// without polling. Called from client goroutines; must be goroutine-safe.
+	OnStateChange func()
 }
 
 func NewManager(cfg *config.LSPSettings) *Manager {
 	return &Manager{
 		servers: make(map[string]*Client),
+		states:  make(map[string]ServerState),
 		config:  cfg,
+	}
+}
+
+// State reports the current state of a server. Safe to call from the UI.
+func (m *Manager) State(server string) ServerState {
+	m.stateMu.Lock()
+	defer m.stateMu.Unlock()
+	return m.states[strings.ToLower(server)]
+}
+
+func (m *Manager) setState(server string, state ServerState) {
+	m.stateMu.Lock()
+	changed := m.states[server] != state
+	m.states[server] = state
+	m.stateMu.Unlock()
+	if changed && m.OnStateChange != nil {
+		m.OnStateChange()
 	}
 }
 
@@ -62,12 +102,15 @@ func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 
 	slog.Info("lsp starting server", "language", lang, "command", serverCfg.Command)
 	m.log(key, "info", "starting "+strings.Join(serverCfg.Command, " "))
+	m.setState(key, ServerStarting)
 
-	client, err := NewClient(serverCfg.Command, workDir, func(level, message string) {
-		m.log(key, level, message)
+	client, err := NewClient(serverCfg.Command, workDir, ClientHooks{
+		OnLog:  func(level, message string) { m.log(key, level, message) },
+		OnExit: func() { m.forget(key) },
 	})
 	if err != nil {
 		m.log(key, "error", err.Error())
+		m.setState(key, ServerFailed)
 		return nil, fmt.Errorf("start LSP for %s: %w", lang, err)
 	}
 	client.OnDiagnostics = m.OnDiagnostics
@@ -76,12 +119,23 @@ func (m *Manager) ClientForLanguage(lang, workDir string) (*Client, error) {
 	if err := client.Initialize(rootURI); err != nil {
 		client.Close()
 		m.log(key, "error", "initialize failed: "+err.Error())
+		m.setState(key, ServerFailed)
 		return nil, fmt.Errorf("initialize LSP for %s: %w", lang, err)
 	}
 
 	m.servers[key] = client
+	m.setState(key, ServerReady)
 	m.log(key, "info", "ready")
 	return client, nil
+}
+
+// forget drops a server that died on its own, so the next request starts a
+// fresh one instead of writing to a dead pipe.
+func (m *Manager) forget(key string) {
+	m.mu.Lock()
+	delete(m.servers, key)
+	m.mu.Unlock()
+	m.setState(key, ServerFailed)
 }
 
 func (m *Manager) SignatureHelpTriggerCharacters(serverKey string) []string {
@@ -136,5 +190,8 @@ func (m *Manager) Shutdown() {
 		}(lang, client)
 	}
 	wg.Wait()
+	for lang := range m.servers {
+		m.setState(lang, ServerStopped)
+	}
 	m.servers = make(map[string]*Client)
 }

--- a/internal/lsp/manager_state_test.go
+++ b/internal/lsp/manager_state_test.go
@@ -1,0 +1,103 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/config"
+)
+
+func fakeServer(t *testing.T, body string) (dir, script string) {
+	t.Helper()
+	dir = t.TempDir()
+	script = filepath.Join(dir, "fake.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n"+body), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return dir, script
+}
+
+func managerFor(script string) *Manager {
+	return NewManager(&config.LSPSettings{
+		Servers: map[string]config.LSPServerConfig{
+			"plaintext": {Command: []string{script}},
+		},
+	})
+}
+
+func TestManagerStateStartsStopped(t *testing.T) {
+	m := managerFor("/nonexistent")
+	if got := m.State("plaintext"); got != ServerStopped {
+		t.Errorf("State = %v, want ServerStopped", got)
+	}
+	if got := m.State("never-configured"); got != ServerStopped {
+		t.Errorf("State of unknown server = %v, want ServerStopped", got)
+	}
+}
+
+func TestManagerStateFailedOnCrash(t *testing.T) {
+	dir, script := fakeServer(t, "echo boom >&2\nexit 1\n")
+	m := managerFor(script)
+
+	if _, err := m.ClientForLanguage("plaintext", dir); err == nil {
+		t.Fatal("expected an error from a server that exits immediately")
+	}
+	if got := m.State("plaintext"); got != ServerFailed {
+		t.Errorf("State = %v, want ServerFailed", got)
+	}
+}
+
+// A server that dies during initialize must not hold the manager lock for the
+// request timeout: the read loop has to release in-flight callers before it
+// reports the exit, or ClientForLanguage and the exit handler deadlock.
+func TestManagerCrashFailsFast(t *testing.T) {
+	dir, script := fakeServer(t, "echo boom >&2\nexit 1\n")
+	m := managerFor(script)
+
+	start := time.Now()
+	if _, err := m.ClientForLanguage("plaintext", dir); err == nil {
+		t.Fatal("expected an error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("took %v, want well under the 10s request timeout", elapsed)
+	}
+}
+
+func TestManagerStateFailedWhenBinaryMissing(t *testing.T) {
+	m := managerFor("/nonexistent-lsp-binary")
+
+	if _, err := m.ClientForLanguage("plaintext", t.TempDir()); err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := m.State("plaintext"); got != ServerFailed {
+		t.Errorf("State = %v, want ServerFailed", got)
+	}
+}
+
+func TestManagerStateChangeNotifies(t *testing.T) {
+	dir, script := fakeServer(t, "echo boom >&2\nexit 1\n")
+	m := managerFor(script)
+
+	changes := make(chan struct{}, 16)
+	m.OnStateChange = func() { changes <- struct{}{} }
+
+	m.ClientForLanguage("plaintext", dir)
+
+	// At least starting and failed.
+	if len(changes) < 2 {
+		t.Errorf("got %d state notifications, want at least 2", len(changes))
+	}
+}
+
+func TestManagerUnknownLanguageLeavesStateStopped(t *testing.T) {
+	m := managerFor("/nonexistent")
+
+	if _, err := m.ClientForLanguage("elvish", t.TempDir()); err == nil {
+		t.Fatal("expected an error for an unconfigured language")
+	}
+	if got := m.State("elvish"); got != ServerStopped {
+		t.Errorf("State = %v, want ServerStopped for an unconfigured language", got)
+	}
+}


### PR DESCRIPTION
Closes #448.

## Motivation

The language segment derived its `⊕` from `exec.LookPath(serverCfg.Command[0])` — whether the binary exists on disk. That says nothing about whether the server started, initialized, or is still alive, so a crashed server still showed as healthy. Same screen, three lines apart:

```
│ 12:28:01 [lsp:plaintext] server exited unexpectedly: EOF          │   ← Output panel
│ 12:28:01 [lsp:plaintext] initialize failed: connection closed     │
╰───────────────────────────────────────────────────────────────────╯
  Ln 1, Col 1   Spaces: 4   UTF-8   LF   plaintext ⊕                    ← status bar
```

The one glanceable health signal was wrong exactly when it mattered.

## PR Changes

`lsp.Manager` tracks per-server state (stopped / starting / ready / failed) from the same lifecycle points that log to the Output panel, and the status bar renders it:

| State | Segment |
|---|---|
| Connected and initialized | `Go ◉` |
| Starting, or not launched yet | `Go ◌` |
| Failed to start, exited, binary missing | `Go ⚠` |
| No server configured | `Go` |

Binary presence is consulted only for a server that has not launched yet — the one failure knowable before the first request. Clicking the segment opens the Output panel.

The icons are single-width under both normal and East Asian width rules. `⊕`, `●` and `○` are ambiguous width, so the old indicator shifted the whole right-hand side of the status bar by a column under `RUNEWIDTH_EASTASIAN=1`. There is a test pinning this.

Two bugs surfaced while wiring it up:

- `readLoop` reported an unexpected exit **before** releasing in-flight requests, so `OnExit` could block on a lock held by the very caller it needed to release. A server dying during initialize wedged `ClientForLanguage` for the full 10s request timeout — 10.01s before, 1.3ms after.
- `call()` did not wake on the client's `done` channel, so a request registered after the read loop drained the pending map waited out the timeout for a reply that could never arrive.

Async state changes also needed a path to the status bar: the event loop ran the full status sync only on user input, so the language segment is split into `SyncLanguageSegment` and updated from both paths.

## Verification

All four states checked against the real binary — healthy `gopls` (`Go ◉`), a server that crashes on startup (`plaintext ⚠`), a missing binary (`plaintext ⚠`), and LSP disabled (`plaintext`, no icon).

Tests: 6 manager state tests including a fail-fast timing guard, 2 icon tests (mapping + width in both modes), race detector clean. Full Go suite and 80-file functional suite pass.

Docs updated in `docs-web/guides/lsp.md` and the README.

