### PR TITLE
feat(cli): open files at a line and column from the command line

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -137,6 +137,7 @@ Usage: ttt [options] [files/folders/URLs...]
 
 Arguments:
   files               Open one or more files
+  file:line[:col]     Open a file with the cursor on that line (and column)
   folders             Open directories as workspace roots
   .                   Open the current directory
   PR URL              Open a GitHub pull request for review
@@ -153,6 +154,7 @@ Options:
 Examples:
   ttt                                           Open current directory
   ttt main.go utils.go                          Open specific files
+  ttt internal/app/widgets.go:42:8              Open at line 42, column 8
   ttt ~/projectA ~/projectB                     Multi-root workspace
   ttt . https://github.com/o/r/pull/123         Review a PR with repo tree
 
@@ -211,7 +213,7 @@ Docs: https://tttedit.dev
 	cmdRegistry := command.NewRegistry()
 	borders := app.BuildBorderSet(cfg.Theme.Borders)
 
-	editor, prURLs := app.BuildApp(&cfg, &borders)
+	editor, prURLs, fileTargets := app.BuildApp(&cfg, &borders)
 	editor.ApplyBorderStyle()
 	editor.Init(screen, renderer, lspManager)
 
@@ -333,6 +335,8 @@ Docs: https://tttedit.dev
 		w, h = flags.sizeW, flags.sizeH
 	}
 	editor.Root.SetSize(w, h)
