### PR TITLE
feat(debug): --listen HTTP command server + raw PTY byte capture in debug dump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Every new feature or bug fix should include tests at multiple levels:
 
 Functional tests are the highest-value tests. Use `tui.exec("Command Name")` for command palette, `tui.pressChord("ctrl+k", "x")` for keybindings, and `tui.snapshot()` to verify results.
 
-### Debug harness (`--exec`, `--plugin`, `--size`, `--debug`)
+### Debug harness (`--exec`, `--plugin`, `--size`, `--debug`, `--listen`)
 
 **USE THIS FOR DEBUGGING AND TESTING.** The editor has a built-in scripted interaction system that is faster than TUI tests and gives you direct access to internal state — reach for it before investigating UI bugs manually.
 
@@ -213,10 +213,20 @@ Supported commands:
 - `copy` — copy the current selection to the clipboard
 - `exec "Command Name"` — run a command by title (same as command palette)
 - `screenshot PATH` — save screen text to file
-- `debug PATH` — save debug state JSON (screen, cursor, buffer, focus, panels, tabs, selection, output log, full widget tree with rect/focus/props per node)
+- `debug PATH` — save debug state JSON (screen, cursor, buffer, focus, panels, tabs, selection, output log, integrated-terminal raw PTY byte tails, full widget tree with rect/focus/props per node)
 - `wait MS` — wait milliseconds
 - `panel ID` — show and focus a bottom panel by ID
-- `quit` — exit the editor
+- `quit` / `shutdown` — exit the editor
+
+**`--listen`** — Start an HTTP command server on `127.0.0.1:4242` (loopback-only — never exposed off the local machine). `POST /exec` runs the same script format as `--exec`, synchronously, against an **already-running** editor — for capturing a repro at the exact moment it happens instead of scripting it in advance:
+
+```bash
+bin/ttt --listen &
+curl -X POST --data "type hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
+```
+
+Pass `?sep=` to use a different command separator, mirroring `--exec-split-on`.
 
 **`--size WxH`** — Force screen dimensions for deterministic layout (e.g. `--size 120x40`). Essential for reproducible screenshots and coordinate-based click tests.
 

--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@ TTT includes a built-in scripted interaction system designed for AI agent intera
 | Flag | Description |
 |------|-------------|
 | `--exec "commands"` | Execute semicolon-separated commands after startup |
+| `--listen` | Start an HTTP command server on `127.0.0.1:4242` (`POST /exec` accepts the same script format as `--exec`, against an already-running editor) |
 | `--plugin FILE` | Load a Lua plugin file on startup with full permissions |
 | `--size WxH` | Force screen dimensions (e.g. `120x40`) for deterministic layout |
 | `--debug` | Enable debug mode regardless of config |
@@ -761,12 +762,20 @@ The `--exec` flag accepts a semicolon-separated string of commands that run sequ
 | `screenshot PATH` | Save the current screen text to a file |
 | `debug PATH` | Save the editor's debug state as JSON to a file |
 | `wait MS` | Wait for the given number of milliseconds |
