### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,35 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!bin/**"
+    - "!node_modules/**"
+    - "!docs-web/node_modules/**"
+    - "!docs-web/dist/**"
+    - "!chaos-output/**"
+    - "!go.sum"
+    - "!flake.lock"
+    - "!config/keybindings.json"
+  path_instructions:
+    - path: "internal/core/**"
+      instructions: >
+        This is the UI-agnostic editor engine and must never import terminal
+        or rendering packages. Flag any import of tcell, term, view, or render
+        packages here.
+    - path: "**/*_test.go"
+      instructions: >
+        Check that new features touching cursor, buffer, selection, or
+        commands have coverage per the project's test-level expectations
+        (unit, e2e, functional).
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` for CodeRabbit AI review on PRs
- Excludes generated/vendor paths (bin/, node_modules, docs-web/dist, go.sum, flake.lock, generated config/keybindings.json)
- Adds path-specific review instructions for internal/core/ (terminal-independence constraint) and *_test.go (test-level coverage expectations)

## Test plan
- [ ] Install the CodeRabbit GitHub App on this repo
- [ ] Confirm it picks up config and reviews this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration, including review preferences, workflow settings, summary generation, and chat responses.
  * Added path-specific review guidance and exclusions for selected files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->