### PR TITLE
fix: surface plugin load failures in the Output panel

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -231,6 +231,14 @@ Docs: https://tttedit.dev
 	defer pluginManager.Shutdown()
 
 	if cfg.Settings.Plugins.IsEnabled() {
+		// Before LoadAll, so a plugin that fails to load can say why.
+		pluginManager.SetLogFactory(func(pluginName string) func(string, string) {
+			return func(level, message string) {
+				editor.LogOutput(level, pluginName, message)
+				screen.PostEvent(tcell.NewEventInterrupt(nil))
+			}
+		})
+
 		pendingApprovals := pluginManager.LoadAll()
 
 		for _, reg := range pluginManager.SidebarPanels {
@@ -259,18 +267,6 @@ Docs: https://tttedit.dev
 				screen.PostEvent(tcell.NewEventInterrupt(result))
 			}
 		}
-		pluginManager.SetLogFactory(func(pluginName string) func(string, string) {
-			return func(level, message string) {
-				editor.Output.AddLine(ui.OutputLine{
-					Time:       time.Now().Format("15:04:05"),
-					PluginName: pluginName,
-					Level:      level,
-					Message:    message,
-				})
-				screen.PostEvent(tcell.NewEventInterrupt(nil))
-			}
-		})
-
 		editor.RegisterStartupPluginCommands()
 
 		pluginsPanel := app.NewPluginsPanel(pluginManager)

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -110,6 +110,13 @@ func (m *Manager) LoadAll() []*Plugin {
 			}
 
 			p.Granted = regEntry.Permissions
+
+			// Wire the log sink before Init, not after: a plugin that fails to
+			// compile reports it from inside Init, and a plugin that fails is
+			// never added to m.plugins for a later backfill to reach.
+			if m.logFactory != nil {
+				p.Log = m.logFactory(p.Name)
+			}
 			if err := p.Init(); err != nil {
 				continue
 			}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -111,9 +111,7 @@ func (m *Manager) LoadAll() []*Plugin {
 
 			p.Granted = regEntry.Permissions
 
-			// Wire the log sink before Init, not after: a plugin that fails to
-			// compile reports it from inside Init, and a plugin that fails is
-			// never added to m.plugins for a later backfill to reach.
+			// Init reports compile failures through p.Log, so wire it first.
 			if m.logFactory != nil {
 				p.Log = m.logFactory(p.Name)
 			}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -117,5 +118,70 @@ func TestWithinDir(t *testing.T) {
 		if got := withinDir(base, c.child); got != c.want {
 			t.Errorf("withinDir(%q, %q) = %v, want %v", base, c.child, got, c.want)
 		}
+	}
+}
+
+// A plugin that fails to compile reports the failure from inside Init, and is
+// never added to m.plugins for a later SetLogFactory backfill to reach. If the
+// log sink is not wired before Init, the error is lost entirely (#395).
+func TestLoadAllLogsInitFailure(t *testing.T) {
+	pluginsDir := t.TempDir()
+	regPath := filepath.Join(t.TempDir(), "registry.json")
+
+	dir := writePluginDir(t, pluginsDir, "broken")
+	entry := filepath.Join(dir, "main.ttt.lua")
+	if err := os.WriteFile(entry, []byte("this is not lua !!"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	reg := `[{"name":"broken","version":"1.0.0","enabled":true,"permissions":{}}]`
+	if err := os.WriteFile(regPath, []byte(reg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logged []string
+	m := NewManager(pluginsDir, regPath)
+	m.SetLogFactory(func(name string) func(string, string) {
+		return func(level, message string) {
+			logged = append(logged, name+" "+level+" "+message)
+		}
+	})
+	m.LoadAll()
+
+	if len(logged) == 0 {
+		t.Fatal("a plugin that fails to compile logged nothing")
+	}
+	if !strings.Contains(logged[0], "broken error init:") {
+		t.Errorf("unexpected log line: %q", logged[0])
+	}
+	if len(m.Plugins()) != 0 {
+		t.Errorf("a plugin that failed to init should not be loaded, got %d", len(m.Plugins()))
+	}
+}
+
+// A plugin that loads cleanly must still get its log sink, so ttt.log works
+// from the plugin's own init.
+func TestLoadAllWiresLogForHealthyPlugin(t *testing.T) {
+	pluginsDir := t.TempDir()
+	regPath := filepath.Join(t.TempDir(), "registry.json")
+
+	dir := writePluginDir(t, pluginsDir, "healthy")
+	entry := filepath.Join(dir, "main.ttt.lua")
+	if err := os.WriteFile(entry, []byte(`local ttt = require("ttt")`+"\n"+`ttt.log("hello from init")`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	reg := `[{"name":"healthy","version":"1.0.0","enabled":true,"permissions":{}}]`
+	if err := os.WriteFile(regPath, []byte(reg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logged []string
+	m := NewManager(pluginsDir, regPath)
+	m.SetLogFactory(func(name string) func(string, string) {
+		return func(level, message string) { logged = append(logged, message) }
+	})
+	m.LoadAll()
+
+	if len(logged) != 1 || logged[0] != "hello from init" {
+		t.Errorf("logged = %v, want a single %q", logged, "hello from init")
 	}
 }


### PR DESCRIPTION
Closes #395.

## Motivation

A plugin that fails to compile is silent — it looks identical to a plugin that loaded and simply isn't responding.

`Init` does report the failure, via `p.logError` → `p.Log`. But `p.Log` was only set by `SetLogFactory`, which `main.go` called *after* `LoadAll()`, and `LoadAll` never calls `wireAPIs`. So `p.Log` was nil for the entire load. Worse, a plugin that fails `Init` is skipped before being appended to `m.plugins`, so `SetLogFactory`'s backfill loop could never reach it either. The plugin that fails hardest was the one whose error you could not see.

Before / after, with a plugin containing a syntax error:

```
│ No output                          │   →   │ 13:37 [brokenplug] init: main.ttt.lua:2: '=' expected │
```

## PR Changes

- `LoadAll` wires the log sink before calling `Init`.
- `main.go` installs the factory before `LoadAll`.
- The factory routes through `App.LogOutput` instead of building the `OutputLine` itself, so plugin logs mirror to slog like every other Output producer.

Two regression tests, both verified to fail without the fix: a plugin that fails to compile logs its error and is not loaded, and a healthy plugin can `ttt.log` from its own init.

Closes out #395: load failures are visible (this PR) and runtime listener errors already reach the panel via `logError` since #447, so a handler that throws mid-`key.press` shows up as `[name] key.press: ...`. The issue's docs portion is scoped to #386 by the issue itself.

The Installed Plugins dialog still shows a bare `error` rather than the message. That was polish rather than silence once the message reaches the Output panel, so it is deliberately not part of this.