-| `quit` | Exit the editor |
+| `quit` / `shutdown` | Exit the editor |
 
 Example — capture a screenshot and debug state, then quit:
 
 ```sh
 ttt --size 120x40 --exec "wait 200; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
+```
+
+Example — drive an already-running editor over `--listen` instead of scripting in advance:
+
+```sh
+ttt --listen &
+curl -X POST --data "type hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 
 ## Architecture

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -349,11 +349,16 @@ Docs: https://tttedit.dev
 		app.LoadPluginFromFile(editor, flags.pluginFile)
 	}
 
+	if cfg.Settings.DebugMode {
+		editor.LogOutput("info", "ttt", "Debug mode enabled")
+	}
+
 	if flags.exec != "" {
 		go app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
 	}
 
 	if flags.listen {
+		editor.LogOutput("info", "ttt", "Listening on "+app.ListenAddr+" (POST /exec)")
 		go app.StartListenServer(editor)
 	}
 

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -70,6 +70,7 @@ type cliFlags struct {
 	execSplitOn  string
 	sizeW, sizeH int
 	debug        bool
+	listen       bool
 }
 
 func parseFlags() cliFlags {
@@ -104,6 +105,8 @@ func parseFlags() cliFlags {
 			}
 		case "--debug":
 			f.debug = true
+		case "--listen":
+			f.listen = true
 		}
 	}
 	return f
@@ -152,6 +155,8 @@ Options:
                       need to send a literal semicolon)
   --plugin <file>     Load a Lua plugin file on startup with full permissions
   --debug             Enable debug mode regardless of config setting
+  --listen            Start an HTTP command server on 127.0.0.1:4242
+                      (POST /exec accepts the same script format as --exec)
 
 Examples:
   ttt                                           Open current directory
@@ -346,6 +351,10 @@ Docs: https://tttedit.dev
 
 	if flags.exec != "" {
 		go app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
+	}
+
+	if flags.listen {
+		go app.StartListenServer(editor)
 	}
 
 	app.RunEventLoop(screen, renderer, editor, &running, editor.CloseTerminal)

--- a/docs-web/src/content/docs/guides/plugin-testing.md
+++ b/docs-web/src/content/docs/guides/plugin-testing.md
@@ -5,10 +5,11 @@ description: Drive plugins headlessly with --plugin and --exec to test them like
 
 TTT ships a scripted-interaction harness that lets you load a plugin, click and type through it, and read back both the rendered screen and the editor's internal state — all headless, in a single command, no real terminal required. It's the fastest way to develop and regression-test a plugin, and it's how the built-in plugins are tested.
 
-## The two flags
+## The flags
 
 - **`--plugin FILE`** loads a single Lua file as a plugin on startup, granted **all permissions** (no approval dialog). Use it to iterate on a plugin without installing it. `ttt.plugin_dir()` resolves to the file's directory.
 - **`--exec "commands"`** runs a semicolon-separated script after startup, then the editor exits. Combine with `--size WxH` for deterministic layout.
+- **`--listen`** starts an HTTP server on `127.0.0.1:4242` instead — `POST /exec` accepts the same script format, run synchronously against an **already-running** editor. Useful when a bug only reproduces from live, organic interaction and you want to capture a screenshot or debug dump at the moment it happens instead of scripting the repro in advance. See [Driving a running editor with `--listen`](#driving-a-running-editor-with---listen) below.
 
 ```sh
 bin/ttt --size 100x30 --plugin ./my-plugin/init.lua README.md \
@@ -31,7 +32,19 @@ The plugin's name (used for its panel id, `plugin.<name>`) is the Lua file's bas
 | `exec "Command Name"` | Run a command by its palette title |
 | `screenshot PATH` | Write the current screen (plain text) to a file |
 | `debug PATH` | Write the editor's full state as JSON to a file |
-| `quit` | Exit |
+| `quit` / `shutdown` | Exit |
+
+## Driving a running editor with `--listen`
+
+`--exec` only runs its script once, at startup, then exits. `--listen` keeps the editor running and lets you POST the same commands to it at any point:
+
+```sh
+bin/ttt --listen &
+curl -X POST --data "type hi; wait 100; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
+```
+
+This is for bugs that only show up during real, organic interaction (typing, clicking, a live child process in the integrated terminal) — you drive the editor by hand until the bug happens, then fire a `debug`/`screenshot` command over `--listen` to capture it, instead of trying to script the repro blind. The server binds to `127.0.0.1` only. Pass `?sep=` to use a separator other than `;`, mirroring `--exec-split-on`.
 
 ## Reading results: screen vs. state
 

