### PR TITLE
test: add lifecycle coverage for Terminal, fix Close() deadlock

### DIFF
--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -25,6 +25,7 @@ type Terminal struct {
 	cmd        *pty.Cmd
 	cols, rows int
 	done       chan struct{}
+	started    bool
 	closed     bool
 	exited     bool
 	OnUpdate   func()
@@ -89,6 +90,9 @@ func defaultShell() string {
 }
 
 func (t *Terminal) Run() {
+	t.mu.Lock()
+	t.started = true
+	t.mu.Unlock()
 	go t.readLoop()
 }
 
@@ -156,6 +160,7 @@ func (t *Terminal) Close() {
 		return
 	}
 	t.closed = true
+	started := t.started
 	t.mu.Unlock()
 
 	t.pt.Close()
@@ -163,7 +168,9 @@ func (t *Terminal) Close() {
 		t.cmd.Process.Kill()
 		t.cmd.Wait()
 	}
-	<-t.done
+	if started {
+		<-t.done
+	}
 }
 
 func (t *Terminal) ScrollbackLen() int {

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,0 +1,169 @@
+package terminal
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/vt10x"
+)
+
+func newTestTerminal(t *testing.T) *Terminal {
+	t.Helper()
+	term, err := New("/bin/sh", 80, 24, 0, nil, "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	return term
+}
+
+func TestNewSpawnsShellWithSize(t *testing.T) {
+	term := newTestTerminal(t)
+	term.Run()
+	defer term.Close()
+
+	cols, rows := term.Size()
+	if cols != 80 || rows != 24 {
+		t.Fatalf("Size() = %d,%d, want 80,24", cols, rows)
+	}
+	if term.pt == nil {
+		t.Fatal("expected pty to be set")
+	}
+	if term.cmd == nil || term.cmd.Process == nil {
+		t.Fatal("expected shell process to be started")
+	}
+}
+
+func TestNewDefaultsScrollback(t *testing.T) {
+	term, err := New("/bin/sh", 80, 24, -5, nil, "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	term.Run()
+	defer term.Close()
+	// A non-positive scrollbackMax must fall back to the default rather than
+	// producing a terminal with no history.
+	if term.vt == nil {
+		t.Fatal("expected vt to be initialized")
+	}
+}
+
+func TestCloseKillsProcessAndStopsReadLoop(t *testing.T) {
+	term := newTestTerminal(t)
+	term.Run()
+
+	// Give the read loop a moment to start before tearing down.
+	time.Sleep(20 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		term.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() did not return — readLoop likely leaked")
+	}
+
+	// Close() blocks on <-t.done, which readLoop closes on exit, so reaching
+	// this point already proves the read goroutine terminated. Confirm the
+	// process was actually reaped too.
+	if term.cmd.ProcessState == nil {
+		t.Fatal("expected process to have exited after Close()")
+	}
+}
+
+func TestCloseWithoutRunDoesNotDeadlock(t *testing.T) {
+	term := newTestTerminal(t)
+
+	done := make(chan struct{})
+	go func() {
+		term.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() deadlocked when Run() was never called")
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	term := newTestTerminal(t)
+	term.Run()
+	time.Sleep(20 * time.Millisecond)
+
+	term.Close()
+
+	doneSecond := make(chan struct{})
+	go func() {
+		term.Close()
+		close(doneSecond)
+	}()
+
+	select {
+	case <-doneSecond:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second Close() call blocked or deadlocked")
+	}
+}
+
+func TestCloseConcurrentIsSafe(t *testing.T) {
+	term := newTestTerminal(t)
+	term.Run()
+	time.Sleep(20 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Go(func() {
+			term.Close()
+		})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Close() calls did not all return")
+	}
+}
+
+func TestWriteStringAndReadLoopUpdatesView(t *testing.T) {
+	term := newTestTerminal(t)
+	defer term.Close()
+
+	updated := make(chan struct{}, 100)
+	term.OnUpdate = func() {
+		select {
+		case updated <- struct{}{}:
+		default:
+		}
+	}
+	term.Run()
+
+	term.WriteString("echo hello_ttt_test\n")
+
+	found := false
+	deadline := time.After(5 * time.Second)
+	for !found {
+		select {
+		case <-updated:
+			term.Snapshot(func(v vt10x.View) {
+				if strings.Contains(v.String(), "hello_ttt_test") {
+					found = true
+				}
+			})
+		case <-deadline:
+			t.Fatal("timed out waiting for shell output to appear in view")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/terminal` had zero test coverage despite owning real PTY/process lifecycle (spawn, resize, cleanup). Adds `terminal_test.go` covering: spawn + initial size, `Close()` killing the process and stopping the read loop, `Close()` idempotency, concurrent `Close()` calls, and read-loop output actually landing in the vt10x view.
- Writing the tests surfaced a real deadlock: `Close()` unconditionally blocks on `<-t.done`, but `t.done` is only closed by `readLoop()`, which only runs if `Run()` was called first. Every current call site (`internal/app/app.go`) happens to call `Run()` immediately after `New()`, so this hasn't fired in production — but it's a landmine for any future caller. Fixed by tracking whether `Run()` started the read loop and only waiting on the channel if it did.

## Test plan
- [x] `go test ./internal/terminal/... -race -v` — all 7 tests pass
- [x] `go build ./...`
- [x] `go test ./...` — full suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing a terminal before it starts no longer causes it to hang.
  * Repeated and concurrent close operations are handled safely.
  * Terminal shutdown now reliably stops the running process and read loop.

* **Tests**
  * Added coverage for terminal sizing, scrollback defaults, process termination, shutdown behavior, and shell output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->