### PR TITLE
feat: extend open_diff API with compact mode and add clipboard_write

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -30,6 +30,16 @@
     "tags": ["docker", "containers", "devops", "infrastructure"]
   },
   {
+    "name": "git-history",
+    "displayName": "Git History",
+    "author": "eugenioenko",
+    "description": "Per-file commit history with inline diffs, compare with HEAD, and file-at-commit viewer",
+    "repo": "https://github.com/eugenioenko/ttt-plugins",
+    "path": "git-history",
+    "version": "0.1.0",
+    "tags": ["git", "history", "diff", "vcs"]
+  },
+  {
     "name": "go-test-runner",
     "displayName": "Go Test Runner",
     "author": "eugenioenko",

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/markdown"
 	"github.com/eugenioenko/ttt/internal/plugin"
@@ -363,12 +364,16 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 			a.EditorGroup.GoToLine(line)
 		}
 	}
-	p.OpenDiff = func(title string, oldLines, newLines []string, filePath string) {
+	p.OpenDiff = func(title string, oldLines, newLines []string, filePath string, extended bool, diffText string) {
 		path := filePath
 		if path == "" {
 			path = title
 		}
-		a.EditorGroup.OpenDiff(path, diff.FileDiff{}, oldLines, newLines, true)
+		fd := diff.FileDiff{}
+		if diffText != "" {
+			fd = diff.Parse(diffText)
+		}
+		a.EditorGroup.OpenDiff(path, fd, oldLines, newLines, extended)
 	}
 	p.OpenReadOnly = func(title, filePath string, lines []string) {
 		a.EditorGroup.OpenBufferReadOnly(title, filePath, lines)
@@ -394,6 +399,9 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	}
 	p.RemoveStatusItem = func(id string) {
 		a.Status.RemoveSegment(id)
+	}
+	p.ClipboardWrite = func(text string) {
+		clipboard.Set(text)
 	}
 	p.SetEcho = func(text string) {
 		a.Status.EchoText = text

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -80,13 +80,14 @@ type Plugin struct {
 	DebugDumpToFile    func(path string) error
 	QuitApp            func()
 	OpenFile           func(path string, line int, readonly bool)
-	OpenDiff           func(title string, oldLines, newLines []string, filePath string)
+	OpenDiff           func(title string, oldLines, newLines []string, filePath string, extended bool, diffText string)
 	OpenReadOnly       func(title, filePath string, lines []string)
 	Notify             func(message, level string)
 	SetStatusItem      func(side, id, text string, priority int, onClick func())
 	RemoveStatusItem   func(id string)
 	SetEcho            func(text string) // status bar shows only this text when non-empty
 	ExecCommand        func(id string) bool
+	ClipboardWrite     func(text string)
 	ListCommands       func() []CommandInfo
 	PublishDiagnostics func(path string, items []DiagnosticItem)
 	ClearDiagnostics   func(path string)

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -343,6 +343,18 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			return 1
 		}))
 
+		L.SetField(mod, "clipboard_write", L.NewFunction(func(L *lua.LState) int {
+			if err := p.Granted.Check("commands"); err != nil {
+				L.ArgError(1, "commands permission not granted")
+				return 0
+			}
+			text := L.CheckString(1)
+			if p.ClipboardWrite != nil {
+				p.ClipboardWrite(text)
+			}
+			return 0
+		}))
+
 		L.SetField(mod, "show_info", L.NewFunction(func(L *lua.LState) int {
 			title := L.CheckString(1)
 			tbl := L.CheckTable(2)
@@ -528,10 +540,18 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 			oldTbl := L.CheckTable(2)
 			newTbl := L.CheckTable(3)
 			filePath := L.OptString(4, "")
+			extended := true
+			if L.GetTop() >= 5 {
+				extended = L.ToBool(5)
+			}
+			diffText := ""
+			if L.GetTop() >= 6 {
+				diffText = L.OptString(6, "")
+			}
 			oldLines := luaTableToStrings(L, oldTbl)
 			newLines := luaTableToStrings(L, newTbl)
 			if p.OpenDiff != nil {
-				p.OpenDiff(title, oldLines, newLines, filePath)
+				p.OpenDiff(title, oldLines, newLines, filePath, extended, diffText)
 			}
 			return 0
 		}))


### PR DESCRIPTION
## Summary
- Extend `open_diff` plugin API with `extended` (bool) and `diffText` (string) params so plugins can show compact (hunks-only) diffs by passing raw unified diff text, or extended (full-file) diffs with old/new lines
- Add `clipboard_write(text)` plugin API gated on the existing `commands` permission
- Register `git-history` plugin in `community-plugins.json`

## Changed files
- `internal/plugin/plugin.go` — add `extended bool, diffText string` to `OpenDiff` signature, add `ClipboardWrite` field
- `internal/plugin/sandbox.go` — wire `open_diff` optional 5th/6th params, add `clipboard_write` Lua binding
- `internal/app/commands_plugin.go` — parse `diffText` via `diff.Parse()`, wire `ClipboardWrite` to `clipboard.Set()`
- `community-plugins.json` — add git-history entry

## Test plan
- [ ] Verify `ttt.open_diff(title, {}, {}, path, false, diffText)` shows compact diff (hunks only)
- [ ] Verify `ttt.open_diff(title, old, new, path, true)` shows extended diff (full file)
- [ ] Verify `ttt.open_diff(title, old, new, path)` defaults to extended (backward compatible)
- [ ] Verify `ttt.clipboard_write(text)` copies text to clipboard with `commands` permission
- [ ] Verify `ttt.clipboard_write` errors without `commands` permission
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)