--- a/internal/app/args_test.go
+++ b/internal/app/args_test.go
@@ -97,3 +97,14 @@ func TestResolveArgsFileLineCol(t *testing.T) {
 		t.Errorf("missing file keeps its literal name: got %+v", openFiles[2])
 	}
 }
+
+func TestResolveArgsIgnoresListenFlag(t *testing.T) {
+	saved := os.Args
+	defer func() { os.Args = saved }()
+	os.Args = []string{"ttt", "--listen"}
+
+	_, openFiles, _, _ := resolveArgs()
+	if len(openFiles) != 0 {
+		t.Errorf("--listen was treated as a file to open: %+v", openFiles)
+	}
+}

--- a/internal/app/debug_dump.go
+++ b/internal/app/debug_dump.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -25,7 +26,18 @@ type DebugState struct {
 	MultiCursor []DebugMultiCursor `json:"multi_cursor,omitempty"`
 	Diagnostics []DebugDiagnostic  `json:"diagnostics"`
 	Output      []string           `json:"output"`
+	Terminals   []DebugTerminal    `json:"terminals,omitempty"`
 	WidgetTree  *DebugWidgetNode   `json:"widget_tree"`
+}
+
+// DebugTerminal reports one integrated-terminal tab's raw PTY byte tail, so
+// a terminal-emulation bug can be diagnosed from what the child process
+// actually sent rather than from ttt's parsed/rendered state.
+type DebugTerminal struct {
+	ID      string `json:"id"`
+	Cols    int    `json:"cols"`
+	Rows    int    `json:"rows"`
+	RawTail string `json:"raw_tail"`
 }
 
 // DebugDiagnostic reports one diagnostic on the active editor (LSP or plugin),
@@ -217,6 +229,16 @@ func (a *App) BuildDebugState() *DebugState {
 		for _, line := range a.Output.Lines {
 			state.Output = append(state.Output, line.Time+" ["+line.PluginName+"] "+line.Message)
 		}
+	}
+
+	for _, tt := range a.Terminals {
+		cols, rows := tt.Term.Size()
+		state.Terminals = append(state.Terminals, DebugTerminal{
+			ID:      tt.ID,
+			Cols:    cols,
+			Rows:    rows,
+			RawTail: strconv.Quote(string(tt.Term.RawTail())),
+		})
 	}
 
 	state.WidgetTree = walkWidget(a.Root.Main)

--- a/internal/app/debug_dump.go
+++ b/internal/app/debug_dump.go
@@ -30,9 +30,8 @@ type DebugState struct {
 	WidgetTree  *DebugWidgetNode   `json:"widget_tree"`
 }
 
