### PR TITLE
fix(terminal): forward mouse click/wheel to PTY apps that enable mouse reporting

### DIFF
--- a/internal/ui/terminal_mouse_forward_test.go
+++ b/internal/ui/terminal_mouse_forward_test.go
@@ -1,0 +1,177 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/terminal"
+	"github.com/eugenioenko/vt10x"
+	"github.com/gdamore/tcell/v3"
+)
+
+func newUpdateChan(term *terminal.Terminal) chan struct{} {
+	updated := make(chan struct{}, 100)
+	term.OnUpdate = func() {
+		select {
+		case updated <- struct{}{}:
+		default:
+		}
+	}
+	return updated
+}
+
+func waitFor(t *testing.T, updated chan struct{}, cond func() bool) {
+	t.Helper()
+	if cond() {
+		return
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-updated:
+			if cond() {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for condition")
+		}
+	}
+}
+
+// newRawMouseLoopbackTerminal spawns the default shell, then drives it into
+// raw mode ("stty raw -echo") and execs cat in its place. A real full-screen
+// TUI always puts its PTY into raw/cbreak mode as one of the first things it
+// does — plain cat never does, so the PTY's line discipline would otherwise
+// stay in canonical (cooked) mode and buffer every write until a newline,
+// which would silently swallow the newline-less escape sequences this test
+// needs to round-trip (both the DECSET mode-enabling sequence and the SGR
+// mouse bytes TerminalWidget forwards). Once raw, cat echoes stdin to stdout
+// byte-for-byte and unbuffered, so anything TerminalWidget writes to the PTY
+// comes straight back through the read loop into RawTail() unmodified.
+func newRawMouseLoopbackTerminal(t *testing.T) (*terminal.Terminal, chan struct{}) {
+	t.Helper()
+	term, err := terminal.New("", 80, 24, 0, nil, "")
+	if err != nil {
+		t.Fatalf("terminal.New() error: %v", err)
+	}
+	term.Run()
+
+	updated := newUpdateChan(term)
+	term.WriteString("stty raw -echo; printf RAWOK; exec cat\n")
+	waitFor(t, updated, func() bool {
+		return strings.Contains(string(term.RawTail()), "RAWOK")
+	})
+	return term, updated
+}
+
+func enableSGRMouseMode(t *testing.T, term *terminal.Terminal, updated chan struct{}) {
+	t.Helper()
+	term.WriteString("\x1b[?1006h\x1b[?1000h")
+	waitFor(t, updated, func() bool {
+		return term.Mode()&vt10x.ModeMouseSgr != 0 && term.Mode()&vt10x.ModeMouseButton != 0
+	})
+}
+
+func TestTerminalWidget_ForwardsSGRMouseClickAndRelease(t *testing.T) {
+	term, updated := newRawMouseLoopbackTerminal(t)
+	defer term.Close()
+	enableSGRMouseMode(t, term, updated)
+
+	tw := NewTerminalWidget(term, &TerminalColorPalette{})
+	tw.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+
+	press := tcell.NewEventMouse(5, 3, tcell.Button1, tcell.ModNone)
+	if result := tw.HandleEvent(press); result != EventCaptured {
+		t.Fatalf("HandleEvent(press) = %v, want EventCaptured", result)
+	}
+	if tw.hasSelection {
+		t.Error("expected no local selection to start while mouse reporting is enabled")
+	}
+
+	waitFor(t, updated, func() bool {
+		return strings.Contains(string(term.RawTail()), "\x1b[<0;6;4M")
+	})
+
+	release := tcell.NewEventMouse(5, 3, tcell.ButtonNone, tcell.ModNone)
+	if result := tw.HandleEvent(release); result != EventConsumed {
+		t.Fatalf("HandleEvent(release) = %v, want EventConsumed", result)
+	}
+
+	waitFor(t, updated, func() bool {
+		return strings.Contains(string(term.RawTail()), "\x1b[<0;6;4m")
+	})
+
+	if tw.mouseButtonHeld != -1 {
+		t.Errorf("mouseButtonHeld = %d after release, want -1", tw.mouseButtonHeld)
+	}
+}
+
+func TestTerminalWidget_ForwardsSGRWheel(t *testing.T) {
+	term, updated := newRawMouseLoopbackTerminal(t)
+	defer term.Close()
+	enableSGRMouseMode(t, term, updated)
+
+	tw := NewTerminalWidget(term, &TerminalColorPalette{})
+	tw.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+
+	wheel := tcell.NewEventMouse(10, 10, tcell.WheelUp, tcell.ModNone)
+	if result := tw.HandleEvent(wheel); result != EventConsumed {
+		t.Fatalf("HandleEvent(wheel) = %v, want EventConsumed", result)
+	}
+	if tw.scrollOffset != 0 {
+		t.Errorf("scrollOffset = %d, want 0 — wheel should forward to the app, not scroll locally", tw.scrollOffset)
+	}
+
+	waitFor(t, updated, func() bool {
+		return strings.Contains(string(term.RawTail()), "\x1b[<64;11;11M")
+	})
+}
+
+func TestTerminalWidget_CtrlClickStaysLocalEvenWithMouseReporting(t *testing.T) {
+	term, updated := newRawMouseLoopbackTerminal(t)
+	defer term.Close()
+	enableSGRMouseMode(t, term, updated)
+
+	tw := NewTerminalWidget(term, &TerminalColorPalette{})
+	tw.SetRect(Rect{X: 0, Y: 0, W: 80, H: 24})
+
+	press := tcell.NewEventMouse(5, 3, tcell.Button1, tcell.ModCtrl)
+	if result := tw.HandleEvent(press); result != EventCaptured {
+		t.Fatalf("HandleEvent(ctrl+press) = %v, want EventCaptured", result)
+	}
+	if !tw.hasSelection {
+		t.Error("expected ctrl+click with no link to start local selection even though mouse reporting is enabled")
+	}
+}
+
+func TestTerminalWidget_WheelScrollsLocallyWithoutMouseReporting(t *testing.T) {
+	term, err := terminal.New("/bin/cat", 20, 5, 1000, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer term.Close()
+	term.Run()
+
+	for i := 0; i < 10; i++ {
+		term.WriteString("line\n")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for term.ScrollbackLen() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if term.ScrollbackLen() == 0 {
+		t.Fatalf("setup: expected live ScrollbackLen() > 0, got %d", term.ScrollbackLen())
+	}
+
+	tw := NewTerminalWidget(term, &TerminalColorPalette{})
+	tw.SetRect(Rect{X: 0, Y: 0, W: 20, H: 5})
+
+	wheel := tcell.NewEventMouse(10, 3, tcell.WheelUp, tcell.ModNone)
+	if result := tw.HandleEvent(wheel); result != EventConsumed {
+		t.Fatalf("HandleEvent(wheel) = %v, want EventConsumed", result)
+	}
+	if tw.scrollOffset == 0 {
+		t.Error("expected wheel to scroll locally when the app has not enabled mouse reporting")
+	}
+}

--- a/internal/ui/terminal_widget.go
+++ b/internal/ui/terminal_widget.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -65,12 +66,19 @@ type TerminalWidget struct {
 	ctrlHeld   bool
 	linkCache  map[int][]linkSpan
 	linkMemo   map[string][]linkSpan
+
+	// mouseButtonHeld is the SGR button code (0/1/2) of a press currently being
+	// forwarded to the PTY, or -1 when none is held. Needed to encode the
+	// matching release and to distinguish a drag (button held) from bare
+	// hover motion, which use different vt10x mouse-tracking modes.
+	mouseButtonHeld int
 }
 
 func NewTerminalWidget(t *terminal.Terminal, palette *TerminalColorPalette) *TerminalWidget {
 	return &TerminalWidget{
-		Term:    t,
-		Palette: palette,
+		Term:            t,
+		Palette:         palette,
+		mouseButtonHeld: -1,
 	}
 }
 
@@ -535,30 +543,71 @@ func (tw *TerminalWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		btn := tev.Buttons()
 		mx, my := tev.Position()
-		if btn&tcell.WheelUp != 0 {
-			tw.scrollUp(3)
+		mouseReporting := tw.Term.Mode()&vt10x.ModeMouseMask != 0
+
+		if btn&(tcell.WheelUp|tcell.WheelDown|tcell.WheelLeft|tcell.WheelRight) != 0 {
+			if mouseReporting {
+				if code, ok := sgrWheelCode(btn); ok {
+					col, row := tw.mousePTYCoords(mx, my)
+					tw.Term.WriteString(encodeSGRMouse(code|sgrModifiers(tev.Modifiers()), col, row, false))
+				}
+				return EventConsumed
+			}
+			switch {
+			case btn&tcell.WheelUp != 0:
+				tw.scrollUp(3)
+			case btn&tcell.WheelDown != 0:
+				tw.scrollDown(3)
+			}
 			return EventConsumed
 		}
-		if btn&tcell.WheelDown != 0 {
-			tw.scrollDown(3)
-			return EventConsumed
+
+		if btn&tcell.Button1 != 0 && tw.ctrlHeld {
+			pos := tw.screenToLine(mx, my)
+			if link := tw.linkAt(pos.Line, pos.Col); link != nil {
+				if link.IsFile && tw.OnOpenFile != nil {
+					tw.OnOpenFile(link.FilePath, link.Line, link.Col)
+				} else if !link.IsFile && tw.OnOpenURL != nil {
+					tw.OnOpenURL(link.URL)
+				}
+				return EventConsumed
+			}
+			// ctrl+click with no link underneath: fall through to local
+			// selection below, even if the app wants mouse reporting —
+			// ctrl+click is a ttt-level affordance, not something to forward.
 		}
-		if btn&(tcell.WheelLeft|tcell.WheelRight) != 0 {
-			return EventConsumed
-		}
-		if btn&tcell.Button1 != 0 {
-			if tw.ctrlHeld {
-				pos := tw.screenToLine(mx, my)
-				if link := tw.linkAt(pos.Line, pos.Col); link != nil {
-					if link.IsFile && tw.OnOpenFile != nil {
-						tw.OnOpenFile(link.FilePath, link.Line, link.Col)
-					} else if !link.IsFile && tw.OnOpenURL != nil {
-						tw.OnOpenURL(link.URL)
+
+		if mouseReporting && !tw.ctrlHeld {
+			if code, ok := sgrButtonCode(btn); ok {
+				held := tw.mouseButtonHeld == code
+				if !held || tw.Term.Mode()&(vt10x.ModeMouseMotion|vt10x.ModeMouseMany) != 0 {
+					sgrCode := code
+					if held {
+						sgrCode |= sgrMotionFlag
 					}
+					col, row := tw.mousePTYCoords(mx, my)
+					tw.Term.WriteString(encodeSGRMouse(sgrCode|sgrModifiers(tev.Modifiers()), col, row, false))
+				}
+				tw.mouseButtonHeld = code
+				return EventCaptured
+			}
+			if btn == tcell.ButtonNone {
+				if tw.mouseButtonHeld >= 0 {
+					col, row := tw.mousePTYCoords(mx, my)
+					tw.Term.WriteString(encodeSGRMouse(tw.mouseButtonHeld|sgrModifiers(tev.Modifiers()), col, row, true))
+					tw.mouseButtonHeld = -1
 					return EventConsumed
 				}
+				if tw.Term.Mode()&vt10x.ModeMouseMany != 0 {
+					col, row := tw.mousePTYCoords(mx, my)
+					tw.Term.WriteString(encodeSGRMouse(sgrButtonNone|sgrMotionFlag|sgrModifiers(tev.Modifiers()), col, row, false))
+					return EventConsumed
+				}
+				return EventIgnored
 			}
+		}
 
+		if btn&tcell.Button1 != 0 {
 			pos := tw.screenToLine(mx, my)
 			if !tw.selecting {
 				tw.selecting = true
@@ -581,6 +630,96 @@ func (tw *TerminalWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 
 	return EventIgnored
+}
+
+// SGR extended mouse mode (\x1b[<Cb;Cx;CyM/m, DECSET 1006) encoding. This is
+// the modern mouse-reporting encoding virtually every full-screen TUI that
+// asks for mouse input expects; legacy X10 encoding (byte-limited to 223
+// columns/rows) is intentionally not supported.
+const (
+	sgrButtonLeft   = 0
+	sgrButtonMiddle = 1
+	sgrButtonRight  = 2
+	sgrButtonNone   = 3 // "no button" motion code, used only with the motion flag
+	sgrWheelUp      = 64
+	sgrWheelDown    = 65
+	sgrWheelLeft    = 66
+	sgrWheelRight   = 67
+	sgrMotionFlag   = 32
+	sgrShiftMod     = 4
+	sgrAltMod       = 8
+	sgrCtrlMod      = 16
+)
+
+func sgrModifiers(mod tcell.ModMask) int {
+	m := 0
+	if mod&tcell.ModShift != 0 {
+		m |= sgrShiftMod
+	}
+	if mod&tcell.ModAlt != 0 {
+		m |= sgrAltMod
+	}
+	if mod&tcell.ModCtrl != 0 {
+		m |= sgrCtrlMod
+	}
+	return m
+}
+
+func sgrButtonCode(btn tcell.ButtonMask) (code int, ok bool) {
+	switch {
+	case btn&tcell.Button1 != 0:
+		return sgrButtonLeft, true
+	case btn&tcell.Button2 != 0:
+		return sgrButtonMiddle, true
+	case btn&tcell.Button3 != 0:
+		return sgrButtonRight, true
+	}
+	return 0, false
+}
+
+func sgrWheelCode(btn tcell.ButtonMask) (code int, ok bool) {
+	switch {
+	case btn&tcell.WheelUp != 0:
+		return sgrWheelUp, true
+	case btn&tcell.WheelDown != 0:
+		return sgrWheelDown, true
+	case btn&tcell.WheelLeft != 0:
+		return sgrWheelLeft, true
+	case btn&tcell.WheelRight != 0:
+		return sgrWheelRight, true
+	}
+	return 0, false
+}
+
+func encodeSGRMouse(code, col, row int, release bool) string {
+	suffix := byte('M')
+	if release {
+		suffix = 'm'
+	}
+	return fmt.Sprintf("\x1b[<%d;%d;%d%c", code, col, row, suffix)
+}
+
+// mousePTYCoords maps a screen position to 1-based coordinates within the
+// terminal's own column/row grid, clamped to its bounds.
+func (tw *TerminalWidget) mousePTYCoords(mx, my int) (col, row int) {
+	r := tw.GetRect()
+	col = mx - r.X + 1
+	row = my - r.Y + 1
+	if col < 1 {
+		col = 1
+	}
+	if row < 1 {
+		row = 1
+	}
+	if cols, rows := tw.Term.Size(); cols > 0 && rows > 0 {
+		if col > cols {
+			col = cols
+		}
+		if row > rows {
+			row = rows
+		}
+	}
+	return col, row
 }
 
 func (tw *TerminalWidget) ClearSelection() {


### PR DESCRIPTION
## Summary
- `TerminalWidget.HandleEvent` consumed all mouse input locally (selection, scrollback paging) no matter what the child app requested. vt10x already tracks DECSET mouse-tracking mode bits (`ModeMouseButton`/`ModeMouseMotion`/`ModeMouseMany`/`ModeMouseSgr`) via `Term.Mode()`, but nothing read them.
- Full-screen apps that do their own mouse handling — `btop`, Claude Code CLI and other Ink-based TUIs — never saw a click or wheel notch land, since it was swallowed by ttt's local selection/scroll instead.
- When `Term.Mode()&vt10x.ModeMouseMask != 0`, mouse press/release/wheel are now encoded as SGR (1006) sequences and written to the PTY instead. Motion (drag/hover) only forwards when `ModeMouseMotion`/`ModeMouseMany` is actually set, matching what each tracking mode is supposed to report.
- Plain shells and any app that never enables mouse reporting keep exactly today's local selection/scrollback behavior — no regression there.
- ctrl+click link-opening (and the local-selection fallback when there's no link under the cursor) stays local either way, per the issue's design note: it's a ttt-level affordance, not something to forward.
- The forwarded press returns `EventCaptured` (mirroring the existing local-selection capture) so a drag that leaves the terminal panel's rect still reaches the widget instead of getting silently dropped once the mouse crosses into another pane.

Base branch is `fix/terminal-panel-sizing-and-scrollbar` (#471) rather than `main` — #471 is explicitly blocked on this fix (Claude Code CLI's own scroll doesn't work end-to-end without it), so this stacks on top and both land together.

Fixes #472.

## Test plan
- [x] `go test ./...`
- [x] `cd tests/functional && pnpm test` (86 files, 287 passed / 27 expected-fail — same baseline as before)
- [x] `gofmt`/`go vet` clean on touched files
- [x] New regression tests in `internal/ui/terminal_mouse_forward_test.go`, using a real PTY with a raw-mode `cat` loopback (no mouse-aware binary needed): `TestTerminalWidget_ForwardsSGRMouseClickAndRelease`, `TestTerminalWidget_ForwardsSGRWheel`, `TestTerminalWidget_CtrlClickStaysLocalEvenWithMouseReporting`, `TestTerminalWidget_WheelScrollsLocallyWithoutMouseReporting`
- [x] Manually verified: ttt opened inside its own integrated terminal, mouse clicks now reach the nested instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)