### PR TITLE
fix(exec): run scripted commands on the event loop so the status bar stays in sync

### DIFF
--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -262,6 +262,10 @@ func RunEventLoop(
 				}
 			case *GitGutterTrigger:
 				app.RequestGitGutterForActiveFile()
+			case *ExecCommandRequest:
+				app.Reg.Execute(v.ID)
+				app.FlushEditorOnChange()
+				syncStatus()
 			case *AutocompleteTrigger:
 				triggerChar := app.charBeforeCursor()
 				isTrigger := triggerChar != "" && (len(app.CompletionTriggers) == 0 || app.isCompletionTrigger(triggerChar))

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -240,7 +240,18 @@ func execCommand(a *App, args string) {
 		slog.Error("exec_script: command not found", "title", title)
 		return
 	}
-	a.Reg.Execute(cmd.ID)
+	// Hand the command to the event loop instead of running it here. `key` and
+	// `click` already post real events, so they get the status bar sync that
+	// follows real input; running a command straight from the script goroutine
+	// skipped that sync and mutated widget state off the main thread.
+	a.Screen.PostEvent(tcell.NewEventInterrupt(&ExecCommandRequest{ID: cmd.ID}))
+}
+
+// ExecCommandRequest is posted as an EventInterrupt so a command named by an
+// --exec script runs on the main thread, on the same path as key and mouse
+// input.
+type ExecCommandRequest struct {
+	ID string
 }
 
 func execScreenshot(a *App, args string) {

--- a/tests/functional/statusbar-tab-switch.test.js
+++ b/tests/functional/statusbar-tab-switch.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createMultiLineFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("status bar after a scripted tab switch", () => {
+  // The two files must sit on different lines: if both cursors are on line 1 a
+  // stale reading and a correct one are identical, and the test cannot fail.
+  it("should report the newly active tab's cursor, not the previous tab's", () => {
+    dir = createTempDir();
+    const first = createMultiLineFile(dir, "first.txt", 80);
+    const second = createMultiLineFile(dir, "second.txt", 80);
+
+    tui.start(first, second);
+    tui.waitStable();
+
+    // second.txt is active; move it to line 20 so the two tabs differ.
+    tui.press("ctrl+g");
+    tui.waitStable();
+    tui.type("20");
+    tui.press("enter");
+    tui.waitStable();
+
+    const onSecond = tui.snapshot();
+
+    tui.exec("View: Previous Tab");
+    tui.waitStable();
+    const onFirst = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[onSecond]).toContain("Ln 20, Col 1");
+    expect(snapshots[onFirst]).toContain("Ln 1, Col 1");
+    expect(snapshots[onFirst]).not.toContain("Ln 20");
+  });
+});


### PR DESCRIPTION
Fixes #460.

## What was stale

`exec "Command Name"` in an `--exec` script called `Reg.Execute` directly from the script goroutine. The event loop runs `syncStatus()` after handling real key and mouse input; a command dispatched this way never reached that, so the editor state changed while the rendered status bar kept the previous values.

Switching tabs is where it shows: after `exec "View: Previous Tab"` the position segment still reads the line from the tab that *had* been active.

```
exec "View: Previous Tab"   rendered: Ln 20, Col 1   actual: first.txt Ln 1   stale
key alt+,                   rendered: Ln 1, Col 1    actual: first.txt Ln 1   ok
click <tab>                 rendered: Ln 1, Col 1    actual: first.txt Ln 1   ok
```

Only the scripted path was affected — `execKey` and `execClick` post real tcell events and go through the loop, so interactive tab switching was always correct. The issue as I first wrote it said this also happened interactively; that was wrong, and I have corrected it.

Since `syncStatus` also drives the explorer's active file, the git gutter request, the `tab.change` plugin event, blame and the outline selection, all of those were skipped too for scripted commands.

## The fix

The command is posted as an `ExecCommandRequest` interrupt and executed on the main thread, on the same path as key and mouse input, followed by the same `FlushEditorOnChange` and `syncStatus`. This also stops the script goroutine from mutating widget state off the main thread, which `CLAUDE.md` calls out as a rule.

Four lines in the event loop, and `execCommand` posting instead of executing.

## Proving the test detects it

`tests/functional/statusbar-tab-switch.test.js` was run against a build of this branch with the fix stashed, and then with it applied:

```
PRE-FIX   exit=1   AssertionError: expected '  File   Edit   Selection   View   Op…' to contain 'Ln 1, Col 1'
POST-FIX  exit=0   Tests  1 passed (1)
```

The two files deliberately sit on different lines. With both cursors on line 1 a stale reading and a correct one are identical and the test cannot fail, so the test moves `second.txt` to line 20 first.

## Suites

`go test ./...` exit 0 (25 packages), `go vet` clean, full `tests/functional` suite exit 0 (281 passed, 27 expected fail).

`clipboard-roundtrip.test.js` failed once under parallel load and passes 3/3 in isolation; it contains no `tui.exec` calls, so it is not touched by this change.

`gofmt -l` reports `internal/ui/editor_group.go`, which is unrelated to this branch — it is already flagged on `main` and I left it alone.