-// DebugTerminal reports one integrated-terminal tab's raw PTY byte tail, so
-// a terminal-emulation bug can be diagnosed from what the child process
-// actually sent rather than from ttt's parsed/rendered state.
+// DebugTerminal reports one integrated-terminal tab's raw, unparsed PTY byte
+// tail, so a terminal-emulation bug can be diagnosed from ground truth.
 type DebugTerminal struct {
 	ID      string `json:"id"`
 	Cols    int    `json:"cols"`

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -67,7 +67,7 @@ func RunExecScriptSep(a *App, script, sep string) {
 			a.Copy()
 		case "panel":
 			execPanel(a, args)
-		case "quit":
+		case "quit", "shutdown":
 			execQuit(a)
 		default:
 			slog.Error("exec_script: unknown command", "action", action)
@@ -355,6 +355,12 @@ Supported commands:
   wait MS            Wait milliseconds
   panel ID           Show and focus a bottom panel by ID
   quit               Exit the editor
+  shutdown           Alias for quit, for use over --listen
+
+--listen starts an HTTP command server on 127.0.0.1:4242 that accepts the
+same script format over POST /exec, so a running editor can be driven
+interactively instead of scripted in advance:
+  curl -X POST --data "type hi; screenshot /tmp/s1.txt" http://127.0.0.1:4242/exec
 
 Example:
   %s --exec "wait 200; screenshot /tmp/s1.txt; quit"`, os.Args[0])

--- a/internal/app/listen.go
+++ b/internal/app/listen.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ListenAddr is the bind address for the --listen HTTP command server.
+// Loopback-only: POST /exec runs arbitrary key/type/click input against the
+// running editor, so this must never be reachable off the local machine.
+const ListenAddr = "127.0.0.1:4242"
+
+// NewExecHandler returns the http.Handler backing the --listen server's
+// POST /exec endpoint. Split out from StartListenServer so tests can drive
+// it through httptest.Server without binding a real socket.
+func NewExecHandler(a *App) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/exec", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "failed to read body", http.StatusBadRequest)
+			return
+		}
+		script := string(body)
+		if strings.TrimSpace(script) == "" {
+			http.Error(w, "empty body", http.StatusBadRequest)
+			return
+		}
+		sep := r.URL.Query().Get("sep")
+		if sep == "" {
+			sep = DefaultExecSeparator
+		}
+		RunExecScriptSep(a, script, sep)
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "ok")
+	})
+	return mux
+}
+
+// StartListenServer starts the --listen HTTP command server. Blocks until
+// the listener fails, so callers run it in a goroutine.
+func StartListenServer(a *App) {
+	ln, err := net.Listen("tcp", ListenAddr)
+	if err != nil {
+		slog.Error("listen: failed to bind", "addr", ListenAddr, "error", err)
+		return
+	}
+	slog.Info("listen: HTTP command server started", "addr", ListenAddr)
+	if err := http.Serve(ln, NewExecHandler(a)); err != nil {
+		slog.Error("listen: server stopped", "error", err)
+	}
+}

--- a/internal/app/listen.go
+++ b/internal/app/listen.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -13,9 +14,11 @@ import (
 // running editor, so this must never be reachable off the local machine.
 const ListenAddr = "127.0.0.1:4242"
 
-// NewExecHandler returns the http.Handler backing the --listen server's
-// POST /exec endpoint. Split out from StartListenServer so tests can drive
-// it through httptest.Server without binding a real socket.
+const maxExecBodySize = 1 << 20 // 1MB
+
+// NewExecHandler is split out from StartListenServer so tests can drive it
+// through httptest.Server. Concurrent /exec requests are not synchronized:
+// --listen is a single-operator debug tool, not a public API.
 func NewExecHandler(a *App) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/exec", func(w http.ResponseWriter, r *http.Request) {
@@ -23,8 +26,14 @@ func NewExecHandler(a *App) http.Handler {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxExecBodySize)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			http.Error(w, "failed to read body", http.StatusBadRequest)
 			return
 		}

--- a/internal/app/listen_test.go
+++ b/internal/app/listen_test.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/render"
+	"github.com/eugenioenko/ttt/internal/term"
+)
+
+func newListenTestApp(t *testing.T) *App {
+	t.Helper()
+	a := buildTestApp(t, config.DefaultSettings())
+
+	sim := term.NewSimScreen()
+	if err := sim.Init(); err != nil {
+		t.Fatal(err)
+	}
+	sim.SetSize(80, 24)
+	a.Screen = term.NewTcellScreenFrom(sim)
+	a.Renderer = &render.Renderer{}
+	a.Reg = command.NewRegistry()
+	running := true
+	a.Running = &running
+	RegisterCommands(a)
+	a.Root.SetSize(80, 24)
+
+	return a
+}
+
+// execHandlerRequest posts body to the /exec endpoint served by NewExecHandler
+// and returns the response.
+func execHandlerRequest(t *testing.T, a *App, method, path, body string) *http.Response {
+	t.Helper()
+	srv := httptest.NewServer(NewExecHandler(a))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest(method, srv.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func TestExecHandlerRunsScriptSynchronously(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "quit")
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	// execQuit sets *a.Running = false before posting its interrupt event, so
+	// by the time RunExecScriptSep (and therefore the handler) returns, the
+	// script's effect is already observable -- proof it ran synchronously.
+	if *a.Running {
+		t.Error("expected quit script to have set Running to false")
+	}
+}
+
+func TestExecHandlerShutdownAliasesQuit(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "shutdown")
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if *a.Running {
+		t.Error("expected shutdown script to have set Running to false")
+	}
+}
+
+func TestExecHandlerRejectsEmptyBody(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "")
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestExecHandlerRejectsNonPost(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodGet, "/exec", "")
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestExecHandlerRespectsSepQueryParam(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec?sep=,", "wait 10,quit")
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if *a.Running {
+		t.Error("expected script split on custom separator to run both commands, including quit")
+	}
+}

--- a/internal/app/listen_test.go
+++ b/internal/app/listen_test.go
@@ -32,8 +32,6 @@ func newListenTestApp(t *testing.T) *App {
 	return a
 }
 
-// execHandlerRequest posts body to the /exec endpoint served by NewExecHandler
-// and returns the response.
 func execHandlerRequest(t *testing.T, a *App, method, path, body string) *http.Response {
 	t.Helper()
 	srv := httptest.NewServer(NewExecHandler(a))
@@ -87,6 +85,16 @@ func TestExecHandlerRejectsEmptyBody(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestExecHandlerRejectsOversizedBody(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", strings.Repeat("a", maxExecBodySize+1))
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
 	}
 }
 

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -118,6 +118,9 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 		if args[i] == "--debug" {
 			continue
 		}
+		if args[i] == "--listen" {
+			continue
+		}
 		if isPRURL(args[i]) {
 			if _, _, _, err := github.ParsePRURL(args[i]); err == nil {
 				prURLs = append(prURLs, args[i])

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -18,6 +18,10 @@ const (
 	AttrBlink     int16 = 32
 )
 
+// rawTailMax bounds the raw PTY byte tail kept for debugging — enough to
+// capture recent terminal-emulation bugs without growing unbounded.
+const rawTailMax = 64 * 1024
+
 type Terminal struct {
 	mu         sync.Mutex
 	vt         vt10x.Terminal
@@ -28,6 +32,7 @@ type Terminal struct {
 	started    bool
 	closed     bool
 	exited     bool
+	rawTail    []byte
 	OnUpdate   func()
 	OnExit     func()
 }
@@ -104,6 +109,7 @@ func (t *Terminal) readLoop() {
 		if n > 0 {
 			t.mu.Lock()
 			t.vt.Write(buf[:n])
+			t.appendRawTail(buf[:n])
 			t.mu.Unlock()
 			if t.OnUpdate != nil {
 				t.OnUpdate()
@@ -183,4 +189,23 @@ func (t *Terminal) Mode() vt10x.ModeFlag {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.vt.Mode()
+}
+
+// appendRawTail must be called with t.mu held.
+func (t *Terminal) appendRawTail(b []byte) {
+	t.rawTail = append(t.rawTail, b...)
+	if excess := len(t.rawTail) - rawTailMax; excess > 0 {
+		t.rawTail = append([]byte(nil), t.rawTail[excess:]...)
+	}
+}
+
+// RawTail returns the most recent bytes read from the PTY, independent of
+// how vt10x parsed and rendered them — ground truth for diagnosing
+// terminal-emulation bugs.
+func (t *Terminal) RawTail() []byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]byte, len(t.rawTail))
+	copy(out, t.rawTail)
+	return out
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -18,8 +18,6 @@ const (
 	AttrBlink     int16 = 32
 )
 
-// rawTailMax bounds the raw PTY byte tail kept for debugging — enough to
-// capture recent terminal-emulation bugs without growing unbounded.
 const rawTailMax = 64 * 1024
 
 type Terminal struct {
@@ -193,15 +191,18 @@ func (t *Terminal) Mode() vt10x.ModeFlag {
 
 // appendRawTail must be called with t.mu held.
 func (t *Terminal) appendRawTail(b []byte) {
-	t.rawTail = append(t.rawTail, b...)
-	if excess := len(t.rawTail) - rawTailMax; excess > 0 {
-		t.rawTail = append([]byte(nil), t.rawTail[excess:]...)
+	if len(b) >= rawTailMax {
+		t.rawTail = append(t.rawTail[:0], b[len(b)-rawTailMax:]...)
+		return
 	}
+	if excess := len(t.rawTail) + len(b) - rawTailMax; excess > 0 {
+		copy(t.rawTail, t.rawTail[excess:])
+		t.rawTail = t.rawTail[:len(t.rawTail)-excess]
+	}
+	t.rawTail = append(t.rawTail, b...)
 }
 
-// RawTail returns the most recent bytes read from the PTY, independent of
-// how vt10x parsed and rendered them — ground truth for diagnosing
-// terminal-emulation bugs.
+// RawTail returns the most recent bytes read from the PTY, unparsed by vt10x.
 func (t *Terminal) RawTail() []byte {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -218,3 +218,20 @@ func TestRawTailCapsAtMaxAndKeepsMostRecent(t *testing.T) {
 		t.Error("expected most recent bytes ('e') to be present")
 	}
 }
+
+func TestRawTailSingleWriteLargerThanMax(t *testing.T) {
+	term := &Terminal{}
+
+	big := append(bytes.Repeat([]byte{'x'}, rawTailMax), bytes.Repeat([]byte{'y'}, 10)...)
+	term.mu.Lock()
+	term.appendRawTail(big)
+	term.mu.Unlock()
+
+	got := term.RawTail()
+	if len(got) != rawTailMax {
+		t.Fatalf("RawTail() len = %d, want %d", len(got), rawTailMax)
+	}
+	if !bytes.HasSuffix(got, bytes.Repeat([]byte{'y'}, 10)) {
+		t.Error("expected the tail to keep the end of an oversized single write")
+	}
+}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"bytes"
 	"strings"
 	"sync"
 	"testing"
@@ -165,5 +166,55 @@ func TestWriteStringAndReadLoopUpdatesView(t *testing.T) {
 		case <-deadline:
 			t.Fatal("timed out waiting for shell output to appear in view")
 		}
+	}
+}
+
+func TestRawTailCapturesWrittenBytes(t *testing.T) {
+	term := newTestTerminal(t)
+	defer term.Close()
+
+	updated := make(chan struct{}, 100)
+	term.OnUpdate = func() {
+		select {
+		case updated <- struct{}{}:
+		default:
+		}
+	}
+	term.Run()
+
+	term.WriteString("echo raw_tail_marker\n")
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-updated:
+			if strings.Contains(string(term.RawTail()), "raw_tail_marker") {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for raw tail to capture shell output")
+		}
+	}
+}
+
+func TestRawTailCapsAtMaxAndKeepsMostRecent(t *testing.T) {
+	term := &Terminal{}
+
+	chunkSize := rawTailMax / 4
+	for _, b := range []byte("abcde") {
+		term.mu.Lock()
+		term.appendRawTail(bytes.Repeat([]byte{b}, chunkSize))
+		term.mu.Unlock()
+	}
+
+	got := term.RawTail()
+	if len(got) != rawTailMax {
+		t.Fatalf("RawTail() len = %d, want %d", len(got), rawTailMax)
+	}
+	if bytes.Contains(got, []byte{'a'}) {
+		t.Error("expected oldest bytes ('a') to have been trimmed")
+	}
+	if !bytes.Contains(got, []byte{'e'}) {
+		t.Error("expected most recent bytes ('e') to be present")
 	}
 }

--- a/tests/e2e/terminal_debug_test.go
+++ b/tests/e2e/terminal_debug_test.go
@@ -1,0 +1,69 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/app"
+)
+
+// TestTerminalDebugStateExposesRawPTYTail drives a real PTY through the
+// integrated terminal and confirms the `debug` command's JSON dump surfaces
+// the raw bytes the child process wrote, independent of ttt's own parsed
+// terminal state -- ground truth for diagnosing terminal-emulation bugs.
+func TestTerminalDebugStateExposesRawPTYTail(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+
+	// cat echoes whatever is written to the PTY, giving deterministic output.
+	h.app.Settings.Terminal.Shell = "/bin/cat"
+	h.exec("terminal.toggle")
+	if len(h.app.Terminals) != 1 {
+		t.Fatalf("expected 1 terminal after toggle, got %d", len(h.app.Terminals))
+	}
+	tab := h.app.Terminals[0]
+	defer tab.Term.Close()
+
+	const marker = "raw_tail_debug_marker"
+	tab.Term.WriteString(marker + "\n")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(string(tab.Term.RawTail()), marker) {
+		time.Sleep(30 * time.Millisecond)
+	}
+	if !strings.Contains(string(tab.Term.RawTail()), marker) {
+		t.Fatal("marker never appeared in raw tail")
+	}
+
+	path := filepath.Join(h.dir, "debug.json")
+	if err := h.app.DumpDebugState(path); err != nil {
+		t.Fatalf("DumpDebugState: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var state app.DebugState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("unmarshal debug state: %v", err)
+	}
+
+	if len(state.Terminals) != 1 {
+		t.Fatalf("expected 1 terminal in debug state, got %d", len(state.Terminals))
+	}
+	dt := state.Terminals[0]
+	if dt.ID != tab.ID {
+		t.Errorf("terminal ID = %q, want %q", dt.ID, tab.ID)
+	}
+	if dt.Cols == 0 || dt.Rows == 0 {
+		t.Errorf("terminal size = %dx%d, want nonzero", dt.Cols, dt.Rows)
+	}
+	if !strings.Contains(dt.RawTail, marker) {
+		t.Errorf("raw_tail = %q, want it to contain %q", dt.RawTail, marker)
+	}
+}


### PR DESCRIPTION
## Summary
- `--listen` starts a loopback-only (`127.0.0.1:4242`) HTTP server; `POST /exec` runs the same script format as `--exec`, synchronously, against an already-running editor — for capturing a repro at the exact moment it happens instead of scripting it in advance. `?sep=` mirrors `--exec-split-on`. Added a `shutdown` alias for `quit` for use over the endpoint.
- `Terminal` now keeps a bounded (64KB) tail of raw bytes read from the PTY, independent of `vt10x` parsing. Exposed via `RawTail()` and surfaced in the `debug` command's JSON dump as `terminals[].raw_tail` (one entry per integrated-terminal tab) — ground truth for diagnosing terminal-emulation bugs, since screenshots and existing debug state only show ttt's own interpretation.

Closes #469.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt` clean on touched files
- [x] `go test ./...` — added unit tests for `RawTail()` capture/capping (`internal/terminal`), an e2e test asserting `debug`'s JSON dump surfaces the raw tail for a live PTY terminal (`tests/e2e`), and `httptest`-backed unit tests for the `/exec` handler's request/response contract (`internal/app`)
- [x] `cd tests/functional && pnpm test` — 86 files, all passing
- [x] Manual smoke test: ran `bin/ttt --listen` under a pty (`script -qc`), curled `POST /exec` with `type hi; screenshot ...` and confirmed "hi" landed in the screenshot, verified `400` on empty body, `405` on non-POST, and `shutdown` exiting the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loopback-only HTTP command server, enabled with `--listen`, for controlling a running editor via `POST /exec`.
  * Added support for `shutdown` as an alternative to `quit`.
  * Added terminal diagnostics showing dimensions and recent raw terminal output.
  * Added support for custom command separators in HTTP requests.

* **Documentation**
  * Updated command-line help and usage examples for the new server, commands, and terminal diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->