+
+	editor.PendingFileTargets = fileTargets
 
 	if flags.pluginFile != "" {
 		app.LoadPluginFromFile(editor, flags.pluginFile)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -83,8 +83,12 @@ type App struct {
 	Version                string
 	PluginManager          *plugin.Manager
 	PendingPluginApprovals []*plugin.Plugin
-	PluginsPanel           *PluginsPanel
-	Output                 *ui.OutputWidget
+	// PendingFileTargets holds cursor positions parsed from `path:line[:col]`
+	// arguments. They are applied after the first render, once the viewport
+	// has a real height to scroll against.
+	PendingFileTargets []FileTarget
+	PluginsPanel       *PluginsPanel
+	Output             *ui.OutputWidget
 	// runningRepoOp is the progress label of the in-flight task, empty when idle.
 	runningRepoOp        string
 	pluginDetailWidgets  map[string]*pluginDetailState

--- a/internal/app/args_test.go
+++ b/internal/app/args_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSplitLineCol(t *testing.T) {
+	cases := []struct {
+		arg  string
+		path string
+		line int
+		col  int
+		ok   bool
+	}{
+		{"main.go:42", "main.go", 42, 0, true},
+		{"main.go:42:8", "main.go", 42, 8, true},
+		{"main.go:42:", "main.go", 42, 0, true},
+		{"internal/app/main.go:7", "internal/app/main.go", 7, 0, true},
+		// When ok is false the argument is returned untouched; callers ignore path.
+		{"main.go", "main.go", 0, 0, false},
+		{"main.go:", "main.go:", 0, 0, false},
+		// A leading drive letter is not a number, so Windows paths survive.
+		{`C:\src\main.go`, `C:\src\main.go`, 0, 0, false},
+		{`C:\src\main.go:42`, `C:\src\main.go`, 42, 0, true},
+		// Line numbers are 1-based; 0 and negatives are part of the name.
+		{"main.go:0", "main.go:0", 0, 0, false},
+		{"main.go:-3", "main.go:-3", 0, 0, false},
+		// No path left once the numbers are stripped.
+		{":42", ":42", 0, 0, false},
+		{"42", "42", 0, 0, false},
+	}
+	for _, c := range cases {
+		path, line, col, ok := splitLineCol(c.arg)
+		if ok != c.ok || path != c.path || line != c.line || col != c.col {
+			t.Errorf("splitLineCol(%q) = (%q, %d, %d, %v), want (%q, %d, %d, %v)",
+				c.arg, path, line, col, ok, c.path, c.line, c.col, c.ok)
+		}
+	}
+}
+
+// A `path:line` argument only counts as a position when the stripped path is a
+// real file. Anything else keeps behaving the way it did before the suffix was
+// understood.
+func TestResolveLineColArgRequiresExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(real, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	target, ok := resolveLineColArg(real + ":42:8")
+	if !ok {
+		t.Fatalf("resolveLineColArg(%q) returned ok=false", real+":42:8")
+	}
+	if target.Path != real || target.Line != 42 || target.Col != 8 {
+		t.Errorf("got %+v, want path=%q line=42 col=8", target, real)
+	}
+
+	if _, ok := resolveLineColArg(filepath.Join(dir, "missing.go") + ":42"); ok {
+		t.Error("a suffix on a path that does not exist must not resolve")
+	}
+	if _, ok := resolveLineColArg(dir + ":42"); ok {
+		t.Error("a directory must not resolve as a line target")
+	}
+}
+
+func TestResolveArgsFileLineCol(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A file whose name genuinely ends in a colon and digits must win over the
+	// positional reading, because it exists.
+	colonName := filepath.Join(dir, "report:12")
+	if err := os.WriteFile(colonName, []byte("x\n"), 0o644); err != nil {
+		t.Skipf("filesystem rejects colons in names: %v", err)
+	}
+
+	saved := os.Args
+	defer func() { os.Args = saved }()
+	os.Args = []string{"ttt", file + ":42:8", colonName, filepath.Join(dir, "new.go:9")}
+
+	_, openFiles, _, _ := resolveArgs()
+	if len(openFiles) != 3 {
+		t.Fatalf("got %d targets, want 3: %+v", len(openFiles), openFiles)
+	}
+	if openFiles[0].Path != file || openFiles[0].Line != 42 || openFiles[0].Col != 8 {
+		t.Errorf("positional suffix: got %+v", openFiles[0])
+	}
+	if openFiles[1].Path != colonName || openFiles[1].Line != 0 {
+		t.Errorf("existing colon-named file: got %+v, want path=%q line=0", openFiles[1], colonName)
+	}
+	if openFiles[2].Line != 0 {
+		t.Errorf("missing file keeps its literal name: got %+v", openFiles[2])
+	}
+}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -176,6 +176,16 @@ func RunEventLoop(
 	syncStatus()
 	redraw()
 
+	// Cursor positions from `path:line[:col]` arguments are applied here rather
+	// than at build time: GoToLineCol centres the target against the viewport
+	// height, which is only real once the first render has laid the widgets out.
+	if len(app.PendingFileTargets) > 0 {
+		app.ApplyFileTargets(app.PendingFileTargets)
+		app.PendingFileTargets = nil
+		syncStatus()
+		redraw()
+	}
+
 	app.ShowPendingPluginApprovals()
 
 	for *running {

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -3,6 +3,7 @@ package app
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/eugenioenko/ttt/internal/config"
@@ -18,7 +19,71 @@ func isPRURL(arg string) bool {
 	return strings.Contains(arg, "github.com/") && strings.Contains(arg, "/pull/")
 }
 
-func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile string, prURLs []string) {
+// FileTarget is a file named on the command line, with the optional 1-based
+// cursor position parsed from a `path:line[:col]` argument. Line and Col are 0
+// when the argument carried no position.
+type FileTarget struct {
+	Path string
+	Line int
+	Col  int
+}
+
+// splitLineCol splits a `path:line[:col]` argument into its path and 1-based
+// line and column. Trailing colons are tolerated so text pasted straight from
+// tools like `grep -n` ("main.go:42:") works. At most two trailing numeric
+// fields are consumed, which leaves Windows paths such as `C:\src\main.go`
+// alone because the drive letter is not followed by a number. ok is false when
+// the argument carries no positional suffix.
+func splitLineCol(arg string) (path string, line, col int, ok bool) {
+	parts := strings.Split(strings.TrimRight(arg, ":"), ":")
+	if len(parts) < 2 {
+		return arg, 0, 0, false
+	}
+	var nums []int
+	end := len(parts)
+	for end > 1 && len(nums) < 2 {
+		n, err := strconv.Atoi(parts[end-1])
+		if err != nil || n < 1 {
+			break
+		}
+		nums = append([]int{n}, nums...)
+		end--
+	}
+	if len(nums) == 0 {
+		return arg, 0, 0, false
+	}
+	path = strings.Join(parts[:end], ":")
+	if path == "" {
+		return arg, 0, 0, false
+	}
+	line = nums[0]
+	if len(nums) > 1 {
+		col = nums[1]
+	}
+	return path, line, col, true
+}
+
+// resolveLineColArg interprets arg as `path:line[:col]` and reports the target
+// only when the stripped path actually names an existing file. Requiring the
+// file to exist keeps ambiguous arguments — a new file whose name contains a
+// colon and a number — behaving as they did before.
+func resolveLineColArg(arg string) (FileTarget, bool) {
+	path, line, col, ok := splitLineCol(arg)
+	if !ok {
+		return FileTarget{}, false
+	}
+	abs, err := filepath.Abs(workspace.ExpandPath(path))
+	if err != nil {
+		return FileTarget{}, false
+	}
+	info, err := os.Stat(abs)
+	if err != nil || info.IsDir() {
+		return FileTarget{}, false
+	}
+	return FileTarget{Path: abs, Line: line, Col: col}, true
+}
+
+func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile string, prURLs []string) {
 	var folders []string
 	var wsFile string
 
@@ -61,18 +126,27 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 		}
 		absPath, err := filepath.Abs(workspace.ExpandPath(args[i]))
 		if err != nil {
-			openFiles = append(openFiles, args[i])
+			openFiles = append(openFiles, FileTarget{Path: args[i]})
 			continue
 		}
 		info, err := os.Stat(absPath)
 		if err != nil {
-			openFiles = append(openFiles, absPath)
+			// Nothing exists at the path as written. Try it as `path:line[:col]`
+			// before falling back to creating a new file, so `ttt main.go:42`
+			// opens main.go at line 42 instead of a file named "main.go:42".
+			// A file that genuinely contains a colon still wins, because the
+			// stat above is attempted first.
+			if target, ok := resolveLineColArg(args[i]); ok {
+				openFiles = append(openFiles, target)
+				continue
+			}
+			openFiles = append(openFiles, FileTarget{Path: absPath})
 			continue
 		}
 		if info.IsDir() {
 			folders = append(folders, absPath)
 		} else {
-			openFiles = append(openFiles, absPath)
+			openFiles = append(openFiles, FileTarget{Path: absPath})
 		}
 	}
 
@@ -96,9 +170,9 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []string, configFile stri
 	return
 }
 
-func BuildApp(cfg *config.AppConfig, borders *term.BorderSet) (*App, []string) {
+func BuildApp(cfg *config.AppConfig, borders *term.BorderSet) (*App, []string, []FileTarget) {
 	ws, openFiles, _, prURLs := resolveArgs()
-	return BuildAppFromConfig(cfg, borders, ws, openFiles), prURLs
+	return BuildAppFromConfig(cfg, borders, ws, openFiles), prURLs, openFiles
 }
 
 var bracketColorSlots = []term.Style{
@@ -121,7 +195,7 @@ func ResolveBracketColorStyles(colors []string) []term.Style {
 	return bracketColorSlots[:n]
 }
 
-func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *workspace.Workspace, openFiles []string) *App {
+func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *workspace.Workspace, openFiles []FileTarget) *App {
 
 	bracketStyles := ResolveBracketColorStyles(cfg.Theme.Editor.BracketColors)
 
@@ -141,8 +215,15 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.BracketColorStyles = bracketStyles
 	editorGroup.Editor.BracketColorStyles = bracketStyles
 	for _, f := range openFiles {
-		editorGroup.OpenFile(f)
+		editorGroup.OpenFile(f.Path)
 		editorGroup.CommitActiveTab()
+		// The tab just opened is the active one, so this lands on the right
+		// buffer without switching tabs. PlaceCursor rather than GoToLineCol:
+		// the viewport has no height yet, and ApplyFileTargets frames the file
+		// left active once the first render has run.
+		if f.Line > 0 {
+			editorGroup.PlaceCursor(f.Line, f.Col)
+		}
 	}
 
 	terminalPanel := ui.NewTerminalPanelWidget()
@@ -237,4 +318,22 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	// changes its diagnostics.
 	app.EditorGroup.OnDiagnosticsChanged = app.refreshProblems
 	return app
+}
+
+// ApplyFileTargets frames the file left active at startup. Every file's cursor
+// is already placed as it opens; the scroll has to wait until here because
+// GoToLineCol centres the line against the viewport height, which is zero until
+// the first render.
+//
+// Only the active file is framed. Scrolling a background tab means switching to
+// it and back, which leaves that tab's viewport shifted, so the other files
+// keep a correct cursor and an unscrolled view instead.
+func (a *App) ApplyFileTargets(targets []FileTarget) {
+	active := a.EditorGroup.ActiveFilePath()
+	for i := len(targets) - 1; i >= 0; i-- {
+		if targets[i].Line > 0 && targets[i].Path == active {
+			a.EditorGroup.GoToLineCol(targets[i].Line, targets[i].Col)
+			return
+		}
+	}
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1110,9 +1110,14 @@ func (g *EditorGroupWidget) SetSearchActive(idx int) {
 	g.Editor.SearchActive = idx
 }
 
-func (g *EditorGroupWidget) GoToLine(line int) {
+// PlaceCursor moves the cursor to a 1-based line and column, clamping both to
+// the buffer and expanding any fold hiding the line. It reports whether an
+// editor was active. Unlike GoToLineCol it never touches the viewport, so it is
+// safe before the first render: a scroll computed against a zero-height
+// viewport leaves the tab mis-framed for as long as it stays open.
+func (g *EditorGroupWidget) PlaceCursor(line, col int) bool {
 	if !g.IsEditorActive() {
-		return
+		return false
 	}
 	if line < 1 {
 		line = 1
@@ -1124,6 +1129,22 @@ func (g *EditorGroupWidget) GoToLine(line int) {
 	g.Editor.ExpandFoldContaining(bufLine)
 	g.Editor.Cursor.Line = bufLine
 	g.Editor.Cursor.Col = 0
+	if col > 1 {
+		lineLen := len([]rune(g.Editor.Buf.Lines[bufLine]))
+		c := col - 1
+		if c > lineLen {
+			c = lineLen
+		}
+		g.Editor.Cursor.Col = c
+	}
+	return true
+}
+
+func (g *EditorGroupWidget) GoToLine(line int) {
+	if !g.PlaceCursor(line, 0) {
+		return
+	}
+	bufLine := g.Editor.Cursor.Line
 	h := g.Editor.Viewport.Height
 	if h <= 0 {
 		r := g.GetRect()

--- a/internal/ui/place_cursor_test.go
+++ b/internal/ui/place_cursor_test.go
@@ -1,0 +1,81 @@
+package ui
+
+import "testing"
+
+func multiLineGroup(t *testing.T, lines int) *EditorGroupWidget {
+	t.Helper()
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+	content := make([]string, lines)
+	for i := range content {
+		content[i] = "package line"
+	}
+	g.tabs[0].Buf.Lines = content
+	return g
+}
+
+// PlaceCursor must never scroll. Startup places cursors before the first
+// render, and a scroll computed against a zero-height viewport leaves the tab
+// mis-framed for as long as it stays open.
+func TestPlaceCursorLeavesViewportAlone(t *testing.T) {
+	g := multiLineGroup(t, 200)
+	topBefore := g.Editor.Viewport.TopLine
+	leftBefore := g.Editor.Viewport.LeftCol
+	heightBefore := g.Editor.Viewport.Height
+
+	if !g.PlaceCursor(120, 5) {
+		t.Fatal("PlaceCursor reported no active editor")
+	}
+	if g.Editor.Cursor.Line != 119 || g.Editor.Cursor.Col != 4 {
+		t.Errorf("cursor = (%d, %d), want (119, 4)", g.Editor.Cursor.Line, g.Editor.Cursor.Col)
+	}
+	if g.Editor.Viewport.TopLine != topBefore {
+		t.Errorf("TopLine moved to %d, want %d — PlaceCursor must not scroll", g.Editor.Viewport.TopLine, topBefore)
+	}
+	if g.Editor.Viewport.LeftCol != leftBefore {
+		t.Errorf("LeftCol moved to %d, want %d — PlaceCursor must not scroll", g.Editor.Viewport.LeftCol, leftBefore)
+	}
+	if g.Editor.Viewport.Height != heightBefore {
+		t.Errorf("Height changed to %d, want %d", g.Editor.Viewport.Height, heightBefore)
+	}
+}
+
+func TestPlaceCursorClampsToBuffer(t *testing.T) {
+	g := multiLineGroup(t, 10)
+
+	g.PlaceCursor(9999, 1)
+	if g.Editor.Cursor.Line != 9 {
+		t.Errorf("line past EOF = %d, want 9", g.Editor.Cursor.Line)
+	}
+
+	g.PlaceCursor(0, 0)
+	if g.Editor.Cursor.Line != 0 {
+		t.Errorf("line before start = %d, want 0", g.Editor.Cursor.Line)
+	}
+
+	// "package line" is 12 runes; a column past the end lands at the end.
+	g.PlaceCursor(3, 500)
+	if g.Editor.Cursor.Col != 12 {
+		t.Errorf("column past EOL = %d, want 12", g.Editor.Cursor.Col)
+	}
+
+	// Columns 0 and 1 both mean the start of the line.
+	g.PlaceCursor(3, 1)
+	if g.Editor.Cursor.Col != 0 {
+		t.Errorf("column 1 = %d, want 0", g.Editor.Cursor.Col)
+	}
+}
+
+// GoToLine, in contrast, is expected to scroll — it is what brings a line into
+// view once the viewport has a real height.
+func TestGoToLineDoesScroll(t *testing.T) {
+	g := multiLineGroup(t, 200)
+	g.Editor.Viewport.Height = 30
+
+	g.GoToLine(120)
+	if g.Editor.Viewport.TopLine == 0 {
+		t.Error("GoToLine left TopLine at 0; it should have scrolled to the target")
+	}
+	if g.Editor.Cursor.Line != 119 {
+		t.Errorf("cursor line = %d, want 119", g.Editor.Cursor.Line)
+	}
+}

--- a/tests/functional/cli-file-line-col.test.js
+++ b/tests/functional/cli-file-line-col.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createMultiLineFile, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("file:line:col command line arguments", () => {
+  it("should open a file with the cursor on the given line", () => {
+    dir = createTempDir();
+    const file = createMultiLineFile(dir, "lines.txt", 80);
+
+    tui.start(`${file}:42`);
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Ln 42");
+    expect(snapshots[s0]).toContain("Line 42");
+  });
+
+  it("should honour a column as well as a line", () => {
+    dir = createTempDir();
+    const file = createMultiLineFile(dir, "lines.txt", 80);
+
+    tui.start(`${file}:42:6`);
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Ln 42, Col 6");
+  });
+
+  // Output pasted from `grep -n` often carries a trailing colon.
+  it("should tolerate a trailing colon", () => {
+    dir = createTempDir();
+    const file = createMultiLineFile(dir, "lines.txt", 80);
+
+    tui.start(`${file}:42:`);
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Ln 42");
+  });
+
+  // A file that exists is opened as itself, so a name ending in a colon and
+  // digits is never mistaken for a position.
+  it("should prefer a real file whose name ends in :digits", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "report:12", "alpha\nbeta\n");
+
+    tui.start(file);
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Ln 1");
+    expect(snapshots[s0]).toContain("alpha");
+  });
+
+  // Only the file left active is framed; the others keep a placed cursor.
+  // This asserts on the active file rather than switching tabs and reading the
+  // status bar: in this harness the rendered status bar lagged a tab switch,
+  // which reproduces with Ctrl+G plus View: Previous Tab and no CLI positions.
+  it("should position the file left active when several are given", () => {
+    dir = createTempDir();
+    const first = createMultiLineFile(dir, "first.txt", 80);
+    const second = createMultiLineFile(dir, "second.txt", 80);
+
+    tui.start(`${first}:10`, `${second}:20`);
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Ln 20");
+    expect(snapshots[s0]).toContain("Line 20");
+  });
+
+  it("should leave a plain path untouched", () => {
+    dir = createTempDir();
+    const file = createMultiLineFile(dir, "lines.txt", 80);
+
+    tui.start(file);
+    tui.waitStable();
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toContain("Ln 1, Col 1");
+  });
+});


### PR DESCRIPTION
## What

`ttt main.go:42` and `ttt main.go:42:8` open the file with the cursor on that line and column.

```sh
ttt internal/app/widgets.go:42        # line 42
ttt internal/app/widgets.go:42:8      # line 42, column 8
ttt internal/app/widgets.go:42:       # trailing colon, as pasted from `grep -n`
```

## Why

It is the form `grep -n`, compilers, linters and language servers already print, so it is what ends up on the clipboard when you are chasing an error. Other editors accept it (`code -g file:42`, `hx file:42`, `nvim +42 file`), and without it that text has to be retyped as a Go to Line.

## Compatibility

A positional argument is only read as a position when the plain path fails to resolve, so nothing that worked before changes:

1. If something exists at the path as written, it wins. A file genuinely named `report:12` still opens as itself.
2. Otherwise the argument is retried as `path:line[:col]`, and only counts as a position when the stripped path names an existing file.
3. Otherwise it stays a literal path, so `ttt notes.txt:9` still creates a buffer with that name when `notes.txt` does not exist.

At most two trailing numeric fields are consumed, so a Windows path such as `C:\src\main.go` is untouched (the drive letter is not a number). `:0` and negative numbers are treated as part of the name, since lines are 1-based.

## Implementation note

Positioning happens in two steps, which is the one part of the diff that is not obvious.

`GoToLineCol` scrolls the target into view, and that scroll is computed against the viewport height — which is zero until the first render. Calling it at startup leaves the tab mis-framed for as long as it stays open: the target line lands just above the visible region, and the horizontal offset sticks too.

So this PR splits `PlaceCursor` out of `GoToLine`. It does the clamping and fold expansion and moves the cursor, but never touches the viewport. `GoToLine` is now `PlaceCursor` plus the existing scroll, so its behaviour is unchanged.

- Each file gets a `PlaceCursor` as it opens, while its tab is still the active one.
- The file left active is framed from the event loop after the first render, which gives it the same framing as an in-editor **Go to Line**.

`internal/ui/place_cursor_test.go` pins the no-scroll invariant, because a `scrollViewport()` added to `PlaceCursor` later would look like a tidy-up and silently bring the mis-framing back.

## Known limitation

With several positioned files, only the file left active is scrolled. The others have a correct cursor but show the top of the file until the cursor next moves, because activating a tab does not scroll to its cursor.

Framing them at startup means switching to each tab and back. When I tried that, tabs visited that way came back with their viewport shifted one column right, clipping the first character of every line. I could not reproduce that with ordinary tab switching, so it appears specific to switching during startup rather than a general problem — but I did not chase it down, and I would rather not build the feature on a mechanism I do not understand. Framing one file covers the common case of a single `file:line` argument.

If you would prefer every named file framed, say so and I will work out what that shift actually is.

## Tests

- `internal/app/args_test.go` — `splitLineCol` table, and that a suffix only resolves against a file that exists, including the colon-named-file and directory cases.
- `internal/ui/place_cursor_test.go` — clamping, and that `PlaceCursor` leaves `TopLine`/`LeftCol`/`Height` alone while `GoToLine` still scrolls.
- `tests/functional/cli-file-line-col.test.js` — six cases through the real binary: line, line+column, trailing colon, a real `report:12` file, several files, and a plain path.

`go test ./...` and the full `tests/functional` suite pass. Framing was checked against an in-editor Go to Line on the same file and size: both give the same viewport.

