### PR TITLE
fix: route bracketed paste into dialog inputs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -559,6 +559,12 @@ func (a *App) PasteText(text string) {
 			return
 		}
 	}
+	if adapter, ok := a.Root.Focused.(*ui.WidgetAdapter); ok {
+		if inp, ok := adapter.FocusedWidget().(*widgets.InputWidget); ok {
+			inp.PasteText(text)
+			return
+		}
+	}
 	a.EditorGroup.PasteText(text)
 }
 

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -61,6 +61,10 @@ func RunExecScriptSep(a *App, script, sep string) {
 			execDebug(a, args)
 		case "wait":
 			execWait(args)
+		case "paste":
+			execPaste(a, args)
+		case "copy":
+			a.Copy()
 		case "panel":
 			execPanel(a, args)
 		case "quit":
@@ -211,6 +215,19 @@ func execType(a *App, args string) {
 	}
 }
 
+func execPaste(a *App, args string) {
+	text := stripQuotes(args)
+	if text == "" {
+		slog.Error("exec_script: paste requires text")
+		return
+	}
+	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	time.Sleep(50 * time.Millisecond)
+	a.PasteText(text)
+	a.FlushEditorOnChange()
+	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+}
+
 func execCommand(a *App, args string) {
 	title := stripQuotes(strings.TrimSpace(args))
 	if title == "" {
@@ -316,6 +333,8 @@ Supported commands:
   click X Y          Simulate mouse click at coordinates
   key COMBO          Simulate key press (e.g., key ctrl+p, key enter)
   type TEXT           Type a string of text
+  paste TEXT          Simulate bracketed paste (terminal paste)
+  copy                Copy selection to clipboard
   exec "Command"     Run a command palette command by title
   screenshot PATH    Save screen text to file
   debug PATH         Save debug state JSON to file

--- a/internal/ui/tree_widget_adapter.go
+++ b/internal/ui/tree_widget_adapter.go
@@ -75,6 +75,8 @@ func (a *WidgetAdapter) wireTabbedCallbacks(w widgets.Widget) {
 
 func (a *WidgetAdapter) Inner() widgets.Widget { return a.W }
 
+func (a *WidgetAdapter) FocusedWidget() widgets.Widget { return a.focus.Focused() }
+
 func (a *WidgetAdapter) Focusable() bool { return true }
 
 func (a *WidgetAdapter) SetFocused(focused bool) {

--- a/tests/e2e/bracketed_paste_test.go
+++ b/tests/e2e/bracketed_paste_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/term"
@@ -67,6 +68,31 @@ func TestBracketedPasteMultiLine(t *testing.T) {
 	}
 	if buf.Lines[2] != "line3" {
 		t.Errorf("line 2: expected 'line3', got %q", buf.Lines[2])
+	}
+}
+
+func TestBracketedPasteIntoDialog(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	h.exec("file.new")
+
+	// Open Save As dialog (new file has no path, so file.save opens Save As)
+	h.exec("file.save")
+	h.redraw()
+
+	// Paste a path into the dialog via bracketed paste
+	h.app.PasteText("/tmp/dialog-paste-test.txt")
+	h.redraw()
+
+	text := h.screenText()
+	if !strings.Contains(text, "dialog-paste-test.txt") {
+		t.Errorf("pasted text not visible in dialog; screen:\n%s", text)
+	}
+
+	// Editor buffer should be untouched
+	buf := h.app.EditorGroup.ActiveBuffer()
+	if buf != nil && len(buf.Lines) > 0 && buf.Lines[0] != "" {
+		t.Errorf("paste leaked into editor: %q", buf.Lines[0])
 	}
 }
 

--- a/tests/functional/dialog-paste.test.js
+++ b/tests/functional/dialog-paste.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, cleanupDir, fileExists } from "./helpers.js";
+import { join } from "node:path";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("dialog paste", () => {
+  it("should paste bracketed text into Save As dialog input", () => {
+    dir = createTempDir();
+    const filePath = join(dir, "pasted.txt");
+
+    tui.start();
+    tui.waitStable();
+
+    // Open Save As dialog (new file has no path)
+    tui.press("ctrl+s");
+    tui.waitStable();
+
+    // Simulate bracketed paste into the dialog
+    tui.paste(filePath);
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+
+    // Confirm with Enter
+    tui.press("enter");
+    tui.waitStable();
+
+    const { snapshots } = tui.run();
+
+    // The dialog should show the pasted path
+    expect(snapshots[s0]).toContain("pasted.txt");
+
+    // The file should have been created at the pasted path
+    expect(fileExists(filePath)).toBe(true);
+  });
+});

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -82,6 +82,14 @@ export function exec(command) {
   commands.push(`exec "${command}"`);
 }
 
+export function paste(text) {
+  commands.push(`paste ${text}`);
+}
+
+export function copy() {
+  commands.push("copy");
+}
+
 export function panel(id) {
   commands.push(`panel ${id}`);
 }


### PR DESCRIPTION
## Summary
- Bracketed paste (how real terminals deliver system clipboard content) bypassed dialog inputs and went straight to the editor
- `PasteText()` only checked `InputHolder` (implemented by `SearchWidget`), not `WidgetAdapter` (used by dialogs)
- Added `FocusedWidget()` to `WidgetAdapter` and a fallback check in `PasteText()`
- Added `paste` and `copy` commands to the `--exec` debug harness + `tui.js` so bracketed paste is testable in functional tests

## Test plan
- [x] E2e test: `TestBracketedPasteIntoDialog` — pastes into Save As dialog, verifies text appears in dialog and not in editor
- [x] Functional test: `dialog-paste.test.js` — uses new `paste` exec command to simulate bracketed paste into Save As dialog
- [x] Existing bracketed paste tests still pass
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)