### PR TITLE
feat: pin tabs

### DIFF
--- a/config/keybindings.json
+++ b/config/keybindings.json
@@ -15,6 +15,7 @@
   { "key": "alt+.", "command": "tab.next" },
   { "key": "alt+,", "command": "tab.prev" },
   { "key": "ctrl+w", "command": "tab.close" },
+  { "key": "ctrl+k enter", "command": "tab.pin" },
   { "key": "ctrl+a", "command": "editor.selectAll" },
   { "key": "ctrl+c", "command": "editor.copy" },
   { "key": "ctrl+x", "command": "editor.cut" },

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -483,6 +483,11 @@ func registerWidgetCallbacks(app *App) {
 		reg.Execute("tab.close")
 	}
 
+	app.EditorGroup.TabBar.OnTabUnpin = func(index int) {
+		app.EditorGroup.SwitchTab(index)
+		app.EditorGroup.TogglePinTab()
+	}
+
 	app.EditorGroup.TabBar.MoreButton.OnClick = func(sx, sy int) {
 		moreMenu := []ui.ContextMenuItem{
 			{Label: "Close All", Command: "tab.closeAll"},
@@ -493,7 +498,13 @@ func registerWidgetCallbacks(app *App) {
 
 	app.EditorGroup.TabBar.OnTabRightClick = func(index, sx, sy int) {
 		app.EditorGroup.SwitchTab(index)
+		pinLabel := "Pin Tab"
+		if app.EditorGroup.IsActiveTabPinned() {
+			pinLabel = "Unpin Tab"
+		}
 		tabContextMenu := []ui.ContextMenuItem{
+			{Label: pinLabel, Shortcut: app.KeyFor("tab.pin"), Command: "tab.pin"},
+			ui.MenuSep(),
 			{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
 			{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
 			{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -439,6 +439,12 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "tab.pin", Title: "View: Toggle Pin Tab",
+		Keywords: []string{"tab", "pin", "unpin"},
+		Handler:  func() { app.EditorGroup.TogglePinTab() },
+	})
+
+	reg.Register(command.Command{
 		ID: "diff.extendedView", Title: "Git: Extended Diff",
 		Keywords: []string{"git", "changes", "compare"},
 		Handler: func() {

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -142,7 +142,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.Editor.BracketColorStyles = bracketStyles
 	for _, f := range openFiles {
 		editorGroup.OpenFile(f)
-		editorGroup.PinActiveTab()
+		editorGroup.CommitActiveTab()
 	}
 
 	terminalPanel := ui.NewTerminalPanelWidget()

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -291,6 +291,7 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "alt+.", Command: "tab.next"},
 		{Key: "alt+,", Command: "tab.prev"},
 		{Key: "ctrl+w", Command: "tab.close"},
+		{Key: "ctrl+k enter", Command: "tab.pin"},
 		{Key: "ctrl+a", Command: "editor.selectAll"},
 		{Key: "ctrl+c", Command: "editor.copy"},
 		{Key: "ctrl+x", Command: "editor.cut"},

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -59,9 +59,9 @@ type editorTab struct {
 	Folds       *fold.State
 	TabSize     int
 	UseTabs     bool
-	Content     Widget
-	Pinned      bool
-	Virtual     bool
+	Content Widget
+	Preview bool
+	Virtual bool
 	LineChanges []diff.LineChangeKind
 	ReadOnly    bool
 }
@@ -75,6 +75,7 @@ type EditorGroupWidget struct {
 	SignatureHelp           *SignatureHelpWidget
 	tabs                    []editorTab
 	active                  int
+	pinnedCount             int
 	TabSize                 int
 	InsertSpaces            bool
 	LineNumbers             bool
@@ -205,16 +206,42 @@ func (g *EditorGroupWidget) FlushNotifications() {
 	g.pendingNotify = nil
 }
 
-func (g *EditorGroupWidget) PinActiveTab() {
+func (g *EditorGroupWidget) CommitActiveTab() {
 	if t := g.activeTab(); t != nil {
-		t.Pinned = true
+		t.Preview = false
 	}
+}
+
+func (g *EditorGroupWidget) TogglePinTab() {
+	if len(g.tabs) == 0 {
+		return
+	}
+	idx := g.active
+	if idx < g.pinnedCount {
+		tab := g.tabs[idx]
+		g.tabs = append(g.tabs[:idx], g.tabs[idx+1:]...)
+		g.pinnedCount--
+		g.tabs = slices.Insert(g.tabs, g.pinnedCount, tab)
+		g.active = g.pinnedCount
+	} else {
+		tab := g.tabs[idx]
+		tab.Preview = false
+		g.tabs = append(g.tabs[:idx], g.tabs[idx+1:]...)
+		g.tabs = slices.Insert(g.tabs, g.pinnedCount, tab)
+		g.active = g.pinnedCount
+		g.pinnedCount++
+	}
+	g.syncTabs()
+}
+
+func (g *EditorGroupWidget) IsActiveTabPinned() bool {
+	return g.active < g.pinnedCount
 }
 
 func (g *EditorGroupWidget) OpenFile(path string) {
 	for i := range g.tabs {
 		if g.tabs[i].FilePath == path {
-			g.tabs[i].Pinned = true
+			g.tabs[i].Preview = false
 			if g.tabs[i].Buf != nil && !g.tabs[i].Buf.Dirty {
 				g.tabs[i].Buf.LoadFile(path)
 			}
@@ -264,11 +291,12 @@ func (g *EditorGroupWidget) OpenFile(path string) {
 		Folds:    folds,
 		TabSize:  tabSize,
 		UseTabs:  useTabs,
+		Preview:  true,
 	}
 	if g.SyntaxHighlight {
 		newTab.Highlighter = highlight.New(path)
 	}
-	if t := g.activeTab(); t != nil && !t.Pinned && t.Content == nil && t.Buf != nil && !t.Buf.Dirty {
+	if t := g.activeTab(); t != nil && t.Preview && t.Content == nil && t.Buf != nil && !t.Buf.Dirty {
 		g.tabs[g.active] = newTab
 		g.syncTabs()
 	} else {
@@ -351,7 +379,6 @@ func (g *EditorGroupWidget) OpenPluginTab(id, title string, content Widget) {
 		FilePath: id,
 		Title:    title,
 		Content:  content,
-		Pinned:   true,
 	})
 	g.SwitchTab(len(g.tabs) - 1)
 }
@@ -361,6 +388,9 @@ func (g *EditorGroupWidget) ClosePluginTab(id string) {
 		if t.FilePath == id {
 			if t.Content != nil && g.OnContentTabClose != nil {
 				g.OnContentTabClose(t.FilePath)
+			}
+			if i < g.pinnedCount {
+				g.pinnedCount--
 			}
 			g.tabs = append(g.tabs[:i], g.tabs[i+1:]...)
 			if len(g.tabs) == 0 {
@@ -585,6 +615,9 @@ func (g *EditorGroupWidget) CloseTab() {
 	if closing.Content != nil && g.OnContentTabClose != nil {
 		g.OnContentTabClose(closing.FilePath)
 	}
+	if g.active < g.pinnedCount {
+		g.pinnedCount--
+	}
 	g.tabs = append(g.tabs[:g.active], g.tabs[g.active+1:]...)
 	if len(g.tabs) == 0 {
 		g.tabs = []editorTab{{
@@ -608,15 +641,24 @@ func (g *EditorGroupWidget) CloseOtherTabs() {
 	if t == nil || len(g.tabs) <= 1 {
 		return
 	}
-	if g.OnContentTabClose != nil {
-		for i, tab := range g.tabs {
-			if i != g.active && tab.Content != nil {
-				g.OnContentTabClose(tab.FilePath)
-			}
+	activeFile := t.FilePath
+	var kept []editorTab
+	for i, tab := range g.tabs {
+		if i == g.active || i < g.pinnedCount {
+			kept = append(kept, tab)
+			continue
+		}
+		if g.OnContentTabClose != nil && tab.Content != nil {
+			g.OnContentTabClose(tab.FilePath)
 		}
 	}
-	g.tabs = []editorTab{*t}
-	g.active = 0
+	g.tabs = kept
+	for i, tab := range g.tabs {
+		if tab.FilePath == activeFile {
+			g.active = i
+			break
+		}
+	}
 	g.syncTabs()
 }
 
@@ -625,9 +667,11 @@ func (g *EditorGroupWidget) CloseOtherSaved() {
 	if t == nil || len(g.tabs) <= 1 {
 		return
 	}
-	kept := []editorTab{*t}
+	activeFile := t.FilePath
+	var kept []editorTab
 	for i := range g.tabs {
-		if i == g.active {
+		if i == g.active || i < g.pinnedCount {
+			kept = append(kept, g.tabs[i])
 			continue
 		}
 		if g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty {
@@ -639,7 +683,12 @@ func (g *EditorGroupWidget) CloseOtherSaved() {
 		}
 	}
 	g.tabs = kept
-	g.active = 0
+	for i, tab := range g.tabs {
+		if tab.FilePath == activeFile {
+			g.active = i
+			break
+		}
+	}
 	g.syncTabs()
 }
 
@@ -656,15 +705,20 @@ func (g *EditorGroupWidget) HasDirtyOtherTabs() bool {
 }
 
 func (g *EditorGroupWidget) CloseAllTabs() {
-	g.tabs = []editorTab{{
-		FilePath: "untitled",
-		Buf:      &buffer.Buffer{Lines: []string{""}},
-		Cur:      &cursor.Cursor{},
-		Vp:       &view.Viewport{},
-		Undo:     g.newUndoStack(),
-		Sel:      &selection.Selection{},
-		Virtual:  true,
-	}}
+	kept := slices.Clone(g.tabs[:g.pinnedCount])
+	if len(kept) == 0 {
+		kept = []editorTab{{
+			FilePath: "untitled",
+			Buf:      &buffer.Buffer{Lines: []string{""}},
+			Cur:      &cursor.Cursor{},
+			Vp:       &view.Viewport{},
+			Undo:     g.newUndoStack(),
+			Sel:      &selection.Selection{},
+			Virtual:  true,
+		}}
+		g.pinnedCount = 0
+	}
+	g.tabs = kept
 	g.active = 0
 	g.syncTabs()
 }
@@ -672,7 +726,7 @@ func (g *EditorGroupWidget) CloseAllTabs() {
 func (g *EditorGroupWidget) CloseAllSaved() {
 	var kept []editorTab
 	for i := range g.tabs {
-		if g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty {
+		if i < g.pinnedCount || (g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty) {
 			kept = append(kept, g.tabs[i])
 		}
 	}
@@ -867,7 +921,6 @@ func (g *EditorGroupWidget) OpenFileReadOnly(path, title string) {
 		TabSize:  tabSize,
 		UseTabs:  detected.UseTabs,
 		ReadOnly: true,
-		Pinned:   true,
 	}
 	if g.SyntaxHighlight {
 		newTab.Highlighter = highlight.New(path)
@@ -907,7 +960,6 @@ func (g *EditorGroupWidget) OpenBufferReadOnly(title, filePath string, lines []s
 		TabSize:  tabSize,
 		UseTabs:  detected.UseTabs,
 		ReadOnly: true,
-		Pinned:   true,
 	}
 	if g.SyntaxHighlight && filePath != "" {
 		newTab.Highlighter = highlight.New(filePath)
@@ -1598,6 +1650,7 @@ func (g *EditorGroupWidget) syncTabs() {
 			Active:   i == g.active,
 			Dirty:    dirty,
 			Closable: closable,
+			Pinned:   i < g.pinnedCount,
 		})
 	}
 	g.TabBar.SetTabs(uiTabs)

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -21,6 +21,7 @@ type Tab struct {
 	Dirty    bool
 	Active   bool
 	Closable bool
+	Pinned   bool
 }
 
 type TabBarWidget struct {
@@ -31,6 +32,7 @@ type TabBarWidget struct {
 	MoreButton       *MoreButtonWidget
 	OnTabClick       func(index int)
 	OnTabClose       func(index int)
+	OnTabUnpin       func(index int)
 	OnTabRightClick  func(index, screenX, screenY int)
 	OnPrevTab        func()
 	OnNextTab        func()
@@ -63,7 +65,11 @@ func (t *TabBarWidget) tabLabel(tab Tab) string {
 	}
 	label += name
 	if tab.Active && tab.Closable {
-		label += " x"
+		if tab.Pinned {
+			label += " ♦"
+		} else {
+			label += " x"
+		}
 	}
 	label += " "
 	return label
@@ -72,11 +78,14 @@ func (t *TabBarWidget) tabLabel(tab Tab) string {
 // drawTabLabel draws a tab label from x, advancing by each rune's display width
 // and clipping to the scrollable inner zone. The dirty marker keeps its own
 // style so it stays visible against the tab background.
-func drawTabLabel(surface Surface, x, innerLeft, innerRight int, label string, dirty bool, style term.Style) {
+func drawTabLabel(surface Surface, x, innerLeft, innerRight int, label string, dirty bool, pinned bool, style term.Style) {
 	for _, ch := range label {
 		chStyle := style
 		if dirty && ch == '●' {
 			chStyle = term.StyleWarning
+		}
+		if pinned && ch == '♦' {
+			chStyle = term.StyleMuted
 		}
 		w := textwidth.Rune(ch)
 		if x >= innerLeft && x+w <= innerRight {
@@ -187,16 +196,17 @@ func (t *TabBarWidget) Render(surface Surface) {
 		sx := s.start - t.ScrollOffset + innerLeft
 		ex := s.end - t.ScrollOffset + innerLeft
 		dirty := t.Tabs[i].Dirty
+		pinned := t.Tabs[i].Pinned
 		if s.active {
 			if sx >= innerLeft && sx < innerRight {
 				surface.SetCell(sx, 1, term.Cell{Ch: b.Vertical, Style: bs})
 			}
-			drawTabLabel(surface, sx+1, innerLeft, innerRight, s.label, dirty, term.StyleActiveTab)
+			drawTabLabel(surface, sx+1, innerLeft, innerRight, s.label, dirty, pinned, term.StyleActiveTab)
 			if ex-1 >= innerLeft && ex-1 < innerRight {
 				surface.SetCell(ex-1, 1, term.Cell{Ch: b.Vertical, Style: bs})
 			}
 		} else {
-			drawTabLabel(surface, sx, innerLeft, innerRight, s.label, dirty, term.StyleInactiveTab)
+			drawTabLabel(surface, sx, innerLeft, innerRight, s.label, dirty, pinned, term.StyleInactiveTab)
 		}
 	}
 
@@ -289,8 +299,12 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 			t.closeDownX = -1
 			localX := mx - r.X - arrowW + t.ScrollOffset
 			for i, s := range t.tabSpans {
-				if s.active && localX == s.end-3 && t.OnTabClose != nil {
-					t.OnTabClose(i)
+				if s.active && localX == s.end-3 {
+					if t.Tabs[i].Pinned && t.OnTabUnpin != nil {
+						t.OnTabUnpin(i)
+					} else if t.OnTabClose != nil {
+						t.OnTabClose(i)
+					}
 					return EventConsumed
 				}
 			}
@@ -332,7 +346,7 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	localX := mx - r.X - arrowW + t.ScrollOffset
 	for i, s := range t.tabSpans {
 		if localX >= s.start && localX < s.end {
-			if s.active && t.OnTabClose != nil {
+			if s.active && (t.OnTabClose != nil || t.OnTabUnpin != nil) {
 				closeX := s.end - 3
 				if localX == closeX {
 					t.closeDownX = mx

--- a/tests/e2e/fold_test.go
+++ b/tests/e2e/fold_test.go
@@ -311,7 +311,7 @@ func TestFoldStatePreservedAcrossTabs(t *testing.T) {
 	os.WriteFile(file2, []byte("package b\n"), 0644)
 
 	h.app.EditorGroup.OpenFile(file1)
-	h.app.EditorGroup.PinActiveTab()
+	h.app.EditorGroup.CommitActiveTab()
 	h.redraw()
 
 	h.app.EditorGroup.Editor.Cursor.Line = 2

--- a/tests/e2e/pin_tab_test.go
+++ b/tests/e2e/pin_tab_test.go
@@ -1,0 +1,165 @@
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPinTab(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "beta.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "gamma.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.redraw()
+
+	if h.app.EditorGroup.IsActiveTabPinned() {
+		t.Fatal("tab should not be pinned initially")
+	}
+
+	h.exec("tab.pin")
+
+	if !h.app.EditorGroup.IsActiveTabPinned() {
+		t.Fatal("tab should be pinned after toggle")
+	}
+	h.assertContains("♦")
+}
+
+func TestPinTabMovesToFront(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "beta.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "gamma.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.redraw()
+
+	// gamma is tab 3 (last), pin it
+	h.exec("tab.pin")
+
+	// After pin, gamma should be at index 0
+	path0, _ := h.app.EditorGroup.TabInfo(0)
+	if !contains(path0, "gamma") {
+		t.Fatalf("pinned gamma should be at tab index 0, got %s", path0)
+	}
+	if !h.app.EditorGroup.IsActiveTabPinned() {
+		t.Fatal("active tab should be pinned")
+	}
+}
+
+func TestUnpinTab(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.redraw()
+
+	h.exec("tab.pin")
+	if !h.app.EditorGroup.IsActiveTabPinned() {
+		t.Fatal("tab should be pinned")
+	}
+
+	h.exec("tab.pin")
+	if h.app.EditorGroup.IsActiveTabPinned() {
+		t.Fatal("tab should be unpinned after second toggle")
+	}
+	h.assertNotContains("♦")
+}
+
+func TestPinMultipleTabs(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "beta.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "gamma.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.redraw()
+
+	// Pin gamma (last/active tab) — moves to front
+	h.exec("tab.pin")
+
+	// After pin: [gamma(pinned), untitled, alpha, beta]
+	// Switch to beta (index 3) and pin it
+	h.app.EditorGroup.SwitchTab(3)
+	h.redraw()
+	h.exec("tab.pin")
+
+	// Verify via TabInfo: first two tabs should be pinned
+	path0, _ := h.app.EditorGroup.TabInfo(0)
+	path1, _ := h.app.EditorGroup.TabInfo(1)
+	if !contains(path0, "gamma") {
+		t.Fatalf("tab 0 should be gamma, got %s", path0)
+	}
+	if !contains(path1, "beta") {
+		t.Fatalf("tab 1 should be beta, got %s", path1)
+	}
+	if !h.app.EditorGroup.IsActiveTabPinned() {
+		t.Fatal("active tab (beta) should be pinned")
+	}
+}
+
+func contains(s, sub string) bool {
+	return indexOf(s, sub) >= 0
+}
+
+func TestCloseTabDecrementsPin(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "beta.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.redraw()
+
+	h.exec("tab.pin")
+	h.exec("tab.close")
+
+	// After closing the pinned tab, the remaining tab should not be pinned
+	if h.app.EditorGroup.IsActiveTabPinned() {
+		t.Fatal("after closing pinned tab, remaining tab should not be pinned")
+	}
+}
+
+func TestCloseOtherTabsKeepsPinned(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "beta.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "gamma.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	h.redraw()
+
+	// Pin alpha: switch to it and pin
+	h.app.EditorGroup.SwitchTab(0)
+	h.redraw()
+	h.exec("tab.pin")
+
+	// Switch to gamma (now unpinned, at end)
+	h.app.EditorGroup.SwitchTab(2)
+	h.redraw()
+
+	// Close others should keep pinned alpha
+	h.app.EditorGroup.CloseOtherTabs()
+	h.redraw()
+
+	h.assertContains("alpha")
+	h.assertContains("gamma")
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary
- Add pin tabs feature: pinned tabs show ♦ instead of x, stay left of unpinned tabs
- Toggle pin via `ctrl+k enter` keybinding or tab context menu (Pin Tab / Unpin Tab)
- Clicking ♦ unpins the tab; Close Others/All/All Saved preserve pinned tabs
- Rename internal `Pinned` bool to `Preview` (inverted semantics) for clarity; pin state tracked by `pinnedCount` counter

## Test plan
- [x] E2E tests: pin, unpin, move-to-front, multi-pin, close-decrement, close-others-keeps-pinned
- [x] Manual verification via `--exec` debug harness: ♦ renders correctly, pin/unpin toggles

Refs #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)