### PR TITLE
feat(git): add an integrated review workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: tests/integration/pnpm-lock.yaml
 
-      - name: Install tui-use
-        run: npm install -g tui-use
-
       - name: Install test dependencies
         working-directory: tests/integration
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run integration tests
         working-directory: tests/integration
@@ -137,9 +134,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: tests/integration/pnpm-lock.yaml
 
-      - name: Install tui-use
-        run: npm install -g tui-use
-
       - name: Install LSP servers
         run: |
           go install golang.org/x/tools/gopls@latest
@@ -160,7 +154,7 @@ jobs:
 
       - name: Install test dependencies
         working-directory: tests/integration
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run LSP tests
         working-directory: tests/integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Lua plugins render UI in sidebar panels, bottom-panel tabs, drawers, and editor 
 | Method | Lua fields | Description |
 |---|---|---|
 | `p:label(text)` or `p:label({...})` | `text`, `style`, `badge`, `width`, borders | Static text line. `style` is a named style (see below). `border`/`border_top`/`border_bottom`/`border_left`/`border_right` draw borders. Supports box model. |
-| `p:title(text)` or `p:title({...})` | `text`, `badge`, `menu`, `on_menu(command)`, `icon`, `padded` | Bold section heading with optional right-aligned badge and dropdown menu. `menu` is `{label, command, separator}` tables; `icon` overrides the dropdown button (default `⋮`). Supports box model. |
+| `p:title(text)` or `p:title({...})` | `text`, `badge`, `menu`, `on_menu(command)`, `icon`, `padded` | Bold section heading with optional right-aligned badge and dropdown menu. `menu` is `{label, command, separator, checked}` tables; optional boolean `checked` reserves and controls a check indicator. `icon` overrides the dropdown button (default `⋮`). Supports box model. |
 | `p:tree({...})` | `items`, `indent` (default 2), `on_select`, `on_expand`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Expandable tree view. Items are `{id, label, icon, badge, muted, expandable, expanded, children}` tables. `key_commands` maps single chars to commands via `on_command`. `truncate_left` truncates overflowing labels from the left (`…tail`) so the end stays visible. |
 | `p:list({...})` | `items`, `on_select`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Flat list (backed by TreeWidget, no indentation). `truncate_left` keeps label tails visible on overflow. |
 | `p:button({...})` | `label`, `on_click` | Clickable button. Label is immutable after creation (accelerator parsing). |
@@ -126,10 +126,12 @@ Lua plugins render UI in sidebar panels, bottom-panel tabs, drawers, and editor 
 | `p:scrollview({...})` | `render(child_panel)` | Scrollable container. Wraps children with mouse wheel scrolling and scrollbar when content overflows. |
 | `p:box({...})` | `render(child_panel)`, `border` (+ per-side), `height` | Container with optional border and fixed height. Children via `render` callback. |
 | `p:divider()` | (none) | Horizontal divider line. Single-line separator, no configuration. |
-| `p:dropdown({...})` | `label`, `entries`, `on_menu(command)` | Dropdown menu button. `entries` are `{label, command, separator}` tables. |
+| `p:dropdown({...})` | `label`, `entries`, `on_menu(command)` | Dropdown menu button. `entries` are `{label, command, separator, checked}` tables; optional boolean `checked` reserves and controls a check indicator. |
 | `p:progress({...})` | `value` (0–1), `style`, `char` (default `▄`) | Horizontal progress bar. |
 | `p:table({...})` | `columns` (`{label, width, align}`), `rows` (arrays of strings), `on_select(row_idx)`, `on_command(cmd, row_idx)`, `node_menu`, `key_commands` | Data table with headers and row selection. Row indices are 1-based. |
 | `p:markdown(text)` or `p:markdown({...})` | `text` | Rendered markdown with selection/copy, auto-wrapped in a scrollview. Wraps at `markdown.wrapWidth` (default 80). |
+
+All menu-entry tables (`menu`, `entries`, and `node_menu`) accept `label`, `command`, `separator`, and optional boolean `checked`. Omitting `checked` keeps the menu indicator-free; `false` shows an unchecked slot and `true` shows a check.
 
 **Raw cell API** (low-level drawing; can be mixed with widgets — raw cells draw directly on the surface, widgets stack from the top over it):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ const { snapshots } = tui.run();
 expect(snapshots[s0]).toContain("hello");
 ```
 
-**Integration tests** (`tests/integration/`) — JavaScript tests using vitest + `tui-use` CLI that drive the binary via a real PTY. Used for tests that need live PTY interaction: LSP, external file changes, settings roundtrip, bracketed paste. Run with `cd tests/integration && pnpm test`. Requires `npm install -g tui-use`.
+**Integration tests** (`tests/integration/`) — JavaScript tests using vitest + the locally pinned `tui-use` CLI to drive the binary via a real PTY. Used for tests that need live PTY interaction: LSP, external file changes, settings roundtrip, bracketed paste. Run with `cd tests/integration && pnpm install && pnpm test`.
 
 ### Test expectations for new features
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Functional tests are the highest-value tests. Use `tui.exec("Command Name")` for
 **`--exec "commands"`** — Execute semicolon-separated commands after startup. Run the real binary, interact with it, capture state, and exit — all in one command:
 
 ```bash
-bin/ttt --size 120x40 --exec "wait 200; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
+bin/ttt --size 120x40 --exec "wait-for Explore; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
 cat /tmp/screen.txt   # see what's rendered
 cat /tmp/state.json   # see full widget tree, focus, selection, panels
 ```
@@ -217,14 +217,17 @@ Supported commands:
 - `screenshot PATH` — save screen text to file
 - `debug PATH` — save debug state JSON (screen, cursor, buffer, focus, panels, tabs, selection, output log, integrated-terminal raw PTY byte tails, full widget tree with rect/focus/props per node)
 - `wait MS` — wait milliseconds
+- `wait-for TEXT [timeout=MS]` — wait until text appears on the actual visible screen; defaults to a bounded 5000ms timeout. Quote text to preserve surrounding whitespace or escapes.
 - `panel ID` — show and focus a bottom panel by ID
 - `quit` / `shutdown` — exit the editor
+
+Every scripted input or main-thread action is acknowledged only after the event loop handles it and redraws. A following `wait-for`, `screenshot`, or `debug` therefore observes that completed visible state, not merely a posted event. Invalid/failed actions stop the script: CLI `--exec` exits nonzero with stderr, while `POST /exec` returns a non-2xx response and error body.
 
 **`--listen`** — Start an HTTP command server on `127.0.0.1:4242` (loopback-only — never exposed off the local machine). `POST /exec` runs the same script format as `--exec`, synchronously, against an **already-running** editor — for capturing a repro at the exact moment it happens instead of scripting it in advance:
 
 ```bash
 bin/ttt --listen &
-curl -X POST --data "type hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 
@@ -237,6 +240,8 @@ Pass `?sep=` to use a different command separator, mirroring `--exec-split-on`.
 **`--debug`** — Enable debug mode regardless of config setting.
 
 **`TTT_CONFIG_DIR` env var** — overrides the config directory entirely (settings, keybindings, themes, plugins, plugin registry). Always set this when running scripted `--exec` sessions that touch settings or plugins, so the developer's real `~/.config/ttt` is not read or mutated. The functional test harness (`tests/functional/tui.js`) sets it automatically.
+
+Headless `--exec` sessions use the process-local clipboard so parallel scripts cannot overwrite each other's or the developer's desktop clipboard. Interactive sessions, including `--listen`, retain system clipboard behavior.
 
 **Lua API equivalents** — Plugins can also call `ttt.screenshot(path)`, `ttt.debug(path)`, `ttt.click(x, y)`, and `ttt.quit()` directly.
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Sidebar search panel (Ctrl+K F) powered by [ripgrep](https://github.com/BurntSus
 
 Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 
+Changed files and files inside expanded commits use a compact directory tree by
+default. Consecutive single-child folders share one row; switch between **Tree**
+and full-path **List** views from the Options menu, command palette, or Settings.
+
 **Staging:**
 - **Spacebar** — toggle stage/unstage on the selected file
 - **`a`** — stage all unstaged files
@@ -524,7 +528,7 @@ Config files are loaded from `<exe-dir>/config/` (bundled defaults) or `~/.confi
 | [`keybindings.json`](config/keybindings.json) | Custom keybindings (VS Code key format) |
 | `themes/*.json` | Custom color themes |
 
-Most settings can be edited from a form instead of by hand: **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). The form is grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (explorer, terminal, search and plugin options live under Advanced). Changes are held until you press **Apply** (also **Settings: Apply Changes**), which writes `settings.json` and applies everything that does not need a restart; **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Settings marked *(restart)* take effect on next launch. LSP settings and external formatters are not exposed in the form — those stay JSON-only.
+Most settings can be edited from a form instead of by hand: **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). The form is grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (Git, explorer, terminal, search and plugin options live under Advanced). Changes are held until you press **Apply** (also **Settings: Apply Changes**), which writes `settings.json` and applies everything that does not need a restart; **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Settings marked *(restart)* take effect on next launch. LSP settings and external formatters are not exposed in the form — those stay JSON-only.
 
 To edit the raw files, use **Settings: Open settings.json** and **Settings: Open keybindings.json**.
 
@@ -552,6 +556,7 @@ To edit the raw files, use **Settings: Open settings.json** and **Settings: Open
 | `search.debounce` | int | `350` | Milliseconds to debounce global search input |
 | `explorer.showHidden` | bool | `true` | Show hidden files (dot-prefixed) in the file explorer |
 | `explorer.showGitIgnored` | bool | `true` | Show gitignored files in the file explorer |
+| `git.fileView` | string | `"tree"` | Show changed and historical commit files as a compact `"tree"` or full-path `"list"` |
 | `terminal.shell` | string | `""` | Shell command for the integrated terminal (empty = system default) |
 | `terminal.scrollback` | int | `1000` | Number of scrollback lines to retain in the terminal |
 | `lsp.saveOnRename` | bool | `false` | Auto-save all files affected by a rename operation |
@@ -583,6 +588,9 @@ Example `~/.config/ttt/settings.json` (also available at [`config/settings.json`
   "explorer": {
     "showHidden": true,
     "showGitIgnored": true
+  },
+  "git": {
+    "fileView": "tree"
   },
   "terminal": {
     "shell": "",

--- a/README.md
+++ b/README.md
@@ -170,9 +170,12 @@ Sidebar search panel (Ctrl+K F) powered by [ripgrep](https://github.com/BurntSus
 
 Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 
-Changed files and files inside expanded commits use a compact directory tree by
-default. Consecutive single-child folders share one row; switch between **Tree**
-and full-path **List** views from the Options menu, command palette, or Settings.
+Changed files and files inside expanded commits use a full-path **List** by
+default. Switch to the compact **Tree** from the Options menu, command palette,
+or Settings; explicit tree selections remain persisted.
+
+Diff layout, context, wrapping, and contrast defaults live in Options. The
+Changes panel three-dot menu keeps contextual access to the same settings.
 
 **Staging:**
 - **Spacebar** — toggle stage/unstage on the selected file
@@ -557,7 +560,7 @@ To edit the raw files, use **Settings: Open settings.json** and **Settings: Open
 | `search.debounce` | int | `350` | Milliseconds to debounce global search input |
 | `explorer.showHidden` | bool | `true` | Show hidden files (dot-prefixed) in the file explorer |
 | `explorer.showGitIgnored` | bool | `true` | Show gitignored files in the file explorer |
-| `git.fileView` | string | `"tree"` | Show changed and historical commit files as a compact `"tree"` or full-path `"list"` |
+| `git.fileView` | string | `"list"` | Show changed and historical commit files as a compact `"tree"` or full-path `"list"` |
 | `sidebar.panelOrder` | string[] | built-in order | Sidebar panel IDs in preferred header order; updated when headers are dragged |
 | `terminal.shell` | string | `""` | Shell command for the integrated terminal (empty = system default) |
 | `terminal.scrollback` | int | `1000` | Number of scrollback lines to retain in the terminal |
@@ -592,7 +595,7 @@ Example `~/.config/ttt/settings.json` (also available at [`config/settings.json`
     "showGitIgnored": true
   },
   "git": {
-    "fileView": "tree"
+    "fileView": "list"
   },
   "sidebar": {
     "panelOrder": ["explorer", "search", "changes", "outline"]

--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ To edit the raw files, use **Settings: Open settings.json** and **Settings: Open
 | `explorer.showHidden` | bool | `true` | Show hidden files (dot-prefixed) in the file explorer |
 | `explorer.showGitIgnored` | bool | `true` | Show gitignored files in the file explorer |
 | `git.fileView` | string | `"tree"` | Show changed and historical commit files as a compact `"tree"` or full-path `"list"` |
+| `sidebar.panelOrder` | string[] | built-in order | Sidebar panel IDs in preferred header order; updated when headers are dragged |
 | `terminal.shell` | string | `""` | Shell command for the integrated terminal (empty = system default) |
 | `terminal.scrollback` | int | `1000` | Number of scrollback lines to retain in the terminal |
 | `lsp.saveOnRename` | bool | `false` | Auto-save all files affected by a rename operation |
@@ -591,6 +592,9 @@ Example `~/.config/ttt/settings.json` (also available at [`config/settings.json`
   },
   "git": {
     "fileView": "tree"
+  },
+  "sidebar": {
+    "panelOrder": ["explorer", "search", "changes", "outline"]
   },
   "terminal": {
     "shell": "",

--- a/README.md
+++ b/README.md
@@ -742,7 +742,6 @@ Tests that require live PTY interaction — scenarios where something external h
 ```sh
 cd tests/integration
 pnpm install
-npm install -g tui-use
 pnpm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ TTT includes a built-in scripted interaction system designed for AI agent intera
 | `--size WxH` | Force screen dimensions (e.g. `120x40`) for deterministic layout |
 | `--debug` | Enable debug mode regardless of config |
 
-The `TTT_CONFIG_DIR` environment variable overrides the config directory (`~/.config/ttt`) entirely — settings, keybindings, themes, and plugins are read from and written to that directory instead. Use it to run scripted sessions isolated from your real configuration.
+The `TTT_CONFIG_DIR` environment variable overrides the config directory (`~/.config/ttt`) entirely — settings, keybindings, themes, and plugins are read from and written to that directory instead. Use it to run scripted sessions isolated from your real configuration. Headless `--exec` sessions also use a process-local clipboard so concurrent automation cannot overwrite the desktop clipboard; interactive sessions, including `--listen`, keep the system clipboard.
 
 ### `--exec` Commands
 
@@ -794,19 +794,22 @@ The `--exec` flag accepts a semicolon-separated string of commands that run sequ
 | `screenshot PATH` | Save the current screen text to a file |
 | `debug PATH` | Save the editor's debug state as JSON to a file |
 | `wait MS` | Wait for the given number of milliseconds |
+| `wait-for TEXT [timeout=MS]` | Wait until text appears on the visible screen (default timeout: 5000ms) |
 | `quit` / `shutdown` | Exit the editor |
+
+Quote `wait-for` text when it contains leading/trailing whitespace or escapes, for example `wait-for "Indexing complete" timeout=10000`. Scripted input and commands are acknowledged only after the main event loop handles and redraws them, so a following `wait-for`, `screenshot`, or `debug` observes their completed visible state. Invalid actions, missing commands/panels, capture failures, and wait timeouts stop the script: CLI `--exec` writes the error to stderr and exits nonzero; `POST /exec` returns a non-2xx response with the same detail.
 
 Example — capture a screenshot and debug state, then quit:
 
 ```sh
-ttt --size 120x40 --exec "wait 200; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
+ttt --size 120x40 --exec "wait-for Explore; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
 ```
 
 Example — drive an already-running editor over `--listen` instead of scripting in advance:
 
 ```sh
 ttt --listen &
-curl -X POST --data "type hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 

--- a/README.md
+++ b/README.md
@@ -349,18 +349,26 @@ TTT supports fully customizable themes via JSON files. You can change every colo
 
 #### Built-in Themes
 
-10 themes ship in [`internal/config/themes/`](internal/config/themes/):
+18 themes ship in [`internal/config/themes/`](internal/config/themes/):
 
 - Aurora
 - Bubblegum
 - Default Dark
 - Default Light
+- Dracula
+- High Contrast Dark
+- High Contrast Light
 - Hotline
 - Monokai
+- Nord
 - One Dark
+- Rainy Day
+- Rainy Day Dark
 - Solarized Dark
 - Solarized Light
+- Turbo Vision
 - Virtru Dark
+- Zenith
 
 <details>
 <summary>Default Dark theme (click to expand)</summary>
@@ -527,6 +535,9 @@ To edit the raw files, use **Settings: Open settings.json** and **Settings: Open
 | `tabSize` | int | `4` | Number of spaces per indentation level |
 | `insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `wordWrap` | bool | `false` | Wrap long lines at the editor width |
+| `diffMode` | string | `"split"` | Default diff layout: `"split"` or `"unified"` |
+| `diffWordWrap` | bool | `false` | Wrap long lines in diff views by default |
+| `diffHighContrast` | bool | `false` | Use semantic green/red foregrounds for changed diff text |
 | `autoIndent` | bool | `true` | Inherit the previous line's indent on Enter, plus one level after `{ ( [ :` (turn off for `noautoindent` behavior) |
 | `autoDedent` | bool | `true` | Dedent one level when typing a closing `} ) ]` on a blank line |
 | `lineNumbers` | bool | `true` | Show line numbers in the gutter |

--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ To edit the raw files, use **Settings: Open settings.json** and **Settings: Open
 | `insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `wordWrap` | bool | `false` | Wrap long lines at the editor width |
 | `diffMode` | string | `"split"` | Default diff layout: `"split"` or `"unified"` |
+| `diffContext` | string | `"changes"` | Default diff context: `"changes"` or the complete `"full"` file |
 | `diffWordWrap` | bool | `false` | Wrap long lines in diff views by default |
 | `diffHighContrast` | bool | `false` | Use semantic green/red foregrounds for changed diff text |
 | `autoIndent` | bool | `true` | Inherit the previous line's indent on Enter, plus one level after `{ ( [ :` (turn off for `noautoindent` behavior) |

--- a/README.md
+++ b/README.md
@@ -178,8 +178,13 @@ Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 - **`-` button** on the "Staged" section header — unstage all files in that section
 
 **Committing:**
-- Inline commit message input below the file list (Tab from the tree to focus it)
+- Inline commit message input above the file list (Tab from the tree to focus it)
 - Type a message and press Enter to commit all staged files
+
+**Commit history:**
+- Expand a commit to browse the files it changed; select a file to open its diff
+- Select the commit label to open its full message and all file diffs in a detail view
+- Collapse individual files or all files in the commit detail view
 
 **Remote operations:**
 - **Pull**, **Push**, **Sync** (pull then push) from the sidebar actions button
@@ -187,6 +192,7 @@ Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 
 **Diff view:**
 - Select a changed file to open a diff with syntax highlighting layered on diff backgrounds
+- Switch between unified and split modes, with optional line wrapping
 - Untracked files open directly in the editor
 
 **Multi-root:**
@@ -200,6 +206,7 @@ Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 - **Ctrl+K P** — opens quick file open (searches all files across workspace folders)
 - Type `>` in quick-open mode to switch to command mode
 - Delete the `>` in command mode to switch to file mode
+- Type `?` to browse searchable help for panels, navigation, and key chords
 - Menu shortcuts resolve dynamically from your keybindings
 
 ### Bottom Panel
@@ -366,6 +373,7 @@ TTT supports fully customizable themes via JSON files. You can change every colo
   "warning": { "fg": "#e2c08d" },
   "border":  { "fg": "#555555" },
   "statusBar": {},
+  "commitMessage": { "fg": "#fafafa", "bg": "#2a2f3a" },
   "tabs": {
     "active":   { "fg": "#ffffff", "bold": true },
     "inactive": { "fg": "#999999" }
@@ -395,7 +403,8 @@ TTT supports fully customizable themes via JSON files. You can change every colo
   "diff": {
     "added":    { "bg": "#1e2e1e" },
     "deleted":  { "bg": "#2e1e1e" },
-    "modified": { "bg": "#2e2e1e" }
+    "modified": { "bg": "#2e2e1e" },
+    "collapsed": { "fg": "#1f1f1f", "bg": "#8ab4d8", "bold": true }
   },
   "scrollbar": { "fg": "#999999", "bg": "#555555" },
   "syntax": {

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -73,6 +73,11 @@ type cliFlags struct {
 	listen       bool
 }
 
+type cliExecOutcome struct {
+	result app.ExecResult
+	err    error
+}
+
 func parseFlags() cliFlags {
 	var f cliFlags
 	args := os.Args[1:]
@@ -131,6 +136,13 @@ func initSimulationScreen(w, h int) *term.TcellScreen {
 }
 
 func main() {
+	exitCode := 0
+	defer func() {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	}()
+
 	for _, arg := range os.Args[1:] {
 		switch arg {
 		case "--help", "-h":
@@ -151,6 +163,8 @@ Options:
   --workspace <file>  Open a saved workspace (.ttt file)
   --config <file>     Use a custom config file
   --exec "commands"   Execute semicolon-separated commands after startup
+                      (wait-for TEXT [timeout=MS] waits for visible text;
+                      invalid or failed actions exit nonzero)
   --exec-split-on <s> Split --exec on <s> instead of ";" (for scripts that
                       need to send a literal semicolon)
   --plugin <file>     Load a Lua plugin file on startup with full permissions
@@ -198,6 +212,7 @@ Docs: https://tttedit.dev
 
 	var screen *term.TcellScreen
 	if flags.exec != "" {
+		clipboard.DisableSystem()
 		screen = initSimulationScreen(flags.sizeW, flags.sizeH)
 	} else {
 		screen = initTerminalScreen()
@@ -353,8 +368,16 @@ Docs: https://tttedit.dev
 		editor.LogOutput("info", "ttt", "Debug mode enabled")
 	}
 
+	var execOutcome chan cliExecOutcome
 	if flags.exec != "" {
-		go app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
+		execOutcome = make(chan cliExecOutcome, 1)
+		go func() {
+			result, err := app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
+			execOutcome <- cliExecOutcome{result: result, err: err}
+			if err != nil {
+				_ = app.StopExecLoop(editor)
+			}
+		}()
 	}
 
 	if flags.listen {
@@ -363,4 +386,14 @@ Docs: https://tttedit.dev
 	}
 
 	app.RunEventLoop(screen, renderer, editor, &running, editor.CloseTerminal)
+	if execOutcome != nil {
+		select {
+		case outcome := <-execOutcome:
+			if outcome.err != nil {
+				fmt.Fprintf(os.Stderr, "ttt: --exec failed after %d action(s): %v\n", outcome.result.Completed, outcome.err)
+				exitCode = 1
+			}
+		default:
+		}
+	}
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -25,7 +25,7 @@
     "showGitIgnored": true
   },
   "git": {
-    "fileView": "tree"
+    "fileView": "list"
   },
   "terminal": {
     "scrollback": 1000

--- a/config/settings.json
+++ b/config/settings.json
@@ -23,6 +23,9 @@
     "showHidden": true,
     "showGitIgnored": true
   },
+  "git": {
+    "fileView": "tree"
+  },
   "terminal": {
     "scrollback": 1000
   },

--- a/config/settings.json
+++ b/config/settings.json
@@ -5,6 +5,8 @@
     "tabSize": 4,
     "insertSpaces": true,
     "wordWrap": false,
+    "diffMode": "split",
+    "diffWordWrap": false,
     "lineNumbers": true,
     "formatOnSave": false,
     "insertFinalNewline": true,

--- a/config/settings.json
+++ b/config/settings.json
@@ -6,6 +6,7 @@
     "insertSpaces": true,
     "wordWrap": false,
     "diffMode": "split",
+    "diffContext": "changes",
     "diffWordWrap": false,
     "lineNumbers": true,
     "formatOnSave": false,

--- a/docs-web/src/content/docs/guides/git.md
+++ b/docs-web/src/content/docs/guides/git.md
@@ -41,7 +41,7 @@ TTT offers two diff modes:
 - **Partial diff view** shows only the changed hunks with surrounding context lines, letting you focus on what actually changed.
 - **Full-file diff view** shows the complete file with changes highlighted inline.
 
-You can toggle between partial and full-file diff views to get the level of detail you need.
+Choose the default layout, context, and line wrapping from the Options menu. The Changes panel's three-dot menu keeps the same controls close to the files they affect. Collapsed context rows use a triangle in the line-number gutter; click one to reveal its omitted lines.
 
 Untracked files open directly in the editor instead of showing a diff.
 

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -1209,10 +1209,11 @@ Used in `actions` (sidebar header menu), `node_menu` (tree/list context menu), a
 | `label`     | string  | yes*     | Display text of the menu item.          |
 | `command`   | string  | yes*     | Command identifier passed to the callback. |
 | `separator` | boolean | no       | If `true`, renders as a separator line instead of an item. When `true`, `label` and `command` are ignored. |
+| `checked`   | boolean | no       | If provided, reserves a check indicator: `true` shows a checkmark and `false` shows an empty slot. Omit it to keep the indicator and its spacing hidden. |
 
 ```lua
 {
-  { label = "Start", command = "start" },
+  { label = "Start", command = "start", checked = true },
   { label = "Stop", command = "stop" },
   { separator = true },
   { label = "Remove", command = "remove" },

--- a/docs-web/src/content/docs/guides/plugin-testing.md
+++ b/docs-web/src/content/docs/guides/plugin-testing.md
@@ -23,6 +23,7 @@ The plugin's name (used for its panel id, `plugin.<name>`) is the Lua file's bas
 | Command | Description |
 |---------|-------------|
 | `wait MS` | Pause (let timers, async callbacks, and renders settle) |
+| `wait-for TEXT [timeout=MS]` | Wait until text is visible on screen (default timeout: 5000ms) |
 | `panel ID` | Open a bottom-panel tab by id (e.g. `panel output`, `panel plugin.init`) |
 | `key COMBO` | Press a key or chord (`key enter`, `key ctrl+k p`, `key tab`) |
 | `type TEXT` | Type a string |
@@ -34,13 +35,15 @@ The plugin's name (used for its panel id, `plugin.<name>`) is the Lua file's bas
 | `debug PATH` | Write the editor's full state as JSON to a file |
 | `quit` / `shutdown` | Exit |
 
+Prefer `wait-for` when a visible state has a reliable text marker. Quote text that contains whitespace or escapes: `wait-for "Indexing complete" timeout=10000`. Scripted input and commands are acknowledged after the main event loop handles and redraws them, so the condition checks the rendered screen rather than whether an event was merely posted. Invalid actions and timeouts stop the script; CLI `--exec` exits nonzero with stderr and `POST /exec` returns a non-2xx response with the error.
+
 ## Driving a running editor with `--listen`
 
 `--exec` only runs its script once, at startup, then exits. `--listen` keeps the editor running and lets you POST the same commands to it at any point:
 
 ```sh
 bin/ttt --listen &
-curl -X POST --data "type hi; wait 100; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 
@@ -75,6 +78,8 @@ TTT_CONFIG_DIR=/tmp/ttt-test bin/ttt --plugin ./init.lua --exec "..."
 ```
 
 Always do this in any automated test — a scripted run of a settings-toggling command will otherwise persist into your real config.
+
+Headless `--exec` sessions use a process-local clipboard, so parallel scripts cannot overwrite the desktop clipboard or each other's copied text. Interactive sessions, including `--listen`, continue to use the system clipboard.
 
 ## Testing a scoped plugin (with a manifest)
 

--- a/docs-web/src/content/docs/guides/themes.md
+++ b/docs-web/src/content/docs/guides/themes.md
@@ -80,6 +80,10 @@ Below is a complete theme file showing every configurable section. All color val
     "fg": "#75715e"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#f8f8f2",
+    "bg": "#34352d"
+  },
   "tabs": {
     "active": {
       "fg": "#f8f8f2",
@@ -149,6 +153,11 @@ Below is a complete theme file showing every configurable section. All color val
     },
     "modified": {
       "bg": "#2e2e1a"
+    },
+    "collapsed": {
+      "fg": "#272822",
+      "bg": "#66d9ef",
+      "bold": true
     }
   },
   "scrollbar": {
@@ -234,12 +243,13 @@ Below is a complete theme file showing every configurable section. All color val
 | `success`, `danger`, `warning` | Semantic colors used for status indicators and messages |
 | `border` | Color for UI borders and dividers |
 | `statusBar` | Status bar at the bottom of the editor |
+| `commitMessage` | Commit message block in the commit detail view |
 | `tabs` | Active and inactive editor tab colors |
 | `sidebar` | File explorer sidebar: section headers, items, and selected item |
 | `dialog` | Command palette and dialog boxes: input field, items, selection, muted text |
 | `editor` | Editor pane: line numbers, active line highlight, selection, search matches, and bracket pair colors. `bracketColors` accepts terminal color names (`yellow`, `magenta`, `cyan`, `red`, `green`, `blue`, `black`, `white`, `brightRed`, `brightGreen`, `brightYellow`, `brightBlue`, `brightMagenta`, `brightCyan`, `brightBlack`, `brightWhite`), syntax style names (`keyword`, `function`, `type`, `comment`, `string`, `number`, `operator`, `builtin`, `variable`, `punctuation`, `tag`, `attribute`), or hex colors (`#rrggbb`). Up to 6 colors cycle by nesting depth. |
 | `menu` | Menu bar dropdown items and active/hovered item |
-| `diff` | Diff view background colors for added, deleted, and modified lines |
+| `diff` | Diff view colors for added, deleted, and modified lines, plus `collapsed` region separators |
 | `scrollbar` | Scrollbar thumb (`fg`) and track (`bg`) colors |
 | `syntax` | Syntax highlighting colors for language tokens |
 | `terminal` | ANSI color palette for the integrated terminal (16 colors) |

--- a/docs-web/src/content/docs/guides/themes.md
+++ b/docs-web/src/content/docs/guides/themes.md
@@ -32,6 +32,8 @@ TTT ships with a collection of built-in themes:
 
 Use **View > Switch Theme** from the menu bar, or search for **Switch Theme** in the command palette (**Ctrl+P**), to open the theme picker. The picker shows a live preview of each theme as you navigate the list, so you can try them out before committing to one.
 
+**Built-in Default** is the code-defined fallback used when `theme` is omitted. It includes the default syntax palette and now appears in both the settings selector and live theme picker. The separate **Default Dark** entry is a regular bundled JSON theme.
+
 ## Customizing
 
 To create a custom theme, copy one of the built-in theme files to your themes directory and edit it:

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -36,6 +36,7 @@ All editor settings are nested under the `editor` key.
 | `editor.insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `editor.wordWrap` | bool | `false` | Wrap long lines at the editor width |
 | `editor.diffMode` | string | `"split"` | Default diff layout: `"split"` or `"unified"` |
+| `editor.diffContext` | string | `"changes"` | Default diff context: `"changes"` or the complete `"full"` file |
 | `editor.diffWordWrap` | bool | `false` | Wrap long lines in diff views by default |
 | `editor.diffHighContrast` | bool | `false` | Use semantic green/red foregrounds for added/deleted text while retaining diff backgrounds |
 | `editor.autoIndent` | bool | `true` | Inherit the previous line's indent on Enter, plus one level after `{ ( [ :` (turn off for `noautoindent` behavior) |
@@ -163,6 +164,9 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
     "trimTrailingWhitespace": false,
     "focusOnOpen": false,
     "syntaxHighlight": true,
+    "diffMode": "split",
+    "diffContext": "changes",
+    "diffWordWrap": false,
     "diffHighContrast": false,
     "gitGutter": true,
     "menuBar": true,

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -11,7 +11,7 @@ Settings are stored in `~/.config/ttt/settings.json`. A complete example is avai
 
 There are two ways to change settings:
 
-- **Settings editor** — **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). Opens a form in an editor tab, grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (explorer, terminal, search and plugin options live under Advanced). Edits are held until you press **Apply** (also available as **Settings: Apply Changes**), which writes `settings.json` and live-applies everything that does not require a restart. **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Rows marked *(restart)* only take effect on next launch.
+- **Settings editor** — **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). Opens a form in an editor tab, grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (Git, explorer, terminal, search and plugin options live under Advanced). Edits are held until you press **Apply** (also available as **Settings: Apply Changes**), which writes `settings.json` and live-applies everything that does not require a restart. **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Rows marked *(restart)* only take effect on next launch.
 - **Raw JSON** — **Settings: Open settings.json** opens the file itself. Needed for the `lsp` settings and `formatters`, neither of which is exposed in the form.
 
 Closing the settings tab with unapplied edits discards them.
@@ -59,6 +59,12 @@ All editor settings are nested under the `editor` key.
 |-----|------|---------|-------------|
 | `explorer.showHidden` | bool | `true` | Show hidden files (dot-prefixed) in the file explorer |
 | `explorer.showGitIgnored` | bool | `true` | Show gitignored files in the file explorer |
+
+## Git
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `git.fileView` | string | `"tree"` | Show working-tree and expanded commit files as a compact `"tree"` or a full-path `"list"` |
 
 ## Terminal
 
@@ -164,6 +170,9 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
   "explorer": {
     "showHidden": true,
     "showGitIgnored": true
+  },
+  "git": {
+    "fileView": "tree"
   },
   "terminal": {
     "shell": "/bin/zsh",

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -66,6 +66,12 @@ All editor settings are nested under the `editor` key.
 |-----|------|---------|-------------|
 | `git.fileView` | string | `"tree"` | Show working-tree and expanded commit files as a compact `"tree"` or a full-path `"list"` |
 
+## Sidebar
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `sidebar.panelOrder` | string[] | built-in order | Preferred sidebar panel-header order. Dragging a header or using **Move Panel Left/Right** updates it automatically. Unknown plugin panel IDs are retained for when that plugin loads. |
+
 ## Terminal
 
 | Key | Type | Default | Description |
@@ -173,6 +179,9 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
   },
   "git": {
     "fileView": "tree"
+  },
+  "sidebar": {
+    "panelOrder": ["explorer", "search", "changes", "outline"]
   },
   "terminal": {
     "shell": "/bin/zsh",

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -35,6 +35,9 @@ All editor settings are nested under the `editor` key.
 | `editor.tabSize` | int | `4` | Number of spaces per indentation level |
 | `editor.insertSpaces` | bool | `true` | Use spaces instead of tabs for indentation |
 | `editor.wordWrap` | bool | `false` | Wrap long lines at the editor width |
+| `editor.diffMode` | string | `"split"` | Default diff layout: `"split"` or `"unified"` |
+| `editor.diffWordWrap` | bool | `false` | Wrap long lines in diff views by default |
+| `editor.diffHighContrast` | bool | `false` | Use semantic green/red foregrounds for added/deleted text while retaining diff backgrounds |
 | `editor.autoIndent` | bool | `true` | Inherit the previous line's indent on Enter, plus one level after `{ ( [ :` (turn off for `noautoindent` behavior) |
 | `editor.autoDedent` | bool | `true` | Dedent one level when typing a closing `} ) ]` on a blank line |
 | `editor.lineNumbers` | bool | `true` | Show line numbers in the gutter |
@@ -148,6 +151,7 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
     "trimTrailingWhitespace": false,
     "focusOnOpen": false,
     "syntaxHighlight": true,
+    "diffHighContrast": false,
     "gitGutter": true,
     "menuBar": true,
     "gutterStyle": "compact",

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -65,7 +65,7 @@ All editor settings are nested under the `editor` key.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `git.fileView` | string | `"tree"` | Show working-tree and expanded commit files as a compact `"tree"` or a full-path `"list"` |
+| `git.fileView` | string | `"list"` | Show working-tree and expanded commit files as a compact `"tree"` or a full-path `"list"` |
 
 ## Sidebar
 
@@ -182,7 +182,7 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
     "showGitIgnored": true
   },
   "git": {
-    "fileView": "tree"
+    "fileView": "list"
   },
   "sidebar": {
     "panelOrder": ["explorer", "search", "changes", "outline"]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -98,6 +98,7 @@ type App struct {
 	commandLine          *ui.CommandLineWidget
 	commandLinePrevFocus ui.Widget
 	settingsView         *settingsView
+	currentChangesLoads  map[string]*currentChangesLoadState
 	// appliedSettings is the last value ApplySettings acted on. Callers routinely
 	// mutate a.Settings before calling it, so a.Settings cannot serve as "before".
 	appliedSettings config.Settings
@@ -425,6 +426,7 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		a.Changes.Screen = screen
 		a.Changes.OnRefreshed = func() {
 			a.Sidebar.SetPanelDirty("changes", a.Changes.TotalChanges() > 0)
+			a.refreshActiveCurrentChanges()
 		}
 	}
 	if a.Repository != nil {
@@ -456,6 +458,7 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	a.EditorGroup.OnContentTabClose = func(id string) {
 		a.cleanupPluginDetailTab(id)
 		a.cleanupSettingsTab(id)
+		a.cleanupCurrentChangesTab(id)
 	}
 	if path := a.EditorGroup.ActiveFilePath(); path != "" {
 		if a.EditorGroup.Editor != nil && a.EditorGroup.Editor.Highlighter != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -63,6 +63,7 @@ type App struct {
 	AutocompleteTimer      *time.Timer
 	HoverTimer             *time.Timer
 	HoverGen               uint64
+	diffOpenGen            int
 	LastHoverLine          int
 	LastHoverCol           int
 	Problems               *ui.ProblemsWidget
@@ -410,6 +411,17 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	a.Renderer = renderer
 	a.LspManager = lspManager
 	a.StartWatcher()
+
+	// Handing the panel the screen is what moves its git reads off the event
+	// path; until now it has been reading inline. Refresh once so the first
+	// scan goes through the same path everything after it will.
+	if a.Changes != nil {
+		a.Changes.Screen = screen
+		a.Changes.OnRefreshed = func() {
+			a.Sidebar.SetPanelDirty("changes", a.Changes.TotalChanges() > 0)
+		}
+		a.Changes.Refresh()
+	}
 
 	a.EditorGroup.OnError = func(msg string) {
 		a.StatusError(msg)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -73,6 +73,7 @@ type App struct {
 	Explorer               *NavigationPanel
 	ExplorerContextNode    *widgets.TreeNode
 	Changes                *ChangesPanel
+	Repository             *RepositoryState
 	Symbols                *SymbolsPanel
 	Reg                    *command.Registry
 	Running                *bool
@@ -132,12 +133,14 @@ func (a *App) ShowSidebar() {
 		a.SplitPanel.DividerPos = ui.DefaultSidebarWidth
 	}
 	a.applySearchHighlights()
+	a.syncRepositoryObservation()
 }
 
 func (a *App) HideSidebar() {
 	a.Sidebar.Visible = false
 	a.SplitPanel.ShowLeft = false
 	a.EditorGroup.ClearSearch()
+	a.syncRepositoryObservation()
 }
 
 func (a *App) applySearchHighlights() {
@@ -310,7 +313,11 @@ func (a *App) refreshWorkspaceWidgets() {
 	a.Explorer.SetRoots(paths)
 
 	a.Search.SetWorkDirs(paths)
-	a.Changes.SetDirs(paths)
+	if a.Repository != nil {
+		a.Repository.SetDirs(paths)
+	} else {
+		a.Changes.SetDirs(paths)
+	}
 }
 
 func (a *App) refreshProblems() {
@@ -412,15 +419,18 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	a.LspManager = lspManager
 	a.StartWatcher()
 
-	// Handing the panel the screen is what moves its git reads off the event
-	// path; until now it has been reading inline. Refresh once so the first
-	// scan goes through the same path everything after it will.
+	// Repository state owns Git observation and returns completed reads through
+	// the same event-loop boundary as the rest of the asynchronous application.
 	if a.Changes != nil {
 		a.Changes.Screen = screen
 		a.Changes.OnRefreshed = func() {
 			a.Sidebar.SetPanelDirty("changes", a.Changes.TotalChanges() > 0)
 		}
-		a.Changes.Refresh()
+	}
+	if a.Repository != nil {
+		a.Repository.SetPoster(screen)
+		a.Repository.Start()
+		a.syncRepositoryObservation()
 	}
 
 	a.EditorGroup.OnError = func(msg string) {

--- a/internal/app/app_lsp.go
+++ b/internal/app/app_lsp.go
@@ -534,11 +534,9 @@ func (a *App) ApplyWorkspaceEdit(edit *lsp.WorkspaceEdit) {
 		a.ApplyTextEdits(edits)
 
 		if a.Settings.LSP.SaveOnRename {
-			a.EditorGroup.Save()
-			if a.EditorGroup.Editor != nil && a.EditorGroup.Editor.Highlighter != nil {
-				lang := a.EditorGroup.Editor.Highlighter.Language()
-				text := strings.Join(a.EditorGroup.Editor.Buf.Lines, "\n")
-				a.NotifyLSPSave(path, lang, text)
+			if a.EditorGroup.Save() {
+				_, lang := a.editorPathLang()
+				a.afterFileSave(path, lang)
 			}
 		}
 	}

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -625,15 +625,17 @@ func registerWidgetCallbacks(app *App) {
 			ui.ContextMenuItem{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
 		)
 		if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
-			cmd := "diff.extendedView"
-			label := "Extended Diff"
-			if dv.IsExtended() {
-				cmd = "diff.compactView"
-				label = "Compact Diff"
+			changesChecked := ui.MenuUnchecked
+			fullChecked := ui.MenuUnchecked
+			if dv.ContextMode() == ui.DiffContextFullFile {
+				fullChecked = ui.MenuChecked
+			} else {
+				changesChecked = ui.MenuChecked
 			}
 			tabContextMenu = append(tabContextMenu,
 				ui.MenuSep(),
-				ui.ContextMenuItem{Label: label, Command: cmd},
+				ui.ContextMenuItem{Label: "Changes Only", Command: "diff.changesOnlyView", Checked: changesChecked},
+				ui.ContextMenuItem{Label: "Full File", Command: "diff.fullFileView", Checked: fullChecked},
 			)
 		}
 		openContextMenu(app, tabContextMenu, sx, sy)

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -70,11 +70,7 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			for _, p := range a.PluginManager.Plugins() {
 				if a.Sidebar.ActivePanel == "plugin."+p.Name && len(p.SidebarMenuEntries) > 0 {
 					for _, e := range p.SidebarMenuEntries {
-						items = append(items, ui.ContextMenuItem{
-							Label:   e.Label,
-							Command: e.Command,
-							IsSep:   e.Separator,
-						})
+						items = append(items, contextMenuItemFromWidgetEntry(e))
 					}
 					break
 				}
@@ -207,32 +203,31 @@ func (a *App) ApplySearchReplaceAll(allMatches map[string][]ui.SearchMatch, repl
 }
 
 func (a *App) openSelectedDiff(extended bool) {
-	g := a.Changes.SelectedGroup()
-	if g != nil {
-	} else {
-	}
-	if g != nil && g.IsPR {
-		_, status, ok := a.Changes.SelectedFile()
-		if ok && a.Changes.OnOpenPRDiff != nil {
-			a.Changes.OnOpenPRDiff(g, status, extended)
-		} else {
-		}
-	} else {
-		dir, status, ok := a.Changes.SelectedFile()
-		if ok && a.Changes.OnOpenDiff != nil {
-			a.Changes.OnOpenDiff(dir, status, extended)
-		} else {
-		}
-	}
+	a.Changes.OpenSelectedDiff(extended)
 }
 
+// OpenChangeDiff shows a working-tree file's changes against HEAD. The reads
+// run in the background: git diff on a large file is slow enough that doing it
+// from the click handler freezes the editor.
 func (a *App) OpenChangeDiff(dir string, status git.FileStatus, extended bool) {
 	fullPath := filepath.Join(dir, status.Path)
 	if status.Status == "?" {
+		// Untracked: nothing to diff against, and no git to wait for.
 		a.EditorGroup.OpenFile(fullPath)
 		a.FocusEditorIfEnabled()
 		return
 	}
+	a.startDiffOpen(func() *DiffOpenResult {
+		return readChangeDiff(dir, status, fullPath, extended)
+	})
+}
+
+func readChangeDiff(dir string, status git.FileStatus, fullPath string, extended bool) *DiffOpenResult {
+	// Falling back to the plain file is what this path has always done when
+	// there is no usable diff — an unreadable one, an empty one, or one git
+	// produced with no hunks in it.
+	fallback := &DiffOpenResult{OpenPath: fullPath}
+
 	var diffText string
 	var err error
 	if status.Status == "R" && status.OldPath != "" {
@@ -241,33 +236,87 @@ func (a *App) OpenChangeDiff(dir string, status git.FileStatus, extended bool) {
 		diffText, err = git.DiffFile(dir, status.Path)
 	}
 	if err != nil || diffText == "" {
-		a.EditorGroup.OpenFile(fullPath)
-		a.FocusEditorIfEnabled()
-		return
+		return fallback
 	}
 	parsed := diff.Parse(diffText)
 	if len(parsed.Hunks) == 0 {
-		a.EditorGroup.OpenFile(fullPath)
-		a.FocusEditorIfEnabled()
-		return
+		return fallback
 	}
-	var oldLines, newLines []string
-	oldContent, err := git.ShowFile(dir, status.Path, "HEAD")
-	if err == nil {
-		oldLines = strings.Split(oldContent, "\n")
-		if len(oldLines) > 0 && oldLines[len(oldLines)-1] == "" {
-			oldLines = oldLines[:len(oldLines)-1]
-		}
+
+	var newLines []string
+	if newData, err := os.ReadFile(fullPath); err == nil {
+		newLines = splitFileLines(string(newData))
 	}
-	newData, err := os.ReadFile(fullPath)
-	if err == nil {
-		newLines = strings.Split(string(newData), "\n")
-		if len(newLines) > 0 && newLines[len(newLines)-1] == "" {
-			newLines = newLines[:len(newLines)-1]
-		}
+	return &DiffOpenResult{
+		TabName:  status.Path + " (diff)",
+		Path:     status.Path,
+		Diff:     parsed,
+		OldLines: gitFileLines(dir, status.Path, "HEAD"),
+		NewLines: newLines,
+		Extended: extended,
 	}
-	a.EditorGroup.OpenDiff(status.Path, parsed, oldLines, newLines, extended)
-	a.FocusEditorIfEnabled()
+}
+
+// OpenCommitDiff shows what one commit did to one file. Unlike OpenChangeDiff
+// neither side comes from the worktree: both are read out of git at the commit
+// and its first parent.
+func (a *App) OpenCommitDiff(dir, ref, short string, status git.FileStatus, extended bool) {
+	a.startDiffOpen(func() *DiffOpenResult {
+		return readCommitDiff(dir, ref, short, status, extended)
+	})
+}
+
+func readCommitDiff(dir, ref, short string, status git.FileStatus, extended bool) *DiffOpenResult {
+	diffText, err := git.CommitFileDiff(dir, ref, status)
+	if err != nil {
+		return &DiffOpenResult{Warn: fmt.Sprintf("Could not read %s at %s", status.Path, short)}
+	}
+	parsed := diff.Parse(diffText)
+	if len(parsed.Hunks) == 0 {
+		// A pure rename or a mode change carries no hunks at all.
+		return &DiffOpenResult{Warn: fmt.Sprintf("No line changes for %s in %s", status.Path, short)}
+	}
+
+	// Both reads are allowed to fail: an added file has no parent blob, a
+	// deleted one has no blob at the commit, and a root commit has no parent at
+	// all. OpenDiffTab renders the hunks alone in that case, exactly as PR
+	// diffs do.
+	oldPath := status.Path
+	if status.OldPath != "" {
+		oldPath = status.OldPath
+	}
+	return &DiffOpenResult{
+		// The key uses the full hash so it stays put as the abbreviation grows;
+		// the label uses the short one because that is what the panel shows.
+		TabName:  fmt.Sprintf("%s:%s (diff)", ref, status.Path),
+		Title:    fmt.Sprintf("%s @ %s", filepath.Base(status.Path), short),
+		Path:     status.Path,
+		Diff:     parsed,
+		OldLines: gitFileLines(dir, oldPath, ref+"^"),
+		NewLines: gitFileLines(dir, status.Path, ref),
+		Extended: extended,
+	}
+}
+
+func splitFileLines(content string) []string {
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// gitFileLines reads a blob at a ref, returning nil when it does not exist.
+func gitFileLines(dir, path, ref string) []string {
+	content, err := git.ShowFile(dir, path, ref)
+	if err != nil {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
 }
 
 func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
@@ -402,6 +451,10 @@ func (a *App) ConfirmDiscard(message string, onConfirm func()) {
 
 func registerWidgetCallbacks(app *App) {
 	reg := app.Reg
+	// Any foreground navigation supersedes a diff read that has not landed yet.
+	// Put invalidation on the editor group's active-content boundary so direct
+	// callers such as plugins cannot bypass it.
+	app.EditorGroup.OnActiveContentChange = app.cancelPendingDiff
 
 	for i := range menuBarMenus {
 		idx := i
@@ -591,6 +644,8 @@ func registerWidgetCallbacks(app *App) {
 	app.Changes.OnOpenPRDiff = func(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
 		app.OpenPRDiff(group, status, extended)
 	}
+	app.Changes.OnOpenCommitDiff = app.OpenCommitDiff
+	app.Changes.OnOpenCommit = app.OpenCommitDetail
 	app.Changes.OnPRGroupMenu = app.ShowPRGroupMenu
 	app.Changes.OnRefreshPR = app.FetchAndOpenPR
 	app.Changes.OnGroupMenu = app.ShowGroupMenu

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -43,17 +43,7 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			{Label: "Help", Command: "search.help"},
 		}
 	case "changes":
-		items = []ui.ContextMenuItem{
-			{Label: "Refresh", Command: "changes.refresh"},
-			ui.MenuSep(),
-			{Label: "Pull", Command: "git.pull"},
-			{Label: "Push", Command: "git.push"},
-			{Label: "Sync", Command: "git.sync"},
-			ui.MenuSep(),
-			{Label: "Open PR Diff", Command: "pr.openDiff"},
-			ui.MenuSep(),
-			{Label: "Help", Command: "changes.help"},
-		}
+		items = a.BuildChangesPanelMenu()
 	case "outline":
 		items = []ui.ContextMenuItem{
 			{Label: "Refresh", Command: "sidebar.outline"},
@@ -79,6 +69,22 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 	}
 	if len(items) > 0 {
 		openContextMenu(a, items, sx, sy)
+	}
+}
+
+func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
+	return []ui.ContextMenuItem{
+		{Label: "Refresh", Command: "changes.refresh"},
+		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
+		{Label: "Diff View", Submenu: a.BuildDiffViewOptions()},
+		ui.MenuSep(),
+		{Label: "Pull", Command: "git.pull"},
+		{Label: "Push", Command: "git.push"},
+		{Label: "Sync", Command: "git.sync"},
+		ui.MenuSep(),
+		{Label: "Open PR Diff", Command: "pr.openDiff"},
+		ui.MenuSep(),
+		{Label: "Help", Command: "changes.help"},
 	}
 }
 

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -203,6 +203,7 @@ func (a *App) ApplySearchReplace(filePath string, matches []ui.SearchMatch, repl
 		a.StatusWarn("Cannot write file: " + err.Error())
 		return
 	}
+	a.invalidateRepositoryPath(filePath, RepositoryStatus)
 	a.EditorGroup.ReloadFile(filePath)
 	a.Search.Refresh()
 	a.StatusNotify(fmt.Sprintf("Replaced %d matches in %s", len(matches), filepath.Base(filePath)))
@@ -232,6 +233,7 @@ func (a *App) ApplySearchReplaceAll(allMatches map[string][]ui.SearchMatch, repl
 				if err := os.WriteFile(filePath, []byte(strings.Join(newLines, "\n")+"\n"), 0644); err != nil {
 					continue
 				}
+				a.invalidateRepositoryPath(filePath, RepositoryStatus)
 				a.EditorGroup.ReloadFile(filePath)
 			}
 			a.Search.Refresh()
@@ -548,9 +550,7 @@ func registerWidgetCallbacks(app *App) {
 		} else {
 			app.EditorGroup.ClearSearch()
 		}
-		if id == "changes" {
-			app.Changes.Refresh()
-		}
+		app.syncRepositoryObservation()
 		if id == "outline" {
 			app.RefreshSymbols()
 		}
@@ -708,6 +708,21 @@ func registerWidgetCallbacks(app *App) {
 	app.Changes.OnCommit = app.CommitChanges
 	app.Changes.OnConfirmDiscard = app.ConfirmDiscard
 	app.Changes.OnError = app.StatusError
+	app.Changes.OnRefresh = func() {
+		if app.Repository != nil {
+			app.Repository.RefreshNow(RepositoryStatus | RepositoryHistory)
+		} else {
+			app.Changes.Refresh()
+		}
+	}
+	app.Changes.OnStatusChanged = func() {
+		app.invalidateAllRepositories(RepositoryStatus)
+	}
+	app.Changes.OnHistoryResult = func(err error) {
+		if app.Repository != nil {
+			app.Repository.HandleHistory(err)
+		}
+	}
 
 	app.ContentSplit.OnResize = func(height int) {
 		if height <= 0 {

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -84,6 +84,8 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 
 func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
+		{Label: "View All Changes", Command: "changes.viewAll"},
+		ui.MenuSep(),
 		{Label: "Refresh", Command: "changes.refresh"},
 		ui.MenuSep(),
 		{Label: "Expand All", Command: "changes.expandAll"},
@@ -106,6 +108,8 @@ func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 // to the tree while leaving network and PR operations in the panel menu.
 func (a *App) BuildChangesContextMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
+		{Label: "View All Changes", Command: "changes.viewAll"},
+		ui.MenuSep(),
 		{Label: "Refresh", Command: "changes.refresh"},
 		ui.MenuSep(),
 		{Label: "Expand All", Command: "changes.expandAll"},
@@ -498,7 +502,10 @@ func registerWidgetCallbacks(app *App) {
 	// Any foreground navigation supersedes a diff read that has not landed yet.
 	// Put invalidation on the editor group's active-content boundary so direct
 	// callers such as plugins cannot bypass it.
-	app.EditorGroup.OnActiveContentChange = app.cancelPendingDiff
+	app.EditorGroup.OnActiveContentChange = func() {
+		app.cancelPendingDiff()
+		app.syncRepositoryObservation()
+	}
 
 	for i := range menuBarMenus {
 		idx := i

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -67,6 +67,13 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			}
 		}
 	}
+	moveItems := a.sidebarMoveMenuItems()
+	if len(moveItems) > 0 {
+		if len(items) > 0 && !items[len(items)-1].IsSep {
+			items = append(items, ui.MenuSep())
+		}
+		items = append(items, moveItems...)
+	}
 	if len(items) > 0 {
 		openContextMenu(a, items, sx, sy)
 	}
@@ -489,6 +496,7 @@ func registerWidgetCallbacks(app *App) {
 	app.Sidebar.Tabs.Config.Actions = []widgets.TabAction{
 		{Icon: "⋮", OnClick: app.ShowSidebarMoreMenu},
 	}
+	app.Sidebar.OnPanelReorder = app.persistSidebarPanelOrder
 
 	app.Sidebar.Tabs.Config.OnOverflow = func(sx, sy int) {
 		ids, titles := app.Sidebar.HiddenTabs()

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -25,6 +25,9 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			{Label: "Add Folder", Command: "workspace.addFolder"},
 			{Label: "Refresh", Command: "explorer.refresh"},
 			ui.MenuSep(),
+			{Label: "Expand All", Command: "explorer.expandAll"},
+			{Label: "Collapse All", Command: "explorer.collapseAll"},
+			ui.MenuSep(),
 			{Label: "Help", Command: "explorer.help"},
 		}
 	case "search":
@@ -82,6 +85,10 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
 		{Label: "Refresh", Command: "changes.refresh"},
+		ui.MenuSep(),
+		{Label: "Expand All", Command: "changes.expandAll"},
+		{Label: "Collapse All", Command: "changes.collapseAll"},
+		ui.MenuSep(),
 		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
 		{Label: "Diff View", Submenu: a.BuildDiffViewOptions()},
 		ui.MenuSep(),
@@ -93,6 +100,24 @@ func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 		ui.MenuSep(),
 		{Label: "Help", Command: "changes.help"},
 	}
+}
+
+// BuildChangesContextMenu keeps the structural and presentation actions close
+// to the tree while leaving network and PR operations in the panel menu.
+func (a *App) BuildChangesContextMenu() []ui.ContextMenuItem {
+	return []ui.ContextMenuItem{
+		{Label: "Refresh", Command: "changes.refresh"},
+		ui.MenuSep(),
+		{Label: "Expand All", Command: "changes.expandAll"},
+		{Label: "Collapse All", Command: "changes.collapseAll"},
+		ui.MenuSep(),
+		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
+		{Label: "Diff View", Submenu: a.BuildDiffViewOptions()},
+	}
+}
+
+func (a *App) ShowChangesContextMenu(sx, sy int) {
+	openContextMenu(a, a.BuildChangesContextMenu(), sx, sy)
 }
 
 func (a *App) DiffSearchSources() []ui.DiffSearchSource {
@@ -409,9 +434,11 @@ func (a *App) ShowPRGroupMenu(group *ui.ChangesGroup, sx, sy int) {
 		},
 	})
 	items := []ui.ContextMenuItem{
-		{Label: "Refresh", Command: refreshID},
+		{Label: "Refresh PR", Command: refreshID},
 		{Label: "Close", Command: closeID},
 	}
+	items = append(items, ui.MenuSep())
+	items = append(items, a.BuildChangesContextMenu()...)
 	openContextMenu(a, items, sx, sy)
 }
 
@@ -422,6 +449,8 @@ func (a *App) ShowGroupMenu(dir string, sx, sy int) {
 		{Label: "Push", Command: "git.push." + dir},
 		{Label: "Sync", Command: "git.sync." + dir},
 	}
+	items = append(items, ui.MenuSep())
+	items = append(items, a.BuildChangesContextMenu()...)
 	registerDirGitCmd := func(id, title string, ops []RepoOp, progress, done string) {
 		reg.Register(command.Command{
 			ID: id, Title: title,
@@ -649,12 +678,17 @@ func registerWidgetCallbacks(app *App) {
 	app.Search.OnReplaceAll = app.ApplySearchReplaceAll
 
 	app.Changes.OnRightClick = func(dir string, status git.FileStatus, sx, sy int) {
+		var items []ui.ContextMenuItem
 		if status.Staged {
-			openContextMenu(app, changesContextMenuStaged, sx, sy)
+			items = append(items, changesContextMenuStaged...)
 		} else {
-			openContextMenu(app, changesContextMenuUnstaged, sx, sy)
+			items = append(items, changesContextMenuUnstaged...)
 		}
+		items = append(items, ui.MenuSep())
+		items = append(items, app.BuildChangesContextMenu()...)
+		openContextMenu(app, items, sx, sy)
 	}
+	app.Changes.OnPanelMenu = app.ShowChangesContextMenu
 
 	app.Changes.OnOpenFile = func(path string) {
 		app.EditorGroup.OpenFile(path)

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -571,15 +571,23 @@ func registerWidgetCallbacks(app *App) {
 		}
 		tabContextMenu := []ui.ContextMenuItem{
 			{Label: pinLabel, Shortcut: app.KeyFor("tab.pin"), Command: "tab.pin"},
-			ui.MenuSep(),
-			{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
-			{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
-			{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
-			{Label: "Close All Saved", Shortcut: "", Command: "tab.closeAllSaved"},
-			ui.MenuSep(),
-			{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
-			{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
 		}
+		if app.EditorGroup.CanMoveActiveTab(-1) {
+			tabContextMenu = append(tabContextMenu, ui.ContextMenuItem{Label: "Move Tab Left", Command: "tab.moveLeft"})
+		}
+		if app.EditorGroup.CanMoveActiveTab(1) {
+			tabContextMenu = append(tabContextMenu, ui.ContextMenuItem{Label: "Move Tab Right", Command: "tab.moveRight"})
+		}
+		tabContextMenu = append(tabContextMenu,
+			ui.MenuSep(),
+			ui.ContextMenuItem{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
+			ui.ContextMenuItem{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
+			ui.ContextMenuItem{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
+			ui.ContextMenuItem{Label: "Close All Saved", Shortcut: "", Command: "tab.closeAllSaved"},
+			ui.MenuSep(),
+			ui.ContextMenuItem{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
+			ui.ContextMenuItem{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
+		)
 		if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
 			cmd := "diff.extendedView"
 			label := "Extended Diff"

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/git"
@@ -31,7 +33,10 @@ type eventPoster interface {
 }
 
 // commitLogLimit is how many commits the log shows.
-const commitLogLimit = 10
+const (
+	commitLogLimit   = 10
+	commitLogTimeout = 10 * time.Second
+)
 
 // ChangesStatusResult carries a finished working-tree scan.
 type ChangesStatusResult struct {
@@ -45,6 +50,7 @@ type CommitLogResult struct {
 	Dir     string
 	Branch  string
 	Entries []git.LogEntry
+	Err     error
 }
 
 // CommitFilesResult carries the file list of a single commit back to the node
@@ -71,34 +77,12 @@ type CommitDetailResult struct {
 }
 
 func readChangesGroups(dirs []string) []changesGroup {
-	var groups []changesGroup
-	seen := make(map[string]bool)
-	for _, dir := range dirs {
-		if root := git.RepoRoot(dir); root != "" {
-			dir = root
-		}
-		if seen[dir] {
-			continue
-		}
-		seen[dir] = true
-		files, err := git.StatusFiles(dir)
-		if err != nil {
-			files = nil
-		}
-		var staged, unstaged []git.FileStatus
-		for _, f := range files {
-			if f.Staged {
-				staged = append(staged, f)
-			} else {
-				unstaged = append(unstaged, f)
-			}
-		}
-		groups = append(groups, changesGroup{
-			Dir:      dir,
-			Name:     filepath.Base(dir),
-			Staged:   staged,
-			Unstaged: unstaged,
-		})
+	ctx, cancel := context.WithTimeout(context.Background(), repositoryStatusTimeout)
+	defer cancel()
+	entries := scanRepositoryStatus(ctx, dirs)
+	groups := make([]changesGroup, 0, len(entries))
+	for _, entry := range entries {
+		groups = append(groups, entry.Group)
 	}
 	return groups
 }
@@ -110,23 +94,41 @@ func (cp *ChangesPanel) ApplyStatus(r *ChangesStatusResult) {
 	if r.Gen != cp.statusGen {
 		return
 	}
+	cp.applyWorkingTree(r.Groups)
+	cp.RefreshHistory()
+}
+
+// applyWorkingTree installs only disk/index status. It preserves the currently
+// rendered commit log unless the selected repository itself changed. The App's
+// repository-state coordinator owns history invalidation for HEAD changes.
+func (cp *ChangesPanel) applyWorkingTree(groups []changesGroup) {
 	cp.saveExpanded()
-	cp.groups = r.Groups
+	cp.groups = groups
 	cp.multiRoot = len(cp.groups)+len(cp.PRGroups) > 1
 	cp.buildTree()
-	cp.lastLogDir = ""
-	cp.refreshCommitLog()
 	if cp.OnRefreshed != nil {
 		cp.OnRefreshed()
 	}
 }
 
 func readCommitLog(dir string, gen int) *CommitLogResult {
+	ctx, cancel := context.WithTimeout(context.Background(), commitLogTimeout)
+	defer cancel()
+	return readCommitLogContext(ctx, dir, gen)
+}
+
+func readCommitLogContext(ctx context.Context, dir string, gen int) *CommitLogResult {
+	entries, err := git.LogWithErrorContext(ctx, dir, commitLogLimit)
+	branch, branchErr := git.BranchNameContext(ctx, dir)
+	if err == nil && branchErr != nil && len(entries) > 0 {
+		err = branchErr
+	}
 	return &CommitLogResult{
 		Gen:     gen,
 		Dir:     dir,
-		Branch:  git.BranchName(dir),
-		Entries: git.Log(dir, commitLogLimit),
+		Branch:  branch,
+		Entries: entries,
+		Err:     err,
 	}
 }
 
@@ -135,6 +137,19 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 	// Both checks, not one: the counter catches a superseded read, and the
 	// directory catches a counter that agrees for some reason it should not.
 	if r.Gen != cp.logGen || r.Dir != cp.lastLogDir {
+		return
+	}
+	cp.logCancel = nil
+	if r.Err != nil {
+		// Preserve the rendered history and make the selected root retryable on
+		// the next repository observation.
+		cp.lastLogDir = ""
+		if cp.OnError != nil {
+			cp.OnError("Could not refresh commit history: " + r.Err.Error())
+		}
+		if cp.OnHistoryResult != nil {
+			cp.OnHistoryResult(r.Err)
+		}
 		return
 	}
 	name := filepath.Base(r.Dir)
@@ -184,6 +199,9 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 		nodes = append(nodes, node)
 	}
 	cp.CommitLog.SetItems(nodes)
+	if cp.OnHistoryResult != nil {
+		cp.OnHistoryResult(nil)
+	}
 
 	// Restore by identity, never by the index SetItems happened to preserve.
 	// Committing prepends rows, and rewriting history can remove them entirely;

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -32,10 +32,13 @@ type eventPoster interface {
 	PostEvent(tcell.Event) error
 }
 
-// commitLogLimit is how many commits the log shows.
+// Commit history starts with a useful window and grows only when requested.
+// The tree already renders just its visible rows, so paging bounds Git and
+// memory work without adding a second navigation model to the sidebar.
 const (
-	commitLogLimit   = 10
-	commitLogTimeout = 10 * time.Second
+	commitLogPageSize  = 50
+	commitLogTimeout   = 10 * time.Second
+	historyLoadOlderID = "history:load-older"
 )
 
 // ChangesStatusResult carries a finished working-tree scan.
@@ -49,6 +52,10 @@ type CommitLogResult struct {
 	Gen     int
 	Dir     string
 	Branch  string
+	Anchor  string
+	Offset  int
+	Append  bool
+	HasMore bool
 	Entries []git.LogEntry
 	Err     error
 }
@@ -68,12 +75,13 @@ type CommitFilesResult struct {
 // one immutable commit. Dir and Ref are the result identity; ApplyCommitDetail
 // only installs it into the loading tab created for that exact pair.
 type CommitDetailResult struct {
-	Dir     string
-	Ref     string
-	Short   string
-	Message string
-	Files   []ui.CommitDetailFile
-	Err     string
+	Dir        string
+	Ref        string
+	Short      string
+	Message    string
+	AuthoredAt time.Time
+	Files      []ui.CommitDetailFile
+	Err        string
 }
 
 func readChangesGroups(dirs []string) []changesGroup {
@@ -118,17 +126,26 @@ func readCommitLog(dir string, gen int) *CommitLogResult {
 }
 
 func readCommitLogContext(ctx context.Context, dir string, gen int) *CommitLogResult {
-	entries, err := git.LogWithErrorContext(ctx, dir, commitLogLimit)
+	anchor, err := git.HeadSHAContext(ctx, dir)
+	page := git.LogPage{}
+	if err == nil {
+		page, err = git.LogPageContext(ctx, dir, anchor, 0, commitLogPageSize)
+	}
 	branch, branchErr := git.BranchNameContext(ctx, dir)
-	if err == nil && branchErr != nil && len(entries) > 0 {
+	if err == nil && branchErr != nil && len(page.Entries) > 0 {
 		err = branchErr
 	}
 	return &CommitLogResult{
-		Gen:     gen,
-		Dir:     dir,
-		Branch:  branch,
-		Entries: entries,
-		Err:     err,
+		Gen: gen, Dir: dir, Branch: branch, Anchor: anchor,
+		HasMore: page.HasMore, Entries: page.Entries, Err: err,
+	}
+}
+
+func readCommitLogPageContext(ctx context.Context, dir, anchor string, offset, gen int) *CommitLogResult {
+	page, err := git.LogPageContext(ctx, dir, anchor, offset, commitLogPageSize)
+	return &CommitLogResult{
+		Gen: gen, Dir: dir, Anchor: anchor, Offset: offset, Append: true,
+		HasMore: page.HasMore, Entries: page.Entries, Err: err,
 	}
 }
 
@@ -140,6 +157,10 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 		return
 	}
 	cp.logCancel = nil
+	if r.Append {
+		cp.applyCommitLogPage(r)
+		return
+	}
 	if r.Err != nil {
 		// Preserve the rendered history and make the selected root retryable on
 		// the next repository observation.
@@ -164,6 +185,10 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 	// of — and so does switching to another root and back.
 	cp.saveCommitLogState()
 	cp.logDir = r.Dir
+	cp.logAnchor = r.Anchor
+	cp.logLoaded = len(r.Entries)
+	cp.logHasMore = r.HasMore
+	cp.logPagePending = false
 	selected := cp.logSelected[r.Dir]
 	cp.logCommits = make(map[string]commitFileRef)
 	cp.logFiles = make(map[string]commitFileRef)
@@ -172,7 +197,7 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 	if r.Branch != "" {
 		branchLabel = fmt.Sprintf("%s · %s", name, r.Branch)
 	}
-	nodes := make([]*widgets.TreeNode, 0, len(r.Entries)+1)
+	nodes := make([]*widgets.TreeNode, 0, len(r.Entries)+2)
 	nodes = append(nodes, &widgets.TreeNode{
 		ID:    "branch",
 		Label: branchLabel,
@@ -180,23 +205,10 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 		Muted: true,
 	})
 	for _, e := range r.Entries {
-		// Keyed on the full hash: the abbreviation git prints can change length
-		// as the repo grows, which would silently orphan both the expansion
-		// state below and the file cache.
-		id := "commit:" + e.Ref
-		cp.logCommits[id] = commitFileRef{Dir: r.Dir, Ref: e.Ref, Short: e.Hash}
-		node := &widgets.TreeNode{
-			ID:         id,
-			Label:      e.Message,
-			Icon:       "●",
-			Badge:      e.Hash,
-			Expandable: true,
-		}
-		if cp.logExpanded[id] {
-			node.Expanded = true
-			node.Children = cp.commitChildren(r.Dir, e.Ref, e.Hash, id)
-		}
-		nodes = append(nodes, node)
+		nodes = append(nodes, cp.commitLogNode(r.Dir, e))
+	}
+	if r.HasMore {
+		nodes = append(nodes, historyLoadOlderNode(false))
 	}
 	cp.CommitLog.SetItems(nodes)
 	if cp.OnHistoryResult != nil {
@@ -229,6 +241,66 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 	}
 	delete(cp.logSelected, r.Dir)
 	cp.CommitLog.SetSelectedIndex(0)
+}
+
+func (cp *ChangesPanel) commitLogNode(dir string, e git.LogEntry) *widgets.TreeNode {
+	// Keyed on the full hash: the abbreviation git prints can change length as
+	// the repo grows, which would silently orphan expansion state and caches.
+	id := "commit:" + e.Ref
+	cp.logCommits[id] = commitFileRef{Dir: dir, Ref: e.Ref, Short: e.Hash}
+	node := &widgets.TreeNode{
+		ID: id, Label: e.Message, Icon: "●", Badge: e.Hash, Expandable: true,
+	}
+	if cp.logExpanded[id] {
+		node.Expanded = true
+		node.Children = cp.commitChildren(dir, e.Ref, e.Hash, id)
+	}
+	return node
+}
+
+func historyLoadOlderNode(loading bool) *widgets.TreeNode {
+	label := "Load older commits…"
+	if loading {
+		label = "Loading older commits…"
+	}
+	return &widgets.TreeNode{ID: historyLoadOlderID, Label: label, Icon: "↓", Muted: true}
+}
+
+func (cp *ChangesPanel) applyCommitLogPage(r *CommitLogResult) {
+	cp.logPagePending = false
+	if r.Anchor != cp.logAnchor || r.Offset != cp.logLoaded {
+		return
+	}
+	if r.Err != nil {
+		cp.replaceHistoryLoadNode(false)
+		if cp.OnError != nil {
+			cp.OnError("Could not load older commits: " + r.Err.Error())
+		}
+		return
+	}
+
+	nodes := cp.CommitLog.Config.Items
+	if len(nodes) > 0 && nodes[len(nodes)-1].ID == historyLoadOlderID {
+		nodes = nodes[:len(nodes)-1]
+	}
+	for _, e := range r.Entries {
+		nodes = append(nodes, cp.commitLogNode(r.Dir, e))
+	}
+	cp.logLoaded += len(r.Entries)
+	cp.logHasMore = r.HasMore
+	if r.HasMore {
+		nodes = append(nodes, historyLoadOlderNode(false))
+	}
+	cp.CommitLog.SetItems(nodes)
+}
+
+func (cp *ChangesPanel) replaceHistoryLoadNode(loading bool) {
+	nodes := cp.CommitLog.Config.Items
+	if len(nodes) == 0 || nodes[len(nodes)-1].ID != historyLoadOlderID {
+		return
+	}
+	nodes[len(nodes)-1] = historyLoadOlderNode(loading)
+	cp.CommitLog.SetItems(nodes)
 }
 
 // commitFileParent extracts only the stable parent identity from a commit-file
@@ -347,6 +419,9 @@ func readCommitDetail(dir, ref, short string) *CommitDetailResult {
 		return result
 	}
 	result.Message = message
+	// The diff is still useful if metadata alone cannot be read, so timestamp
+	// failure degrades gracefully instead of replacing the whole document.
+	result.AuthoredAt, _ = git.CommitAuthoredAt(dir, ref)
 
 	files, err := git.CommitFiles(dir, ref)
 	if err != nil {
@@ -380,6 +455,7 @@ func (a *App) OpenCommitDetail(dir, ref, short string) {
 	}
 
 	detail := ui.NewCommitDetailWidget(dir, ref, short, a.EditorGroup.SyntaxHighlight)
+	a.wireCommitDetailContext(tabID, detail)
 	a.EditorGroup.ApplyDiffDefaults(detail)
 	a.EditorGroup.OpenPluginTab(tabID, "Commit "+short, detail)
 	a.FocusEditorIfEnabled()
@@ -399,6 +475,9 @@ func (a *App) ApplyCommitDetail(result *CommitDetailResult) {
 	detail := a.EditorGroup.CommitDetailWidgetByTab(commitDetailTabID(result.Ref))
 	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref {
 		return
+	}
+	if !result.AuthoredAt.IsZero() {
+		detail.Metadata = "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04 PM -0700")
 	}
 	detail.SetDetail(result.Message, result.Files, result.Err)
 }

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -230,13 +230,7 @@ func commitFileParent(id string) (parentID, ref string, ok bool) {
 
 // selectLogNode selects a node by ID, reporting whether it was there to select.
 func (cp *ChangesPanel) selectLogNode(id string) bool {
-	for i, node := range cp.CommitLog.FlatList() {
-		if node.ID == id {
-			cp.CommitLog.SetSelectedIndex(i)
-			return true
-		}
-	}
-	return false
+	return revealTreeSelection(cp.CommitLog, id)
 }
 
 func readCommitFiles(dir, ref, short, nodeID string) *CommitFilesResult {

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -1,0 +1,467 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/view"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+// Reading git is slow enough to be felt. `git status` on a large repository
+// takes long enough that running it from a key or click handler freezes the
+// whole editor until it returns — not just the panel. Every read here therefore
+// happens on a goroutine and comes back through the event loop, which is where
+// widget state is allowed to be touched, the same way RunRepoTask already
+// handles git writes.
+//
+// Panels with no screen — the constructor's first refresh, and unit tests — run
+// the same reads inline. That is a deliberate second path, so the async one has
+// its own tests rather than inheriting confidence from the inline one.
+
+// eventPoster is the one thing the panel needs from the screen: a way to hand a
+// finished read back to the event loop. Narrow so a test can stand in for it.
+type eventPoster interface {
+	PostEvent(tcell.Event) error
+}
+
+// commitLogLimit is how many commits the log shows.
+const commitLogLimit = 10
+
+// ChangesStatusResult carries a finished working-tree scan.
+type ChangesStatusResult struct {
+	Gen    int
+	Groups []changesGroup
+}
+
+// CommitLogResult carries a finished read of one repository's recent commits.
+type CommitLogResult struct {
+	Gen     int
+	Dir     string
+	Branch  string
+	Entries []git.LogEntry
+}
+
+// CommitFilesResult carries the file list of a single commit back to the node
+// that asked for it.
+type CommitFilesResult struct {
+	Dir    string
+	Ref    string
+	Short  string
+	NodeID string
+	Files  []git.FileStatus
+	Err    error
+}
+
+// CommitDetailResult carries the complete message and every per-file diff for
+// one immutable commit. Dir and Ref are the result identity; ApplyCommitDetail
+// only installs it into the loading tab created for that exact pair.
+type CommitDetailResult struct {
+	Dir     string
+	Ref     string
+	Short   string
+	Message string
+	Files   []ui.CommitDetailFile
+	Err     string
+}
+
+func readChangesGroups(dirs []string) []changesGroup {
+	var groups []changesGroup
+	seen := make(map[string]bool)
+	for _, dir := range dirs {
+		if root := git.RepoRoot(dir); root != "" {
+			dir = root
+		}
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		files, err := git.StatusFiles(dir)
+		if err != nil {
+			files = nil
+		}
+		var staged, unstaged []git.FileStatus
+		for _, f := range files {
+			if f.Staged {
+				staged = append(staged, f)
+			} else {
+				unstaged = append(unstaged, f)
+			}
+		}
+		groups = append(groups, changesGroup{
+			Dir:      dir,
+			Name:     filepath.Base(dir),
+			Staged:   staged,
+			Unstaged: unstaged,
+		})
+	}
+	return groups
+}
+
+// ApplyStatus installs a finished scan. Results from a superseded refresh are
+// dropped: several can be in flight after a burst of file changes, and the last
+// one started is the only one describing the tree as it is now.
+func (cp *ChangesPanel) ApplyStatus(r *ChangesStatusResult) {
+	if r.Gen != cp.statusGen {
+		return
+	}
+	cp.saveExpanded()
+	cp.groups = r.Groups
+	cp.multiRoot = len(cp.groups)+len(cp.PRGroups) > 1
+	cp.buildTree()
+	cp.lastLogDir = ""
+	cp.refreshCommitLog()
+	if cp.OnRefreshed != nil {
+		cp.OnRefreshed()
+	}
+}
+
+func readCommitLog(dir string, gen int) *CommitLogResult {
+	return &CommitLogResult{
+		Gen:     gen,
+		Dir:     dir,
+		Branch:  git.BranchName(dir),
+		Entries: git.Log(dir, commitLogLimit),
+	}
+}
+
+// ApplyCommitLog rebuilds the commit log from a finished read.
+func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
+	// Both checks, not one: the counter catches a superseded read, and the
+	// directory catches a counter that agrees for some reason it should not.
+	if r.Gen != cp.logGen || r.Dir != cp.lastLogDir {
+		return
+	}
+	name := filepath.Base(r.Dir)
+	if r.Branch != "" {
+		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s (%s)", name, r.Branch)
+	} else {
+		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s", name)
+	}
+
+	// Record what was open before the rebuild, so a Refresh triggered by
+	// staging a file does not collapse the commit the reader was in the middle
+	// of — and so does switching to another root and back.
+	cp.saveCommitLogState()
+	cp.logDir = r.Dir
+	selected := cp.logSelected[r.Dir]
+	cp.logCommits = make(map[string]commitFileRef)
+	cp.logFiles = make(map[string]commitFileRef)
+
+	branchLabel := name
+	if r.Branch != "" {
+		branchLabel = fmt.Sprintf("%s · %s", name, r.Branch)
+	}
+	nodes := make([]*widgets.TreeNode, 0, len(r.Entries)+1)
+	nodes = append(nodes, &widgets.TreeNode{
+		ID:    "branch",
+		Label: branchLabel,
+		Icon:  "⎇",
+		Muted: true,
+	})
+	for _, e := range r.Entries {
+		// Keyed on the full hash: the abbreviation git prints can change length
+		// as the repo grows, which would silently orphan both the expansion
+		// state below and the file cache.
+		id := "commit:" + e.Ref
+		cp.logCommits[id] = commitFileRef{Dir: r.Dir, Ref: e.Ref, Short: e.Hash}
+		node := &widgets.TreeNode{
+			ID:         id,
+			Label:      e.Message,
+			Icon:       "●",
+			Badge:      e.Hash,
+			Expandable: true,
+		}
+		if cp.logExpanded[id] {
+			node.Expanded = true
+			node.Children = cp.commitChildren(r.Dir, e.Ref, e.Hash, id)
+		}
+		nodes = append(nodes, node)
+	}
+	cp.CommitLog.SetItems(nodes)
+
+	// Restore by identity, never by the index SetItems happened to preserve.
+	// Committing prepends rows, and rewriting history can remove them entirely;
+	// in either case the old index now names something the reader did not pick.
+	cp.pendingLogSelection = ""
+	if selected == "" {
+		cp.CommitLog.SetSelectedIndex(0)
+		return
+	}
+	if cp.selectLogNode(selected) {
+		return
+	}
+
+	// A commit file can be absent temporarily while its surviving parent is
+	// expanded and the file list is in flight. Rest on that parent and restore
+	// the child when it arrives. Every other missing identity is permanently
+	// gone from this log, so the inert branch header is the safe resting place.
+	if parentID, ref, isCommitFile := commitFileParent(selected); isCommitFile {
+		key := r.Dir + "\x00" + ref
+		if cp.commitNode(parentID) != nil && cp.commitFilesPending[key] {
+			cp.selectLogNode(parentID)
+			cp.pendingLogSelection = selected
+			return
+		}
+	}
+	delete(cp.logSelected, r.Dir)
+	cp.CommitLog.SetSelectedIndex(0)
+}
+
+// commitFileParent extracts only the stable parent identity from a commit-file
+// node ID. The path after the hash may itself contain colons, so it remains
+// opaque; full Git object IDs cannot contain the separator.
+func commitFileParent(id string) (parentID, ref string, ok bool) {
+	rest, ok := strings.CutPrefix(id, "cfile:commit:")
+	if !ok {
+		return "", "", false
+	}
+	ref, _, ok = strings.Cut(rest, ":")
+	if !ok || ref == "" {
+		return "", "", false
+	}
+	return "commit:" + ref, ref, true
+}
+
+// selectLogNode selects a node by ID, reporting whether it was there to select.
+func (cp *ChangesPanel) selectLogNode(id string) bool {
+	for i, node := range cp.CommitLog.FlatList() {
+		if node.ID == id {
+			cp.CommitLog.SetSelectedIndex(i)
+			return true
+		}
+	}
+	return false
+}
+
+func readCommitFiles(dir, ref, short, nodeID string) *CommitFilesResult {
+	files, err := git.CommitFiles(dir, ref)
+	return &CommitFilesResult{Dir: dir, Ref: ref, Short: short, NodeID: nodeID, Files: files, Err: err}
+}
+
+// recordCommitFiles caches a finished read and clears its in-flight mark.
+//
+// A failure is deliberately not cached. A commit's contents are immutable,
+// which is what makes the cache safe — but a failure is not a fact about the
+// commit, it is a fact about the moment, and index.lock or a mid-rebase repo
+// clears on its own. Caching one would leave that commit permanently empty.
+func (cp *ChangesPanel) recordCommitFiles(r *CommitFilesResult) {
+	key := r.Dir + "\x00" + r.Ref
+	delete(cp.commitFilesPending, key)
+	if r.Err == nil {
+		cp.cacheCommitFiles(key, r.Files)
+	}
+}
+
+func (cp *ChangesPanel) childrenFor(r *CommitFilesResult) []*widgets.TreeNode {
+	if r.Err != nil {
+		return []*widgets.TreeNode{errorNode(r.NodeID)}
+	}
+	return cp.commitFileNodes(r.Dir, r.Ref, r.Short, r.NodeID, r.Files)
+}
+
+// fetchCommitFiles reads one commit's file list in the background. A commit
+// already being read is skipped rather than queued, so holding down the expand
+// key cannot start a run of identical git processes.
+func (cp *ChangesPanel) fetchCommitFiles(dir, ref, short, nodeID string) {
+	key := dir + "\x00" + ref
+	if cp.commitFilesPending[key] {
+		return
+	}
+	cp.commitFilesPending[key] = true
+	screen := cp.Screen
+	go func() {
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitFiles(dir, ref, short, nodeID)))
+	}()
+}
+
+// ApplyCommitFiles installs a commit's file list under the node that asked for
+// it. The node is looked up by ID rather than held as a pointer: the log may
+// have been rebuilt, or moved to another repository, while git was running.
+func (cp *ChangesPanel) ApplyCommitFiles(r *CommitFilesResult) {
+	cp.recordCommitFiles(r)
+	if r.Dir != cp.logDir {
+		return
+	}
+	node := cp.commitNode(r.NodeID)
+	if node == nil {
+		return
+	}
+	node.Children = cp.childrenFor(r)
+	// Same slice, but the widget has to re-flatten now that it has children.
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+
+	if cp.pendingLogSelection != "" {
+		parentID, _, isCommitFile := commitFileParent(cp.pendingLogSelection)
+		if !isCommitFile || parentID != r.NodeID {
+			return
+		}
+		if cp.selectLogNode(cp.pendingLogSelection) {
+			cp.pendingLogSelection = ""
+			return
+		}
+		// This parent's read completed without the selected child, so that
+		// identity can no longer arrive. Keep the cursor on the surviving parent
+		// and stop carrying the dead selection into later rebuilds.
+		cp.pendingLogSelection = ""
+		cp.selectLogNode(r.NodeID)
+		cp.logSelected[r.Dir] = r.NodeID
+	}
+}
+
+func (cp *ChangesPanel) commitNode(id string) *widgets.TreeNode {
+	for _, node := range cp.CommitLog.Config.Items {
+		if node.ID == id {
+			return node
+		}
+	}
+	return nil
+}
+
+func commitDetailTabID(ref string) string {
+	return "commit:" + ref
+}
+
+func readCommitDetail(dir, ref, short string) *CommitDetailResult {
+	result := &CommitDetailResult{Dir: dir, Ref: ref, Short: short}
+	message, err := git.CommitMessage(dir, ref)
+	if err != nil {
+		result.Err = fmt.Sprintf("Could not read commit %s", short)
+		return result
+	}
+	result.Message = message
+
+	files, err := git.CommitFiles(dir, ref)
+	if err != nil {
+		result.Err = fmt.Sprintf("Could not read files for commit %s", short)
+		return result
+	}
+	result.Files = make([]ui.CommitDetailFile, 0, len(files))
+	for _, file := range files {
+		detail := ui.CommitDetailFile{Path: file.Path, OldPath: file.OldPath}
+		diffText, err := git.CommitFileDiff(dir, ref, file)
+		if err != nil {
+			detail.Error = fmt.Sprintf("Could not read diff for %s", file.Path)
+		} else {
+			detail.Diff = diff.Parse(diffText)
+		}
+		result.Files = append(result.Files, detail)
+	}
+	return result
+}
+
+// OpenCommitDetail puts a loading tab in front of the reader immediately, then
+// performs every Git read off the event loop. Reopening an immutable commit
+// reuses its full-hash tab and never starts a duplicate read.
+func (a *App) OpenCommitDetail(dir, ref, short string) {
+	a.cancelPendingDiff()
+	tabID := commitDetailTabID(ref)
+	if a.EditorGroup.CommitDetailWidgetByTab(tabID) != nil {
+		a.EditorGroup.SwitchToTabByPath(tabID)
+		a.FocusEditorIfEnabled()
+		return
+	}
+
+	detail := ui.NewCommitDetailWidget(dir, ref, short, a.EditorGroup.SyntaxHighlight)
+	a.EditorGroup.ApplyDiffDefaults(detail)
+	a.EditorGroup.OpenPluginTab(tabID, "Commit "+short, detail)
+	a.FocusEditorIfEnabled()
+	if a.Screen == nil {
+		a.ApplyCommitDetail(readCommitDetail(dir, ref, short))
+		return
+	}
+	screen := a.Screen
+	go func() {
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitDetail(dir, ref, short)))
+	}()
+}
+
+// ApplyCommitDetail fills only the still-open tab whose repository and full
+// hash match the result. Closing the tab while Git runs supersedes the request.
+func (a *App) ApplyCommitDetail(result *CommitDetailResult) {
+	detail := a.EditorGroup.CommitDetailWidgetByTab(commitDetailTabID(result.Ref))
+	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref {
+		return
+	}
+	detail.SetDetail(result.Message, result.Files, result.Err)
+}
+
+// DiffOpenResult is a diff that has finished being read and is ready to show.
+// Exactly one of Warn, OpenPath and TabName is set: a message the reader should
+// see instead, a plain file to open because there was no usable diff, or the
+// diff itself.
+type DiffOpenResult struct {
+	Gen      int
+	Warn     string
+	OpenPath string
+
+	TabName  string
+	Title    string
+	Path     string
+	Diff     diff.FileDiff
+	OldLines []string
+	NewLines []string
+	Extended bool
+}
+
+// startDiffOpen runs a diff read in the background. Only the most recent
+// request is honoured: clicking through a list of files faster than git can
+// answer should land on the file clicked last, not on whichever read finished
+// last.
+// cancelPendingDiff discards whatever diff read is still running. Any way of
+// putting something else in front of the reader supersedes a diff they asked
+// for earlier — not only starting another background read — so every immediate
+// open has to say so, or the slow one lands on top of it seconds later.
+func (a *App) cancelPendingDiff() {
+	a.diffOpenGen++
+	a.setDiffOpenSegment("")
+}
+
+func (a *App) startDiffOpen(read func() *DiffOpenResult) {
+	a.diffOpenGen++
+	gen := a.diffOpenGen
+	if a.Screen == nil {
+		r := read()
+		r.Gen = gen
+		a.ApplyDiffOpen(r)
+		return
+	}
+	// Say something while git runs. The editor stays usable either way, but a
+	// click that produces nothing at all for several seconds reads as ignored.
+	a.setDiffOpenSegment("Opening diff…")
+	screen := a.Screen
+	go func() {
+		r := read()
+		r.Gen = gen
+		screen.PostEvent(tcell.NewEventInterrupt(r))
+	}()
+}
+
+func (a *App) setDiffOpenSegment(text string) {
+	a.Status.SetSegment(view.StatusSegment{
+		ID: "diffopen", Side: "left", Priority: 160, Text: text,
+	})
+}
+
+// ApplyDiffOpen shows a finished diff read.
+func (a *App) ApplyDiffOpen(r *DiffOpenResult) {
+	if r.Gen != a.diffOpenGen {
+		return
+	}
+	a.setDiffOpenSegment("")
+	switch {
+	case r.Warn != "":
+		a.StatusWarn(r.Warn)
+		return
+	case r.OpenPath != "":
+		a.EditorGroup.OpenFile(r.OpenPath)
+	default:
+		a.EditorGroup.OpenDiffTab(r.TabName, r.Title, r.Path, r.Diff, r.OldLines, r.NewLines, r.Extended)
+	}
+	a.FocusEditorIfEnabled()
+}

--- a/internal/app/changes_async_test.go
+++ b/internal/app/changes_async_test.go
@@ -327,6 +327,7 @@ func TestOpenCommitDetailUsesDiffDefaults(t *testing.T) {
 	settings := config.DefaultSettings()
 	settings.Editor.DiffMode = config.DiffModeUnified
 	settings.Editor.DiffWordWrap = true
+	settings.Editor.DiffHighContrast = true
 	a := buildTestApp(t, settings)
 	a.OpenCommitDetail(dir, ref, short)
 
@@ -337,6 +338,9 @@ func TestOpenCommitDetailUsesDiffDefaults(t *testing.T) {
 	if detail.Mode() != ui.DiffModeUnified || detail.WrapMode() != ui.DiffWrapOn {
 		t.Fatalf("commit detail defaults = mode %v wrap %v, want unified/on",
 			detail.Mode(), detail.WrapMode())
+	}
+	if !detail.DiffHighContrast() {
+		t.Fatal("commit detail did not inherit the high-contrast diff setting")
 	}
 }
 

--- a/internal/app/changes_async_test.go
+++ b/internal/app/changes_async_test.go
@@ -1,0 +1,850 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/view"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+// testPoster stands in for the screen, so a test can hold a finished read and
+// decide when it is applied.
+type testPoster struct {
+	events chan tcell.Event
+}
+
+func newTestPoster() *testPoster {
+	return &testPoster{events: make(chan tcell.Event, 8)}
+}
+
+func (p *testPoster) PostEvent(ev tcell.Event) error {
+	p.events <- ev
+	return nil
+}
+
+func (p *testPoster) await(t *testing.T) any {
+	t.Helper()
+	select {
+	case ev := <-p.events:
+		return ev.(*tcell.EventInterrupt).Data()
+	case <-time.After(5 * time.Second):
+		t.Fatal("no result was posted")
+		return nil
+	}
+}
+
+func dirtyRepo(t *testing.T) string {
+	t.Helper()
+	dir := commitLogRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func asyncPanel(t *testing.T, dirs ...string) (*ChangesPanel, *testPoster) {
+	t.Helper()
+	cp := NewChangesPanel(dirs...)
+	p := newTestPoster()
+	cp.Screen = p
+	return cp, p
+}
+
+// The whole point of the sweep: Refresh must not run git before it returns. A
+// panel that has read the working tree by the time Refresh returns is a panel
+// that froze the event loop to do it.
+func TestRefreshDoesNotReadGitBeforeReturning(t *testing.T) {
+	cp, p := asyncPanel(t, dirtyRepo(t))
+
+	cp.Refresh()
+	if n := cp.TotalChanges(); n != 0 {
+		t.Fatalf("Refresh returned with %d changes already read; it ran git inline", n)
+	}
+
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	if cp.TotalChanges() == 0 {
+		t.Error("the scan produced nothing once applied")
+	}
+}
+
+// Several scans can be in flight after a burst of file changes. Only the last
+// one started describes the tree as it is now.
+func TestApplyStatusDropsASupersededScan(t *testing.T) {
+	cp, p := asyncPanel(t, dirtyRepo(t))
+
+	cp.Refresh()
+	stale := p.await(t).(*ChangesStatusResult)
+	cp.Refresh() // a newer scan starts, so the first one is now out of date
+	fresh := p.await(t).(*ChangesStatusResult)
+
+	cp.ApplyStatus(stale)
+	if cp.TotalChanges() != 0 {
+		t.Error("a superseded scan was applied")
+	}
+	cp.ApplyStatus(fresh)
+	if cp.TotalChanges() == 0 {
+		t.Error("the current scan was dropped")
+	}
+}
+
+// Expanding a commit shows a placeholder immediately rather than waiting for
+// git, and the placeholder is replaced when the read lands.
+func TestExpandingACommitPostsInsteadOfBlocking(t *testing.T) {
+	cp, p := asyncPanel(t, dirtyRepo(t))
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+
+	node := cp.CommitLog.Config.Items[1]
+	if _, ok := cp.logCommits[node.ID]; !ok {
+		t.Fatalf("expected a commit node, got %q", node.ID)
+	}
+	node.Expanded = true
+	cp.loadCommitFiles(node)
+
+	if len(node.Children) != 1 || node.Children[0].ID != node.ID+loadingSuffix {
+		t.Fatalf("expected a loading placeholder, got %+v", node.Children)
+	}
+
+	cp.ApplyCommitFiles(p.await(t).(*CommitFilesResult))
+	if len(node.Children) != 1 || node.Children[0].Label != "a.txt" {
+		t.Fatalf("expected the commit's file, got %+v", node.Children[0])
+	}
+}
+
+// Holding the expand key must not start a run of identical git processes.
+func TestExpandingTwiceStartsOneRead(t *testing.T) {
+	cp, p := asyncPanel(t, dirtyRepo(t))
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+
+	node := cp.CommitLog.Config.Items[1]
+	commit := cp.logCommits[node.ID]
+	cp.fetchCommitFiles(commit.Dir, commit.Ref, commit.Short, node.ID)
+	cp.fetchCommitFiles(commit.Dir, commit.Ref, commit.Short, node.ID)
+
+	cp.ApplyCommitFiles(p.await(t).(*CommitFilesResult))
+	select {
+	case ev := <-p.events:
+		t.Fatalf("a second read was started: %#v", ev)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// A read that finishes after the log has moved to another repository must not
+// be pushed into whatever node now holds that ID.
+func TestApplyCommitFilesIgnoresAResultFromAnotherRepo(t *testing.T) {
+	cp, p := asyncPanel(t, dirtyRepo(t))
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+
+	node := cp.CommitLog.Config.Items[1]
+	node.Children = nil
+	cp.ApplyCommitFiles(&CommitFilesResult{
+		Dir:    cp.logDir + "-somewhere-else",
+		Ref:    "deadbeef",
+		NodeID: node.ID,
+		Files:  []git.FileStatus{{Status: "M", Path: "wrong.txt"}},
+	})
+	if len(node.Children) != 0 {
+		t.Errorf("a result from another repo was applied: %+v", node.Children)
+	}
+}
+
+// Clicking through files faster than git can answer should land on the file
+// clicked last, not on whichever read happened to finish last.
+func TestApplyDiffOpenDropsASupersededRead(t *testing.T) {
+	a := &App{}
+	a.diffOpenGen = 7
+	before := a.EditorGroup
+	a.ApplyDiffOpen(&DiffOpenResult{Gen: 3, Warn: "should not be shown"})
+	if a.EditorGroup != before {
+		t.Error("a superseded diff read was applied")
+	}
+}
+
+func TestReadCommitDetailIncludesBodyAndEveryFileInGitOrder(t *testing.T) {
+	dir := commitLogRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("new file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "-A"},
+		{"commit", "-qm", "Detail subject", "-m", "Body line one.\n\nBody line two."},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	refCommand := exec.Command("git", "rev-parse", "HEAD")
+	refCommand.Dir = dir
+	refOutput, err := refCommand.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := strings.TrimSpace(string(refOutput))
+
+	result := readCommitDetail(dir, ref, ref[:7])
+	if result.Err != "" {
+		t.Fatal(result.Err)
+	}
+	wantMessage := "Detail subject\n\nBody line one.\n\nBody line two."
+	if result.Message != wantMessage {
+		t.Fatalf("message = %q, want %q", result.Message, wantMessage)
+	}
+	statuses, err := git.CommitFiles(dir, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != len(statuses) || len(result.Files) != 2 {
+		t.Fatalf("detail files = %d, Git files = %d", len(result.Files), len(statuses))
+	}
+	for index, status := range statuses {
+		got := result.Files[index]
+		if got.Path != status.Path {
+			t.Errorf("file %d = %q, want Git-order path %q", index, got.Path, status.Path)
+		}
+		if len(got.Diff.Hunks) == 0 {
+			t.Errorf("file %q has no parsed diff hunks", got.Path)
+		}
+	}
+}
+
+func TestApplyCommitDetailUsesOpenTabRepositoryAndHashIdentity(t *testing.T) {
+	a := buildTestApp(t, config.DefaultSettings())
+	const (
+		dir   = "/repo"
+		ref   = "0123456789012345678901234567890123456789"
+		short = "0123456"
+	)
+	tabID := commitDetailTabID(ref)
+	detail := ui.NewCommitDetailWidget(dir, ref, short, false)
+	a.EditorGroup.OpenPluginTab(tabID, "Commit "+short, detail)
+
+	a.ApplyCommitDetail(&CommitDetailResult{Dir: "/other", Ref: ref, Short: short, Message: "wrong repo"})
+	if !detail.Loading {
+		t.Fatal("a result from another repository filled the loading tab")
+	}
+	a.ApplyCommitDetail(&CommitDetailResult{Dir: dir, Ref: ref, Short: short, Message: "subject\n\nbody"})
+	if detail.Loading || detail.Message != "subject\n\nbody" {
+		t.Fatalf("matching result was not applied: loading=%v message=%q", detail.Loading, detail.Message)
+	}
+
+	a.EditorGroup.ClosePluginTab(tabID)
+	a.ApplyCommitDetail(&CommitDetailResult{Dir: dir, Ref: ref, Short: short, Message: "late"})
+	if a.EditorGroup.CommitDetailWidgetByTab(tabID) != nil {
+		t.Fatal("a result reopened a detail tab that was closed while Git ran")
+	}
+}
+
+func TestOpenCommitDetailKeysTabsOnFullHashAndReusesEachCommit(t *testing.T) {
+	dir := commitLogRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("second\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", "second"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	logCommand := exec.Command("git", "log", "-2", "--format=%H %h")
+	logCommand.Dir = dir
+	output, err := logCommand.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("log returned %d commits", len(lines))
+	}
+	type identity struct{ ref, short string }
+	ids := make([]identity, 0, 2)
+	for _, line := range lines {
+		ref, short, ok := strings.Cut(line, " ")
+		if !ok {
+			t.Fatalf("malformed log identity %q", line)
+		}
+		ids = append(ids, identity{ref: ref, short: short})
+	}
+
+	a := buildTestApp(t, config.DefaultSettings())
+	a.OpenCommitDetail(dir, ids[0].ref, ids[0].short)
+	firstTabID := "commit:" + ids[0].ref
+	secondTabID := "commit:" + ids[1].ref
+	first := a.EditorGroup.CommitDetailWidgetByTab(firstTabID)
+	a.OpenCommitDetail(dir, ids[1].ref, ids[1].short)
+	second := a.EditorGroup.CommitDetailWidgetByTab(secondTabID)
+	if first == nil || second == nil || first == second {
+		t.Fatalf("full hashes did not create distinct detail tabs: first=%p second=%p", first, second)
+	}
+	if got := a.EditorGroup.ActiveFilePath(); got != secondTabID {
+		t.Fatalf("active tab = %q, want second full-hash tab", got)
+	}
+
+	a.OpenCommitDetail(dir, ids[0].ref, ids[0].short)
+	if got := a.EditorGroup.CommitDetailWidgetByTab(firstTabID); got != first {
+		t.Fatal("reopening an immutable commit replaced its existing tab")
+	}
+	if got := a.EditorGroup.ActiveFilePath(); got != firstTabID {
+		t.Fatalf("reopened tab = %q, want first full-hash tab", got)
+	}
+}
+
+func TestOpenCommitDetailUsesDiffDefaults(t *testing.T) {
+	dir := commitLogRepo(t)
+	cmd := exec.Command("git", "log", "-1", "--format=%H %h")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, short, ok := strings.Cut(strings.TrimSpace(string(output)), " ")
+	if !ok {
+		t.Fatalf("malformed commit identity %q", output)
+	}
+
+	settings := config.DefaultSettings()
+	settings.Editor.DiffMode = config.DiffModeUnified
+	settings.Editor.DiffWordWrap = true
+	a := buildTestApp(t, settings)
+	a.OpenCommitDetail(dir, ref, short)
+
+	detail := a.EditorGroup.CommitDetailWidgetByTab(commitDetailTabID(ref))
+	if detail == nil {
+		t.Fatal("commit detail did not open")
+	}
+	if detail.Mode() != ui.DiffModeUnified || detail.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("commit detail defaults = mode %v wrap %v, want unified/on",
+			detail.Mode(), detail.WrapMode())
+	}
+}
+
+func TestCommitLogRefreshPostsInsteadOfBlocking(t *testing.T) {
+	cp, p := asyncPanel(t, dirtyRepo(t))
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+
+	// ApplyStatus asks for the log; it must not have read it inline.
+	if cp.logDir != "" {
+		t.Fatal("the commit log was read on the event path")
+	}
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+	if cp.logDir == "" || cp.CommitLog.ItemCount() < 2 {
+		t.Error("the commit log was not populated once applied")
+	}
+}
+
+// Every foreground content change goes through the editor-group hook wired by
+// RegisterCommands. These are deliberately routes that never call an App open
+// helper: a tab switch and the same direct OpenDiff call plugins use.
+func TestForegroundNavigationCancelsAPendingDiff(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		prepare  func(*App)
+		navigate func(*App) string
+	}{
+		{
+			name: "tab switch",
+			prepare: func(a *App) {
+				a.EditorGroup.NewFile()
+			},
+			navigate: func(a *App) string {
+				a.EditorGroup.SwitchTab(0)
+				return a.EditorGroup.ActiveFilePath()
+			},
+		},
+		{
+			name: "plugin-style diff open",
+			navigate: func(a *App) string {
+				a.EditorGroup.OpenDiff("plugin.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, false)
+				return a.EditorGroup.ActiveFilePath()
+			},
+		},
+		{
+			name: "active tab close",
+			prepare: func(a *App) {
+				a.EditorGroup.NewFile()
+			},
+			navigate: func(a *App) string {
+				a.EditorGroup.CloseTab()
+				return a.EditorGroup.ActiveFilePath()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := buildTestApp(t, config.DefaultSettings())
+			a.Reg = command.NewRegistry()
+			RegisterCommands(a)
+			if tc.prepare != nil {
+				tc.prepare(a)
+			}
+			a.diffOpenGen = 4
+			a.setDiffOpenSegment("Opening diff…")
+
+			want := tc.navigate(a)
+			a.ApplyDiffOpen(&DiffOpenResult{
+				Gen: 4, TabName: "superseded (diff)", Path: "superseded.txt", Diff: diff.FileDiff{},
+			})
+			if got := a.EditorGroup.ActiveFilePath(); got != want {
+				t.Fatalf("late diff replaced foreground navigation: got %q, want %q", got, want)
+			}
+			if text := segmentText(a.Status, "diffopen"); text != "" {
+				t.Errorf("the in-progress message was left behind: %q", text)
+			}
+		})
+	}
+}
+
+// Applying the current result changes active content too, but only after its
+// generation has been accepted. The common hook must not prevent that result
+// from opening normally.
+func TestCurrentDiffOpensThroughActiveContentHook(t *testing.T) {
+	a := buildTestApp(t, config.DefaultSettings())
+	a.Reg = command.NewRegistry()
+	RegisterCommands(a)
+	a.diffOpenGen = 4
+	a.ApplyDiffOpen(&DiffOpenResult{
+		Gen: 4, TabName: "current (diff)", Path: "current.txt", Diff: diff.FileDiff{},
+	})
+	if got := a.EditorGroup.ActiveFilePath(); got != "current (diff)" {
+		t.Fatalf("current diff did not open: got %q", got)
+	}
+}
+
+// A watcher reload changes bytes underneath the reader; it is not a choice to
+// look at something else and must not supersede the diff they requested.
+func TestExternalReloadDoesNotCancelPendingDiff(t *testing.T) {
+	a := buildTestApp(t, config.DefaultSettings())
+	a.Reg = command.NewRegistry()
+	RegisterCommands(a)
+	path := filepath.Join(t.TempDir(), "watched.txt")
+	if err := os.WriteFile(path, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.EditorGroup.OpenFile(path)
+	a.diffOpenGen = 4
+	a.setDiffOpenSegment("Opening diff…")
+
+	if err := os.WriteFile(path, []byte("after\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.EditorGroup.ReloadFile(path)
+	a.ApplyDiffOpen(&DiffOpenResult{
+		Gen: 4, TabName: "requested (diff)", Path: path, Diff: diff.FileDiff{},
+	})
+	if got := a.EditorGroup.ActiveFilePath(); got != "requested (diff)" {
+		t.Fatalf("external reload cancelled requested diff: active=%q", got)
+	}
+}
+
+// Reopening the active file is foreground navigation even though its tab index
+// does not move. Unlike ReloadFile above, this is the reader choosing what to
+// show, so a diff requested earlier must not reclaim the editor afterward.
+func TestForegroundReopenOfActiveFileCancelsPendingDiff(t *testing.T) {
+	a := buildTestApp(t, config.DefaultSettings())
+	a.Reg = command.NewRegistry()
+	RegisterCommands(a)
+	path := filepath.Join(t.TempDir(), "active.txt")
+	if err := os.WriteFile(path, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.EditorGroup.OpenFile(path)
+	a.diffOpenGen = 4
+	a.setDiffOpenSegment("Opening diff…")
+
+	if err := os.WriteFile(path, []byte("reopened\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.EditorGroup.OpenFile(path)
+	if got := a.EditorGroup.ActiveBuffer().Lines[0]; got != "reopened" {
+		t.Fatalf("precondition: foreground reopen did not reload the buffer: %q", got)
+	}
+
+	a.ApplyDiffOpen(&DiffOpenResult{
+		Gen: 4, TabName: "superseded (diff)", Path: "superseded.txt", Diff: diff.FileDiff{},
+	})
+	if got := a.EditorGroup.ActiveFilePath(); got != path {
+		t.Fatalf("late diff replaced explicitly reopened active file: got %q, want %q", got, path)
+	}
+	if text := segmentText(a.Status, "diffopen"); text != "" {
+		t.Errorf("the in-progress message was left behind: %q", text)
+	}
+}
+
+// Tab-cleanup commands are navigation only when they change the active view.
+// Keeping the same pinned or dirty tab must not discard a requested diff.
+func TestTabCleanupWithoutNavigationDoesNotCancelPendingDiff(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		prepare func(*testing.T, *App)
+		cleanup func(*App)
+	}{
+		{
+			name: "close all keeps active pinned tab",
+			prepare: func(_ *testing.T, a *App) {
+				a.EditorGroup.TogglePinTab()
+				a.EditorGroup.NewFile()
+				a.EditorGroup.SwitchTab(0)
+			},
+			cleanup: func(a *App) { a.EditorGroup.CloseAllTabs() },
+		},
+		{
+			name: "close all saved keeps active dirty tab",
+			prepare: func(t *testing.T, a *App) {
+				dir := t.TempDir()
+				first := filepath.Join(dir, "first.txt")
+				second := filepath.Join(dir, "second.txt")
+				for _, path := range []string{first, second} {
+					if err := os.WriteFile(path, []byte(path+"\n"), 0o644); err != nil {
+						t.Fatal(err)
+					}
+					a.EditorGroup.OpenFile(path)
+					a.EditorGroup.CommitActiveTab()
+				}
+				a.EditorGroup.SwitchToTabByPath(first)
+				a.EditorGroup.ActiveBuffer().Dirty = true
+			},
+			cleanup: func(a *App) { a.EditorGroup.CloseAllSaved() },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := buildTestApp(t, config.DefaultSettings())
+			a.Reg = command.NewRegistry()
+			RegisterCommands(a)
+			tc.prepare(t, a)
+			wantBefore := a.EditorGroup.ActiveFilePath()
+			a.diffOpenGen = 4
+			a.setDiffOpenSegment("Opening diff…")
+
+			tc.cleanup(a)
+			if got := a.EditorGroup.ActiveFilePath(); got != wantBefore {
+				t.Fatalf("precondition: cleanup changed active tab: got %q, want %q", got, wantBefore)
+			}
+			a.ApplyDiffOpen(&DiffOpenResult{
+				Gen: 4, TabName: "requested (diff)", Path: "requested.txt", Diff: diff.FileDiff{},
+			})
+			if got := a.EditorGroup.ActiveFilePath(); got != "requested (diff)" {
+				t.Fatalf("cleanup without navigation cancelled requested diff: active=%q", got)
+			}
+		})
+	}
+}
+
+func segmentText(bar *view.StatusBar, id string) string {
+	for _, seg := range bar.LeftSegments() {
+		if seg.ID == id {
+			return seg.Text
+		}
+	}
+	return ""
+}
+
+// Emptying the log is a desired state like any other, so a read still running
+// must not arrive and put the cleared repository back.
+func TestClearingTheLogInvalidatesAReadInFlight(t *testing.T) {
+	cp, p := asyncPanel(t, dirtyRepo(t))
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	inFlight := p.await(t).(*CommitLogResult)
+
+	// Everything deselected and no groups left: the log has nothing to show.
+	cp.groups = nil
+	cp.refreshCommitLog()
+
+	cp.ApplyCommitLog(inFlight)
+	if cp.logDir != "" || cp.CommitLog.ItemCount() != 0 {
+		t.Errorf("a stale read resurrected the cleared repo: logDir=%q items=%d",
+			cp.logDir, cp.CommitLog.ItemCount())
+	}
+}
+
+// A selected file under a commit cannot be restored at rebuild time, because
+// its siblings are still being read. Dropping it puts the reader on the commit
+// row instead of the file they were on.
+func TestSelectionOfACommitChildSurvivesAnAsyncRebuild(t *testing.T) {
+	dir := dirtyRepo(t)
+	// Three files in the commit, so the single "Loading…" placeholder does not
+	// happen to sit at the same index as the child being restored. With a
+	// one-file commit the indices coincide and the restore looks to work even
+	// when it does not happen.
+	for _, name := range []string{"one.txt", "two.txt", "three.txt"} {
+		addCommitFile(t, dir, name)
+	}
+	commitAll(t, dir, "three more")
+
+	cp, p := asyncPanel(t, dir)
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+
+	node := cp.CommitLog.Config.Items[1]
+	node.Expanded = true
+	cp.loadCommitFiles(node)
+	cp.ApplyCommitFiles(p.await(t).(*CommitFilesResult))
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+
+	child := node.Children[len(node.Children)-1].ID
+	if !cp.selectLogNode(child) {
+		t.Fatalf("could not select %q to begin with", child)
+	}
+
+	// Rebuild with the cache emptied, as an eviction would leave it, so the
+	// children have to be read again.
+	cp.commitFiles = map[string][]git.FileStatus{}
+	cp.commitFilesOrder = nil
+	cp.lastLogDir = ""
+	cp.refreshCommitLog()
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+	if cp.pendingLogSelection != child {
+		t.Fatalf("pending selection = %q, want %q", cp.pendingLogSelection, child)
+	}
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != node.ID {
+		id := "<nil>"
+		if got != nil {
+			id = got.ID
+		}
+		t.Fatalf("deferred child rests on %q, want parent %q", id, node.ID)
+	}
+
+	// Another rebuild before the file list arrives must preserve the deferred
+	// child, rather than replacing it with the temporary parent selection.
+	files := p.await(t).(*CommitFilesResult)
+	cp.lastLogDir = ""
+	cp.refreshCommitLog()
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+	if cp.pendingLogSelection != child {
+		t.Fatalf("second rebuild replaced pending child with %q", cp.pendingLogSelection)
+	}
+	cp.ApplyCommitFiles(files)
+
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != child {
+		id := "<nil>"
+		if got != nil {
+			id = got.ID
+		}
+		t.Errorf("selection landed on %q, want %q", id, child)
+	}
+}
+
+func TestFailedCommitFileReadStopsDeferringItsSelection(t *testing.T) {
+	dir := dirtyRepo(t)
+	addCommitFile(t, dir, "one.txt")
+	commitAll(t, dir, "one more")
+
+	cp, p := asyncPanel(t, dir)
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+
+	node := cp.CommitLog.Config.Items[1]
+	node.Expanded = true
+	cp.loadCommitFiles(node)
+	cp.ApplyCommitFiles(p.await(t).(*CommitFilesResult))
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+	child := node.Children[0].ID
+	if !cp.selectLogNode(child) {
+		t.Fatalf("could not select %q", child)
+	}
+
+	cp.commitFiles = map[string][]git.FileStatus{}
+	cp.commitFilesOrder = nil
+	cp.lastLogDir = ""
+	cp.refreshCommitLog()
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+	if cp.pendingLogSelection != child {
+		t.Fatalf("precondition: pending selection = %q, want %q", cp.pendingLogSelection, child)
+	}
+
+	failed := p.await(t).(*CommitFilesResult)
+	failed.Files = nil
+	failed.Err = errors.New("read failed")
+	cp.ApplyCommitFiles(failed)
+	if cp.pendingLogSelection != "" {
+		t.Fatalf("failed read left selection %q deferred", cp.pendingLogSelection)
+	}
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != node.ID {
+		id := "<nil>"
+		if got != nil {
+			id = got.ID
+		}
+		t.Fatalf("failed child rests on %q, want parent %q", id, node.ID)
+	}
+}
+
+// A missing identity is only deferred when its parent commit is still in the
+// log and its children can therefore still arrive. If the commit itself was
+// removed by a reset, rebase, amend, or branch switch, preserving the numeric
+// row would silently retarget the selection to another commit's file.
+func TestRemovedCommitSelectionRestsOnBranchHeader(t *testing.T) {
+	dir := commitLogRepo(t)
+	addCommitFile(t, dir, "newest.txt")
+	commitAll(t, dir, "newest")
+
+	cp := newRefreshedPanel(dir)
+	if len(cp.CommitLog.Config.Items) < 3 {
+		t.Fatalf("need branch header and two commits, got %d items", len(cp.CommitLog.Config.Items))
+	}
+	newest := cp.CommitLog.Config.Items[1]
+	older := cp.CommitLog.Config.Items[2]
+	for _, node := range []*widgets.TreeNode{newest, older} {
+		node.Expanded = true
+		cp.loadCommitFiles(node)
+		if len(node.Children) == 0 {
+			t.Fatalf("expanded commit %q has no children", node.ID)
+		}
+	}
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+	removedChild := newest.Children[0].ID
+	if !cp.selectLogNode(removedChild) {
+		t.Fatalf("could not select %q", removedChild)
+	}
+	cp.CommitLog.SetFocused(true)
+
+	cmd := exec.Command("git", "reset", "--hard", "HEAD^")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git reset: %v\n%s", err, out)
+	}
+	cp.Refresh()
+
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != "branch" {
+		id := "<nil>"
+		if got != nil {
+			id = got.ID
+		}
+		t.Fatalf("removed commit selection retargeted %q, want branch header", id)
+	}
+	if cp.pendingLogSelection != "" {
+		t.Fatalf("removed selection was deferred as %q", cp.pendingLogSelection)
+	}
+	if _, remembered := cp.logSelected[dir]; remembered {
+		t.Fatalf("removed selection remains remembered as %q", cp.logSelected[dir])
+	}
+
+	opened := false
+	cp.OnOpenCommitDiff = func(string, string, string, git.FileStatus, bool) { opened = true }
+	cp.OpenSelectedDiff(false)
+	if opened {
+		t.Fatal("branch-header resting selection opened an unrelated commit file")
+	}
+}
+
+func TestRepoWithoutSavedSelectionDoesNotInheritAnotherReposIndex(t *testing.T) {
+	first := commitLogRepo(t)
+	addCommitFile(t, first, "newest.txt")
+	commitAll(t, first, "newest")
+	second := commitLogRepo(t)
+
+	cp := newRefreshedPanel(first)
+	newest := cp.CommitLog.Config.Items[1]
+	newest.Expanded = true
+	cp.loadCommitFiles(newest)
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+	if len(newest.Children) == 0 || !cp.selectLogNode(newest.Children[0].ID) {
+		t.Fatal("could not select a commit child in the first repo")
+	}
+
+	cp.SetDirs([]string{second})
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != "branch" {
+		id := "<nil>"
+		if got != nil {
+			id = got.ID
+		}
+		t.Fatalf("new repo inherited selection index %q, want branch header", id)
+	}
+}
+
+// A deferred restore is only valid while the reader has not made a newer
+// choice. Moving to another row while the children load must transfer ownership
+// of the selection to that deliberate navigation.
+func TestDeliberateCommitLogMoveCancelsDeferredSelection(t *testing.T) {
+	dir := dirtyRepo(t)
+	for _, name := range []string{"one.txt", "two.txt", "three.txt"} {
+		addCommitFile(t, dir, name)
+	}
+	commitAll(t, dir, "three more")
+
+	cp, p := asyncPanel(t, dir)
+	cp.Refresh()
+	cp.ApplyStatus(p.await(t).(*ChangesStatusResult))
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+
+	node := cp.CommitLog.Config.Items[1]
+	node.Expanded = true
+	cp.loadCommitFiles(node)
+	cp.ApplyCommitFiles(p.await(t).(*CommitFilesResult))
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+	child := node.Children[len(node.Children)-1].ID
+	if !cp.selectLogNode(child) {
+		t.Fatalf("could not select %q to begin with", child)
+	}
+
+	cp.commitFiles = map[string][]git.FileStatus{}
+	cp.commitFilesOrder = nil
+	cp.lastLogDir = ""
+	cp.refreshCommitLog()
+	cp.ApplyCommitLog(p.await(t).(*CommitLogResult))
+	if cp.pendingLogSelection != child {
+		t.Fatalf("precondition: pending selection = %q, want %q", cp.pendingLogSelection, child)
+	}
+
+	// Set up a one-step real navigation rather than assigning the final choice:
+	// TreeWidget invokes OnSelect only for keyboard/mouse movement.
+	cp.CommitLog.SetSelectedIndex(0)
+	cp.CommitLog.HandleEvent(tcell.NewEventKey(tcell.KeyDown, "", tcell.ModNone))
+	want := cp.CommitLog.Selected()
+	if want == nil || want.ID == child {
+		t.Fatalf("failed to move away from deferred child: got %#v", want)
+	}
+	if cp.pendingLogSelection != "" {
+		t.Fatalf("deliberate move left deferred selection %q armed", cp.pendingLogSelection)
+	}
+
+	cp.ApplyCommitFiles(p.await(t).(*CommitFilesResult))
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != want.ID {
+		id := "<nil>"
+		if got != nil {
+			id = got.ID
+		}
+		t.Fatalf("late children overrode deliberate move: got %q, want %q", id, want.ID)
+	}
+}
+
+func addCommitFile(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(name+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func commitAll(t *testing.T, dir, message string) {
+	t.Helper()
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", message}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}

--- a/internal/app/changes_async_test.go
+++ b/internal/app/changes_async_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -96,6 +97,60 @@ func TestApplyStatusDropsASupersededScan(t *testing.T) {
 	cp.ApplyStatus(fresh)
 	if cp.TotalChanges() == 0 {
 		t.Error("the current scan was dropped")
+	}
+}
+
+func TestCommitLogFailurePreservesHistoryAndRemainsRetryable(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.lastLogDir = "/repo"
+	cp.logDir = "/repo"
+	cp.logGen = 4
+	existing := &widgets.TreeNode{ID: "commit:good", Label: "last good commit"}
+	cp.CommitLog.SetItems([]*widgets.TreeNode{existing})
+	var callbackErr error
+	cp.OnHistoryResult = func(err error) { callbackErr = err }
+
+	cp.ApplyCommitLog(&CommitLogResult{
+		Gen: 4, Dir: "/repo", Err: errors.New("temporary log failure"),
+	})
+	if len(cp.CommitLog.Config.Items) != 1 || cp.CommitLog.Config.Items[0] != existing {
+		t.Fatalf("history failure replaced last good items: %+v", cp.CommitLog.Config.Items)
+	}
+	if cp.lastLogDir != "" {
+		t.Fatalf("failed history read left retry guard at %q", cp.lastLogDir)
+	}
+	if callbackErr == nil {
+		t.Fatal("history failure was not reported to the freshness coordinator")
+	}
+}
+
+func TestCancelHistoryReadCancelsContextAndSupersedesResult(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	ctx, cancel := context.WithCancel(context.Background())
+	cp.logCancel = cancel
+	cp.logGen = 7
+
+	cp.CancelHistoryRead()
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("CancelHistoryRead did not cancel the active history context")
+	}
+	if cp.logGen != 8 {
+		t.Fatalf("history generation = %d, want 8", cp.logGen)
+	}
+}
+
+func TestCommitHistoryRefreshKeyUsesCoordinatorCallback(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	called := 0
+	cp.OnRefresh = func() { called++ }
+
+	if !cp.handleCommitLogKey(tcell.NewEventKey(tcell.KeyRune, "r", tcell.ModNone), nil) {
+		t.Fatal("commit-history refresh key was not handled")
+	}
+	if called != 1 {
+		t.Fatalf("coordinator refresh callback called %d times, want 1", called)
 	}
 }
 

--- a/internal/app/changes_async_test.go
+++ b/internal/app/changes_async_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -154,6 +155,51 @@ func TestCommitHistoryRefreshKeyUsesCoordinatorCallback(t *testing.T) {
 	}
 }
 
+func TestCommitHistoryLoadsOlderCommitsOnDemand(t *testing.T) {
+	dir := commitLogRepo(t)
+	for i := 0; i < 51; i++ {
+		cmd := exec.Command("git", "commit", "--allow-empty", "-qm", fmt.Sprintf("older page %02d", i))
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("create history commit %d: %v\n%s", i, err, out)
+		}
+	}
+	cp, poster := asyncPanel(t, dir)
+	cp.Refresh()
+	cp.ApplyStatus(poster.await(t).(*ChangesStatusResult))
+	cp.ApplyCommitLog(poster.await(t).(*CommitLogResult))
+	items := cp.CommitLog.Config.Items
+	if cp.logLoaded != commitLogPageSize || !cp.logHasMore {
+		t.Fatalf("initial page state = loaded %d hasMore %v", cp.logLoaded, cp.logHasMore)
+	}
+	if len(items) != commitLogPageSize+2 || items[len(items)-1].ID != historyLoadOlderID {
+		t.Fatalf("initial history rows = %d, tail=%+v", len(items), items[len(items)-1])
+	}
+
+	cp.openCommitLogNode(items[len(items)-1])
+	if tail := cp.CommitLog.Config.Items[len(items)-1]; tail.Label != "Loading older commits…" {
+		t.Fatalf("loading sentinel = %q", tail.Label)
+	}
+	// A repeated activation while the page is in flight is idempotent.
+	cp.openCommitLogNode(cp.CommitLog.Config.Items[len(items)-1])
+	cp.ApplyCommitLog(poster.await(t).(*CommitLogResult))
+	items = cp.CommitLog.Config.Items
+	if cp.logLoaded != 52 || cp.logHasMore {
+		t.Fatalf("completed page state = loaded %d hasMore %v", cp.logLoaded, cp.logHasMore)
+	}
+	if len(items) != 53 { // branch header plus all 52 commits
+		t.Fatalf("completed history rows = %d, want 53", len(items))
+	}
+	if items[len(items)-1].ID == historyLoadOlderID {
+		t.Fatal("load-older sentinel remained after the final page")
+	}
+	select {
+	case duplicate := <-poster.events:
+		t.Fatalf("repeated sentinel activation started another page: %#v", duplicate)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 // Expanding a commit shows a placeholder immediately rather than waiting for
 // git, and the placeholder is replaced when the read lands.
 func TestExpandingACommitPostsInsteadOfBlocking(t *testing.T) {
@@ -266,6 +312,9 @@ func TestReadCommitDetailIncludesBodyAndEveryFileInGitOrder(t *testing.T) {
 	if result.Message != wantMessage {
 		t.Fatalf("message = %q, want %q", result.Message, wantMessage)
 	}
+	if result.AuthoredAt.IsZero() {
+		t.Fatal("commit detail omitted the authored timestamp")
+	}
 	statuses, err := git.CommitFiles(dir, ref)
 	if err != nil {
 		t.Fatal(err)
@@ -299,9 +348,15 @@ func TestApplyCommitDetailUsesOpenTabRepositoryAndHashIdentity(t *testing.T) {
 	if !detail.Loading {
 		t.Fatal("a result from another repository filled the loading tab")
 	}
-	a.ApplyCommitDetail(&CommitDetailResult{Dir: dir, Ref: ref, Short: short, Message: "subject\n\nbody"})
+	authoredAt := time.Date(2026, time.August, 21, 17, 42, 0, 0, time.FixedZone("EDT", -4*60*60))
+	a.ApplyCommitDetail(&CommitDetailResult{
+		Dir: dir, Ref: ref, Short: short, Message: "subject\n\nbody", AuthoredAt: authoredAt,
+	})
 	if detail.Loading || detail.Message != "subject\n\nbody" {
 		t.Fatalf("matching result was not applied: loading=%v message=%q", detail.Loading, detail.Message)
+	}
+	if detail.Metadata != "Authored Aug 21, 2026 at 5:42 PM -0400" {
+		t.Fatalf("commit metadata = %q", detail.Metadata)
 	}
 
 	a.EditorGroup.ClosePluginTab(tabID)

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -28,6 +29,7 @@ type ChangesPanel struct {
 	multiRoot  bool
 	expanded   map[string]bool
 	lastLogDir string
+	logCancel  context.CancelFunc
 	// commandContext remembers which tree the reader last acted in. Modal
 	// widgets temporarily take focus before running a command, so live widget
 	// focus cannot reliably identify the selection the command should use.
@@ -78,6 +80,9 @@ type ChangesPanel struct {
 	OnConfirmDiscard func(message string, onConfirm func())
 	OnError          func(message string)
 	OnRefreshed      func()
+	OnRefresh        func()
+	OnStatusChanged  func()
+	OnHistoryResult  func(error)
 
 	PRGroups []prGroup
 }
@@ -246,7 +251,11 @@ func (cp *ChangesPanel) applied(err error) {
 	if err != nil && cp.OnError != nil {
 		cp.OnError(err.Error())
 	}
-	cp.Refresh()
+	if cp.OnStatusChanged != nil {
+		cp.OnStatusChanged()
+	} else {
+		cp.Refresh()
+	}
 }
 
 // paths splits a file list into the untracked ones, which are deleted outright,
@@ -297,6 +306,10 @@ func (cp *ChangesPanel) refreshCommitLog() {
 		// read still running — otherwise that read arrives and resurrects the
 		// repository that was just cleared.
 		cp.logGen++
+		if cp.logCancel != nil {
+			cp.logCancel()
+			cp.logCancel = nil
+		}
 		cp.saveCommitLogState()
 		cp.lastLogDir = ""
 		cp.logDir = ""
@@ -306,17 +319,42 @@ func (cp *ChangesPanel) refreshCommitLog() {
 	if dir == cp.lastLogDir {
 		return
 	}
+	if cp.logCancel != nil {
+		cp.logCancel()
+	}
 	cp.lastLogDir = dir
 	cp.logGen++
 	gen := cp.logGen
+	ctx, cancel := context.WithTimeout(context.Background(), commitLogTimeout)
+	cp.logCancel = cancel
 	if cp.Screen == nil {
-		cp.ApplyCommitLog(readCommitLog(dir, gen))
+		result := readCommitLogContext(ctx, dir, gen)
+		cancel()
+		cp.ApplyCommitLog(result)
 		return
 	}
 	screen := cp.Screen
 	go func() {
-		screen.PostEvent(tcell.NewEventInterrupt(readCommitLog(dir, gen)))
+		result := readCommitLogContext(ctx, dir, gen)
+		cancel()
+		screen.PostEvent(tcell.NewEventInterrupt(result))
 	}()
+}
+
+// RefreshHistory forces a fresh read of the selected repository's branch and
+// recent commits. Working-tree invalidations deliberately do not call this:
+// saving a file changes status, not immutable history.
+func (cp *ChangesPanel) RefreshHistory() {
+	cp.lastLogDir = ""
+	cp.refreshCommitLog()
+}
+
+func (cp *ChangesPanel) CancelHistoryRead() {
+	if cp.logCancel != nil {
+		cp.logCancel()
+		cp.logCancel = nil
+	}
+	cp.logGen++
 }
 
 // saveCommitLogState records the currently rendered log's expansion and
@@ -482,7 +520,11 @@ func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.Tre
 	}
 	switch term.KeyRune(ev) {
 	case 'r', 'R':
-		cp.Refresh()
+		if cp.OnRefresh != nil {
+			cp.OnRefresh()
+		} else {
+			cp.Refresh()
+		}
 		return true
 	case 'c', 'o', 'v':
 		cp.openCommitFile(node, false)
@@ -783,6 +825,8 @@ func (cp *ChangesPanel) handleKey(ev *tcell.EventKey) bool {
 	case 'r', 'R':
 		if inPR {
 			cp.refreshSelectedPR()
+		} else if cp.OnRefresh != nil {
+			cp.OnRefresh()
 		} else {
 			cp.Refresh()
 		}

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -58,6 +59,10 @@ type ChangesPanel struct {
 	// full hashes, which do not collide across repos.
 	logExpanded map[string]bool
 	logSelected map[string]string
+	// logFolderExpanded is separate from logExpanded because commits default to
+	// collapsed while path folders default to expanded.
+	logFolderExpanded map[string]bool
+	fileView          string
 
 	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
 	OnOpenCommitDiff func(dir, ref, short string, status git.FileStatus, extended bool)
@@ -120,14 +125,16 @@ type prGroup struct {
 
 func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp := &ChangesPanel{
-		Dirs:        dirs,
-		multiRoot:   len(dirs) > 1,
-		expanded:    make(map[string]bool),
-		commitFiles: make(map[string][]git.FileStatus),
-		logCommits:  make(map[string]commitFileRef),
-		logFiles:    make(map[string]commitFileRef),
-		logExpanded: make(map[string]bool),
-		logSelected: make(map[string]string),
+		Dirs:              dirs,
+		multiRoot:         len(dirs) > 1,
+		expanded:          make(map[string]bool),
+		commitFiles:       make(map[string][]git.FileStatus),
+		logCommits:        make(map[string]commitFileRef),
+		logFiles:          make(map[string]commitFileRef),
+		logExpanded:       make(map[string]bool),
+		logSelected:       make(map[string]string),
+		logFolderExpanded: make(map[string]bool),
+		fileView:          config.GitFileViewTree,
 
 		commitFilesPending: make(map[string]bool),
 	}
@@ -178,6 +185,11 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 		},
 		OnCommand: func(cmd string, node *widgets.TreeNode) {
 			if cmd == "activate" {
+				if isCommitFolderNode(node) {
+					node.Expanded = !node.Expanded
+					cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+					return
+				}
 				cp.openCommitLogNode(node)
 			}
 		},
@@ -320,6 +332,7 @@ func (cp *ChangesPanel) saveCommitLogState() {
 		} else {
 			delete(cp.logExpanded, node.ID)
 		}
+		cp.saveCommitFolderState(node.Children)
 	}
 	if cp.pendingLogSelection != "" {
 		// A second rebuild can land while the selected child's read is still in
@@ -328,6 +341,15 @@ func (cp *ChangesPanel) saveCommitLogState() {
 		cp.logSelected[cp.logDir] = cp.pendingLogSelection
 	} else if node := cp.CommitLog.Selected(); node != nil {
 		cp.logSelected[cp.logDir] = node.ID
+	}
+}
+
+func (cp *ChangesPanel) saveCommitFolderState(nodes []*widgets.TreeNode) {
+	for _, node := range nodes {
+		if isCommitFolderNode(node) {
+			cp.logFolderExpanded[node.ID] = node.Expanded
+		}
+		cp.saveCommitFolderState(node.Children)
 	}
 }
 
@@ -405,19 +427,25 @@ func (cp *ChangesPanel) commitFileNodes(dir, ref, short, parentID string, files 
 		// that changed nothing against its first parent is the usual cause.
 		return []*widgets.TreeNode{{ID: parentID + emptySuffix, Label: "No files", Muted: true}}
 	}
-	nodes := make([]*widgets.TreeNode, 0, len(files))
-	for _, f := range files {
+	makeLeaf := func(f git.FileStatus) *widgets.TreeNode {
 		id := fmt.Sprintf("cfile:%s:%s", parentID, f.Path)
 		cp.logFiles[id] = commitFileRef{Dir: dir, Ref: ref, Short: short, Status: f}
-		nodes = append(nodes, &widgets.TreeNode{
+		return &widgets.TreeNode{
 			ID:           id,
 			Label:        f.Path,
 			Icon:         ui.StatusBadge(f.Status),
 			IconStyle:    ui.StatusStyle(f.Status),
 			TruncateLeft: true,
-		})
+		}
 	}
-	return nodes
+	if cp.fileView == config.GitFileViewList {
+		nodes := make([]*widgets.TreeNode, 0, len(files))
+		for _, f := range files {
+			nodes = append(nodes, makeLeaf(f))
+		}
+		return nodes
+	}
+	return compactFileTree("history:"+parentID, files, makeLeaf, cp.logFolderExpanded)
 }
 
 func (cp *ChangesPanel) openCommitFile(node *widgets.TreeNode, extended bool) {
@@ -496,10 +524,7 @@ func (cp *ChangesPanel) buildTree() {
 					{Icon: "−", Command: "unstageAll"},
 				},
 			}
-			for _, f := range g.Staged {
-				child := cp.fileNode(g.Dir, f, true)
-				stagedNode.Children = append(stagedNode.Children, child)
-			}
+			stagedNode.Children = cp.fileNodes(fmt.Sprintf("work:%d:staged", gi), g.Dir, g.Staged, true)
 			sectionNodes = append(sectionNodes, stagedNode)
 		}
 
@@ -515,10 +540,7 @@ func (cp *ChangesPanel) buildTree() {
 					{Icon: "+", Command: "stageAll"},
 				},
 			}
-			for _, f := range g.Unstaged {
-				child := cp.fileNode(g.Dir, f, false)
-				changesNode.Children = append(changesNode.Children, child)
-			}
+			changesNode.Children = cp.fileNodes(fmt.Sprintf("work:%d:changes", gi), g.Dir, g.Unstaged, false)
 			sectionNodes = append(sectionNodes, changesNode)
 		}
 
@@ -549,11 +571,8 @@ func (cp *ChangesPanel) buildTree() {
 				{Icon: "⋮", Command: "prGroupMenu"},
 			},
 		}
-		for _, f := range pg.Files {
-			child := cp.fileNode(pg.Dir, f, false)
-			child.Actions = nil
-			prRoot.Children = append(prRoot.Children, child)
-		}
+		prRoot.Children = cp.fileNodes(fmt.Sprintf("pr:%d", pi), pg.Dir, pg.Files, false)
+		clearTreeActions(prRoot.Children)
 		roots = append(roots, prRoot)
 	}
 
@@ -561,7 +580,19 @@ func (cp *ChangesPanel) buildTree() {
 		cp.restoreExpanded(root)
 	}
 
+	selected := ""
+	if node := cp.Tree.Selected(); node != nil {
+		selected = node.ID
+	}
 	cp.Tree.SetItems(roots)
+	revealTreeSelection(cp.Tree, selected)
+}
+
+func clearTreeActions(nodes []*widgets.TreeNode) {
+	for _, node := range nodes {
+		node.Actions = nil
+		clearTreeActions(node.Children)
+	}
 }
 
 func (cp *ChangesPanel) fileNode(dir string, f git.FileStatus, staged bool) *widgets.TreeNode {
@@ -631,6 +662,9 @@ func (cp *ChangesPanel) selectedGroupDir() string {
 			return cp.groups[idx].Dir
 		}
 	}
+	if gi := workingFolderGroupIndex(node); gi >= 0 && gi < len(cp.groups) {
+		return cp.groups[gi].Dir
+	}
 	return ""
 }
 
@@ -648,7 +682,18 @@ func (cp *ChangesPanel) selectedInPR() bool {
 		}
 		return false
 	}
-	return strings.HasPrefix(node.ID, "pr:")
+	return strings.HasPrefix(node.ID, "pr:") || strings.HasPrefix(node.ID, "folder:pr:")
+}
+
+func workingFolderGroupIndex(node *widgets.TreeNode) int {
+	if node == nil || !strings.HasPrefix(node.ID, "folder:work:") {
+		return -1
+	}
+	var gi int
+	if _, err := fmt.Sscanf(node.ID, "folder:work:%d:", &gi); err != nil {
+		return -1
+	}
+	return gi
 }
 
 func (cp *ChangesPanel) handleCommand(cmd string, node *widgets.TreeNode) {

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -70,6 +70,7 @@ type ChangesPanel struct {
 	OnOpenPRDiff     func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
 	OnOpenFile       func(path string)
 	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
+	OnPanelMenu      func(screenX, screenY int)
 	OnCommit         func(dir string, message string)
 	OnGroupMenu      func(dir string, screenX, screenY int)
 	OnPRGroupMenu    func(group *ui.ChangesGroup, screenX, screenY int)
@@ -192,6 +193,9 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 				}
 				cp.openCommitLogNode(node)
 			}
+		},
+		OnMenu: func(_ []widgets.MenuEntry, _ *widgets.TreeNode, sx, sy int) {
+			cp.showPanelMenu(sx, sy)
 		},
 		OnKey: func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
 			return cp.handleCommitLogKey(ev, node)
@@ -491,11 +495,46 @@ func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.Tre
 }
 
 func (cp *ChangesPanel) saveExpanded() {
-	for _, node := range cp.Tree.FlatList() {
-		if node.Expandable || len(node.Children) > 0 {
-			cp.expanded[node.ID] = node.Expanded
+	var visit func([]*widgets.TreeNode)
+	visit = func(nodes []*widgets.TreeNode) {
+		for _, node := range nodes {
+			if node.Expandable || len(node.Children) > 0 {
+				cp.expanded[node.ID] = node.Expanded
+			}
+			visit(node.Children)
 		}
 	}
+	visit(cp.Tree.Config.Items)
+}
+
+// ExpandAll opens the working-tree hierarchy and every already-loaded folder
+// in commit file trees. Commit rows themselves remain untouched: expanding all
+// of them would launch a Git read for every visible commit at once.
+func (cp *ChangesPanel) ExpandAll() {
+	cp.Tree.ExpandAll()
+	cp.setCommitFoldersExpanded(true)
+	cp.saveExpanded()
+}
+
+func (cp *ChangesPanel) CollapseAll() {
+	cp.Tree.CollapseAll()
+	cp.setCommitFoldersExpanded(false)
+	cp.saveExpanded()
+}
+
+func (cp *ChangesPanel) setCommitFoldersExpanded(expanded bool) {
+	var visit func([]*widgets.TreeNode)
+	visit = func(nodes []*widgets.TreeNode) {
+		for _, node := range nodes {
+			if isCommitFolderNode(node) {
+				node.Expanded = expanded
+				cp.logFolderExpanded[node.ID] = expanded
+			}
+			visit(node.Children)
+		}
+	}
+	visit(cp.CommitLog.Config.Items)
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
 }
 
 func (cp *ChangesPanel) restoreExpanded(node *widgets.TreeNode) {
@@ -842,6 +881,13 @@ func (cp *ChangesPanel) handleMenu(node *widgets.TreeNode, sx, sy int) {
 			}
 			return
 		}
+	}
+	cp.showPanelMenu(sx, sy)
+}
+
+func (cp *ChangesPanel) showPanelMenu(sx, sy int) {
+	if cp.OnPanelMenu != nil {
+		cp.OnPanelMenu(sx, sy)
 	}
 }
 

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -82,7 +82,6 @@ const (
 	changesWorkingTree changesCommandContext = iota
 	changesCommitLog
 
-	changesHistoryDefaultHeight = 8 // title plus the log's former seven rows
 	changesHistoryMinHeight     = 4 // title plus three usable log rows
 	changesWorkingTreeMinHeight = 5 // input, divider, and three tree rows
 )
@@ -201,7 +200,8 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp.Split.Top = top
 	cp.Split.Bottom = bottom
 	cp.Split.ShowBottom = true
-	cp.Split.BottomH = changesHistoryDefaultHeight
+	cp.Split.BottomH = 0
+	cp.Split.BottomRatio = 0.5
 	cp.Split.MinBottomH = changesHistoryMinHeight
 	cp.Split.MinTopH = changesWorkingTreeMinHeight
 	cp.Split.OnResize = func(height int) {

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -146,7 +146,7 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 		logExpanded:       make(map[string]bool),
 		logSelected:       make(map[string]string),
 		logFolderExpanded: make(map[string]bool),
-		fileView:          config.GitFileViewTree,
+		fileView:          config.GitFileViewList,
 
 		commitFilesPending: make(map[string]bool),
 	}

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -17,14 +17,51 @@ type ChangesPanel struct {
 	Input     *widgets.InputWidget
 	CommitLog *widgets.TreeWidget
 	Adapter   *ui.WidgetAdapter
+	Split     *ui.ContentSplitWidget
 	Dirs      []string
+	// Screen is how a finished background read gets back onto the event loop.
+	// With no screen the panel reads git inline instead — see changes_async.go.
+	Screen eventPoster
 
 	groups     []changesGroup
 	multiRoot  bool
 	expanded   map[string]bool
 	lastLogDir string
+	// commandContext remembers which tree the reader last acted in. Modal
+	// widgets temporarily take focus before running a command, so live widget
+	// focus cannot reliably identify the selection the command should use.
+	commandContext changesCommandContext
+
+	// logDir is the repo the commit log currently displays, as opposed to
+	// lastLogDir which only guards redundant rebuilds. They differ because
+	// Refresh clears the guard while the rendered log stays put.
+	logDir string
+	// commitFiles caches a commit's file list. A commit's contents never
+	// change, so an entry can never go stale — only numerous, hence the bound.
+	commitFiles      map[string][]git.FileStatus
+	commitFilesOrder []string
+	// commitFilesPending marks reads already in flight, so repeated expands of
+	// one commit do not each start their own git process.
+	commitFilesPending map[string]bool
+	logCommits         map[string]commitFileRef
+	logFiles           map[string]commitFileRef
+	// statusGen and logGen let a finished read tell whether a newer one has
+	// already superseded it.
+	statusGen int
+	logGen    int
+	// pendingLogSelection is a selection that could not be restored yet because
+	// the node it names is a commit's child and those children are still being
+	// read.
+	pendingLogSelection string
+	// logExpanded and logSelected outlive any one repo's log, so switching
+	// between roots in a workspace and back returns to what was open. Keys are
+	// full hashes, which do not collide across repos.
+	logExpanded map[string]bool
+	logSelected map[string]string
 
 	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
+	OnOpenCommitDiff func(dir, ref, short string, status git.FileStatus, extended bool)
+	OnOpenCommit     func(dir, ref, short string)
 	OnOpenPRDiff     func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
 	OnOpenFile       func(path string)
 	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
@@ -34,15 +71,40 @@ type ChangesPanel struct {
 	OnRefreshPR      func(url string)
 	OnConfirmDiscard func(message string, onConfirm func())
 	OnError          func(message string)
+	OnRefreshed      func()
 
 	PRGroups []prGroup
 }
+
+type changesCommandContext uint8
+
+const (
+	changesWorkingTree changesCommandContext = iota
+	changesCommitLog
+
+	changesHistoryDefaultHeight = 8 // title plus the log's former seven rows
+	changesHistoryMinHeight     = 4 // title plus three usable log rows
+	changesWorkingTreeMinHeight = 5 // input, divider, and three tree rows
+)
 
 type changesGroup struct {
 	Dir      string
 	Name     string
 	Staged   []git.FileStatus
 	Unstaged []git.FileStatus
+}
+
+// commitFileRef ties a commit-log node back to the file it stands for. The
+// panel keeps a map rather than encoding dir, hash and path into the node ID:
+// all three can contain a colon, and parseFileNode's reverse scan is already at
+// its limit with two fields.
+type commitFileRef struct {
+	Dir string
+	// Ref is the full hash, which is what git is asked with and what the tab
+	// key is built from. Short is only ever shown to the reader.
+	Ref    string
+	Short  string
+	Status git.FileStatus
 }
 
 type prGroup struct {
@@ -59,9 +121,16 @@ type prGroup struct {
 
 func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp := &ChangesPanel{
-		Dirs:      dirs,
-		multiRoot: len(dirs) > 1,
-		expanded:  make(map[string]bool),
+		Dirs:        dirs,
+		multiRoot:   len(dirs) > 1,
+		expanded:    make(map[string]bool),
+		commitFiles: make(map[string][]git.FileStatus),
+		logCommits:  make(map[string]commitFileRef),
+		logFiles:    make(map[string]commitFileRef),
+		logExpanded: make(map[string]bool),
+		logSelected: make(map[string]string),
+
+		commitFilesPending: make(map[string]bool),
 	}
 
 	cp.Input = widgets.NewInputWidget(widgets.InputConfig{
@@ -85,24 +154,67 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 		OnSelect: func(node *widgets.TreeNode) {
 			cp.refreshCommitLog()
 		},
+		OnFocus: func() {
+			cp.commandContext = changesWorkingTree
+		},
 		OnKey: func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
 			return cp.handleKey(ev)
 		},
 	})
 
-	cp.CommitLog = widgets.NewListWidget(nil)
+	cp.CommitLog = widgets.NewTreeWidget(widgets.TreeConfig{
+		Indent:             1,
+		EmptyText:          "No commits",
+		ActivateExpandable: true,
+		OnSelect: func(_ *widgets.TreeNode) {
+			// A deferred restore belongs to the selection that existed before the
+			// rebuild. Once the reader moves, their newer choice owns the cursor.
+			cp.pendingLogSelection = ""
+		},
+		OnFocus: func() {
+			cp.commandContext = changesCommitLog
+		},
+		OnExpand: func(node *widgets.TreeNode) {
+			cp.loadCommitFiles(node)
+		},
+		OnCommand: func(cmd string, node *widgets.TreeNode) {
+			if cmd == "activate" {
+				cp.openCommitLogNode(node)
+			}
+		},
+		OnKey: func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
+			return cp.handleCommitLogKey(ev, node)
+		},
+	})
 
-	logBox := &widgets.BoxWidget{FixedHeight: 7}
+	logTitle := widgets.NewTitleWidget(widgets.TitleConfig{Title: "Commit History"})
+
+	logBox := &widgets.BoxWidget{}
 	logBox.Child = cp.CommitLog
 
 	divTop := widgets.NewDividerWidget(widgets.DividerConfig{})
-	divBottom := widgets.NewDividerWidget(widgets.DividerConfig{})
 
-	vstack := widgets.NewVStackWidget(cp.Tree, divBottom, cp.Input, divTop, logBox)
+	top := widgets.NewVStackWidget(cp.Input, divTop, cp.Tree)
+	bottom := widgets.NewVStackWidget(logTitle, logBox)
 
-	cp.Adapter = ui.NewWidgetAdapter(vstack)
+	cp.Split = ui.NewContentSplitWidget()
+	cp.Split.Top = top
+	cp.Split.Bottom = bottom
+	cp.Split.ShowBottom = true
+	cp.Split.BottomH = changesHistoryDefaultHeight
+	cp.Split.MinBottomH = changesHistoryMinHeight
+	cp.Split.MinTopH = changesWorkingTreeMinHeight
+	cp.Split.OnResize = func(height int) {
+		// Like the sidebar width, this value lives for the panel's lifetime but is
+		// not written to settings. The split itself applies both child minimums.
+		cp.Split.BottomH = height
+	}
 
-	cp.Refresh()
+	cp.Adapter = ui.NewWidgetAdapter(cp.Split)
+
+	// No refresh here. At construction there is no screen to come back through,
+	// so the scan would run inline and hold up startup by however long `git
+	// status` takes. App.Init hands the panel a screen and refreshes then.
 	return cp
 }
 
@@ -143,40 +255,20 @@ func filePaths(files []git.FileStatus) []string {
 }
 
 func (cp *ChangesPanel) Refresh() {
-	cp.lastLogDir = ""
-	cp.saveExpanded()
-	cp.groups = nil
-	seen := make(map[string]bool)
-	for _, dir := range cp.Dirs {
-		if root := git.RepoRoot(dir); root != "" {
-			dir = root
-		}
-		if seen[dir] {
-			continue
-		}
-		seen[dir] = true
-		files, err := git.StatusFiles(dir)
-		if err != nil {
-			files = nil
-		}
-		var staged, unstaged []git.FileStatus
-		for _, f := range files {
-			if f.Staged {
-				staged = append(staged, f)
-			} else {
-				unstaged = append(unstaged, f)
-			}
-		}
-		cp.groups = append(cp.groups, changesGroup{
-			Dir:      dir,
-			Name:     filepath.Base(dir),
-			Staged:   staged,
-			Unstaged: unstaged,
-		})
+	cp.statusGen++
+	gen := cp.statusGen
+	dirs := append([]string(nil), cp.Dirs...)
+	read := func() *ChangesStatusResult {
+		return &ChangesStatusResult{Gen: gen, Groups: readChangesGroups(dirs)}
 	}
-	cp.multiRoot = len(cp.groups)+len(cp.PRGroups) > 1
-	cp.buildTree()
-	cp.refreshCommitLog()
+	if cp.Screen == nil {
+		cp.ApplyStatus(read())
+		return
+	}
+	screen := cp.Screen
+	go func() {
+		screen.PostEvent(tcell.NewEventInterrupt(read()))
+	}()
 }
 
 func (cp *ChangesPanel) refreshCommitLog() {
@@ -185,7 +277,13 @@ func (cp *ChangesPanel) refreshCommitLog() {
 		dir = cp.groups[0].Dir
 	}
 	if dir == "" {
+		// Emptying the log is a desired state too, so it has to invalidate a
+		// read still running — otherwise that read arrives and resurrects the
+		// repository that was just cleared.
+		cp.logGen++
+		cp.saveCommitLogState()
 		cp.lastLogDir = ""
+		cp.logDir = ""
 		cp.CommitLog.SetItems(nil)
 		return
 	}
@@ -193,36 +291,175 @@ func (cp *ChangesPanel) refreshCommitLog() {
 		return
 	}
 	cp.lastLogDir = dir
-	branch := git.BranchName(dir)
-	name := filepath.Base(dir)
-
-	if branch != "" {
-		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s (%s)", name, branch)
-	} else {
-		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s", name)
+	cp.logGen++
+	gen := cp.logGen
+	if cp.Screen == nil {
+		cp.ApplyCommitLog(readCommitLog(dir, gen))
+		return
 	}
+	screen := cp.Screen
+	go func() {
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitLog(dir, gen)))
+	}()
+}
 
-	entries := git.Log(dir, 10)
-	nodes := make([]*widgets.TreeNode, 0, len(entries)+1)
-	branchLabel := name
-	if branch != "" {
-		branchLabel = fmt.Sprintf("%s · %s", name, branch)
+// saveCommitLogState records the currently rendered log's expansion and
+// selection before it is thrown away. Collapsed entries are dropped rather than
+// stored as false: absent already means collapsed, and that keeps the map the
+// size of what is open rather than of everything ever opened.
+func (cp *ChangesPanel) saveCommitLogState() {
+	if cp.logDir == "" {
+		return
 	}
-	nodes = append(nodes, &widgets.TreeNode{
-		ID:    "branch",
-		Label: branchLabel,
-		Icon:  "⎇",
+	for _, node := range cp.CommitLog.Config.Items {
+		if _, ok := cp.logCommits[node.ID]; !ok {
+			continue
+		}
+		if node.Expanded {
+			cp.logExpanded[node.ID] = true
+		} else {
+			delete(cp.logExpanded, node.ID)
+		}
+	}
+	if cp.pendingLogSelection != "" {
+		// A second rebuild can land while the selected child's read is still in
+		// flight. Preserve the identity that can still arrive, not the parent row
+		// where the cursor is resting temporarily.
+		cp.logSelected[cp.logDir] = cp.pendingLogSelection
+	} else if node := cp.CommitLog.Selected(); node != nil {
+		cp.logSelected[cp.logDir] = node.ID
+	}
+}
+
+// commitFilesCacheMax bounds the file-list cache. Entries are small and never
+// go stale, so the only reason to evict is that a long session browsing history
+// would otherwise grow one entry per commit ever opened, without limit.
+const commitFilesCacheMax = 256
+
+func (cp *ChangesPanel) cacheCommitFiles(key string, files []git.FileStatus) {
+	if _, exists := cp.commitFiles[key]; !exists {
+		cp.commitFilesOrder = append(cp.commitFilesOrder, key)
+	}
+	cp.commitFiles[key] = files
+	for len(cp.commitFilesOrder) > commitFilesCacheMax {
+		oldest := cp.commitFilesOrder[0]
+		cp.commitFilesOrder = cp.commitFilesOrder[1:]
+		delete(cp.commitFiles, oldest)
+	}
+}
+
+// loadCommitFiles fills in a commit's children when it is expanded. TreeWidget
+// calls this before it re-flattens, so mutating Children here is enough — no
+// second SetItems.
+func (cp *ChangesPanel) loadCommitFiles(node *widgets.TreeNode) {
+	commit, ok := cp.logCommits[node.ID]
+	if !ok {
+		return
+	}
+	// A read still running keeps its placeholder; one that failed is retried,
+	// since the failure was never cached.
+	if len(node.Children) > 0 {
+		first := node.Children[0].ID
+		if first != node.ID+errorSuffix {
+			return
+		}
+	}
+	node.Children = cp.commitChildren(commit.Dir, commit.Ref, commit.Short, node.ID)
+}
+
+// commitChildren returns what to render under a commit. A cached list renders
+// straight away; anything else has to be read, and git must not run on the
+// event path — so the read is started and a placeholder stands in until it
+// lands. A panel with no screen has no event loop to come back through and
+// reads inline instead.
+func (cp *ChangesPanel) commitChildren(dir, ref, short, parentID string) []*widgets.TreeNode {
+	if files, cached := cp.commitFiles[dir+"\x00"+ref]; cached {
+		return cp.commitFileNodes(dir, ref, short, parentID, files)
+	}
+	if cp.Screen == nil {
+		r := readCommitFiles(dir, ref, short, parentID)
+		cp.recordCommitFiles(r)
+		return cp.childrenFor(r)
+	}
+	cp.fetchCommitFiles(dir, ref, short, parentID)
+	return []*widgets.TreeNode{{
+		ID:    parentID + loadingSuffix,
+		Label: "Loading…",
 		Muted: true,
-	})
-	for _, e := range entries {
+	}}
+}
+
+const (
+	loadingSuffix = ":loading"
+	errorSuffix   = ":error"
+	emptySuffix   = ":empty"
+)
+
+func errorNode(parentID string) *widgets.TreeNode {
+	return &widgets.TreeNode{ID: parentID + errorSuffix, Label: "Could not read commit", Muted: true}
+}
+
+func (cp *ChangesPanel) commitFileNodes(dir, ref, short, parentID string, files []git.FileStatus) []*widgets.TreeNode {
+	if len(files) == 0 {
+		// An expandable node that opens onto nothing reads as broken. A merge
+		// that changed nothing against its first parent is the usual cause.
+		return []*widgets.TreeNode{{ID: parentID + emptySuffix, Label: "No files", Muted: true}}
+	}
+	nodes := make([]*widgets.TreeNode, 0, len(files))
+	for _, f := range files {
+		id := fmt.Sprintf("cfile:%s:%s", parentID, f.Path)
+		cp.logFiles[id] = commitFileRef{Dir: dir, Ref: ref, Short: short, Status: f}
 		nodes = append(nodes, &widgets.TreeNode{
-			ID:    e.Hash,
-			Label: e.Message,
-			Icon:  "●",
-			Badge: e.Hash,
+			ID:           id,
+			Label:        f.Path,
+			Icon:         ui.StatusBadge(f.Status),
+			IconStyle:    ui.StatusStyle(f.Status),
+			TruncateLeft: true,
 		})
 	}
-	cp.CommitLog.SetItems(nodes)
+	return nodes
+}
+
+func (cp *ChangesPanel) openCommitFile(node *widgets.TreeNode, extended bool) {
+	if node == nil || cp.OnOpenCommitDiff == nil {
+		return
+	}
+	ref, ok := cp.logFiles[node.ID]
+	if !ok {
+		return
+	}
+	cp.OnOpenCommitDiff(ref.Dir, ref.Ref, ref.Short, ref.Status, extended)
+}
+
+func (cp *ChangesPanel) openCommitLogNode(node *widgets.TreeNode) {
+	if node == nil {
+		return
+	}
+	if commit, ok := cp.logCommits[node.ID]; ok {
+		if cp.OnOpenCommit != nil {
+			cp.OnOpenCommit(commit.Dir, commit.Ref, commit.Short)
+		}
+		return
+	}
+	cp.openCommitFile(node, false)
+}
+
+func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.TreeNode) bool {
+	if ev.Key() != tcell.KeyRune {
+		return false
+	}
+	switch term.KeyRune(ev) {
+	case 'r', 'R':
+		cp.Refresh()
+		return true
+	case 'c', 'o', 'v':
+		cp.openCommitFile(node, false)
+		return true
+	case 'e':
+		cp.openCommitFile(node, true)
+		return true
+	}
+	return false
 }
 
 func (cp *ChangesPanel) saveExpanded() {
@@ -722,6 +959,9 @@ func (cp *ChangesPanel) confirmDiscardAll(gi int) {
 }
 
 func (cp *ChangesPanel) SelectedFile() (dir string, status git.FileStatus, ok bool) {
+	if cp.commandContext != changesWorkingTree {
+		return
+	}
 	node := cp.Tree.Selected()
 	if node == nil {
 		return
@@ -820,6 +1060,9 @@ func (cp *ChangesPanel) RemovePRGroups() {
 }
 
 func (cp *ChangesPanel) DiscardSelected() {
+	if cp.commandContext != changesWorkingTree {
+		return
+	}
 	dir, status, _, ok := cp.parseFileNode(cp.Tree.Selected())
 	if !ok || status.Staged {
 		return
@@ -828,6 +1071,9 @@ func (cp *ChangesPanel) DiscardSelected() {
 }
 
 func (cp *ChangesPanel) ToggleStageSelected() {
+	if cp.commandContext != changesWorkingTree {
+		return
+	}
 	node := cp.Tree.Selected()
 	if node == nil {
 		return
@@ -844,6 +1090,10 @@ func (cp *ChangesPanel) ToggleStageSelected() {
 }
 
 func (cp *ChangesPanel) OpenSelectedDiff(extended bool) {
+	if cp.commandContext == changesCommitLog {
+		cp.openCommitFile(cp.CommitLog.Selected(), extended)
+		return
+	}
 	node := cp.Tree.Selected()
 	if node == nil {
 		return
@@ -856,6 +1106,10 @@ func (cp *ChangesPanel) OpenSelectedDiff(extended bool) {
 }
 
 func (cp *ChangesPanel) ActivateSelected() {
+	if cp.commandContext == changesCommitLog {
+		cp.openCommitLogNode(cp.CommitLog.Selected())
+		return
+	}
 	if cp.selectedInPR() {
 		cp.OpenSelectedDiff(false)
 	} else {

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -39,6 +39,12 @@ type ChangesPanel struct {
 	// lastLogDir which only guards redundant rebuilds. They differ because
 	// Refresh clears the guard while the rendered log stays put.
 	logDir string
+	// logAnchor is the immutable HEAD used for every loaded page. logLoaded is
+	// the next --skip offset; the remaining fields keep the sentinel idempotent.
+	logAnchor      string
+	logLoaded      int
+	logHasMore     bool
+	logPagePending bool
 	// commitFiles caches a commit's file list. A commit's contents never
 	// change, so an entry can never go stale — only numerous, hence the bound.
 	commitFiles      map[string][]git.FileStatus
@@ -313,6 +319,10 @@ func (cp *ChangesPanel) refreshCommitLog() {
 		cp.saveCommitLogState()
 		cp.lastLogDir = ""
 		cp.logDir = ""
+		cp.logAnchor = ""
+		cp.logLoaded = 0
+		cp.logHasMore = false
+		cp.logPagePending = false
 		cp.CommitLog.SetItems(nil)
 		return
 	}
@@ -355,6 +365,34 @@ func (cp *ChangesPanel) CancelHistoryRead() {
 		cp.logCancel = nil
 	}
 	cp.logGen++
+	cp.logPagePending = false
+}
+
+// loadOlderHistory appends the next page from the same HEAD snapshot. It is an
+// explicit action instead of scroll-triggered loading: reaching the last row
+// with keyboard navigation should not unexpectedly move the list underneath
+// the reader.
+func (cp *ChangesPanel) loadOlderHistory() {
+	if cp.logPagePending || !cp.logHasMore || cp.logDir == "" || cp.logAnchor == "" {
+		return
+	}
+	cp.logPagePending = true
+	cp.replaceHistoryLoadNode(true)
+	dir, anchor, offset, gen := cp.logDir, cp.logAnchor, cp.logLoaded, cp.logGen
+	ctx, cancel := context.WithTimeout(context.Background(), commitLogTimeout)
+	cp.logCancel = cancel
+	if cp.Screen == nil {
+		result := readCommitLogPageContext(ctx, dir, anchor, offset, gen)
+		cancel()
+		cp.ApplyCommitLog(result)
+		return
+	}
+	screen := cp.Screen
+	go func() {
+		result := readCommitLogPageContext(ctx, dir, anchor, offset, gen)
+		cancel()
+		screen.PostEvent(tcell.NewEventInterrupt(result))
+	}()
 }
 
 // saveCommitLogState records the currently rendered log's expansion and
@@ -503,6 +541,10 @@ func (cp *ChangesPanel) openCommitFile(node *widgets.TreeNode, extended bool) {
 
 func (cp *ChangesPanel) openCommitLogNode(node *widgets.TreeNode) {
 	if node == nil {
+		return
+	}
+	if node.ID == historyLoadOlderID {
+		cp.loadOlderHistory()
 		return
 	}
 	if commit, ok := cp.logCommits[node.ID]; ok {

--- a/internal/app/changes_panel_layout_test.go
+++ b/internal/app/changes_panel_layout_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestChangesPanelPlacesCommitInputAboveWorkingTree(t *testing.T) {
+	cp := NewChangesPanel()
+	if cp.Adapter.Inner() != cp.Split {
+		t.Fatalf("changes panel root = %T, want its content split", cp.Adapter.Inner())
+	}
+	top, ok := cp.Split.Top.(*widgets.VStackWidget)
+	if !ok {
+		t.Fatalf("changes panel top = %T, want *widgets.VStackWidget", cp.Split.Top)
+	}
+	if len(top.Children) != 3 {
+		t.Fatalf("changes panel top has %d children, want 3", len(top.Children))
+	}
+	if top.Children[0] != cp.Input {
+		t.Errorf("first child = %T, want commit input", top.Children[0])
+	}
+	if _, ok := top.Children[1].(*widgets.DividerWidget); !ok {
+		t.Errorf("second child = %T, want divider", top.Children[1])
+	}
+	if top.Children[2] != cp.Tree {
+		t.Errorf("third child = %T, want working-tree changes", top.Children[2])
+	}
+
+	bottom, ok := cp.Split.Bottom.(*widgets.VStackWidget)
+	if !ok {
+		t.Fatalf("changes panel bottom = %T, want *widgets.VStackWidget", cp.Split.Bottom)
+	}
+	if len(bottom.Children) != 2 {
+		t.Fatalf("changes panel bottom has %d children, want 2", len(bottom.Children))
+	}
+	if _, ok := bottom.Children[0].(*widgets.TitleWidget); !ok {
+		t.Errorf("first bottom child = %T, want commit-history title", bottom.Children[0])
+	}
+	if box, ok := bottom.Children[1].(*widgets.BoxWidget); !ok {
+		t.Errorf("second bottom child = %T, want commit-history box", bottom.Children[1])
+	} else if box.FixedHeight != 0 {
+		t.Errorf("commit-history box has fixed height %d, want grow layout", box.FixedHeight)
+	}
+
+	// Focus follows visual order: the primary action is ready immediately, and
+	// one Tab reaches the working-tree actions beneath it.
+	cp.Adapter.SetFocused(true)
+	if got := cp.Adapter.FocusedWidget(); got != cp.Input {
+		t.Errorf("initial focus = %T, want commit input", got)
+	}
+	cp.Adapter.HandleEvent(tcell.NewEventKey(tcell.KeyTab, "", tcell.ModNone))
+	if got := cp.Adapter.FocusedWidget(); got != cp.Tree {
+		t.Errorf("focus after Tab = %T, want working-tree changes", got)
+	}
+	cp.Adapter.HandleEvent(tcell.NewEventKey(tcell.KeyTab, "", tcell.ModNone))
+	if got := cp.Adapter.FocusedWidget(); got != cp.CommitLog {
+		t.Errorf("focus after second Tab = %T, want commit history", got)
+	}
+}

--- a/internal/app/changes_tree.go
+++ b/internal/app/changes_tree.go
@@ -161,8 +161,8 @@ func expandPathToID(nodes []*widgets.TreeNode, id string) bool {
 func (cp *ChangesPanel) FileView() string { return cp.fileView }
 
 func (cp *ChangesPanel) SetFileView(view string) {
-	if view != config.GitFileViewList {
-		view = config.GitFileViewTree
+	if view != config.GitFileViewTree {
+		view = config.GitFileViewList
 	}
 	if cp.fileView == view {
 		return

--- a/internal/app/changes_tree.go
+++ b/internal/app/changes_tree.go
@@ -1,0 +1,209 @@
+package app
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/widgets"
+)
+
+const commitFolderPrefix = "folder:history:"
+
+type filePathDir struct {
+	name  string
+	path  string
+	dirs  map[string]*filePathDir
+	files []git.FileStatus
+}
+
+func newFilePathDir(name, path string) *filePathDir {
+	return &filePathDir{name: name, path: path, dirs: make(map[string]*filePathDir)}
+}
+
+// compactFileTree turns Git's slash-separated paths into directory nodes.
+// Consecutive directories with no files or siblings render as one row, which
+// preserves the hierarchy without spending most of a short sidebar on folders.
+func compactFileTree(scope string, files []git.FileStatus, makeLeaf func(git.FileStatus) *widgets.TreeNode, expanded map[string]bool) []*widgets.TreeNode {
+	root := newFilePathDir("", "")
+	for _, file := range files {
+		parts := strings.Split(file.Path, "/")
+		if len(parts) == 1 {
+			root.files = append(root.files, file)
+			continue
+		}
+		dir := root
+		for _, part := range parts[:len(parts)-1] {
+			childPath := part
+			if dir.path != "" {
+				childPath = dir.path + "/" + part
+			}
+			child := dir.dirs[part]
+			if child == nil {
+				child = newFilePathDir(part, childPath)
+				dir.dirs[part] = child
+			}
+			dir = child
+		}
+		dir.files = append(dir.files, file)
+	}
+
+	return compactPathChildren(scope, root, makeLeaf, expanded)
+}
+
+func compactPathChildren(scope string, dir *filePathDir, makeLeaf func(git.FileStatus) *widgets.TreeNode, expanded map[string]bool) []*widgets.TreeNode {
+	dirNames := make([]string, 0, len(dir.dirs))
+	for name := range dir.dirs {
+		dirNames = append(dirNames, name)
+	}
+	slices.Sort(dirNames)
+
+	nodes := make([]*widgets.TreeNode, 0, len(dirNames)+len(dir.files))
+	for _, name := range dirNames {
+		start := dir.dirs[name]
+		current := start
+		labels := []string{current.name}
+		for len(current.files) == 0 && len(current.dirs) == 1 {
+			for _, child := range current.dirs {
+				current = child
+				labels = append(labels, current.name)
+			}
+		}
+
+		id := "folder:" + scope + ":" + start.path
+		isExpanded := true
+		if saved, ok := expanded[id]; ok {
+			isExpanded = saved
+		}
+		nodes = append(nodes, &widgets.TreeNode{
+			ID:         id,
+			Label:      strings.Join(labels, "/"),
+			Expandable: true,
+			Expanded:   isExpanded,
+			Children:   compactPathChildren(scope, current, makeLeaf, expanded),
+		})
+	}
+
+	slices.SortFunc(dir.files, func(a, b git.FileStatus) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	for _, file := range dir.files {
+		leaf := makeLeaf(file)
+		leaf.Label = gitPathBase(file.Path)
+		leaf.TruncateLeft = false
+		nodes = append(nodes, leaf)
+	}
+	return nodes
+}
+
+func gitPathBase(path string) string {
+	if slash := strings.LastIndexByte(path, '/'); slash >= 0 {
+		return path[slash+1:]
+	}
+	return path
+}
+
+func isCommitFolderNode(node *widgets.TreeNode) bool {
+	return node != nil && strings.HasPrefix(node.ID, commitFolderPrefix)
+}
+
+func selectedViewTargetID(tree *widgets.TreeWidget) string {
+	if tree == nil || tree.Selected() == nil {
+		return ""
+	}
+	node := tree.Selected()
+	if strings.HasPrefix(node.ID, "folder:") {
+		if leaf := firstFileDescendant(node.Children); leaf != nil {
+			return leaf.ID
+		}
+	}
+	return node.ID
+}
+
+func firstFileDescendant(nodes []*widgets.TreeNode) *widgets.TreeNode {
+	for _, node := range nodes {
+		if strings.HasPrefix(node.ID, "file:") || strings.HasPrefix(node.ID, "cfile:") {
+			return node
+		}
+		if leaf := firstFileDescendant(node.Children); leaf != nil {
+			return leaf
+		}
+	}
+	return nil
+}
+
+// revealTreeSelection restores by stable identity and opens only the ancestors
+// needed to make that identity visible. It deliberately never falls back to a
+// numeric row, since Tree and List have different visible row counts.
+func revealTreeSelection(tree *widgets.TreeWidget, id string) bool {
+	if tree == nil || id == "" || !expandPathToID(tree.Config.Items, id) {
+		return false
+	}
+	tree.SetItems(tree.Config.Items)
+	tree.SelectByID(id)
+	return tree.Selected() != nil && tree.Selected().ID == id
+}
+
+func expandPathToID(nodes []*widgets.TreeNode, id string) bool {
+	for _, node := range nodes {
+		if node.ID == id {
+			return true
+		}
+		if expandPathToID(node.Children, id) {
+			node.Expanded = true
+			return true
+		}
+	}
+	return false
+}
+
+func (cp *ChangesPanel) FileView() string { return cp.fileView }
+
+func (cp *ChangesPanel) SetFileView(view string) {
+	if view != config.GitFileViewList {
+		view = config.GitFileViewTree
+	}
+	if cp.fileView == view {
+		return
+	}
+
+	workingSelection := selectedViewTargetID(cp.Tree)
+	logSelection := selectedViewTargetID(cp.CommitLog)
+	cp.saveExpanded()
+	cp.saveCommitLogState()
+	cp.fileView = view
+	cp.buildTree()
+	cp.rebuildCommitFileNodes()
+	revealTreeSelection(cp.Tree, workingSelection)
+	revealTreeSelection(cp.CommitLog, logSelection)
+}
+
+func (cp *ChangesPanel) rebuildCommitFileNodes() {
+	cp.logFiles = make(map[string]commitFileRef)
+	for _, node := range cp.CommitLog.Config.Items {
+		commit, ok := cp.logCommits[node.ID]
+		if !ok || len(node.Children) == 0 {
+			continue
+		}
+		files, cached := cp.commitFiles[commit.Dir+"\x00"+commit.Ref]
+		if cached {
+			node.Children = cp.commitFileNodes(commit.Dir, commit.Ref, commit.Short, node.ID, files)
+		}
+	}
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+}
+
+func (cp *ChangesPanel) fileNodes(scope, dir string, files []git.FileStatus, staged bool) []*widgets.TreeNode {
+	makeLeaf := func(file git.FileStatus) *widgets.TreeNode {
+		return cp.fileNode(dir, file, staged)
+	}
+	if cp.fileView == config.GitFileViewList {
+		nodes := make([]*widgets.TreeNode, 0, len(files))
+		for _, file := range files {
+			nodes = append(nodes, makeLeaf(file))
+		}
+		return nodes
+	}
+	return compactFileTree(scope, files, makeLeaf, cp.expanded)
+}

--- a/internal/app/changes_tree_test.go
+++ b/internal/app/changes_tree_test.go
@@ -33,6 +33,7 @@ func nodeWithID(nodes []*widgets.TreeNode, id string) *widgets.TreeNode {
 
 func TestChangesTreeCompactsPathsAndKeepsFileIdentity(t *testing.T) {
 	cp := NewChangesPanel("/repo")
+	cp.SetFileView(config.GitFileViewTree)
 	cp.groups = []changesGroup{{
 		Dir:  "/repo",
 		Name: "repo",
@@ -66,6 +67,7 @@ func TestChangesTreeCompactsPathsAndKeepsFileIdentity(t *testing.T) {
 
 func TestGitFileViewSwitchPreservesSelectionAndRevealsAncestors(t *testing.T) {
 	cp := NewChangesPanel("/repo")
+	cp.SetFileView(config.GitFileViewTree)
 	cp.groups = []changesGroup{{
 		Dir:      "/repo",
 		Name:     "repo",
@@ -102,6 +104,7 @@ func TestGitFileViewSwitchPreservesSelectionAndRevealsAncestors(t *testing.T) {
 
 func TestCommitFilesUseTreeAndFolderLabelsToggle(t *testing.T) {
 	cp := NewChangesPanel("/repo")
+	cp.SetFileView(config.GitFileViewTree)
 	const ref = "0123456789012345678901234567890123456789"
 	commitID := "commit:" + ref
 	files := []git.FileStatus{
@@ -148,6 +151,7 @@ func TestCommitFilesUseTreeAndFolderLabelsToggle(t *testing.T) {
 
 func TestChangesExpandCollapseAllCoversWorkingAndLoadedCommitFileTrees(t *testing.T) {
 	cp := NewChangesPanel("/repo")
+	cp.SetFileView(config.GitFileViewTree)
 	cp.groups = []changesGroup{{
 		Dir:      "/repo",
 		Name:     "repo",
@@ -245,6 +249,7 @@ func TestCompactFileTreeTreatsColonAsPathContent(t *testing.T) {
 
 func TestWorkingFolderSelectionKeepsItsRepositoryContext(t *testing.T) {
 	cp := NewChangesPanel("/one", "/two")
+	cp.SetFileView(config.GitFileViewTree)
 	cp.groups = []changesGroup{
 		{Dir: "/one", Name: "one", Unstaged: []git.FileStatus{{Status: "M", Path: "one.go"}}},
 		{Dir: "/two", Name: "two", Unstaged: []git.FileStatus{{Status: "M", Path: "nested/two.go"}}},

--- a/internal/app/changes_tree_test.go
+++ b/internal/app/changes_tree_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
 )
@@ -142,6 +143,91 @@ func TestCommitFilesUseTreeAndFolderLabelsToggle(t *testing.T) {
 	cp.SetFileView(config.GitFileViewTree)
 	if got := cp.CommitLog.Selected(); got == nil || got.ID != oneID || got.Label != "one.go" {
 		t.Fatalf("commit file selection did not survive the switch back to tree: %+v", got)
+	}
+}
+
+func TestChangesExpandCollapseAllCoversWorkingAndLoadedCommitFileTrees(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.groups = []changesGroup{{
+		Dir:      "/repo",
+		Name:     "repo",
+		Unstaged: []git.FileStatus{{Status: "M", Path: "internal/app/file.go"}},
+	}}
+	cp.buildTree()
+	workingFolder := nodeWithLabel(cp.Tree.Config.Items, "internal/app")
+	if workingFolder == nil {
+		t.Fatal("missing working-tree folder")
+	}
+
+	const ref = "0123456789012345678901234567890123456789"
+	commitID := "commit:" + ref
+	cp.logCommits[commitID] = commitFileRef{Dir: "/repo", Ref: ref, Short: ref[:7]}
+	commit := &widgets.TreeNode{
+		ID:       commitID,
+		Label:    "nested files",
+		Expanded: true,
+		Children: cp.commitFileNodes("/repo", ref, ref[:7], commitID, []git.FileStatus{{Status: "M", Path: "pkg/history/one.go"}}),
+	}
+	cp.CommitLog.SetItems([]*widgets.TreeNode{commit})
+	commitFolder := nodeWithLabel(commit.Children, "pkg/history")
+
+	cp.CollapseAll()
+	if cp.Tree.Config.Items[0].Expanded || workingFolder.Expanded || commitFolder.Expanded {
+		t.Fatalf("CollapseAll left file-tree branches open: section=%v work=%v history=%v",
+			cp.Tree.Config.Items[0].Expanded, workingFolder.Expanded, commitFolder.Expanded)
+	}
+	if !commit.Expanded {
+		t.Fatal("CollapseAll should not collapse commit rows and trigger history-wide behavior")
+	}
+	cp.buildTree()
+	workingFolder = nodeWithLabel(cp.Tree.Config.Items, "internal/app")
+	if workingFolder == nil || workingFolder.Expanded {
+		t.Fatal("collapsed folder state did not survive a working-tree rebuild")
+	}
+
+	cp.ExpandAll()
+	if !cp.Tree.Config.Items[0].Expanded || !workingFolder.Expanded || !commitFolder.Expanded {
+		t.Fatalf("ExpandAll left file-tree branches closed: section=%v work=%v history=%v",
+			cp.Tree.Config.Items[0].Expanded, workingFolder.Expanded, commitFolder.Expanded)
+	}
+}
+
+func TestChangesFolderAndHistoryRightClickUsePanelMenu(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	called := 0
+	cp.OnPanelMenu = func(x, y int) {
+		if x != 12 || y != 7 {
+			t.Fatalf("panel menu position = %d,%d, want 12,7", x, y)
+		}
+		called++
+	}
+	folder := &widgets.TreeNode{ID: "folder:work:src", Label: "src", Expandable: true}
+	cp.handleMenu(folder, 12, 7)
+	cp.CommitLog.Config.OnMenu(nil, &widgets.TreeNode{ID: "commit:abc"}, 12, 7)
+	if called != 2 {
+		t.Fatalf("panel menu calls = %d, want working folder and history row", called)
+	}
+}
+
+func TestChangesMenusExposeTreeActionsAndPresentationSubmenus(t *testing.T) {
+	settings := config.DefaultSettings()
+	a := &App{Settings: &settings}
+	for name, items := range map[string][]ui.ContextMenuItem{
+		"panel":   a.BuildChangesPanelMenu(),
+		"context": a.BuildChangesContextMenu(),
+	} {
+		commands := map[string]bool{}
+		labels := map[string]bool{}
+		for _, item := range items {
+			commands[item.Command] = true
+			labels[item.Label] = true
+		}
+		if !commands["changes.expandAll"] || !commands["changes.collapseAll"] {
+			t.Errorf("%s menu missing tree actions: %+v", name, items)
+		}
+		if !labels["Git Files"] || !labels["Diff View"] {
+			t.Errorf("%s menu missing presentation submenus: %+v", name, items)
+		}
 	}
 }
 

--- a/internal/app/changes_tree_test.go
+++ b/internal/app/changes_tree_test.go
@@ -225,6 +225,9 @@ func TestChangesMenusExposeTreeActionsAndPresentationSubmenus(t *testing.T) {
 		if !commands["changes.expandAll"] || !commands["changes.collapseAll"] {
 			t.Errorf("%s menu missing tree actions: %+v", name, items)
 		}
+		if !commands["changes.viewAll"] {
+			t.Errorf("%s menu missing combined change-set action: %+v", name, items)
+		}
 		if !labels["Git Files"] || !labels["Diff View"] {
 			t.Errorf("%s menu missing presentation submenus: %+v", name, items)
 		}

--- a/internal/app/changes_tree_test.go
+++ b/internal/app/changes_tree_test.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+func findTreeNode(nodes []*widgets.TreeNode, match func(*widgets.TreeNode) bool) *widgets.TreeNode {
+	for _, node := range nodes {
+		if match(node) {
+			return node
+		}
+		if found := findTreeNode(node.Children, match); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func nodeWithLabel(nodes []*widgets.TreeNode, label string) *widgets.TreeNode {
+	return findTreeNode(nodes, func(node *widgets.TreeNode) bool { return node.Label == label })
+}
+
+func nodeWithID(nodes []*widgets.TreeNode, id string) *widgets.TreeNode {
+	return findTreeNode(nodes, func(node *widgets.TreeNode) bool { return node.ID == id })
+}
+
+func TestChangesTreeCompactsPathsAndKeepsFileIdentity(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.groups = []changesGroup{{
+		Dir:  "/repo",
+		Name: "repo",
+		Unstaged: []git.FileStatus{
+			{Status: "M", Path: "README.md"},
+			{Status: "M", Path: "docs-web/src/content/docs/themes.md"},
+			{Status: "M", Path: "docs-web/src/content/docs/settings.md"},
+			{Status: "M", Path: "internal/app/changes_panel.go"},
+			{Status: "M", Path: "internal/ui/diff_widget.go"},
+		},
+	}}
+	cp.buildTree()
+
+	section := cp.Tree.Config.Items[0]
+	if nodeWithLabel(section.Children, "docs-web/src/content/docs") == nil {
+		t.Fatalf("single-child directory chain was not compacted: %+v", section.Children)
+	}
+	internal := nodeWithLabel(section.Children, "internal")
+	if internal == nil || nodeWithLabel(internal.Children, "app") == nil || nodeWithLabel(internal.Children, "ui") == nil {
+		t.Fatalf("branching directories lost their hierarchy: %+v", internal)
+	}
+	leaf := nodeWithLabel(section.Children, "changes_panel.go")
+	if leaf == nil {
+		t.Fatal("tree did not render the file basename")
+	}
+	dir, status, staged, ok := cp.parseFileNode(leaf)
+	if !ok || dir != "/repo" || status.Path != "internal/app/changes_panel.go" || staged {
+		t.Fatalf("tree leaf lost its canonical file identity: dir=%q status=%+v staged=%v ok=%v", dir, status, staged, ok)
+	}
+}
+
+func TestGitFileViewSwitchPreservesSelectionAndRevealsAncestors(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.groups = []changesGroup{{
+		Dir:      "/repo",
+		Name:     "repo",
+		Unstaged: []git.FileStatus{{Status: "M", Path: "deep/nested/file.go"}},
+	}}
+	cp.buildTree()
+
+	section := cp.Tree.Config.Items[0]
+	folder := nodeWithLabel(section.Children, "deep/nested")
+	if folder == nil {
+		t.Fatal("missing compact folder")
+	}
+	folder.Expanded = false
+	cp.Tree.SetItems(cp.Tree.Config.Items)
+
+	cp.SetFileView(config.GitFileViewList)
+	fileID := "file:/repo:deep/nested/file.go:false"
+	if !revealTreeSelection(cp.Tree, fileID) {
+		t.Fatal("flat view did not contain the nested file")
+	}
+	if got := cp.Tree.Selected(); got == nil || got.Label != "deep/nested/file.go" {
+		t.Fatalf("flat view label = %+v, want full path", got)
+	}
+
+	cp.SetFileView(config.GitFileViewTree)
+	if got := cp.Tree.Selected(); got == nil || got.ID != fileID || got.Label != "file.go" {
+		t.Fatalf("tree switch did not preserve the selected file: %+v", got)
+	}
+	folder = nodeWithLabel(cp.Tree.Config.Items, "deep/nested")
+	if folder == nil || !folder.Expanded {
+		t.Fatal("selected file's collapsed ancestor was not revealed")
+	}
+}
+
+func TestCommitFilesUseTreeAndFolderLabelsToggle(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	const ref = "0123456789012345678901234567890123456789"
+	commitID := "commit:" + ref
+	files := []git.FileStatus{
+		{Status: "M", Path: "pkg/history/one.go"},
+		{Status: "A", Path: "pkg/history/two.go"},
+	}
+	cp.commitFiles["/repo\x00"+ref] = files
+	cp.logCommits[commitID] = commitFileRef{Dir: "/repo", Ref: ref, Short: ref[:7]}
+	commit := &widgets.TreeNode{
+		ID:       commitID,
+		Label:    "nested files",
+		Expanded: true,
+		Children: cp.commitFileNodes("/repo", ref, ref[:7], commitID, files),
+	}
+	cp.CommitLog.SetItems([]*widgets.TreeNode{commit})
+
+	folder := nodeWithLabel(commit.Children, "pkg/history")
+	if folder == nil || !strings.HasPrefix(folder.ID, commitFolderPrefix) {
+		t.Fatalf("commit files were not grouped under a history folder: %+v", commit.Children)
+	}
+	if !revealTreeSelection(cp.CommitLog, folder.ID) {
+		t.Fatal("could not select commit folder")
+	}
+	cp.CommitLog.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if folder.Expanded {
+		t.Fatal("activating a commit folder label did not collapse it")
+	}
+
+	cp.SetFileView(config.GitFileViewList)
+	oneID := "cfile:" + commitID + ":pkg/history/one.go"
+	leaf := nodeWithID(cp.CommitLog.Config.Items, oneID)
+	if leaf == nil || leaf.Label != "pkg/history/one.go" {
+		t.Fatalf("list view did not restore full commit paths: %+v", leaf)
+	}
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != oneID {
+		t.Fatalf("folder selection did not move deterministically to its first file: %+v", got)
+	}
+
+	cp.SetFileView(config.GitFileViewTree)
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != oneID || got.Label != "one.go" {
+		t.Fatalf("commit file selection did not survive the switch back to tree: %+v", got)
+	}
+}
+
+func TestCompactFileTreeTreatsColonAsPathContent(t *testing.T) {
+	nodes := compactFileTree("test", []git.FileStatus{{Status: "M", Path: "dir:one/file:name.go"}}, func(file git.FileStatus) *widgets.TreeNode {
+		return &widgets.TreeNode{ID: file.Path, Label: file.Path}
+	}, nil)
+	if len(nodes) != 1 || nodes[0].Label != "dir:one" || len(nodes[0].Children) != 1 || nodes[0].Children[0].Label != "file:name.go" {
+		t.Fatalf("colon-containing path was split as identity syntax: %+v", nodes)
+	}
+}
+
+func TestWorkingFolderSelectionKeepsItsRepositoryContext(t *testing.T) {
+	cp := NewChangesPanel("/one", "/two")
+	cp.groups = []changesGroup{
+		{Dir: "/one", Name: "one", Unstaged: []git.FileStatus{{Status: "M", Path: "one.go"}}},
+		{Dir: "/two", Name: "two", Unstaged: []git.FileStatus{{Status: "M", Path: "nested/two.go"}}},
+	}
+	cp.multiRoot = true
+	cp.buildTree()
+
+	folder := nodeWithLabel(cp.Tree.Config.Items[1].Children, "nested")
+	if folder == nil || !revealTreeSelection(cp.Tree, folder.ID) {
+		t.Fatal("could not select the second repository's folder")
+	}
+	if got := cp.selectedGroupDir(); got != "/two" {
+		t.Errorf("folder selection resolved repo %q, want /two", got)
+	}
+	if gi := cp.groupIndexFromNode(folder); gi != -1 {
+		t.Errorf("folder unexpectedly gained repo-wide bulk actions through group index %d", gi)
+	}
+	cp.buildTree()
+	if got := cp.Tree.Selected(); got == nil || got.ID != folder.ID {
+		t.Fatalf("status rebuild did not preserve the selected folder: %+v", got)
+	}
+}

--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -167,30 +167,44 @@ func (a *App) debugRunPlugin() {
 
 func (a *App) debugScreenshot() {
 	a.DismissDialog()
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		path := "screenshot.txt"
-		if err := a.DumpScreenshot(path); err != nil {
-			a.Status.SetNotification("Screenshot error: "+err.Error(), view.NotifyError, 3*time.Second)
-		} else {
-			a.Status.SetNotification("Screenshot saved: "+path, view.NotifyInfo, 3*time.Second)
-		}
-		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	}()
+	time.AfterFunc(50*time.Millisecond, func() {
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&DebugWriteRequest{Kind: "screenshot", Path: "screenshot.txt"}))
+	})
 }
 
 func (a *App) debugDumpState() {
 	a.DismissDialog()
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		path := "debug-state.json"
-		if err := a.DumpDebugState(path); err != nil {
+	time.AfterFunc(50*time.Millisecond, func() {
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&DebugWriteRequest{Kind: "state", Path: "debug-state.json"}))
+	})
+}
+
+// DebugWriteRequest returns delayed debug capture work to the main event loop.
+// Both Screenshot and BuildDebugState read widget state and must not race the
+// renderer from a timer goroutine.
+type DebugWriteRequest struct {
+	Kind string
+	Path string
+}
+
+func (a *App) HandleDebugWriteRequest(request *DebugWriteRequest) {
+	var err error
+	switch request.Kind {
+	case "screenshot":
+		err = a.DumpScreenshot(request.Path)
+		if err != nil {
+			a.Status.SetNotification("Screenshot error: "+err.Error(), view.NotifyError, 3*time.Second)
+		} else {
+			a.Status.SetNotification("Screenshot saved: "+request.Path, view.NotifyInfo, 3*time.Second)
+		}
+	case "state":
+		err = a.DumpDebugState(request.Path)
+		if err != nil {
 			a.Status.SetNotification("Dump error: "+err.Error(), view.NotifyError, 3*time.Second)
 		} else {
-			a.Status.SetNotification("State saved: "+path, view.NotifyInfo, 3*time.Second)
+			a.Status.SetNotification("State saved: "+request.Path, view.NotifyInfo, 3*time.Second)
 		}
-		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	}()
+	}
 }
 
 func (a *App) debugKeyboardTester() {

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/ui"
 )
 
 func (a *App) editorPathLang() (string, string) {
@@ -288,6 +289,42 @@ func (a *App) DiffPrevHunk() {
 	a.EditorGroup.GoToLine(target + 1) // GoToLine is 1-based
 }
 
+func (a *App) DiffToggleWrap() {
+	if surface := a.EditorGroup.ActiveDiffModeSurface(); surface != nil {
+		surface.SetWrapMode(surface.WrapMode().Toggle())
+	}
+}
+
+func (a *App) DiffToggleUnified() {
+	if surface := a.EditorGroup.ActiveDiffModeSurface(); surface != nil {
+		surface.SetMode(surface.Mode().Toggle())
+	}
+}
+
+func (a *App) DiffUseSplitMode() {
+	if surface := a.EditorGroup.ActiveDiffModeSurface(); surface != nil {
+		surface.SetMode(ui.DiffModeSplit)
+	}
+}
+
+func (a *App) DiffUseUnifiedMode() {
+	if surface := a.EditorGroup.ActiveDiffModeSurface(); surface != nil {
+		surface.SetMode(ui.DiffModeUnified)
+	}
+}
+
+func (a *App) CommitDetailCollapseAll() {
+	if detail := a.EditorGroup.ActiveCommitDetailWidget(); detail != nil {
+		detail.CollapseAllFiles()
+	}
+}
+
+func (a *App) CommitDetailExpandAll() {
+	if detail := a.EditorGroup.ActiveCommitDetailWidget(); detail != nil {
+		detail.ExpandAllFiles()
+	}
+}
+
 func registerEditorCommands(app *App) {
 	reg := app.Reg
 
@@ -301,6 +338,42 @@ func registerEditorCommands(app *App) {
 		ID: "diff.prevHunk", Title: "Git: Previous Changed Hunk",
 		Keywords: []string{"git", "diff", "hunk", "change", "navigate"},
 		Handler:  app.DiffPrevHunk,
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.toggleWrap", Title: "Git: Toggle Diff Wrap",
+		Keywords: []string{"git", "diff", "wrap", "line"},
+		Handler:  app.DiffToggleWrap,
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.toggleUnified", Title: "Git: Toggle Unified Diff",
+		Keywords: []string{"git", "diff", "unified", "split", "stack"},
+		Handler:  app.DiffToggleUnified,
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.splitView", Title: "Git: Split Diff",
+		Keywords: []string{"git", "diff", "split", "side by side", "mode"},
+		Handler:  app.DiffUseSplitMode,
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.unifiedView", Title: "Git: Unified Diff",
+		Keywords: []string{"git", "diff", "unified", "stack", "mode"},
+		Handler:  app.DiffUseUnifiedMode,
+	})
+
+	reg.Register(command.Command{
+		ID: "commitDetail.collapseAll", Title: "Git: Collapse All Commit Files",
+		Keywords: []string{"git", "commit", "detail", "collapse", "files"},
+		Handler:  app.CommitDetailCollapseAll,
+	})
+
+	reg.Register(command.Command{
+		ID: "commitDetail.expandAll", Title: "Git: Expand All Commit Files",
+		Keywords: []string{"git", "commit", "detail", "expand", "files"},
+		Handler:  app.CommitDetailExpandAll,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -319,6 +319,18 @@ func (a *App) DiffUseUnifiedMode() {
 	}
 }
 
+func (a *App) DiffUseChangesOnlyContext() {
+	if surface := a.EditorGroup.ActiveDiffContextSurface(); surface != nil {
+		surface.SetContextMode(ui.DiffContextChangesOnly)
+	}
+}
+
+func (a *App) DiffUseFullFileContext() {
+	if surface := a.EditorGroup.ActiveDiffContextSurface(); surface != nil {
+		surface.SetContextMode(ui.DiffContextFullFile)
+	}
+}
+
 func (a *App) CommitDetailCollapseAll() {
 	if detail := a.EditorGroup.ActiveCommitDetailWidget(); detail != nil {
 		detail.CollapseAllFiles()
@@ -368,6 +380,18 @@ func registerEditorCommands(app *App) {
 		ID: "diff.unifiedView", Title: "Git: Unified Diff",
 		Keywords: []string{"git", "diff", "unified", "stack", "mode"},
 		Handler:  app.DiffUseUnifiedMode,
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.changesOnlyView", Title: "Git: Show Changes Only",
+		Keywords: []string{"git", "diff", "compact", "collapsed", "context", "hunks"},
+		Handler:  app.DiffUseChangesOnlyContext,
+	})
+
+	reg.Register(command.Command{
+		ID: "diff.fullFileView", Title: "Git: Show Full File",
+		Keywords: []string{"git", "diff", "extended", "context", "complete", "file"},
+		Handler:  app.DiffUseFullFileContext,
 	})
 
 	reg.Register(command.Command{
@@ -539,9 +563,7 @@ func registerEditorCommands(app *App) {
 		ID: "diff.extendedView", Title: "Git: Extended Diff",
 		Keywords: []string{"git", "changes", "compare"},
 		Handler: func() {
-			if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
-				dv.SetExtended(true)
-			}
+			app.DiffUseFullFileContext()
 		},
 	})
 
@@ -549,9 +571,7 @@ func registerEditorCommands(app *App) {
 		ID: "diff.compactView", Title: "Git: Compact Diff",
 		Keywords: []string{"git", "changes", "compare"},
 		Handler: func() {
-			if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
-				dv.SetExtended(false)
-			}
+			app.DiffUseChangesOnlyContext()
 		},
 	})
 

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -518,6 +518,18 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "tab.moveLeft", Title: "View: Move Tab Left",
+		Keywords: []string{"tab", "reorder", "move", "left"},
+		Handler:  func() { app.EditorGroup.MoveActiveTab(-1) },
+	})
+
+	reg.Register(command.Command{
+		ID: "tab.moveRight", Title: "View: Move Tab Right",
+		Keywords: []string{"tab", "reorder", "move", "right"},
+		Handler:  func() { app.EditorGroup.MoveActiveTab(1) },
+	})
+
+	reg.Register(command.Command{
 		ID: "diff.extendedView", Title: "Git: Extended Diff",
 		Keywords: []string{"git", "changes", "compare"},
 		Handler: func() {

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -153,8 +153,9 @@ func (a *App) SaveFileAs() {
 		initial = current
 	}
 	a.ShowInputDialog("Save As", "Filename", initial, func(path string) {
-		if path != "" {
-			a.EditorGroup.SaveAs(path)
+		if path != "" && a.EditorGroup.SaveAs(path) {
+			path, lang := a.editorPathLang()
+			a.afterFileSave(path, lang)
 		}
 	})
 }
@@ -191,6 +192,10 @@ func (a *App) doSaveFile() {
 		return
 	}
 	path, lang = a.editorPathLang()
+	a.afterFileSave(path, lang)
+}
+
+func (a *App) afterFileSave(path, lang string) {
 	if lang != "" {
 		text := strings.Join(a.EditorGroup.Editor.Buf.Lines, "\n")
 		a.NotifyLSPSave(path, lang, text)
@@ -200,6 +205,7 @@ func (a *App) doSaveFile() {
 	if a.PluginManager != nil && path != "" {
 		a.PluginManager.DispatchEvent("file.save", path)
 	}
+	a.invalidateRepositoryPath(path, RepositoryStatus)
 }
 
 func (a *App) forceQuit() {

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -122,6 +122,18 @@ func registerExplorerCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "explorer.expandAll", Title: "Explorer: Expand All",
+		Keywords: []string{"view", "file", "tree", "folder", "expand"},
+		Handler:  app.Explorer.ExpandAll,
+	})
+
+	reg.Register(command.Command{
+		ID: "explorer.collapseAll", Title: "Explorer: Collapse All",
+		Keywords: []string{"view", "file", "tree", "folder", "collapse"},
+		Handler:  app.Explorer.CollapseAll,
+	})
+
+	reg.Register(command.Command{
 		ID: "explorer.open", Title: "Explorer: Toggle Node",
 		Keywords: []string{"view", "file"},
 		Handler:  func() { app.Explorer.Tree.ActivateSelected() },

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -131,6 +131,7 @@ func (a *App) SaveWorkspace() {
 			a.StatusError("Error: " + err.Error())
 		} else {
 			a.Workspace.FilePath = abs
+			a.invalidateRepositoryPath(abs, RepositoryStatus)
 			a.StatusNotify("Workspace saved: " + abs)
 		}
 	})
@@ -246,7 +247,11 @@ func registerGitCommands(app *App) {
 		ID: "changes.refresh", Title: "Git: Refresh Changes",
 		Keywords: []string{"git", "changes", "reload"},
 		Handler: func() {
-			app.Changes.Refresh()
+			if app.Repository != nil {
+				app.Repository.RefreshNow(RepositoryStatus | RepositoryHistory)
+			} else {
+				app.Changes.Refresh()
+			}
 		},
 	})
 

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -244,6 +244,13 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID:       "changes.viewAll",
+		Title:    "Git: View All Current Changes",
+		Keywords: []string{"git", "changes", "diff", "all", "working tree"},
+		Handler:  app.OpenCurrentChanges,
+	})
+
+	reg.Register(command.Command{
 		ID: "changes.refresh", Title: "Git: Refresh Changes",
 		Keywords: []string{"git", "changes", "reload"},
 		Handler: func() {

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -251,6 +251,18 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "changes.expandAll", Title: "Git: Expand All File Trees",
+		Keywords: []string{"git", "changes", "tree", "folder", "expand"},
+		Handler:  app.Changes.ExpandAll,
+	})
+
+	reg.Register(command.Command{
+		ID: "changes.collapseAll", Title: "Git: Collapse All File Trees",
+		Keywords: []string{"git", "changes", "tree", "folder", "collapse"},
+		Handler:  app.Changes.CollapseAll,
+	})
+
+	reg.Register(command.Command{
 		ID: "changes.stage", Title: "Git: Stage File",
 		Keywords: []string{"git", "changes", "add"},
 		Handler: func() {

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -38,6 +38,11 @@ func (a *App) ToggleDiffWordWrapDefault() {
 	a.SaveAndApplySettings()
 }
 
+func (a *App) ToggleDiffHighContrast() {
+	a.Settings.Editor.DiffHighContrast = !a.Settings.Editor.DiffHighContrast
+	a.SaveAndApplySettings()
+}
+
 func (a *App) UseTreeGitFileView() {
 	a.Settings.Git.FileView = config.GitFileViewTree
 	a.SaveAndApplySettings()
@@ -191,27 +196,6 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		wordWrapChecked = ui.MenuChecked
 	}
 
-	splitDiffChecked := ui.MenuUnchecked
-	unifiedDiffChecked := ui.MenuUnchecked
-	if a.Settings.Editor.DiffMode == config.DiffModeUnified {
-		unifiedDiffChecked = ui.MenuChecked
-	} else {
-		splitDiffChecked = ui.MenuChecked
-	}
-
-	diffWordWrapChecked := ui.MenuUnchecked
-	if a.Settings.Editor.DiffWordWrap {
-		diffWordWrapChecked = ui.MenuChecked
-	}
-
-	treeGitFilesChecked := ui.MenuUnchecked
-	listGitFilesChecked := ui.MenuUnchecked
-	if a.Settings.Git.FileView == config.GitFileViewList {
-		listGitFilesChecked = ui.MenuChecked
-	} else {
-		treeGitFilesChecked = ui.MenuChecked
-	}
-
 	bracketColorChecked := ui.MenuUnchecked
 	if a.Settings.Editor.BracketPairColorization {
 		bracketColorChecked = ui.MenuChecked
@@ -250,11 +234,8 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
-		{Label: "Split Diff", Command: "options.useSplitDiff", Checked: splitDiffChecked},
-		{Label: "Unified Diff", Command: "options.useUnifiedDiff", Checked: unifiedDiffChecked},
-		{Label: "Diff Word Wrap", Command: "options.toggleDiffWordWrap", Checked: diffWordWrapChecked},
-		{Label: "Git Files: Tree", Command: "options.useGitFileTree", Checked: treeGitFilesChecked},
-		{Label: "Git Files: List", Command: "options.useGitFileList", Checked: listGitFilesChecked},
+		{Label: "Diff View", Submenu: a.BuildDiffViewOptions()},
+		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
 		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
 		{Label: "Auto Dedent", Command: "options.toggleAutoDedent", Checked: autoDedentChecked},
 		{Label: "Syntax Highlight", Command: "options.toggleSyntaxHighlight", Checked: syntaxChecked},
@@ -272,6 +253,33 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		{Label: "Open Settings", Command: "settings.openUI"},
 	}
 	return items
+}
+
+func menuChecked(checked bool) int {
+	if checked {
+		return ui.MenuChecked
+	}
+	return ui.MenuUnchecked
+}
+
+// BuildDiffViewOptions is shared by the global Options menu and the Changes
+// panel menu so both surfaces expose identical defaults and checked state.
+func (a *App) BuildDiffViewOptions() []ui.ContextMenuItem {
+	return []ui.ContextMenuItem{
+		{Label: "Split", Command: "options.useSplitDiff", Checked: menuChecked(a.Settings.Editor.DiffMode != config.DiffModeUnified)},
+		{Label: "Unified", Command: "options.useUnifiedDiff", Checked: menuChecked(a.Settings.Editor.DiffMode == config.DiffModeUnified)},
+		{Label: "Wrap Lines", Command: "options.toggleDiffWordWrap", Checked: menuChecked(a.Settings.Editor.DiffWordWrap)},
+		{Label: "High Contrast", Command: "options.toggleDiffHighContrast", Checked: menuChecked(a.Settings.Editor.DiffHighContrast)},
+	}
+}
+
+// BuildGitFileOptions keeps the Tree/List choice consistent everywhere the
+// Changes panel can be configured.
+func (a *App) BuildGitFileOptions() []ui.ContextMenuItem {
+	return []ui.ContextMenuItem{
+		{Label: "Tree", Command: "options.useGitFileTree", Checked: menuChecked(a.Settings.Git.FileView != config.GitFileViewList)},
+		{Label: "List", Command: "options.useGitFileList", Checked: menuChecked(a.Settings.Git.FileView == config.GitFileViewList)},
+	}
 }
 
 func registerOptionsCommands(app *App) {
@@ -311,6 +319,12 @@ func registerOptionsCommands(app *App) {
 		ID: "options.toggleDiffWordWrap", Title: "Toggle Diff Word Wrap Default",
 		Keywords: []string{"preferences", "settings", "git", "diff", "wrap", "default"},
 		Handler:  app.ToggleDiffWordWrapDefault,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.toggleDiffHighContrast", Title: "Toggle High Contrast Diffs",
+		Keywords: []string{"preferences", "settings", "git", "diff", "contrast", "color", "accessibility"},
+		Handler:  app.ToggleDiffHighContrast,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -195,6 +195,26 @@ func (a *App) ShowBorderStylePicker() {
 	}, nil)
 }
 
+func (a *App) ShowDiffViewModePicker() {
+	a.ShowSelectDialog("Diff View Mode", diffModeItems(), func(id string) {
+		if id == config.DiffModeUnified {
+			a.UseUnifiedDiffByDefault()
+			return
+		}
+		a.UseSplitDiffByDefault()
+	}, nil)
+}
+
+func (a *App) ShowDiffContextPicker() {
+	a.ShowSelectDialog("Diff Context", diffContextItems(), func(id string) {
+		if id == config.DiffContextFull {
+			a.UseFullFileDiffByDefault()
+			return
+		}
+		a.UseChangesOnlyDiffByDefault()
+	}, nil)
+}
+
 func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	lineNumbersChecked := ui.MenuUnchecked
 	if a.Settings.Editor.LineNumbers {
@@ -244,7 +264,10 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
-		{Label: "Diff View", Submenu: a.BuildDiffViewOptions()},
+		{Label: "Diff View Mode", Command: "options.diffViewMode"},
+		{Label: "Diff Context", Command: "options.diffContext"},
+		{Label: "Wrap Diff Lines", Command: "options.toggleDiffWordWrap", Checked: menuChecked(a.Settings.Editor.DiffWordWrap)},
+		{Label: "High Contrast Diffs", Command: "options.toggleDiffHighContrast", Checked: menuChecked(a.Settings.Editor.DiffHighContrast)},
 		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
 		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
 		{Label: "Auto Dedent", Command: "options.toggleAutoDedent", Checked: autoDedentChecked},
@@ -272,8 +295,8 @@ func menuChecked(checked bool) int {
 	return ui.MenuUnchecked
 }
 
-// BuildDiffViewOptions is shared by the global Options menu and the Changes
-// panel menu so both surfaces expose identical defaults and checked state.
+// BuildDiffViewOptions keeps the Changes panel's contextual presentation menu
+// tied to the same persisted defaults exposed in Options.
 func (a *App) BuildDiffViewOptions() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
 		{Label: "Split", Command: "options.useSplitDiff", Checked: menuChecked(a.Settings.Editor.DiffMode != config.DiffModeUnified)},
@@ -315,6 +338,18 @@ func registerOptionsCommands(app *App) {
 		ID: "options.toggleWordWrap", Title: "Toggle Word Wrap",
 		Keywords: []string{"preferences", "settings", "editor", "view"},
 		Handler:  app.ToggleWordWrap,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.diffViewMode", Title: "Change Diff View Mode",
+		Keywords: []string{"preferences", "settings", "git", "diff", "split", "unified", "mode"},
+		Handler:  app.ShowDiffViewModePicker,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.diffContext", Title: "Change Diff Context",
+		Keywords: []string{"preferences", "settings", "git", "diff", "changes", "full", "context"},
+		Handler:  app.ShowDiffContextPicker,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -38,6 +38,16 @@ func (a *App) ToggleDiffWordWrapDefault() {
 	a.SaveAndApplySettings()
 }
 
+func (a *App) UseTreeGitFileView() {
+	a.Settings.Git.FileView = config.GitFileViewTree
+	a.SaveAndApplySettings()
+}
+
+func (a *App) UseListGitFileView() {
+	a.Settings.Git.FileView = config.GitFileViewList
+	a.SaveAndApplySettings()
+}
+
 func (a *App) ToggleAutoDedent() {
 	enabled := !a.Settings.Editor.IsAutoDedentEnabled()
 	a.Settings.Editor.AutoDedent = &enabled
@@ -194,6 +204,14 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		diffWordWrapChecked = ui.MenuChecked
 	}
 
+	treeGitFilesChecked := ui.MenuUnchecked
+	listGitFilesChecked := ui.MenuUnchecked
+	if a.Settings.Git.FileView == config.GitFileViewList {
+		listGitFilesChecked = ui.MenuChecked
+	} else {
+		treeGitFilesChecked = ui.MenuChecked
+	}
+
 	bracketColorChecked := ui.MenuUnchecked
 	if a.Settings.Editor.BracketPairColorization {
 		bracketColorChecked = ui.MenuChecked
@@ -235,6 +253,8 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		{Label: "Split Diff", Command: "options.useSplitDiff", Checked: splitDiffChecked},
 		{Label: "Unified Diff", Command: "options.useUnifiedDiff", Checked: unifiedDiffChecked},
 		{Label: "Diff Word Wrap", Command: "options.toggleDiffWordWrap", Checked: diffWordWrapChecked},
+		{Label: "Git Files: Tree", Command: "options.useGitFileTree", Checked: treeGitFilesChecked},
+		{Label: "Git Files: List", Command: "options.useGitFileList", Checked: listGitFilesChecked},
 		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
 		{Label: "Auto Dedent", Command: "options.toggleAutoDedent", Checked: autoDedentChecked},
 		{Label: "Syntax Highlight", Command: "options.toggleSyntaxHighlight", Checked: syntaxChecked},
@@ -291,6 +311,18 @@ func registerOptionsCommands(app *App) {
 		ID: "options.toggleDiffWordWrap", Title: "Toggle Diff Word Wrap Default",
 		Keywords: []string{"preferences", "settings", "git", "diff", "wrap", "default"},
 		Handler:  app.ToggleDiffWordWrapDefault,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useGitFileTree", Title: "View Git Files as Tree",
+		Keywords: []string{"preferences", "settings", "git", "changes", "history", "files", "tree"},
+		Handler:  app.UseTreeGitFileView,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useGitFileList", Title: "View Git Files as List",
+		Keywords: []string{"preferences", "settings", "git", "changes", "history", "files", "flat", "list"},
+		Handler:  app.UseListGitFileView,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -33,6 +33,16 @@ func (a *App) UseUnifiedDiffByDefault() {
 	a.SaveAndApplySettings()
 }
 
+func (a *App) UseChangesOnlyDiffByDefault() {
+	a.Settings.Editor.DiffContext = config.DiffContextChanges
+	a.SaveAndApplySettings()
+}
+
+func (a *App) UseFullFileDiffByDefault() {
+	a.Settings.Editor.DiffContext = config.DiffContextFull
+	a.SaveAndApplySettings()
+}
+
 func (a *App) ToggleDiffWordWrapDefault() {
 	a.Settings.Editor.DiffWordWrap = !a.Settings.Editor.DiffWordWrap
 	a.SaveAndApplySettings()
@@ -268,6 +278,10 @@ func (a *App) BuildDiffViewOptions() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
 		{Label: "Split", Command: "options.useSplitDiff", Checked: menuChecked(a.Settings.Editor.DiffMode != config.DiffModeUnified)},
 		{Label: "Unified", Command: "options.useUnifiedDiff", Checked: menuChecked(a.Settings.Editor.DiffMode == config.DiffModeUnified)},
+		ui.MenuSep(),
+		{Label: "Changes Only", Command: "options.useChangesOnlyDiff", Checked: menuChecked(a.Settings.Editor.DiffContext != config.DiffContextFull)},
+		{Label: "Full File", Command: "options.useFullFileDiff", Checked: menuChecked(a.Settings.Editor.DiffContext == config.DiffContextFull)},
+		ui.MenuSep(),
 		{Label: "Wrap Lines", Command: "options.toggleDiffWordWrap", Checked: menuChecked(a.Settings.Editor.DiffWordWrap)},
 		{Label: "High Contrast", Command: "options.toggleDiffHighContrast", Checked: menuChecked(a.Settings.Editor.DiffHighContrast)},
 	}
@@ -313,6 +327,18 @@ func registerOptionsCommands(app *App) {
 		ID: "options.useUnifiedDiff", Title: "Use Unified Diff by Default",
 		Keywords: []string{"preferences", "settings", "git", "diff", "unified", "default"},
 		Handler:  app.UseUnifiedDiffByDefault,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useChangesOnlyDiff", Title: "Show Changes Only by Default",
+		Keywords: []string{"preferences", "settings", "git", "diff", "compact", "context", "default"},
+		Handler:  app.UseChangesOnlyDiffByDefault,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useFullFileDiff", Title: "Show Full File Diff by Default",
+		Keywords: []string{"preferences", "settings", "git", "diff", "extended", "context", "default"},
+		Handler:  app.UseFullFileDiffByDefault,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -23,6 +23,21 @@ func (a *App) ToggleWordWrap() {
 	a.SaveAndApplySettings()
 }
 
+func (a *App) UseSplitDiffByDefault() {
+	a.Settings.Editor.DiffMode = config.DiffModeSplit
+	a.SaveAndApplySettings()
+}
+
+func (a *App) UseUnifiedDiffByDefault() {
+	a.Settings.Editor.DiffMode = config.DiffModeUnified
+	a.SaveAndApplySettings()
+}
+
+func (a *App) ToggleDiffWordWrapDefault() {
+	a.Settings.Editor.DiffWordWrap = !a.Settings.Editor.DiffWordWrap
+	a.SaveAndApplySettings()
+}
+
 func (a *App) ToggleAutoDedent() {
 	enabled := !a.Settings.Editor.IsAutoDedentEnabled()
 	a.Settings.Editor.AutoDedent = &enabled
@@ -166,6 +181,19 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		wordWrapChecked = ui.MenuChecked
 	}
 
+	splitDiffChecked := ui.MenuUnchecked
+	unifiedDiffChecked := ui.MenuUnchecked
+	if a.Settings.Editor.DiffMode == config.DiffModeUnified {
+		unifiedDiffChecked = ui.MenuChecked
+	} else {
+		splitDiffChecked = ui.MenuChecked
+	}
+
+	diffWordWrapChecked := ui.MenuUnchecked
+	if a.Settings.Editor.DiffWordWrap {
+		diffWordWrapChecked = ui.MenuChecked
+	}
+
 	bracketColorChecked := ui.MenuUnchecked
 	if a.Settings.Editor.BracketPairColorization {
 		bracketColorChecked = ui.MenuChecked
@@ -204,6 +232,9 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
+		{Label: "Split Diff", Command: "options.useSplitDiff", Checked: splitDiffChecked},
+		{Label: "Unified Diff", Command: "options.useUnifiedDiff", Checked: unifiedDiffChecked},
+		{Label: "Diff Word Wrap", Command: "options.toggleDiffWordWrap", Checked: diffWordWrapChecked},
 		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
 		{Label: "Auto Dedent", Command: "options.toggleAutoDedent", Checked: autoDedentChecked},
 		{Label: "Syntax Highlight", Command: "options.toggleSyntaxHighlight", Checked: syntaxChecked},
@@ -242,6 +273,24 @@ func registerOptionsCommands(app *App) {
 		ID: "options.toggleWordWrap", Title: "Toggle Word Wrap",
 		Keywords: []string{"preferences", "settings", "editor", "view"},
 		Handler:  app.ToggleWordWrap,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useSplitDiff", Title: "Use Split Diff by Default",
+		Keywords: []string{"preferences", "settings", "git", "diff", "split", "default"},
+		Handler:  app.UseSplitDiffByDefault,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useUnifiedDiff", Title: "Use Unified Diff by Default",
+		Keywords: []string{"preferences", "settings", "git", "diff", "unified", "default"},
+		Handler:  app.UseUnifiedDiffByDefault,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.toggleDiffWordWrap", Title: "Toggle Diff Word Wrap Default",
+		Keywords: []string{"preferences", "settings", "git", "diff", "wrap", "default"},
+		Handler:  app.ToggleDiffWordWrapDefault,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_palette.go
+++ b/internal/app/commands_palette.go
@@ -39,16 +39,13 @@ func (a *App) OpenCommandPalette(fileMode bool, initialText ...string) {
 }
 
 func (a *App) ShowThemePicker() {
-	names := config.ListThemes()
-	if len(names) == 0 {
+	items := themeItems()
+	if len(items) == 0 {
 		return
-	}
-	items := make([]widgets.SelectItem, len(names))
-	for i, name := range names {
-		items[i] = widgets.SelectItem{ID: name, Label: name}
 	}
 	originalStyleMap := a.Screen.GetStyleMap()
 	originalPalette := *a.Palette
+	originalBorders := *a.Borders
 	applyTheme := func(theme config.ThemeConfig) {
 		a.Screen.SetStyleMap(BuildStyleMap(theme))
 		*a.Palette = BuildTerminalPalette(theme)
@@ -80,6 +77,7 @@ func (a *App) ShowThemePicker() {
 			a.DismissDialog()
 			a.Screen.SetStyleMap(originalStyleMap)
 			*a.Palette = originalPalette
+			*a.Borders = originalBorders
 			a.Renderer.Clear()
 		},
 	})

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -503,11 +503,7 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	p.ShowContextMenu = func(entries []widgets.MenuEntry, x, y int, onCommand func(string)) {
 		items := make([]ui.ContextMenuItem, len(entries))
 		for i, e := range entries {
-			items[i] = ui.ContextMenuItem{
-				Label:   e.Label,
-				Command: e.Command,
-				IsSep:   e.Separator,
-			}
+			items[i] = contextMenuItemFromWidgetEntry(e)
 		}
 		a.captureMenuFocus()
 		menu := ui.NewContextMenuWidget(items, x, y)
@@ -771,11 +767,7 @@ func (a *App) handleRemoteRegistryResult(result *RemoteRegistryResult) {
 func (a *App) ShowPluginDropdownMenu(entries []widgets.MenuEntry, x, y int) {
 	items := make([]ui.ContextMenuItem, len(entries))
 	for i, e := range entries {
-		items[i] = ui.ContextMenuItem{
-			Label:   e.Label,
-			Command: e.Command,
-			IsSep:   e.Separator,
-		}
+		items[i] = contextMenuItemFromWidgetEntry(e)
 	}
 	a.captureMenuFocus()
 	menu := ui.NewContextMenuWidget(items, x, y)
@@ -791,6 +783,21 @@ func (a *App) ShowPluginDropdownMenu(entries []widgets.MenuEntry, x, y int) {
 	}
 	a.Root.PushOverlay(ui.Overlay{Widget: menu, Modal: true})
 	a.Root.SetFocus(menu)
+}
+
+func contextMenuItemFromWidgetEntry(entry widgets.MenuEntry) ui.ContextMenuItem {
+	item := ui.ContextMenuItem{
+		Label:   entry.Label,
+		Command: entry.Command,
+		IsSep:   entry.Separator,
+	}
+	if entry.Checked != nil {
+		item.Checked = ui.MenuUnchecked
+		if *entry.Checked {
+			item.Checked = ui.MenuChecked
+		}
+	}
+	return item
 }
 
 func (a *App) handlePluginDropdownCommand(cmd string) {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -483,7 +483,17 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 		fsRoots = append(fsRoots, p.Dir)
 	}
 	p.Filesystem = NewPluginFilesystemAPI(fsRoots...)
+	if fs, ok := p.Filesystem.(*PluginFilesystemAPI); ok {
+		fs.onWrite = func(path string) {
+			a.invalidateRepositoryPath(path, RepositoryStatus)
+		}
+	}
 	p.System = NewPluginSystemAPI()
+	if system, ok := p.System.(*PluginSystemAPI); ok {
+		system.onExec = func() {
+			a.postRepositoryInvalidation("", RepositoryStatus|RepositoryHistory)
+		}
+	}
 	p.Network = NewPluginNetworkAPI()
 	a.wirePluginLog(p)
 	p.Markdown = a.Settings.Markdown

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -85,6 +85,9 @@ func (a *App) ApplySettings(s config.Settings) {
 	if a.Changes != nil {
 		a.Changes.SetFileView(s.Git.FileView)
 	}
+	if a.Sidebar != nil {
+		a.Sidebar.SetPanelOrder(s.Sidebar.PanelOrder)
+	}
 
 	// LoadTheme also accepts the empty built-in-default ID used by both theme
 	// pickers, so every surfaced theme follows one resolve-and-apply path.

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -14,6 +14,13 @@ func configuredDiffMode(mode string) ui.DiffMode {
 	return ui.DiffModeSplit
 }
 
+func configuredDiffContext(contextMode string) ui.DiffContextMode {
+	if contextMode == config.DiffContextFull {
+		return ui.DiffContextFullFile
+	}
+	return ui.DiffContextChangesOnly
+}
+
 func (a *App) ReloadSettings() {
 	s := config.LoadSettings()
 	a.ApplySettings(s)
@@ -41,7 +48,7 @@ func (a *App) ApplySettings(s config.Settings) {
 	a.EditorGroup.ShowTrailingNewline = s.Editor.IsShowTrailingNewlineEnabled()
 	a.EditorGroup.TrimTrailingWhitespace = s.Editor.TrimTrailingWhitespace
 	a.EditorGroup.WordWrap = s.Editor.WordWrap
-	a.EditorGroup.SetDiffDefaults(configuredDiffMode(s.Editor.DiffMode), s.Editor.DiffWordWrap)
+	a.EditorGroup.SetDiffDefaults(configuredDiffMode(s.Editor.DiffMode), configuredDiffContext(s.Editor.DiffContext), s.Editor.DiffWordWrap)
 	a.EditorGroup.SetDiffHighContrast(s.Editor.DiffHighContrast)
 	a.EditorGroup.BracketPairColorization = s.Editor.BracketPairColorization
 	a.EditorGroup.UndoDeleteCursorStart = s.Editor.UndoDeleteCursorStart

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -42,6 +42,7 @@ func (a *App) ApplySettings(s config.Settings) {
 	a.EditorGroup.TrimTrailingWhitespace = s.Editor.TrimTrailingWhitespace
 	a.EditorGroup.WordWrap = s.Editor.WordWrap
 	a.EditorGroup.SetDiffDefaults(configuredDiffMode(s.Editor.DiffMode), s.Editor.DiffWordWrap)
+	a.EditorGroup.SetDiffHighContrast(s.Editor.DiffHighContrast)
 	a.EditorGroup.BracketPairColorization = s.Editor.BracketPairColorization
 	a.EditorGroup.UndoDeleteCursorStart = s.Editor.UndoDeleteCursorStart
 	a.EditorGroup.ApplyUndoDeleteCursorStart(s.Editor.UndoDeleteCursorStart)
@@ -82,16 +83,11 @@ func (a *App) ApplySettings(s config.Settings) {
 		a.Explorer.Reload()
 	}
 
-	// An empty theme name means the built-in default, and must still be applied —
-	// otherwise switching back to it leaves the previous theme's colors on screen.
+	// LoadTheme also accepts the empty built-in-default ID used by both theme
+	// pickers, so every surfaced theme follows one resolve-and-apply path.
 	var themeBorders *term.BorderSet
 	if a.Screen != nil {
-		theme, ok := config.DefaultTheme(), s.Theme == ""
-		if !ok {
-			loaded, err := config.LoadTheme(s.Theme)
-			theme, ok = loaded, err == nil
-		}
-		if ok {
+		if theme, err := config.LoadTheme(s.Theme); err == nil {
 			a.Screen.SetStyleMap(BuildStyleMap(theme))
 			*a.Palette = BuildTerminalPalette(theme)
 			borders := BuildBorderSet(theme.Borders)

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -4,7 +4,15 @@ import (
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/ui"
 )
+
+func configuredDiffMode(mode string) ui.DiffMode {
+	if mode == config.DiffModeUnified {
+		return ui.DiffModeUnified
+	}
+	return ui.DiffModeSplit
+}
 
 func (a *App) ReloadSettings() {
 	s := config.LoadSettings()
@@ -33,6 +41,7 @@ func (a *App) ApplySettings(s config.Settings) {
 	a.EditorGroup.ShowTrailingNewline = s.Editor.IsShowTrailingNewlineEnabled()
 	a.EditorGroup.TrimTrailingWhitespace = s.Editor.TrimTrailingWhitespace
 	a.EditorGroup.WordWrap = s.Editor.WordWrap
+	a.EditorGroup.SetDiffDefaults(configuredDiffMode(s.Editor.DiffMode), s.Editor.DiffWordWrap)
 	a.EditorGroup.BracketPairColorization = s.Editor.BracketPairColorization
 	a.EditorGroup.UndoDeleteCursorStart = s.Editor.UndoDeleteCursorStart
 	a.EditorGroup.ApplyUndoDeleteCursorStart(s.Editor.UndoDeleteCursorStart)

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -82,6 +82,9 @@ func (a *App) ApplySettings(s config.Settings) {
 		a.Explorer.Settings = s.Explorer
 		a.Explorer.Reload()
 	}
+	if a.Changes != nil {
+		a.Changes.SetFileView(s.Git.FileView)
+	}
 
 	// LoadTheme also accepts the empty built-in-default ID used by both theme
 	// pickers, so every surfaced theme follows one resolve-and-apply path.

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -349,6 +349,18 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "sidebar.movePanelLeft", Title: "View: Move Sidebar Panel Left",
+		Keywords: []string{"view", "sidebar", "panel", "tab", "reorder", "left"},
+		Handler:  func() { app.MoveActiveSidebarPanel(-1) },
+	})
+
+	reg.Register(command.Command{
+		ID: "sidebar.movePanelRight", Title: "View: Move Sidebar Panel Right",
+		Keywords: []string{"view", "sidebar", "panel", "tab", "reorder", "right"},
+		Handler:  func() { app.MoveActiveSidebarPanel(1) },
+	})
+
+	reg.Register(command.Command{
 		ID: "panel.toggle", Title: "View: Toggle Panel",
 		Keywords: []string{"view", "bottom", "show", "hide"},
 		Handler:  app.ToggleBottomPanel,

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -311,7 +311,6 @@ func registerViewCommands(app *App) {
 		ID: "sidebar.changes", Title: "Show Changes",
 		Keywords: []string{"view", "git", "diff", "source control"},
 		Handler: func() {
-			app.Changes.Refresh()
 			app.ShowPanel("changes", app.Changes.Adapter)
 		},
 	})

--- a/internal/app/commit_commands_test.go
+++ b/internal/app/commit_commands_test.go
@@ -1,0 +1,142 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/gdamore/tcell/v3"
+)
+
+func commitCommandApp(t *testing.T, stageWorkingFile bool) (string, *ChangesPanel, *App, string) {
+	t.Helper()
+	dir := dirtyRepo(t)
+	if stageWorkingFile {
+		if err := git.Stage(dir, "a.txt"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cp := newRefreshedPanel(dir)
+	commitID := expandFirstCommit(t, cp)
+	commitNode := cp.commitNode(commitID)
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+	if len(commitNode.Children) == 0 {
+		t.Fatal("commit has no file children")
+	}
+	childID := commitNode.Children[0].ID
+	if !cp.selectLogNode(childID) {
+		t.Fatalf("could not select commit file %q", childID)
+	}
+	// Keep a valid but stale working-tree selection to prove commands do not
+	// silently fall through to the other tree.
+	for i, node := range cp.Tree.FlatList() {
+		if _, _, _, ok := cp.parseFileNode(node); ok {
+			cp.Tree.SetSelectedIndex(i)
+			break
+		}
+	}
+
+	a := buildTestApp(t, config.DefaultSettings())
+	a.Changes = cp
+	a.Reg = command.NewRegistry()
+	RegisterCommands(a)
+	a.Root.SetFocus(cp.Adapter)
+	for i := 0; i < 10 && !cp.CommitLog.IsFocused(); i++ {
+		cp.Adapter.HandleEvent(tcell.NewEventKey(tcell.KeyTab, "", tcell.ModNone))
+	}
+	if !cp.CommitLog.IsFocused() {
+		t.Fatal("could not focus commit log through the changes panel")
+	}
+	return dir, cp, a, childID
+}
+
+// The changes panel has two independent selections. Registered commands are
+// also the surface used by ttt.exec_command and --exec, so they must follow the
+// tree the reader last acted in rather than a stale selection in the other one.
+func TestRegisteredOpenCommandsUseRememberedCommitFile(t *testing.T) {
+	for _, tc := range []struct {
+		command  string
+		extended bool
+	}{
+		{command: "changes.openDiff"},
+		{command: "changes.openExtendedDiff", extended: true},
+		{command: "changes.openFile"},
+	} {
+		t.Run(tc.command, func(t *testing.T) {
+			_, cp, a, childID := commitCommandApp(t, false)
+			if !a.Reg.Execute(tc.command) {
+				t.Fatalf("command %q was not registered", tc.command)
+			}
+
+			file := cp.logFiles[childID]
+			want := fmt.Sprintf("%s:%s (diff)", file.Ref, file.Status.Path)
+			if got := a.EditorGroup.ActiveFilePath(); got != want {
+				t.Fatalf("%s opened %q from the working tree, want commit diff %q", tc.command, got, want)
+			}
+			if dv := a.EditorGroup.ActiveDiffWidget(); dv == nil || dv.IsExtended() != tc.extended {
+				t.Fatalf("%s extended mode = %v, want %v", tc.command, dv != nil && dv.IsExtended(), tc.extended)
+			}
+		})
+	}
+}
+
+// The palette takes focus before it executes a command. That transient modal
+// state must not erase which changes-panel tree the reader was acting in.
+func TestPaletteOpenDiffUsesRememberedCommitFile(t *testing.T) {
+	_, cp, a, childID := commitCommandApp(t, false)
+	a.OpenCommandPalette(false, ">Git: Open Compact Diff")
+	a.Root.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+
+	file := cp.logFiles[childID]
+	want := fmt.Sprintf("%s:%s (diff)", file.Ref, file.Status.Path)
+	if got := a.EditorGroup.ActiveFilePath(); got != want {
+		t.Fatalf("palette command opened %q from the working tree, want commit diff %q", got, want)
+	}
+}
+
+func TestRegisteredWorkingTreeCommandsNoOpInCommitContext(t *testing.T) {
+	t.Run("stage", func(t *testing.T) {
+		dir, _, a, _ := commitCommandApp(t, false)
+		if !a.Reg.Execute("changes.stage") {
+			t.Fatal("changes.stage was not registered")
+		}
+		files, err := git.StatusFiles(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, file := range files {
+			if file.Path == "a.txt" && file.Staged {
+				t.Fatal("history-focused changes.stage staged stale working-tree selection a.txt")
+			}
+		}
+	})
+
+	t.Run("unstage", func(t *testing.T) {
+		dir, _, a, _ := commitCommandApp(t, true)
+		if !a.Reg.Execute("changes.unstage") {
+			t.Fatal("changes.unstage was not registered")
+		}
+		files, err := git.StatusFiles(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, file := range files {
+			if file.Path == "a.txt" && file.Staged {
+				return
+			}
+		}
+		t.Fatal("history-focused changes.unstage unstaged stale working-tree selection a.txt")
+	})
+
+	t.Run("discard", func(t *testing.T) {
+		_, _, a, _ := commitCommandApp(t, false)
+		if !a.Reg.Execute("changes.discard") {
+			t.Fatal("changes.discard was not registered")
+		}
+		if a.Root.HasModalOverlay() {
+			t.Fatal("history-focused changes.discard opened a dialog for the stale working-tree selection")
+		}
+	})
+}

--- a/internal/app/commit_log_test.go
+++ b/internal/app/commit_log_test.go
@@ -1,0 +1,367 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+// newRefreshedPanel builds a panel and completes its first scan. With no screen
+// the panel reads git inline, so the data is there when Refresh returns.
+func newRefreshedPanel(dirs ...string) *ChangesPanel {
+	cp := NewChangesPanel(dirs...)
+	cp.Refresh()
+	return cp
+}
+
+func commitLogRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test User"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The message carries the temp dir so two fixtures never produce the same
+	// commit hash: identical content, message, author and second would.
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", "only " + dir}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+// A failed read is a fact about the moment, not about the commit, so it must not
+// land in the cache that exists because commits are immutable. Caching it would
+// leave that commit showing an empty file list for the rest of the session.
+func TestCommitFileNodesDoesNotCacheFailures(t *testing.T) {
+	dir := commitLogRepo(t)
+	cp := newRefreshedPanel(dir)
+
+	const missing = "0000000000000000000000000000000000000000"
+	nodes := cp.commitChildren(dir, missing, "0000000", "commit:"+missing)
+	if len(nodes) != 1 || nodes[0].ID != "commit:"+missing+errorSuffix {
+		t.Fatalf("expected a single error placeholder, got %+v", nodes)
+	}
+	if _, cached := cp.commitFiles[dir+"\x00"+missing]; cached {
+		t.Error("a failed read was cached")
+	}
+}
+
+// The empty result of a merge that changed nothing IS a fact about the commit,
+// so it is cached — and it still renders a placeholder rather than an
+// expandable node that opens onto nothing.
+func TestCommitFileNodesCachesSuccess(t *testing.T) {
+	dir := commitLogRepo(t)
+	cp := newRefreshedPanel(dir)
+
+	var commit commitFileRef
+	for _, c := range cp.logCommits {
+		commit = c
+	}
+	if commit.Ref == "" {
+		t.Fatal("no commit in the log")
+	}
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	full, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("resolve full hash: %v", err)
+	}
+	if want := strings.TrimSpace(string(full)); commit.Ref != want {
+		t.Errorf("log entry ref = %q, want full hash %q", commit.Ref, want)
+	}
+	nodes := cp.commitChildren(dir, commit.Ref, commit.Short, "commit:"+commit.Ref)
+	if len(nodes) != 1 || nodes[0].Label != "a.txt" {
+		t.Fatalf("expected the commit's one file, got %+v", nodes[0])
+	}
+	if _, cached := cp.commitFiles[dir+"\x00"+commit.Ref]; !cached {
+		t.Error("a successful read was not cached")
+	}
+	// Through the bounded helper, not straight into the map — otherwise the
+	// cache has no eviction order and the bound never fires.
+	if len(cp.commitFilesOrder) != 1 {
+		t.Errorf("insertion order holds %d entries, want 1", len(cp.commitFilesOrder))
+	}
+}
+
+func TestCommitRowActivationOpensDetailWithoutExpanding(t *testing.T) {
+	dir := commitLogRepo(t)
+	cp := newRefreshedPanel(dir)
+	var node *widgets.TreeNode
+	for index, candidate := range cp.CommitLog.FlatList() {
+		if _, ok := cp.logCommits[candidate.ID]; ok {
+			node = candidate
+			cp.CommitLog.SetSelectedIndex(index)
+			break
+		}
+	}
+	if node == nil {
+		t.Fatal("no commit row")
+	}
+
+	var opened commitFileRef
+	cp.OnOpenCommit = func(dir, ref, short string) {
+		opened = commitFileRef{Dir: dir, Ref: ref, Short: short}
+	}
+	cp.CommitLog.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	want := cp.logCommits[node.ID]
+	if opened.Dir != want.Dir || opened.Ref != want.Ref || opened.Short != want.Short {
+		t.Fatalf("activated commit = %+v, want %+v", opened, want)
+	}
+	if node.Expanded {
+		t.Fatal("Enter expanded the commit instead of only activating it")
+	}
+
+	cp.CommitLog.HandleEvent(tcell.NewEventKey(tcell.KeyRight, "", tcell.ModNone))
+	if !node.Expanded {
+		t.Fatal("explicit disclosure no longer expands the commit")
+	}
+}
+
+// Expanding a commit whose previous read failed must retry rather than keep the
+// placeholder forever, which is what a plain len(Children) > 0 guard would do.
+func TestLoadCommitFilesRetriesAfterFailure(t *testing.T) {
+	dir := commitLogRepo(t)
+	cp := newRefreshedPanel(dir)
+
+	var node *widgets.TreeNode
+	for _, n := range cp.CommitLog.Config.Items {
+		if _, ok := cp.logCommits[n.ID]; ok {
+			node = n
+			break
+		}
+	}
+	if node == nil {
+		t.Fatal("no commit node in the log")
+	}
+
+	node.Children = []*widgets.TreeNode{errorNode(node.ID)}
+	cp.loadCommitFiles(node)
+	if len(node.Children) != 1 || node.Children[0].Label != "a.txt" {
+		t.Fatalf("expected a retry to load the file, got %+v", node.Children[0])
+	}
+
+	// A loaded list is not re-read.
+	node.Children[0].Label = "sentinel"
+	cp.loadCommitFiles(node)
+	if node.Children[0].Label != "sentinel" {
+		t.Error("an already-loaded commit was re-read")
+	}
+}
+
+// git's abbreviated hash is not stable: its length follows core.abbrev and the
+// repo's object count. Keying node IDs or the file cache on it means both
+// silently orphan the first time the abbreviation grows, collapsing every
+// expanded commit. Node IDs must be built from the full hash.
+func TestCommitLogNodeIDsSurviveAbbreviationChange(t *testing.T) {
+	dir := commitLogRepo(t)
+
+	cp := newRefreshedPanel(dir)
+	var before []string
+	for _, n := range cp.CommitLog.Config.Items {
+		if _, ok := cp.logCommits[n.ID]; ok {
+			before = append(before, n.ID)
+		}
+	}
+	if len(before) == 0 {
+		t.Fatal("no commit nodes in the log")
+	}
+
+	// Widen the abbreviation the way a growing repo would.
+	cmd := exec.Command("git", "config", "core.abbrev", "20")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git config: %v\n%s", err, out)
+	}
+
+	cp2 := newRefreshedPanel(dir)
+	var after []string
+	for _, n := range cp2.CommitLog.Config.Items {
+		if _, ok := cp2.logCommits[n.ID]; ok {
+			after = append(after, n.ID)
+		}
+	}
+	if len(after) != len(before) {
+		t.Fatalf("commit count changed: %d -> %d", len(before), len(after))
+	}
+	for i := range before {
+		if before[i] != after[i] {
+			t.Errorf("node ID moved with the abbreviation: %q -> %q", before[i], after[i])
+		}
+	}
+
+	// The badge, which is display only, is expected to have grown.
+	for _, n := range cp2.CommitLog.Config.Items {
+		if _, ok := cp2.logCommits[n.ID]; ok && len(n.Badge) != 20 {
+			t.Errorf("badge should follow core.abbrev, got %q", n.Badge)
+		}
+	}
+}
+
+// A new commit prepends a row to the log. Keeping the selected *index* across
+// that rebuild moves the selection onto a different commit, so the next Enter
+// expands the wrong one. Selection is restored by node ID instead.
+func TestCommitLogSelectionSurvivesANewCommit(t *testing.T) {
+	dir := commitLogRepo(t)
+	cp := newRefreshedPanel(dir)
+
+	// Select the one commit in the log (index 0 is the branch header).
+	var target string
+	for i, n := range cp.CommitLog.FlatList() {
+		if _, ok := cp.logCommits[n.ID]; ok {
+			cp.CommitLog.SetSelectedIndex(i)
+			target = n.ID
+			break
+		}
+	}
+	if target == "" {
+		t.Fatal("no commit node in the log")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", "newer"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	cp.Refresh()
+
+	got := cp.CommitLog.Selected()
+	if got == nil || got.ID != target {
+		id := "<nil>"
+		if got != nil {
+			id = got.ID
+		}
+		t.Errorf("selection moved: want %q, got %q", target, id)
+	}
+}
+
+func addCommit(t *testing.T, dir, name, message string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(name+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", message}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func expandFirstCommit(t *testing.T, cp *ChangesPanel) string {
+	t.Helper()
+	for _, n := range cp.CommitLog.Config.Items {
+		if _, ok := cp.logCommits[n.ID]; ok {
+			n.Expanded = true
+			cp.loadCommitFiles(n)
+			return n.ID
+		}
+	}
+	t.Fatal("no commit node in the log")
+	return ""
+}
+
+func expandedIDs(cp *ChangesPanel) map[string]bool {
+	out := map[string]bool{}
+	for _, n := range cp.CommitLog.Config.Items {
+		if _, ok := cp.logCommits[n.ID]; ok && n.Expanded {
+			out[n.ID] = true
+		}
+	}
+	return out
+}
+
+// Switching to another root in a multi-root workspace and back should return to
+// what was open, the way the changes tree above it already does.
+func TestCommitLogExpansionSurvivesARepoSwitch(t *testing.T) {
+	a := commitLogRepo(t)
+	b := commitLogRepo(t)
+
+	cp := newRefreshedPanel(a, b)
+	opened := expandFirstCommit(t, cp)
+	cp.saveCommitLogState()
+
+	// Move the log to the other repo, then back.
+	forceLogDir(t, cp, b)
+	if expandedIDs(cp)[opened] {
+		t.Fatal("repo B's log should not carry repo A's expansion")
+	}
+	forceLogDir(t, cp, a)
+
+	if !expandedIDs(cp)[opened] {
+		t.Error("expansion was lost across a repo switch")
+	}
+}
+
+// forceLogDir rebuilds the commit log for dir, standing in for the selection
+// change that normally drives it.
+func forceLogDir(t *testing.T, cp *ChangesPanel, dir string) {
+	t.Helper()
+	saved := cp.Dirs
+	cp.Dirs = []string{dir}
+	cp.lastLogDir = ""
+	cp.Refresh()
+	cp.Dirs = saved
+}
+
+// Entries are small and never stale, so the cache exists to be kept — but a
+// long session browsing history must not grow it without limit.
+func TestCommitFilesCacheIsBounded(t *testing.T) {
+	dir := commitLogRepo(t)
+	cp := newRefreshedPanel(dir)
+
+	for i := range commitFilesCacheMax + 20 {
+		cp.cacheCommitFiles(fmt.Sprintf("%s\x00key%d", dir, i), nil)
+	}
+	if len(cp.commitFiles) != commitFilesCacheMax {
+		t.Errorf("cache holds %d entries, want the bound of %d", len(cp.commitFiles), commitFilesCacheMax)
+	}
+	if len(cp.commitFilesOrder) != commitFilesCacheMax {
+		t.Errorf("insertion order holds %d, want %d", len(cp.commitFilesOrder), commitFilesCacheMax)
+	}
+	// The oldest went first, the newest is still there.
+	if _, ok := cp.commitFiles[fmt.Sprintf("%s\x00key0", dir)]; ok {
+		t.Error("the oldest entry should have been evicted")
+	}
+	if _, ok := cp.commitFiles[fmt.Sprintf("%s\x00key%d", dir, commitFilesCacheMax+19)]; !ok {
+		t.Error("the newest entry should still be cached")
+	}
+}
+
+// Re-caching a key already present must not add a second order entry, or the
+// bound would evict live entries while the map stayed under it.
+func TestCommitFilesCacheOrderHasNoDuplicates(t *testing.T) {
+	cp := newRefreshedPanel(commitLogRepo(t))
+	for range 5 {
+		cp.cacheCommitFiles("same", nil)
+	}
+	if len(cp.commitFilesOrder) != 1 {
+		t.Errorf("order holds %d entries for one key, want 1", len(cp.commitFilesOrder))
+	}
+}

--- a/internal/app/current_changes.go
+++ b/internal/app/current_changes.go
@@ -1,0 +1,349 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+const currentChangesTimeout = 30 * time.Second
+
+type CurrentChangesResult struct {
+	Dir         string
+	TabID       string
+	Gen         uint64
+	Fingerprint string
+	Summary     string
+	Files       []ui.CommitDetailFile
+	Err         string
+}
+
+type currentChangesLoadState struct {
+	cancel               context.CancelFunc
+	appliedFingerprint   string
+	requestedFingerprint string
+}
+
+type currentFileState struct {
+	status   git.FileStatus
+	staged   bool
+	unstaged bool
+}
+
+func currentChangesTabID(dir string) string {
+	return "current-changes:" + filepath.Clean(dir)
+}
+
+func currentChangesTitle(dir string, multiRoot bool) string {
+	if multiRoot {
+		return "Changes · " + filepath.Base(dir)
+	}
+	return "Current Changes"
+}
+
+func (a *App) selectedChangesDir() string {
+	if a == nil || a.Changes == nil {
+		return ""
+	}
+	dir := a.Changes.selectedGroupDir()
+	if dir == "" && len(a.Changes.groups) > 0 {
+		dir = a.Changes.groups[0].Dir
+	}
+	if dir == "" && len(a.Changes.Dirs) > 0 {
+		dir = a.Changes.Dirs[0]
+	}
+	if root := git.RepoRoot(dir); root != "" {
+		dir = root
+	}
+	return dir
+}
+
+// OpenCurrentChanges opens one stable, live change-set tab per repository.
+// The repository coordinator supplies freshness; this loader supplies the
+// heavier per-file diff document only while that tab is active.
+func (a *App) OpenCurrentChanges() {
+	dir := a.selectedChangesDir()
+	if dir == "" {
+		a.StatusWarn("No repository selected")
+		return
+	}
+	tabID := currentChangesTabID(dir)
+	detail := a.EditorGroup.CurrentChangesWidgetByTab(tabID)
+	created := detail == nil
+	if detail == nil {
+		detail = ui.NewCurrentChangesWidget(dir, a.EditorGroup.SyntaxHighlight)
+		a.EditorGroup.ApplyDiffDefaults(detail)
+		a.EditorGroup.OpenPluginTab(tabID, currentChangesTitle(dir, len(a.Changes.groups) > 1), detail)
+	} else {
+		a.EditorGroup.SwitchToTabByPath(tabID)
+	}
+	a.FocusEditorIfEnabled()
+	if created {
+		a.refreshCurrentChanges(detail, a.currentChangesSourceFingerprint(dir))
+	}
+	// Activating the tab makes the repository coordinator visible and starts
+	// its normal freshness cycle through OnActiveContentChange.
+	if a.Repository == nil && !created {
+		a.refreshCurrentChanges(detail, a.currentChangesSourceFingerprint(dir))
+	}
+}
+
+func (a *App) refreshActiveCurrentChanges() {
+	if a == nil || a.EditorGroup == nil {
+		return
+	}
+	if detail := a.EditorGroup.ActiveCurrentChangesWidget(); detail != nil {
+		fingerprint := a.currentChangesSourceFingerprint(detail.Dir)
+		state := a.currentChangesLoadState(currentChangesTabID(detail.Dir))
+		if fingerprint != state.appliedFingerprint && fingerprint != state.requestedFingerprint {
+			a.refreshCurrentChanges(detail, fingerprint)
+		}
+	}
+}
+
+func (a *App) currentChangesLoadState(tabID string) *currentChangesLoadState {
+	if a.currentChangesLoads == nil {
+		a.currentChangesLoads = make(map[string]*currentChangesLoadState)
+	}
+	state := a.currentChangesLoads[tabID]
+	if state == nil {
+		state = &currentChangesLoadState{}
+		a.currentChangesLoads[tabID] = state
+	}
+	return state
+}
+
+func (a *App) refreshCurrentChanges(detail *ui.CommitDetailWidget, fingerprint string) {
+	if detail == nil || !detail.CurrentChanges {
+		return
+	}
+	tabID := currentChangesTabID(detail.Dir)
+	state := a.currentChangesLoadState(tabID)
+	if state.cancel != nil {
+		state.cancel()
+	}
+	state.requestedFingerprint = fingerprint
+	detail.LoadGen++
+	gen := detail.LoadGen
+	if len(detail.Files) == 0 && detail.Message == "" {
+		detail.Loading = true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), currentChangesTimeout)
+	state.cancel = cancel
+	read := func() *CurrentChangesResult {
+		result := readCurrentChanges(ctx, detail.Dir, tabID, gen)
+		result.Fingerprint = fingerprint
+		return result
+	}
+	if a.Screen == nil {
+		result := read()
+		cancel()
+		a.ApplyCurrentChanges(result)
+		return
+	}
+	screen := a.Screen
+	go func() {
+		result := read()
+		cancel()
+		screen.PostEvent(tcell.NewEventInterrupt(result))
+	}()
+}
+
+func (a *App) ApplyCurrentChanges(result *CurrentChangesResult) {
+	if result == nil {
+		return
+	}
+	detail := a.EditorGroup.CurrentChangesWidgetByTab(result.TabID)
+	if detail == nil || detail.Dir != result.Dir || detail.LoadGen != result.Gen {
+		return
+	}
+	state := a.currentChangesLoadState(result.TabID)
+	state.cancel = nil
+	state.requestedFingerprint = ""
+	if result.Err == "" {
+		state.appliedFingerprint = result.Fingerprint
+	}
+	detail.SetDetail(result.Summary, result.Files, result.Err)
+}
+
+func (a *App) cleanupCurrentChangesTab(id string) {
+	if state := a.currentChangesLoads[id]; state != nil && state.cancel != nil {
+		state.cancel()
+	}
+	delete(a.currentChangesLoads, id)
+	a.syncRepositoryObservation()
+}
+
+func (a *App) closeCurrentChanges() {
+	for id, state := range a.currentChangesLoads {
+		if state.cancel != nil {
+			state.cancel()
+		}
+		delete(a.currentChangesLoads, id)
+	}
+}
+
+// currentChangesSourceFingerprint keeps repository polling cheap. Git status
+// supplies the path/state identity; file metadata catches content edits that
+// remain the same status (for example M before and after an external write).
+func (a *App) currentChangesSourceFingerprint(dir string) string {
+	if a == nil || a.Changes == nil {
+		return "status-unavailable"
+	}
+	var group *changesGroup
+	for i := range a.Changes.groups {
+		if filepath.Clean(a.Changes.groups[i].Dir) == filepath.Clean(dir) {
+			group = &a.Changes.groups[i]
+			break
+		}
+	}
+	if group == nil {
+		return "status-unavailable"
+	}
+	statuses := make([]git.FileStatus, 0, len(group.Staged)+len(group.Unstaged))
+	statuses = append(statuses, group.Staged...)
+	statuses = append(statuses, group.Unstaged...)
+	states := mergeCurrentFileStates(statuses)
+	var fingerprint strings.Builder
+	fingerprint.WriteString(filepath.Clean(dir))
+	for _, state := range states {
+		fmt.Fprintf(&fingerprint, "\x00%s\x00%s\x00%s\x00%t\x00%t", state.status.Status,
+			state.status.OldPath, state.status.Path, state.staged, state.unstaged)
+		info, err := os.Stat(filepath.Join(dir, state.status.Path))
+		if err != nil {
+			fingerprint.WriteString("\x00missing")
+			continue
+		}
+		fmt.Fprintf(&fingerprint, "\x00%d\x00%d\x00%d", info.Size(), info.ModTime().UnixNano(), info.Mode())
+	}
+	return fingerprint.String()
+}
+
+func readCurrentChanges(ctx context.Context, dir, tabID string, gen uint64) *CurrentChangesResult {
+	result := &CurrentChangesResult{Dir: dir, TabID: tabID, Gen: gen}
+	statuses, err := git.StatusFilesContext(ctx, dir)
+	if err != nil {
+		result.Err = "Could not read current changes: " + err.Error()
+		return result
+	}
+
+	states := mergeCurrentFileStates(statuses)
+	result.Files = make([]ui.CommitDetailFile, 0, len(states))
+	staged, unstaged, mixed := 0, 0, 0
+	additions, deletions := 0, 0
+	for _, state := range states {
+		stateLabel := "unstaged"
+		switch {
+		case state.staged && state.unstaged:
+			stateLabel = "mixed"
+			mixed++
+		case state.staged:
+			stateLabel = "staged"
+			staged++
+		default:
+			unstaged++
+		}
+		status := combinedCurrentStatus(state)
+		pathLabel := state.status.Path
+		if state.status.OldPath != "" && state.status.OldPath != state.status.Path {
+			pathLabel = state.status.OldPath + " → " + state.status.Path
+		}
+		file := ui.CommitDetailFile{
+			Path:         state.status.Path,
+			OldPath:      state.status.OldPath,
+			Heading:      fmt.Sprintf("%s  %s · %s", ui.StatusBadge(status), pathLabel, stateLabel),
+			HeadingStyle: ui.StatusStyle(status),
+		}
+		diffText, diffErr := git.DiffWorkingTreeFileContext(ctx, dir, git.FileStatus{
+			Status: status, Path: state.status.Path, OldPath: state.status.OldPath,
+		})
+		if diffErr != nil {
+			file.Error = "Could not read current diff for " + state.status.Path
+		} else {
+			file.Diff = diff.Parse(diffText)
+			added, deleted := currentDiffStats(file.Diff)
+			additions += added
+			deletions += deleted
+		}
+		result.Files = append(result.Files, file)
+	}
+	result.Summary = currentChangesSummary(len(states), additions, deletions, staged, unstaged, mixed)
+	return result
+}
+
+func mergeCurrentFileStates(statuses []git.FileStatus) []currentFileState {
+	states := make([]currentFileState, 0, len(statuses))
+	index := make(map[string]int, len(statuses))
+	for _, status := range statuses {
+		i, ok := index[status.Path]
+		if !ok {
+			i = len(states)
+			index[status.Path] = i
+			states = append(states, currentFileState{status: status})
+		}
+		state := &states[i]
+		if status.OldPath != "" {
+			state.status.OldPath = status.OldPath
+		}
+		if status.Staged {
+			state.staged = true
+			if state.status.Status == "M" || state.status.Status == "" {
+				state.status.Status = status.Status
+			}
+		} else {
+			state.unstaged = true
+			if status.Status == "?" || status.Status == "D" {
+				state.status.Status = status.Status
+			}
+		}
+	}
+	return states
+}
+
+func combinedCurrentStatus(state currentFileState) string {
+	if state.status.Status == "" {
+		return "M"
+	}
+	return state.status.Status
+}
+
+func currentDiffStats(file diff.FileDiff) (added, deleted int) {
+	for _, line := range file.AllLines() {
+		if line.Left.Kind == diff.Deleted {
+			deleted++
+		}
+		if line.Right.Kind == diff.Added {
+			added++
+		}
+	}
+	return added, deleted
+}
+
+func currentChangesSummary(files, additions, deletions, staged, unstaged, mixed int) string {
+	if files == 0 {
+		return "Working tree clean"
+	}
+	fileLabel := "file"
+	if files != 1 {
+		fileLabel = "files"
+	}
+	parts := []string{fmt.Sprintf("%d %s", files, fileLabel), fmt.Sprintf("+%d −%d", additions, deletions)}
+	if staged > 0 {
+		parts = append(parts, fmt.Sprintf("%d staged", staged))
+	}
+	if unstaged > 0 {
+		parts = append(parts, fmt.Sprintf("%d unstaged", unstaged))
+	}
+	if mixed > 0 {
+		parts = append(parts, fmt.Sprintf("%d mixed", mixed))
+	}
+	return strings.Join(parts, " · ")
+}

--- a/internal/app/current_changes.go
+++ b/internal/app/current_changes.go
@@ -80,6 +80,7 @@ func (a *App) OpenCurrentChanges() {
 	created := detail == nil
 	if detail == nil {
 		detail = ui.NewCurrentChangesWidget(dir, a.EditorGroup.SyntaxHighlight)
+		a.wireCommitDetailContext(tabID, detail)
 		a.EditorGroup.ApplyDiffDefaults(detail)
 		a.EditorGroup.OpenPluginTab(tabID, currentChangesTitle(dir, len(a.Changes.groups) > 1), detail)
 	} else {

--- a/internal/app/current_changes_test.go
+++ b/internal/app/current_changes_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func TestReadCurrentChangesCombinesMixedAndUntrackedFiles(t *testing.T) {
+	dir := commitLogRepo(t)
+	path := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(path, []byte("staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "add", "a.txt")
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("stage: %v\n%s", err, output)
+	}
+	if err := os.WriteFile(path, []byte("final working tree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readCurrentChanges(context.Background(), dir, currentChangesTabID(dir), 4)
+	if result.Err != "" {
+		t.Fatal(result.Err)
+	}
+	if len(result.Files) != 2 {
+		t.Fatalf("current change files = %d, want 2: %+v", len(result.Files), result.Files)
+	}
+	if !strings.Contains(result.Summary, "2 files") || !strings.Contains(result.Summary, "1 mixed") || !strings.Contains(result.Summary, "1 unstaged") {
+		t.Fatalf("summary = %q", result.Summary)
+	}
+	if !strings.Contains(result.Files[0].Heading, "mixed") {
+		t.Fatalf("mixed heading = %q", result.Files[0].Heading)
+	}
+	lines := result.Files[0].Diff.AllLines()
+	foundFinal := false
+	for _, line := range lines {
+		if line.Right.Text == "final working tree" {
+			foundFinal = true
+		}
+		if line.Right.Text == "staged" {
+			t.Fatal("combined diff stopped at the index instead of the working tree")
+		}
+	}
+	if !foundFinal {
+		t.Fatalf("combined diff omitted final working tree: %+v", lines)
+	}
+	if !strings.HasPrefix(result.Files[1].Heading, "U  ") || len(result.Files[1].Diff.Hunks) == 0 {
+		t.Fatalf("untracked file was not synthesized as an addition: %+v", result.Files[1])
+	}
+}
+
+func TestApplyCurrentChangesDropsSupersededResult(t *testing.T) {
+	dir := "/repo"
+	tabID := currentChangesTabID(dir)
+	detail := ui.NewCurrentChangesWidget(dir, false)
+	detail.LoadGen = 2
+	a := &App{EditorGroup: ui.NewEditorGroupWidget(nil, 4, true, "default")}
+	a.EditorGroup.OpenPluginTab(tabID, "Current Changes", detail)
+
+	a.ApplyCurrentChanges(&CurrentChangesResult{Dir: dir, TabID: tabID, Gen: 1, Summary: "stale"})
+	if detail.Message == "stale" {
+		t.Fatal("superseded current changes result was applied")
+	}
+	a.ApplyCurrentChanges(&CurrentChangesResult{Dir: dir, TabID: tabID, Gen: 2, Summary: "fresh"})
+	if detail.Message != "fresh" {
+		t.Fatalf("current result message = %q", detail.Message)
+	}
+}
+
+func TestActiveCurrentChangesSkipsUnchangedPollAndReloadsSameStatusContent(t *testing.T) {
+	dir := commitLogRepo(t)
+	path := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(path, []byte("first external edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	statuses, err := git.StatusFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	group := changesGroup{Dir: dir}
+	for _, status := range statuses {
+		if status.Staged {
+			group.Staged = append(group.Staged, status)
+		} else {
+			group.Unstaged = append(group.Unstaged, status)
+		}
+	}
+	detail := ui.NewCurrentChangesWidget(dir, false)
+	tabID := currentChangesTabID(dir)
+	a := &App{
+		Changes:     NewChangesPanel(dir),
+		EditorGroup: ui.NewEditorGroupWidget(nil, 4, true, "default"),
+	}
+	a.Changes.groups = []changesGroup{group}
+	a.EditorGroup.OpenPluginTab(tabID, "Current Changes", detail)
+	fingerprint := a.currentChangesSourceFingerprint(dir)
+	a.currentChangesLoadState(tabID).appliedFingerprint = fingerprint
+
+	a.refreshActiveCurrentChanges()
+	if detail.LoadGen != 0 {
+		t.Fatalf("unchanged poll started diff load generation %d", detail.LoadGen)
+	}
+
+	if err := os.WriteFile(path, []byte("second external edit with a different size\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.refreshActiveCurrentChanges()
+	if detail.LoadGen != 1 {
+		t.Fatalf("same-status content edit did not start one diff load: generation %d", detail.LoadGen)
+	}
+	refreshed := false
+	if len(detail.Files) > 0 {
+		for _, line := range detail.Files[0].Diff.AllLines() {
+			if strings.Contains(line.Right.Text, "second external edit") {
+				refreshed = true
+			}
+		}
+	}
+	if !refreshed {
+		t.Fatalf("refreshed diff omitted new content: %+v", detail.Files)
+	}
+}

--- a/internal/app/debug_dump.go
+++ b/internal/app/debug_dump.go
@@ -472,9 +472,17 @@ func (a *App) DumpDebugState(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return err
+	}
+	a.postRepositoryInvalidation(path, RepositoryStatus)
+	return nil
 }
 
 func (a *App) DumpScreenshot(path string) error {
-	return os.WriteFile(path, []byte(a.Screenshot()), 0644)
+	if err := os.WriteFile(path, []byte(a.Screenshot()), 0644); err != nil {
+		return err
+	}
+	a.postRepositoryInvalidation(path, RepositoryStatus)
+	return nil
 }

--- a/internal/app/detail_context.go
+++ b/internal/app/detail_context.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+const commitDetailContextTimeout = 15 * time.Second
+
+type CommitDetailContextResult struct {
+	TabID     string
+	Dir       string
+	Ref       string
+	Gen       uint64
+	FileIndex int
+	FileKey   string
+	OldLines  []string
+	NewLines  []string
+}
+
+func (a *App) wireCommitDetailContext(tabID string, detail *ui.CommitDetailWidget) {
+	if detail == nil {
+		return
+	}
+	detail.OnFetchContext = func(fileIndex int, file ui.CommitDetailFile) {
+		ctx, cancel := context.WithTimeout(context.Background(), commitDetailContextTimeout)
+		dir, ref, gen, current := detail.Dir, detail.Ref, detail.LoadGen, detail.CurrentChanges
+		read := func() *CommitDetailContextResult {
+			defer cancel()
+			return readCommitDetailContext(ctx, tabID, dir, ref, gen, current, fileIndex, file)
+		}
+		if a.Screen == nil {
+			a.ApplyCommitDetailContext(read())
+			return
+		}
+		screen := a.Screen
+		go func() {
+			screen.PostEvent(tcell.NewEventInterrupt(read()))
+		}()
+	}
+}
+
+func readCommitDetailContext(ctx context.Context, tabID, dir, ref string, gen uint64, current bool, fileIndex int, file ui.CommitDetailFile) *CommitDetailContextResult {
+	result := &CommitDetailContextResult{
+		TabID: tabID, Dir: dir, Ref: ref, Gen: gen,
+		FileIndex: fileIndex, FileKey: ui.CommitDetailContextKey(file),
+	}
+	oldPath := file.Path
+	if file.OldPath != "" {
+		oldPath = file.OldPath
+	}
+	if current {
+		if content, err := git.ShowFileContext(ctx, dir, oldPath, "HEAD"); err == nil {
+			result.OldLines = splitFileLines(content)
+		}
+		if content, err := os.ReadFile(filepath.Join(dir, file.Path)); err == nil {
+			result.NewLines = splitFileLines(string(content))
+		}
+		return result
+	}
+	if content, err := git.ShowFileContext(ctx, dir, oldPath, ref+"^"); err == nil {
+		result.OldLines = splitFileLines(content)
+	}
+	if content, err := git.ShowFileContext(ctx, dir, file.Path, ref); err == nil {
+		result.NewLines = splitFileLines(content)
+	}
+	return result
+}
+
+func (a *App) ApplyCommitDetailContext(result *CommitDetailContextResult) {
+	if result == nil {
+		return
+	}
+	detail := a.EditorGroup.CommitDetailWidgetByTab(result.TabID)
+	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref || detail.LoadGen != result.Gen {
+		return
+	}
+	detail.ApplyFileContext(result.FileIndex, result.FileKey, result.OldLines, result.NewLines)
+}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -394,6 +394,8 @@ func RunEventLoop(
 				app.Changes.ApplyCommitFiles(v)
 			case *CommitDetailResult:
 				app.ApplyCommitDetail(v)
+			case *CommitDetailContextResult:
+				app.ApplyCommitDetailContext(v)
 			case *CurrentChangesResult:
 				app.ApplyCurrentChanges(v)
 			case *DiffOpenResult:

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -38,6 +38,7 @@ func RunEventLoop(
 	if app.Repository != nil {
 		defer app.Repository.Close()
 	}
+	defer app.closeCurrentChanges()
 
 	lastBlameLine := -1
 	lastBlameFile := ""
@@ -393,6 +394,8 @@ func RunEventLoop(
 				app.Changes.ApplyCommitFiles(v)
 			case *CommitDetailResult:
 				app.ApplyCommitDetail(v)
+			case *CurrentChangesResult:
+				app.ApplyCurrentChanges(v)
 			case *DiffOpenResult:
 				app.ApplyDiffOpen(v)
 			case *FileChangedResult:

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -35,6 +35,9 @@ func RunEventLoop(
 	if app.Watcher != nil {
 		defer app.Watcher.Close()
 	}
+	if app.Repository != nil {
+		defer app.Repository.Close()
+	}
 
 	lastBlameLine := -1
 	lastBlameFile := ""
@@ -372,6 +375,16 @@ func RunEventLoop(
 				app.SyncLanguageSegment()
 			case *RepoOpResult:
 				app.HandleRepoOpResult(v)
+			case *RepositoryStatusResult:
+				app.Repository.HandleStatus(v)
+			case *RepositoryInvalidationRequest:
+				app.handleRepositoryInvalidation(v)
+			case *DebugWriteRequest:
+				app.HandleDebugWriteRequest(v)
+			case *repositoryDebounceTick:
+				app.Repository.HandleDebounce(v)
+			case *repositoryPollTick:
+				app.Repository.HandlePoll(v)
 			case *ChangesStatusResult:
 				app.Changes.ApplyStatus(v)
 			case *CommitLogResult:

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -213,6 +213,39 @@ func RunEventLoop(
 
 	app.ShowPendingPluginApprovals()
 
+	handleKey := func(tev *tcell.EventKey) {
+		app.cancelHoverTimer()
+		if app.EditorGroup.SignatureHelp != nil {
+			switch tev.Key() {
+			case tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,
+				tcell.KeyHome, tcell.KeyEnd, tcell.KeyPgUp, tcell.KeyPgDn:
+				app.DismissSignatureHelp()
+			}
+		}
+		slog.Debug("key", "key", tev.Key(), "rune", string(term.KeyRune(tev)), "mod", tev.Modifiers())
+		app.Root.HandleEvent(tev)
+		app.FlushEditorOnChange()
+		app.RefreshAutocomplete()
+		syncStatus()
+	}
+
+	handleMouse := func(tev *tcell.EventMouse) {
+		mx, my := tev.Position()
+		btn := tev.Buttons()
+		slog.Debug("mouse", "x", mx, "y", my, "btn", btn)
+		app.DismissSignatureHelp()
+		if app.EditorGroup.Hover == nil {
+			if btn == 0 {
+				app.checkMouseHover(mx, my)
+			}
+		} else if !app.isMouseOverHover(mx, my) && !app.EditorGroup.Hover.IsDragging() {
+			app.DismissHover()
+		}
+		app.Root.HandleEvent(tev)
+		app.FlushEditorOnChange()
+		syncStatus()
+	}
+
 	for *running {
 		ev := screen.PollEvent()
 		switch tev := ev.(type) {
@@ -241,36 +274,11 @@ func RunEventLoop(
 			}
 
 		case *tcell.EventKey:
-			app.cancelHoverTimer()
-			if app.EditorGroup.SignatureHelp != nil {
-				switch tev.Key() {
-				case tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,
-					tcell.KeyHome, tcell.KeyEnd, tcell.KeyPgUp, tcell.KeyPgDn:
-					app.DismissSignatureHelp()
-				}
-			}
-			slog.Debug("key", "key", tev.Key(), "rune", string(term.KeyRune(tev)), "mod", tev.Modifiers())
-			app.Root.HandleEvent(tev)
-			app.FlushEditorOnChange()
-			app.RefreshAutocomplete()
-			syncStatus()
+			handleKey(tev)
 			redraw()
 
 		case *tcell.EventMouse:
-			mx, my := tev.Position()
-			btn := tev.Buttons()
-			slog.Debug("mouse", "x", mx, "y", my, "btn", btn)
-			app.DismissSignatureHelp()
-			if app.EditorGroup.Hover == nil {
-				if btn == 0 {
-					app.checkMouseHover(mx, my)
-				}
-			} else if !app.isMouseOverHover(mx, my) && !app.EditorGroup.Hover.IsDragging() {
-				app.DismissHover()
-			}
-			app.Root.HandleEvent(tev)
-			app.FlushEditorOnChange()
-			syncStatus()
+			handleMouse(tev)
 			redraw()
 
 		case *tcell.EventResize:
@@ -281,6 +289,8 @@ func RunEventLoop(
 			redraw()
 
 		case *tcell.EventInterrupt:
+			var execDone chan error
+			var execErr error
 			switch v := tev.Data().(type) {
 			case string:
 				if v != "" {
@@ -301,10 +311,20 @@ func RunEventLoop(
 				}
 			case *GitGutterTrigger:
 				app.RequestGitGutterForActiveFile()
-			case *ExecCommandRequest:
-				app.Reg.Execute(v.ID)
-				app.FlushEditorOnChange()
+			case *execInputRequest:
+				switch event := v.Event.(type) {
+				case *tcell.EventKey:
+					handleKey(event)
+				case *tcell.EventMouse:
+					handleMouse(event)
+				default:
+					execErr = failedExec("unsupported input event %T", v.Event)
+				}
+				execDone = v.Done
+			case *execMainRequest:
+				execErr = v.Run()
 				syncStatus()
+				execDone = v.Done
 			case *AutocompleteTrigger:
 				triggerChar := app.charBeforeCursor()
 				isTrigger := triggerChar != "" && (len(app.CompletionTriggers) == 0 || app.isCompletionTrigger(triggerChar))
@@ -453,6 +473,9 @@ func RunEventLoop(
 				}
 			}
 			redraw()
+			if execDone != nil {
+				execDone <- execErr
+			}
 		}
 	}
 }

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -14,6 +14,12 @@ import (
 	"github.com/gdamore/tcell/v3"
 )
 
+// BranchNameResult carries a finished `git rev-parse` for the status bar.
+type BranchNameResult struct {
+	Gen  int
+	Name string
+}
+
 type BlameResult struct {
 	Gen  int
 	Info *git.BlameInfo
@@ -41,7 +47,26 @@ func RunEventLoop(
 	lastCursorFile := ""
 	lastBranchDir := app.Workspace.Primary()
 	blameGen := 0
-	app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: git.BranchName(lastBranchDir)})
+	branchGen := 0
+
+	// git rev-parse is a subprocess like any other, so reading the branch name
+	// from here would block the loop that is about to draw the status bar.
+	setBranch := func(dir string) {
+		// Bump the generation first, so that clearing the segment — which is a
+		// desired state like any other — also invalidates a lookup still
+		// running. Returning early without it left a stale branch name landing
+		// on a file that belongs to no repository at all.
+		branchGen++
+		gen := branchGen
+		app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: ""})
+		if dir == "" {
+			return
+		}
+		go func() {
+			screen.PostEvent(tcell.NewEventInterrupt(&BranchNameResult{Gen: gen, Name: git.BranchName(dir)}))
+		}()
+	}
+	setBranch(lastBranchDir)
 
 	syncStatus := func() {
 		line, col := app.EditorGroup.ActiveCursor()
@@ -95,11 +120,7 @@ func RunEventLoop(
 
 		if repoDir != lastBranchDir {
 			lastBranchDir = repoDir
-			if repoDir != "" {
-				app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: git.BranchName(repoDir)})
-			} else {
-				app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: ""})
-			}
+			setBranch(repoDir)
 		}
 
 		// Trigger git gutter computation when switching to a new file
@@ -261,6 +282,10 @@ func RunEventLoop(
 				if v != "" {
 					closeTerminal(v)
 				}
+			case *BranchNameResult:
+				if v.Gen == branchGen {
+					app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: v.Name})
+				}
 			case *BlameResult:
 				if v.Gen == blameGen && v.Info != nil {
 					app.Status.SetSegment(view.StatusSegment{ID: "blame", Side: "left", Priority: 200, Text: fmt.Sprintf("%s, %s",
@@ -347,6 +372,16 @@ func RunEventLoop(
 				app.SyncLanguageSegment()
 			case *RepoOpResult:
 				app.HandleRepoOpResult(v)
+			case *ChangesStatusResult:
+				app.Changes.ApplyStatus(v)
+			case *CommitLogResult:
+				app.Changes.ApplyCommitLog(v)
+			case *CommitFilesResult:
+				app.Changes.ApplyCommitFiles(v)
+			case *CommitDetailResult:
+				app.ApplyCommitDetail(v)
+			case *DiffOpenResult:
+				app.ApplyDiffOpen(v)
 			case *FileChangedResult:
 				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,75 +14,166 @@ import (
 	"github.com/gdamore/tcell/v3"
 )
 
-// DefaultExecSeparator splits exec scripts when no override is given.
-const DefaultExecSeparator = ";"
+const (
+	DefaultExecSeparator  = ";"
+	defaultWaitForTimeout = 5 * time.Second
+	execRequestTimeout    = 5 * time.Second
+	waitForPollInterval   = 25 * time.Millisecond
+	maxExecMilliseconds   = int64((1<<63 - 1) / int64(time.Millisecond))
+)
 
-// RunExecScript parses a separator-delimited script string and executes each
-// command sequentially. Intended to be run in a goroutine after the event loop
-// starts.
-func RunExecScript(a *App, script string) {
-	RunExecScriptSep(a, script, DefaultExecSeparator)
+type ExecErrorKind string
+
+const (
+	ExecErrorInvalid ExecErrorKind = "invalid"
+	ExecErrorFailed  ExecErrorKind = "failed"
+	ExecErrorTimeout ExecErrorKind = "timeout"
+)
+
+type ExecResult struct {
+	Completed int
 }
 
-// RunExecScriptSep is RunExecScript with a caller-chosen separator. Semicolons
-// are unusable when the script must type or send one -- `;` is a Vim motion,
-// for instance -- so callers can pick a delimiter that cannot collide with
-// their payload.
-func RunExecScriptSep(a *App, script, sep string) {
+type ExecError struct {
+	Kind    ExecErrorKind
+	Index   int
+	Command string
+	Action  string
+	Err     error
+}
+
+func (e *ExecError) Error() string {
+	return fmt.Sprintf("command %d %q: %v", e.Index, e.Command, e.Err)
+}
+
+func (e *ExecError) Unwrap() error {
+	return e.Err
+}
+
+type execActionError struct {
+	kind ExecErrorKind
+	err  error
+}
+
+func (e *execActionError) Error() string {
+	return e.err.Error()
+}
+
+func (e *execActionError) Unwrap() error {
+	return e.err
+}
+
+func invalidExec(format string, args ...any) error {
+	return &execActionError{kind: ExecErrorInvalid, err: fmt.Errorf(format, args...)}
+}
+
+func failedExec(format string, args ...any) error {
+	return &execActionError{kind: ExecErrorFailed, err: fmt.Errorf(format, args...)}
+}
+
+func timeoutExec(format string, args ...any) error {
+	return &execActionError{kind: ExecErrorTimeout, err: fmt.Errorf(format, args...)}
+}
+
+type execInputRequest struct {
+	Event tcell.Event
+	Done  chan error
+}
+
+type execMainRequest struct {
+	Run  func() error
+	Done chan error
+}
+
+func RunExecScript(a *App, script string) (ExecResult, error) {
+	return RunExecScriptSep(a, script, DefaultExecSeparator)
+}
+
+func RunExecScriptSep(a *App, script, sep string) (ExecResult, error) {
 	if sep == "" {
 		sep = DefaultExecSeparator
 	}
-	commands := strings.Split(script, sep)
-	for _, raw := range commands {
+	var result ExecResult
+	commandIndex := 0
+	for _, raw := range strings.Split(script, sep) {
 		cmd := strings.TrimSpace(raw)
 		if cmd == "" {
 			continue
 		}
+		commandIndex++
 		action, args := parseExecCommand(cmd)
 		slog.Debug("exec_script", "action", action, "args", args)
 
-		switch action {
-		case "click":
-			execClick(a, args)
-		case "rclick":
-			execRClick(a, args)
-		case "hover":
-			execHover(a, args)
-		case "drag":
-			execDrag(a, args)
-		case "key":
-			execKey(a, args)
-		case "type":
-			execType(a, args)
-		case "exec":
-			execCommand(a, args)
-		case "screenshot":
-			execScreenshot(a, args)
-		case "debug":
-			execDebug(a, args)
-		case "wait":
-			execWait(args)
-		case "paste":
-			execPaste(a, args)
-		case "copy":
-			a.Copy()
-		case "panel":
-			execPanel(a, args)
-		case "quit", "shutdown":
-			execQuit(a)
-		default:
-			slog.Error("exec_script: unknown command", "action", action)
+		if err := runExecAction(a, action, args); err != nil {
+			kind := ExecErrorFailed
+			var actionErr *execActionError
+			if errors.As(err, &actionErr) {
+				kind = actionErr.kind
+			}
+			return result, &ExecError{
+				Kind:    kind,
+				Index:   commandIndex,
+				Command: cmd,
+				Action:  action,
+				Err:     err,
+			}
 		}
-
-		// Small implicit delay between commands to let the event loop process
+		result.Completed++
+		if action == "quit" || action == "shutdown" {
+			return result, nil
+		}
 		time.Sleep(50 * time.Millisecond)
+	}
+	return result, nil
+}
+
+func runExecAction(a *App, action, args string) error {
+	switch action {
+	case "click":
+		return execClick(a, args)
+	case "rclick":
+		return execRClick(a, args)
+	case "hover":
+		return execHover(a, args)
+	case "drag":
+		return execDrag(a, args)
+	case "key":
+		return execKey(a, args)
+	case "type":
+		return execType(a, args)
+	case "exec":
+		return execCommand(a, args)
+	case "screenshot":
+		return execScreenshot(a, args)
+	case "debug":
+		return execDebug(a, args)
+	case "wait":
+		return execWait(args)
+	case "wait-for":
+		return execWaitFor(a, args)
+	case "paste":
+		return execPaste(a, args)
+	case "copy":
+		if strings.TrimSpace(args) != "" {
+			return invalidExec("copy does not accept arguments")
+		}
+		return runExecMain(a, func() error {
+			a.Copy()
+			return nil
+		})
+	case "panel":
+		return execPanel(a, args)
+	case "quit", "shutdown":
+		if strings.TrimSpace(args) != "" {
+			return invalidExec("%s does not accept arguments", action)
+		}
+		return StopExecLoop(a)
+	default:
+		return invalidExec("unknown action %q", action)
 	}
 }
 
-// parseExecCommand splits a command string into action and arguments.
-// Handles quoted strings for the exec command (e.g., exec "Command Name").
 func parseExecCommand(cmd string) (string, string) {
-	// Find the first space to split action from args
 	idx := strings.IndexByte(cmd, ' ')
 	if idx < 0 {
 		return cmd, ""
@@ -89,246 +181,349 @@ func parseExecCommand(cmd string) (string, string) {
 	return cmd[:idx], strings.TrimSpace(cmd[idx+1:])
 }
 
-func execClick(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 2 {
-		slog.Error("exec_script: click requires X Y", "args", args)
-		return
-	}
-	x, err := strconv.Atoi(parts[0])
+func execClick(a *App, args string) error {
+	x, y, err := parseCoordinates("click", args, 2)
 	if err != nil {
-		slog.Error("exec_script: invalid click X", "value", parts[0], "error", err)
-		return
+		return err
 	}
-	y, err := strconv.Atoi(parts[1])
-	if err != nil {
-		slog.Error("exec_script: invalid click Y", "value", parts[1], "error", err)
-		return
+	if err := postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.Button1, tcell.ModNone)); err != nil {
+		return err
 	}
-
-	// Press
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button1, tcell.ModNone))
 	time.Sleep(50 * time.Millisecond)
-	// Release
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.ButtonNone, tcell.ModNone))
 }
 
-// execRClick simulates a secondary (right) mouse click, which opens context
-// menus. Right-click is tcell.Button2 (see menus.go).
-func execRClick(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 2 {
-		slog.Error("exec_script: rclick requires X Y", "args", args)
-		return
-	}
-	x, err := strconv.Atoi(parts[0])
+func execRClick(a *App, args string) error {
+	x, y, err := parseCoordinates("rclick", args, 2)
 	if err != nil {
-		slog.Error("exec_script: invalid rclick X", "value", parts[0], "error", err)
-		return
+		return err
 	}
-	y, err := strconv.Atoi(parts[1])
-	if err != nil {
-		slog.Error("exec_script: invalid rclick Y", "value", parts[1], "error", err)
-		return
+	if err := postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.Button2, tcell.ModNone)); err != nil {
+		return err
 	}
-
-	// Press
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button2, tcell.ModNone))
 	time.Sleep(50 * time.Millisecond)
-	// Release
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.ButtonNone, tcell.ModNone))
 }
 
-func execHover(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 2 {
-		slog.Error("exec_script: hover requires X Y", "args", args)
-		return
-	}
-	x, err := strconv.Atoi(parts[0])
+func execHover(a *App, args string) error {
+	x, y, err := parseCoordinates("hover", args, 2)
 	if err != nil {
-		slog.Error("exec_script: invalid hover X", "value", parts[0], "error", err)
-		return
+		return err
 	}
-	y, err := strconv.Atoi(parts[1])
-	if err != nil {
-		slog.Error("exec_script: invalid hover Y", "value", parts[1], "error", err)
-		return
-	}
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.ButtonNone, tcell.ModNone))
 }
 
-func execDrag(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 4 {
-		slog.Error("exec_script: drag requires X1 Y1 X2 Y2", "args", args)
-		return
+func execDrag(a *App, args string) error {
+	x, y, err := parseCoordinates("drag", args, 4)
+	if err != nil {
+		return err
 	}
-	x1, err1 := strconv.Atoi(parts[0])
-	y1, err2 := strconv.Atoi(parts[1])
-	x2, err3 := strconv.Atoi(parts[2])
-	y2, err4 := strconv.Atoi(parts[3])
-	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
-		slog.Error("exec_script: invalid drag coordinates", "args", args)
-		return
+	if err := postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.Button1, tcell.ModNone)); err != nil {
+		return err
 	}
-
-	a.Screen.PostEvent(tcell.NewEventMouse(x1, y1, tcell.Button1, tcell.ModNone))
 	time.Sleep(30 * time.Millisecond)
 
-	steps := 10
+	const steps = 10
 	for i := 1; i <= steps; i++ {
-		mx := x1 + (x2-x1)*i/steps
-		my := y1 + (y2-y1)*i/steps
-		a.Screen.PostEvent(tcell.NewEventMouse(mx, my, tcell.Button1, tcell.ModNone))
+		mx := x[0] + (x[1]-x[0])*i/steps
+		my := y[0] + (y[1]-y[0])*i/steps
+		if err := postExecInput(a, tcell.NewEventMouse(mx, my, tcell.Button1, tcell.ModNone)); err != nil {
+			return err
+		}
 		time.Sleep(15 * time.Millisecond)
 	}
 
-	a.Screen.PostEvent(tcell.NewEventMouse(x2, y2, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[1], y[1], tcell.ButtonNone, tcell.ModNone))
 }
 
-func execKey(a *App, args string) {
+func parseCoordinates(action, args string, count int) ([2]int, [2]int, error) {
+	var xs, ys [2]int
+	parts := strings.Fields(args)
+	if len(parts) != count {
+		return xs, ys, invalidExec("%s requires %d coordinates", action, count)
+	}
+	values := make([]int, count)
+	for i, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return xs, ys, invalidExec("invalid %s coordinate %q: %v", action, part, err)
+		}
+		values[i] = value
+	}
+	xs[0], ys[0] = values[0], values[1]
+	if count == 4 {
+		xs[1], ys[1] = values[2], values[3]
+	}
+	return xs, ys, nil
+}
+
+func execKey(a *App, args string) error {
 	combo := strings.TrimSpace(args)
 	if combo == "" {
-		slog.Error("exec_script: key requires a key combo")
-		return
+		return invalidExec("key requires a key combo")
 	}
 
 	steps, err := config.ParseKeyString(combo)
 	if err != nil {
-		slog.Error("exec_script: invalid key combo", "combo", combo, "error", err)
-		return
+		return invalidExec("invalid key combo %q: %v", combo, err)
 	}
 
 	for _, step := range steps {
 		key, mod, ch := comboToTcell(step)
-		a.Screen.PostEvent(tcell.NewEventKey(key, keyEventStr(ch), mod))
+		if err := postExecInput(a, tcell.NewEventKey(key, keyEventStr(ch), mod)); err != nil {
+			return err
+		}
 		time.Sleep(30 * time.Millisecond)
 	}
+	return nil
 }
 
-func execType(a *App, args string) {
+func execType(a *App, args string) error {
 	text := stripQuotes(args)
 	for _, r := range text {
-		a.Screen.PostEvent(tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone))
+		if err := postExecInput(a, tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone)); err != nil {
+			return err
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	return nil
 }
 
-func execPaste(a *App, args string) {
+func execPaste(a *App, args string) error {
 	text := stripQuotes(args)
 	if text == "" {
-		slog.Error("exec_script: paste requires text")
-		return
+		return invalidExec("paste requires text")
 	}
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	time.Sleep(50 * time.Millisecond)
-	a.PasteText(text)
-	a.FlushEditorOnChange()
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	return runExecMain(a, func() error {
+		a.PasteText(text)
+		a.FlushEditorOnChange()
+		return nil
+	})
 }
 
-func execCommand(a *App, args string) {
+func execCommand(a *App, args string) error {
 	title := stripQuotes(strings.TrimSpace(args))
 	if title == "" {
-		slog.Error("exec_script: exec requires a command title")
-		return
+		return invalidExec("exec requires a command title")
 	}
 
-	cmd, ok := a.Reg.FindByTitle(title)
-	if !ok {
-		slog.Error("exec_script: command not found", "title", title)
-		return
-	}
-	// Hand the command to the event loop instead of running it here. `key` and
-	// `click` already post real events, so they get the status bar sync that
-	// follows real input; running a command straight from the script goroutine
-	// skipped that sync and mutated widget state off the main thread.
-	a.Screen.PostEvent(tcell.NewEventInterrupt(&ExecCommandRequest{ID: cmd.ID}))
+	return runExecMain(a, func() error {
+		cmd, ok := a.Reg.FindByTitle(title)
+		if !ok {
+			return invalidExec("command %q not found", title)
+		}
+		if !a.Reg.Execute(cmd.ID) {
+			return failedExec("command %q disappeared before execution", title)
+		}
+		a.FlushEditorOnChange()
+		return nil
+	})
 }
 
-// ExecCommandRequest is posted as an EventInterrupt so a command named by an
-// --exec script runs on the main thread, on the same path as key and mouse
-// input.
-type ExecCommandRequest struct {
-	ID string
-}
-
-func execScreenshot(a *App, args string) {
+func execScreenshot(a *App, args string) error {
 	path := stripQuotes(strings.TrimSpace(args))
 	if path == "" {
-		slog.Error("exec_script: screenshot requires a file path")
-		return
+		return invalidExec("screenshot requires a file path")
 	}
-	// Trigger a redraw so the screen is up-to-date
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	time.Sleep(50 * time.Millisecond)
-
-	if err := a.DumpScreenshot(path); err != nil {
-		slog.Error("exec_script: screenshot failed", "path", path, "error", err)
-	}
+	return runExecMain(a, func() error {
+		if err := a.DumpScreenshot(path); err != nil {
+			return failedExec("screenshot %q failed: %v", path, err)
+		}
+		return nil
+	})
 }
 
-func execDebug(a *App, args string) {
+func execDebug(a *App, args string) error {
 	path := stripQuotes(strings.TrimSpace(args))
 	if path == "" {
-		slog.Error("exec_script: debug requires a file path")
-		return
+		return invalidExec("debug requires a file path")
 	}
-	// Trigger a redraw so state is current
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	time.Sleep(50 * time.Millisecond)
-
-	if err := a.DumpDebugState(path); err != nil {
-		slog.Error("exec_script: debug dump failed", "path", path, "error", err)
-	}
+	return runExecMain(a, func() error {
+		if err := a.DumpDebugState(path); err != nil {
+			return failedExec("debug dump %q failed: %v", path, err)
+		}
+		return nil
+	})
 }
 
-func execWait(args string) {
+func execWait(args string) error {
 	ms := strings.TrimSpace(args)
 	if ms == "" {
-		slog.Error("exec_script: wait requires milliseconds")
-		return
+		return invalidExec("wait requires milliseconds")
 	}
-	n, err := strconv.Atoi(ms)
+	duration, err := parseExecMilliseconds(ms, true)
 	if err != nil {
-		slog.Error("exec_script: invalid wait duration", "value", ms, "error", err)
-		return
+		return invalidExec("invalid wait duration %q", ms)
 	}
-	time.Sleep(time.Duration(n) * time.Millisecond)
+	time.Sleep(duration)
+	return nil
 }
 
-func execPanel(a *App, args string) {
+func execWaitFor(a *App, args string) error {
+	text, timeout, err := parseWaitForArgs(args)
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		var visible bool
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return timeoutExec("screen text %q not visible after %s", text, timeout)
+		}
+		requestTimeout := min(remaining, execRequestTimeout)
+		if err := runExecMainTimeout(a, func() error {
+			visible = strings.Contains(a.Screenshot(), text)
+			return nil
+		}, requestTimeout); err != nil {
+			return err
+		}
+		if visible {
+			return nil
+		}
+		remaining = time.Until(deadline)
+		if remaining <= 0 {
+			return timeoutExec("screen text %q not visible after %s", text, timeout)
+		}
+		time.Sleep(min(waitForPollInterval, remaining))
+	}
+}
+
+func parseWaitForArgs(args string) (string, time.Duration, error) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return "", 0, invalidExec("wait-for requires screen text")
+	}
+
+	text := args
+	option := ""
+	if strings.HasPrefix(args, "\"") {
+		end := quotedStringEnd(args)
+		if end < 0 {
+			return "", 0, invalidExec("wait-for has an unterminated quoted string")
+		}
+		quoted := args[:end]
+		unquoted, err := strconv.Unquote(quoted)
+		if err != nil {
+			return "", 0, invalidExec("invalid wait-for text: %v", err)
+		}
+		text = unquoted
+		option = strings.TrimSpace(args[end:])
+	} else {
+		fields := strings.Fields(args)
+		last := fields[len(fields)-1]
+		if strings.HasPrefix(last, "timeout=") {
+			option = last
+			text = strings.TrimSpace(strings.TrimSuffix(args, last))
+		}
+	}
+
+	if text == "" {
+		return "", 0, invalidExec("wait-for requires non-empty screen text")
+	}
+	timeout := defaultWaitForTimeout
+	if option != "" {
+		if strings.ContainsAny(option, " \t\r\n") || !strings.HasPrefix(option, "timeout=") {
+			return "", 0, invalidExec("wait-for expects optional timeout=MS after the text")
+		}
+		ms := strings.TrimPrefix(option, "timeout=")
+		parsed, err := parseExecMilliseconds(ms, false)
+		if err != nil {
+			return "", 0, invalidExec("invalid wait-for timeout %q", ms)
+		}
+		timeout = parsed
+	}
+	return text, timeout, nil
+}
+
+func parseExecMilliseconds(value string, allowZero bool) (time.Duration, error) {
+	milliseconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || milliseconds < 0 || (!allowZero && milliseconds == 0) || milliseconds > maxExecMilliseconds {
+		return 0, fmt.Errorf("milliseconds out of range")
+	}
+	return time.Duration(milliseconds) * time.Millisecond, nil
+}
+
+func quotedStringEnd(s string) int {
+	escaped := false
+	for i := 1; i < len(s); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch s[i] {
+		case '\\':
+			escaped = true
+		case '"':
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func execPanel(a *App, args string) error {
 	id := stripQuotes(strings.TrimSpace(args))
 	if id == "" {
-		slog.Error("exec_script: panel requires a panel ID")
-		return
+		return invalidExec("panel requires a panel ID")
 	}
-	if !a.BottomPanel.HasPanel(id) {
-		slog.Error("exec_script: panel not found", "id", id)
-		return
-	}
-	a.BottomPanel.SetActivePanel(id)
-	if !a.ContentSplit.ShowBottom {
-		r := a.ContentSplit.GetRect()
-		maxH := r.H - 4
-		if a.ContentSplit.BottomH <= 1 || a.ContentSplit.BottomH > maxH {
-			a.ContentSplit.BottomH = min(r.H/2, maxH)
+	return runExecMain(a, func() error {
+		if !a.BottomPanel.HasPanel(id) {
+			return invalidExec("panel %q not found", id)
 		}
-		a.ContentSplit.ShowBottom = true
-	}
-	if w := a.BottomPanel.ActiveWidget(); w != nil {
-		a.Root.SetFocus(w)
-	}
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+		a.BottomPanel.SetActivePanel(id)
+		if !a.ContentSplit.ShowBottom {
+			r := a.ContentSplit.GetRect()
+			maxH := r.H - 4
+			if a.ContentSplit.BottomH <= 1 || a.ContentSplit.BottomH > maxH {
+				a.ContentSplit.BottomH = min(r.H/2, maxH)
+			}
+			a.ContentSplit.ShowBottom = true
+		}
+		if w := a.BottomPanel.ActiveWidget(); w != nil {
+			a.Root.SetFocus(w)
+		}
+		return nil
+	})
 }
 
-func execQuit(a *App) {
-	*a.Running = false
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+func postExecInput(a *App, event tcell.Event) error {
+	done := make(chan error, 1)
+	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execInputRequest{Event: event, Done: done})); err != nil {
+		return failedExec("failed to post input event: %v", err)
+	}
+	return awaitExecRequest(done, execRequestTimeout)
 }
 
-// stripQuotes removes surrounding double quotes from a string if present.
+func runExecMain(a *App, run func() error) error {
+	return runExecMainTimeout(a, run, execRequestTimeout)
+}
+
+func runExecMainTimeout(a *App, run func() error, timeout time.Duration) error {
+	done := make(chan error, 1)
+	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execMainRequest{Run: run, Done: done})); err != nil {
+		return failedExec("failed to post main-thread action: %v", err)
+	}
+	return awaitExecRequest(done, timeout)
+}
+
+func awaitExecRequest(done <-chan error, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		return timeoutExec("event loop did not acknowledge action within %s", timeout)
+	}
+}
+
+func StopExecLoop(a *App) error {
+	return runExecMain(a, func() error {
+		*a.Running = false
+		return nil
+	})
+}
+
 func stripQuotes(s string) string {
 	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
 		return s[1 : len(s)-1]
@@ -336,7 +531,6 @@ func stripQuotes(s string) string {
 	return s
 }
 
-// ExecScriptUsage returns the usage text for the --exec flag.
 func ExecScriptUsage() string {
 	return fmt.Sprintf(`--exec "commands"  Execute semicolon-separated commands after startup
 
@@ -353,15 +547,20 @@ Supported commands:
   screenshot PATH    Save screen text to file
   debug PATH         Save debug state JSON to file
   wait MS            Wait milliseconds
+  wait-for TEXT [timeout=MS]
+                     Wait until visible screen text appears (default 5000ms)
   panel ID           Show and focus a bottom panel by ID
   quit               Exit the editor
   shutdown           Alias for quit, for use over --listen
 
+Invalid actions fail --exec with a nonzero exit and POST /exec with a non-2xx
+response. Quote wait-for text to preserve surrounding whitespace or escapes.
+
 --listen starts an HTTP command server on 127.0.0.1:4242 that accepts the
 same script format over POST /exec, so a running editor can be driven
 interactively instead of scripted in advance:
-  curl -X POST --data "type hi; screenshot /tmp/s1.txt" http://127.0.0.1:4242/exec
+  curl -X POST --data "type hi; wait-for hi; screenshot /tmp/s1.txt" http://127.0.0.1:4242/exec
 
 Example:
-  %s --exec "wait 200; screenshot /tmp/s1.txt; quit"`, os.Args[0])
+  %s --exec "wait-for Explore; screenshot /tmp/s1.txt; quit"`, os.Args[0])
 }

--- a/internal/app/exec_script_test.go
+++ b/internal/app/exec_script_test.go
@@ -1,0 +1,164 @@
+package app
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/view"
+)
+
+func TestParseWaitForArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        string
+		wantText    string
+		wantTimeout time.Duration
+	}{
+		{name: "plain text", args: "Explore", wantText: "Explore", wantTimeout: defaultWaitForTimeout},
+		{name: "plain whitespace", args: "working tree clean", wantText: "working tree clean", wantTimeout: defaultWaitForTimeout},
+		{name: "numeric suffix is text", args: "build 123", wantText: "build 123", wantTimeout: defaultWaitForTimeout},
+		{name: "explicit timeout", args: "ready now timeout=125", wantText: "ready now", wantTimeout: 125 * time.Millisecond},
+		{name: "quoted escapes", args: `"  ready \"now\"  " timeout=250`, wantText: `  ready "now"  `, wantTimeout: 250 * time.Millisecond},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text, timeout, err := parseWaitForArgs(tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if text != tc.wantText {
+				t.Errorf("text = %q, want %q", text, tc.wantText)
+			}
+			if timeout != tc.wantTimeout {
+				t.Errorf("timeout = %s, want %s", timeout, tc.wantTimeout)
+			}
+		})
+	}
+}
+
+func TestParseWaitForArgsRejectsInvalidSyntax(t *testing.T) {
+	for _, args := range []string{
+		"",
+		`"unterminated`,
+		`"ready" eventually`,
+		"ready timeout=0",
+		"timeout=100",
+	} {
+		t.Run(args, func(t *testing.T) {
+			if _, _, err := parseWaitForArgs(args); err == nil {
+				t.Fatalf("parseWaitForArgs(%q) succeeded, want error", args)
+			}
+		})
+	}
+}
+
+func TestParseExecMillisecondsBoundaries(t *testing.T) {
+	maximum := strconv.FormatInt(maxExecMilliseconds, 10)
+	overflow := strconv.FormatInt(maxExecMilliseconds+1, 10)
+
+	duration, err := parseExecMilliseconds(maximum, false)
+	if err != nil {
+		t.Fatalf("maximum representable milliseconds rejected: %v", err)
+	}
+	if want := time.Duration(maxExecMilliseconds) * time.Millisecond; duration != want {
+		t.Fatalf("duration = %s, want %s", duration, want)
+	}
+	if _, err := parseExecMilliseconds(overflow, false); err == nil {
+		t.Fatalf("first overflowing millisecond value %s accepted", overflow)
+	}
+	if duration, err := parseExecMilliseconds("0", true); err != nil || duration != 0 {
+		t.Fatalf("wait zero = %s, %v; want accepted zero", duration, err)
+	}
+	if _, err := parseExecMilliseconds("0", false); err == nil {
+		t.Fatal("wait-for accepted zero timeout")
+	}
+}
+
+func TestExecDurationOverflowIsTypedInvalidInput(t *testing.T) {
+	a := newListenTestApp(t)
+	overflow := strconv.FormatInt(maxExecMilliseconds+1, 10)
+	tests := []string{
+		"wait " + overflow,
+		`wait-for x timeout=` + overflow,
+	}
+
+	for _, script := range tests {
+		t.Run(script, func(t *testing.T) {
+			start := time.Now()
+			result, err := RunExecScript(a, script)
+			if result.Completed != 0 {
+				t.Fatalf("completed = %d, want 0", result.Completed)
+			}
+			var execErr *ExecError
+			if !errors.As(err, &execErr) || execErr.Kind != ExecErrorInvalid {
+				t.Fatalf("error = %T %v, want invalid ExecError", err, err)
+			}
+			if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+				t.Fatalf("overflow rejection took %s", elapsed)
+			}
+		})
+	}
+}
+
+func TestRunExecScriptReturnsTypedPartialResult(t *testing.T) {
+	a := newListenTestApp(t)
+
+	result, err := RunExecScript(a, "wait 0; click nope 2; type skipped")
+
+	if result.Completed != 1 {
+		t.Fatalf("completed = %d, want 1", result.Completed)
+	}
+	var execErr *ExecError
+	if !errors.As(err, &execErr) {
+		t.Fatalf("error = %T %v, want *ExecError", err, err)
+	}
+	if execErr.Kind != ExecErrorInvalid || execErr.Index != 2 || execErr.Action != "click" {
+		t.Fatalf("exec error = %+v, want invalid click at command 2", execErr)
+	}
+}
+
+func TestRunExecScriptWaitForObservesDelayedVisibleScreen(t *testing.T) {
+	a := newListenTestApp(t)
+	posted := make(chan error, 1)
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		posted <- runExecMain(a, func() error {
+			a.Status.SetNotification("ASYNC READY", view.NotifyInfo, time.Second)
+			return nil
+		})
+	}()
+
+	result, err := RunExecScript(a, `wait-for "ASYNC READY" timeout=1000`)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Completed != 1 {
+		t.Fatalf("completed = %d, want 1", result.Completed)
+	}
+	if err := <-posted; err != nil {
+		t.Fatalf("posting visible text: %v", err)
+	}
+}
+
+func TestRunExecScriptWaitForTimeoutIsBounded(t *testing.T) {
+	a := newListenTestApp(t)
+	start := time.Now()
+
+	result, err := RunExecScript(a, `wait-for "never visible" timeout=40`)
+	elapsed := time.Since(start)
+
+	if result.Completed != 0 {
+		t.Fatalf("completed = %d, want 0", result.Completed)
+	}
+	var execErr *ExecError
+	if !errors.As(err, &execErr) || execErr.Kind != ExecErrorTimeout {
+		t.Fatalf("error = %T %v, want timeout ExecError", err, err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("wait-for took %s, want bounded near 40ms", elapsed)
+	}
+}

--- a/internal/app/explorer.go
+++ b/internal/app/explorer.go
@@ -95,6 +95,16 @@ func (n *NavigationPanel) Reload() {
 	n.Tree.Reload()
 }
 
+func (n *NavigationPanel) ExpandAll() {
+	n.Tree.ExpandAllWhere(func(node *widgets.TreeNode) bool {
+		return !node.Muted
+	})
+}
+
+func (n *NavigationPanel) CollapseAll() {
+	n.Tree.CollapseAll()
+}
+
 func (n *NavigationPanel) SetRoots(paths []string) {
 	expanded := map[string]bool{}
 	n.Tree.CollectExpanded(expanded)

--- a/internal/app/explorer_expand_test.go
+++ b/internal/app/explorer_expand_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+)
+
+func TestExplorerExpandAllLoadsOneNewLevelAndCollapseAllClosesEverything(t *testing.T) {
+	rootPath := t.TempDir()
+	nestedPath := filepath.Join(rootPath, "src", "nested")
+	if err := os.MkdirAll(nestedPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedPath, "file.go"), []byte("package nested\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hiddenPath := filepath.Join(rootPath, ".hidden")
+	if err := os.Mkdir(hiddenPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	explorer := NewNavigationPanel(config.DefaultExplorerSettings(), rootPath)
+	root := explorer.Tree.Config.Items[0]
+	src := nodeWithLabel(root.Children, "src")
+	if src == nil || len(src.Children) != 0 {
+		t.Fatalf("test setup: src = %+v", src)
+	}
+
+	explorer.ExpandAll()
+	nested := nodeWithLabel(src.Children, "nested")
+	if !root.Expanded || !src.Expanded || nested == nil {
+		t.Fatalf("first expand did not open represented folders: root=%v src=%v nested=%+v", root.Expanded, src.Expanded, nested)
+	}
+	if nested.Expanded || len(nested.Children) != 0 {
+		t.Fatal("newly revealed nested folder should not recursively walk the filesystem in the same action")
+	}
+	hidden := nodeWithLabel(root.Children, ".hidden")
+	if hidden == nil || hidden.Expanded {
+		t.Fatalf("muted hidden folder should remain manually expandable: %+v", hidden)
+	}
+
+	explorer.ExpandAll()
+	if !nested.Expanded || nodeWithLabel(nested.Children, "file.go") == nil {
+		t.Fatal("second expand did not open the newly represented level")
+	}
+	explorer.CollapseAll()
+	if root.Expanded || src.Expanded || nested.Expanded {
+		t.Fatalf("collapse left folders open: root=%v src=%v nested=%v", root.Expanded, src.Expanded, nested.Expanded)
+	}
+}

--- a/internal/app/fileops.go
+++ b/internal/app/fileops.go
@@ -32,6 +32,7 @@ func (a *App) FileOpNewFile(path string, reload func()) {
 			a.StatusError("Error: " + err.Error())
 			return
 		}
+		a.invalidateRepositoryPath(newPath, RepositoryStatus)
 		reload()
 		a.EditorGroup.OpenFile(newPath)
 		a.FocusEditor()
@@ -77,6 +78,8 @@ func (a *App) FileOpRename(path string, reload func()) {
 			a.StatusError("Error: " + err.Error())
 			return
 		}
+		a.invalidateRepositoryPath(path, RepositoryStatus)
+		a.invalidateRepositoryPath(newPath, RepositoryStatus)
 		a.EditorGroup.RenamePath(path, newPath)
 		reload()
 	})
@@ -97,6 +100,7 @@ func (a *App) FileOpDelete(path string, reload func()) {
 					a.StatusError("Error: " + err.Error())
 					return
 				}
+				a.invalidateRepositoryPath(path, RepositoryStatus)
 				reload()
 			},
 		},

--- a/internal/app/listen.go
+++ b/internal/app/listen.go
@@ -46,7 +46,20 @@ func NewExecHandler(a *App) http.Handler {
 		if sep == "" {
 			sep = DefaultExecSeparator
 		}
-		RunExecScriptSep(a, script, sep)
+		if _, err := RunExecScriptSep(a, script, sep); err != nil {
+			status := http.StatusUnprocessableEntity
+			var execErr *ExecError
+			if errors.As(err, &execErr) {
+				switch execErr.Kind {
+				case ExecErrorInvalid:
+					status = http.StatusBadRequest
+				case ExecErrorTimeout:
+					status = http.StatusRequestTimeout
+				}
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, "ok")
 	})

--- a/internal/app/listen_test.go
+++ b/internal/app/listen_test.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
@@ -28,6 +30,24 @@ func newListenTestApp(t *testing.T) *App {
 	a.Running = &running
 	RegisterCommands(a)
 	a.Root.SetSize(80, 24)
+	loopDone := make(chan struct{})
+	go func() {
+		RunEventLoop(a.Screen, a.Renderer, a, a.Running, a.CloseTerminal)
+		close(loopDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-loopDone:
+			return
+		default:
+		}
+		_ = StopExecLoop(a)
+		select {
+		case <-loopDone:
+		case <-time.After(time.Second):
+			t.Error("event loop did not stop")
+		}
+	})
 
 	return a
 }
@@ -57,9 +77,7 @@ func TestExecHandlerRunsScriptSynchronously(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	// execQuit sets *a.Running = false before posting its interrupt event, so
-	// by the time RunExecScriptSep (and therefore the handler) returns, the
-	// script's effect is already observable -- proof it ran synchronously.
+	// The handler returns only after the event loop has acknowledged quit.
 	if *a.Running {
 		t.Error("expected quit script to have set Running to false")
 	}
@@ -118,5 +136,61 @@ func TestExecHandlerRespectsSepQueryParam(t *testing.T) {
 	}
 	if *a.Running {
 		t.Error("expected script split on custom separator to run both commands, including quit")
+	}
+}
+
+func TestExecHandlerWaitsForAcknowledgedVisibleInput(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", `type hello; wait-for hello timeout=500`)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(a.Screenshot(), "hello") {
+		t.Fatal("handler returned before typed text was visible")
+	}
+}
+
+func TestExecHandlerRejectsInvalidAction(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "not-an-action")
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `unknown action "not-an-action"`) {
+		t.Fatalf("body = %q, want useful invalid-action error", body)
+	}
+}
+
+func TestExecHandlerReportsExecutionFailure(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "screenshot /missing/parent/screen.txt")
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "screenshot") {
+		t.Fatalf("body = %q, want screenshot failure", body)
+	}
+}
+
+func TestExecHandlerReportsWaitForTimeout(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", `wait-for "never visible" timeout=40`)
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `screen text "never visible" not visible`) {
+		t.Fatalf("body = %q, want timeout detail", body)
 	}
 }

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -289,7 +289,10 @@ func handleRightClick(app *App, mx, my int) {
 			if my > sidebarR.Y+1 {
 				ev := tcell.NewEventMouse(mx, my, tcell.Button2, 0)
 				if w := app.Sidebar.ActiveWidget(); w != nil {
-					w.HandleEvent(ev)
+					result := w.HandleEvent(ev)
+					if result == ui.EventIgnored && app.Sidebar.ActivePanel == "changes" {
+						app.ShowChangesContextMenu(mx, my)
+					}
 				}
 			}
 			return

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -207,12 +207,25 @@ func (a *App) BuildViewMenu() []ui.ContextMenuItem {
 	if surface.WrapMode() == ui.DiffWrapOn {
 		wrapChecked = ui.MenuChecked
 	}
-	return append(items,
+	items = append(items,
 		ui.MenuSep(),
 		ui.ContextMenuItem{Label: "Diff: Split", Command: "diff.splitView", Checked: splitChecked},
 		ui.ContextMenuItem{Label: "Diff: Unified", Command: "diff.unifiedView", Checked: unifiedChecked},
-		ui.ContextMenuItem{Label: "Diff: Wrap Lines", Command: "diff.toggleWrap", Checked: wrapChecked},
 	)
+	if contextSurface := a.EditorGroup.ActiveDiffContextSurface(); contextSurface != nil {
+		changesChecked := ui.MenuUnchecked
+		fullChecked := ui.MenuUnchecked
+		if contextSurface.ContextMode() == ui.DiffContextFullFile {
+			fullChecked = ui.MenuChecked
+		} else {
+			changesChecked = ui.MenuChecked
+		}
+		items = append(items,
+			ui.ContextMenuItem{Label: "Diff: Changes Only", Command: "diff.changesOnlyView", Checked: changesChecked},
+			ui.ContextMenuItem{Label: "Diff: Full File", Command: "diff.fullFileView", Checked: fullChecked},
+		)
+	}
+	return append(items, ui.ContextMenuItem{Label: "Diff: Wrap Lines", Command: "diff.toggleWrap", Checked: wrapChecked})
 }
 
 func openMenuBarDropdown(app *App, index int) {

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -179,7 +179,38 @@ func openContextMenu(app *App, items []ui.ContextMenuItem, x, y int) {
 	app.Root.SetFocus(menu)
 }
 
-const menuOptionsIndex = 4
+const (
+	menuViewIndex    = 3
+	menuOptionsIndex = 4
+)
+
+// BuildViewMenu adds per-surface presentation overrides only while a diff is
+// active. Options holds the persisted defaults used by newly opened diffs;
+// these View controls never rewrite those settings.
+func (a *App) BuildViewMenu() []ui.ContextMenuItem {
+	items := append([]ui.ContextMenuItem(nil), menuBarMenus[menuViewIndex]...)
+	surface := a.EditorGroup.ActiveDiffModeSurface()
+	if surface == nil {
+		return items
+	}
+	splitChecked := ui.MenuUnchecked
+	unifiedChecked := ui.MenuUnchecked
+	if surface.Mode() == ui.DiffModeUnified {
+		unifiedChecked = ui.MenuChecked
+	} else {
+		splitChecked = ui.MenuChecked
+	}
+	wrapChecked := ui.MenuUnchecked
+	if surface.WrapMode() == ui.DiffWrapOn {
+		wrapChecked = ui.MenuChecked
+	}
+	return append(items,
+		ui.MenuSep(),
+		ui.ContextMenuItem{Label: "Diff: Split", Command: "diff.splitView", Checked: splitChecked},
+		ui.ContextMenuItem{Label: "Diff: Unified", Command: "diff.unifiedView", Checked: unifiedChecked},
+		ui.ContextMenuItem{Label: "Diff: Wrap Lines", Command: "diff.toggleWrap", Checked: wrapChecked},
+	)
+}
 
 func openMenuBarDropdown(app *App, index int) {
 	if index < 0 || index >= len(menuBarMenus) {
@@ -196,7 +227,9 @@ func openMenuBarDropdown(app *App, index int) {
 		anchorY = 0
 	}
 	items := menuBarMenus[index]
-	if index == menuOptionsIndex {
+	if index == menuViewIndex {
+		items = app.BuildViewMenu()
+	} else if index == menuOptionsIndex {
 		items = app.BuildOptionsMenu()
 	}
 	menu := ui.NewContextMenuWidget(resolveShortcuts(reg, items), anchorX, anchorY)

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -187,45 +187,8 @@ const (
 	menuOptionsIndex = 4
 )
 
-// BuildViewMenu adds per-surface presentation overrides only while a diff is
-// active. Options holds the persisted defaults used by newly opened diffs;
-// these View controls never rewrite those settings.
 func (a *App) BuildViewMenu() []ui.ContextMenuItem {
-	items := append([]ui.ContextMenuItem(nil), menuBarMenus[menuViewIndex]...)
-	surface := a.EditorGroup.ActiveDiffModeSurface()
-	if surface == nil {
-		return items
-	}
-	splitChecked := ui.MenuUnchecked
-	unifiedChecked := ui.MenuUnchecked
-	if surface.Mode() == ui.DiffModeUnified {
-		unifiedChecked = ui.MenuChecked
-	} else {
-		splitChecked = ui.MenuChecked
-	}
-	wrapChecked := ui.MenuUnchecked
-	if surface.WrapMode() == ui.DiffWrapOn {
-		wrapChecked = ui.MenuChecked
-	}
-	items = append(items,
-		ui.MenuSep(),
-		ui.ContextMenuItem{Label: "Diff: Split", Command: "diff.splitView", Checked: splitChecked},
-		ui.ContextMenuItem{Label: "Diff: Unified", Command: "diff.unifiedView", Checked: unifiedChecked},
-	)
-	if contextSurface := a.EditorGroup.ActiveDiffContextSurface(); contextSurface != nil {
-		changesChecked := ui.MenuUnchecked
-		fullChecked := ui.MenuUnchecked
-		if contextSurface.ContextMode() == ui.DiffContextFullFile {
-			fullChecked = ui.MenuChecked
-		} else {
-			changesChecked = ui.MenuChecked
-		}
-		items = append(items,
-			ui.ContextMenuItem{Label: "Diff: Changes Only", Command: "diff.changesOnlyView", Checked: changesChecked},
-			ui.ContextMenuItem{Label: "Diff: Full File", Command: "diff.fullFileView", Checked: fullChecked},
-		)
-	}
-	return append(items, ui.ContextMenuItem{Label: "Diff: Wrap Lines", Command: "diff.toggleWrap", Checked: wrapChecked})
+	return append([]ui.ContextMenuItem(nil), menuBarMenus[menuViewIndex]...)
 }
 
 func openMenuBarDropdown(app *App, index int) {

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -129,6 +129,9 @@ func resolveShortcuts(reg *command.Registry, items []ui.ContextMenuItem) []ui.Co
 	resolved := make([]ui.ContextMenuItem, len(items))
 	for i, item := range items {
 		resolved[i] = item
+		if len(item.Submenu) > 0 {
+			resolved[i].Submenu = resolveShortcuts(reg, item.Submenu)
+		}
 		if item.Command != "" {
 			if cmd, ok := reg.Get(item.Command); ok && cmd.Shortcut != "" {
 				resolved[i].Shortcut = cmd.Shortcut

--- a/internal/app/plugin_api.go
+++ b/internal/app/plugin_api.go
@@ -318,6 +318,7 @@ func (e *PluginEditorAPI) ClearSearch() {
 // PluginFilesystemAPI implements plugin.FilesystemAPI with path restrictions.
 type PluginFilesystemAPI struct {
 	allowedRoots []string
+	onWrite      func(path string)
 }
 
 func NewPluginFilesystemAPI(allowedRoots ...string) *PluginFilesystemAPI {
@@ -364,7 +365,13 @@ func (f *PluginFilesystemAPI) WriteFile(path, content string) error {
 	if err := f.validatePath(path); err != nil {
 		return err
 	}
-	return os.WriteFile(path, []byte(content), 0644)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return err
+	}
+	if f.onWrite != nil {
+		f.onWrite(path)
+	}
+	return nil
 }
 
 func (f *PluginFilesystemAPI) FileExists(path string) bool {
@@ -391,7 +398,9 @@ func (f *PluginFilesystemAPI) ListDir(path string) ([]plugin.FileEntry, error) {
 }
 
 // PluginSystemAPI implements plugin.SystemAPI.
-type PluginSystemAPI struct{}
+type PluginSystemAPI struct {
+	onExec func()
+}
 
 func NewPluginSystemAPI() *PluginSystemAPI {
 	return &PluginSystemAPI{}
@@ -437,6 +446,10 @@ func (s *PluginSystemAPI) Exec(binary string, args []string, stdin string) (stri
 		cmd.Stdin = strings.NewReader(stdin)
 	}
 	err := cmd.Run()
+	if s.onExec != nil {
+		// A failing command may still have partially mutated the repository.
+		s.onExec()
+	}
 	exitCode := 0
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/internal/app/plugin_api_test.go
+++ b/internal/app/plugin_api_test.go
@@ -5,7 +5,31 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
 )
+
+func TestContextMenuItemFromWidgetEntryPreservesOptionalCheckedState(t *testing.T) {
+	checked, unchecked := true, false
+	tests := []struct {
+		name    string
+		checked *bool
+		want    int
+	}{
+		{name: "omitted", want: 0},
+		{name: "unchecked", checked: &unchecked, want: ui.MenuUnchecked},
+		{name: "checked", checked: &checked, want: ui.MenuChecked},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			item := contextMenuItemFromWidgetEntry(widgets.MenuEntry{Label: "Mode", Command: "mode", Checked: test.checked})
+			if item.Checked != test.want {
+				t.Fatalf("checked indicator = %d, want %d", item.Checked, test.want)
+			}
+		})
+	}
+}
 
 func TestSetPathNilDeletesKey(t *testing.T) {
 	m := map[string]any{

--- a/internal/app/plugin_api_test.go
+++ b/internal/app/plugin_api_test.go
@@ -283,6 +283,8 @@ func TestPluginSystemAPI_ExecStdin(t *testing.T) {
 		t.Skip("cat not available")
 	}
 	api := NewPluginSystemAPI()
+	execCount := 0
+	api.onExec = func() { execCount++ }
 
 	stdout, _, code, err := api.Exec("cat", nil, "hello from stdin\n")
 	if err != nil || code != 0 {
@@ -300,5 +302,8 @@ func TestPluginSystemAPI_ExecStdin(t *testing.T) {
 	}
 	if stdout != "" {
 		t.Errorf("expected empty stdout, got %q", stdout)
+	}
+	if execCount != 2 {
+		t.Fatalf("system command completions invalidated repository %d times, want 2", execCount)
 	}
 }

--- a/internal/app/repo_ops.go
+++ b/internal/app/repo_ops.go
@@ -79,6 +79,9 @@ func (a *App) RunRepoTask(task RepoTask) {
 func (a *App) HandleRepoOpResult(r *RepoOpResult) {
 	a.runningRepoOp = ""
 	a.setRepoOpSegment("")
+	// Pulls, commits, hooks, and even failed operations can partially mutate the
+	// worktree, index, or HEAD. Observe both resources before reporting outcome.
+	a.invalidateAllRepositories(RepositoryStatus | RepositoryHistory)
 
 	if r.Err != nil {
 		a.StatusError(fmt.Sprintf("%s failed: %v", r.Task.Progress, r.Err))
@@ -88,7 +91,6 @@ func (a *App) HandleRepoOpResult(r *RepoOpResult) {
 		r.Task.OnDone()
 	}
 	a.StatusNotify(r.Task.Done)
-	a.Changes.Refresh()
 }
 
 func (a *App) setRepoOpSegment(text string) {

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -1,0 +1,500 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/gdamore/tcell/v3"
+)
+
+// RepositoryResource identifies independently stale Git-derived data.
+// Working-tree changes do not imply that immutable history changed.
+type RepositoryResource uint8
+
+const (
+	RepositoryStatus RepositoryResource = 1 << iota
+	RepositoryHistory
+
+	repositoryRefreshDebounce = 150 * time.Millisecond
+	repositoryPollInterval    = 2 * time.Second
+	repositoryStatusTimeout   = 10 * time.Second
+)
+
+type repositoryStatusEntry struct {
+	Group       changesGroup
+	Revision    string
+	StatusErr   error
+	RevisionErr error
+}
+
+// RepositoryStatusResult carries one complete multi-root observation back to
+// the event loop. Seq is the desired-state sequence, not merely a request ID:
+// invalidating while a read is running makes that result stale immediately.
+type RepositoryStatusResult struct {
+	Seq     uint64
+	Entries []repositoryStatusEntry
+}
+
+// RepositoryInvalidationRequest lets background plugin/debug work return to
+// the main event loop before touching coordinator state. An empty Path means
+// every configured repository may have changed.
+type RepositoryInvalidationRequest struct {
+	Path      string
+	Resources RepositoryResource
+}
+
+type repositoryDebounceTick struct{ Gen uint64 }
+type repositoryPollTick struct{ Gen uint64 }
+
+type repositoryTimer interface {
+	Stop() bool
+}
+
+type repositoryScheduler interface {
+	AfterFunc(time.Duration, func()) repositoryTimer
+}
+
+type realRepositoryScheduler struct{}
+
+func (realRepositoryScheduler) AfterFunc(d time.Duration, f func()) repositoryTimer {
+	return time.AfterFunc(d, f)
+}
+
+// RepositoryState owns freshness and scheduling for Git-derived application
+// state. Widgets still own presentation state such as selection and expansion;
+// they no longer need every mutation source to remember a raw Refresh call.
+//
+// All methods except timer callbacks and readStatus run on the main event-loop
+// goroutine. Those callbacks only post typed events back to that boundary.
+type RepositoryState struct {
+	changes *ChangesPanel
+	dirs    []string
+	poster  eventPoster
+
+	scheduler    repositoryScheduler
+	readStatus   func(context.Context, []string, uint64) *RepositoryStatusResult
+	debounceWait time.Duration
+	pollWait     time.Duration
+	statusWait   time.Duration
+
+	started bool
+	closed  bool
+	visible bool
+	dirty   RepositoryResource
+
+	requested    uint64
+	inFlight     bool
+	statusCancel context.CancelFunc
+
+	debounceTimer repositoryTimer
+	debounceGen   uint64
+	pollTimer     repositoryTimer
+	pollGen       uint64
+
+	lastGroups    map[string]changesGroup
+	lastRevisions map[string]string
+}
+
+func NewRepositoryState(changes *ChangesPanel, dirs []string) *RepositoryState {
+	return &RepositoryState{
+		changes:       changes,
+		dirs:          append([]string(nil), dirs...),
+		scheduler:     realRepositoryScheduler{},
+		readStatus:    readRepositoryStatus,
+		debounceWait:  repositoryRefreshDebounce,
+		pollWait:      repositoryPollInterval,
+		statusWait:    repositoryStatusTimeout,
+		lastGroups:    make(map[string]changesGroup),
+		lastRevisions: make(map[string]string),
+	}
+}
+
+func (s *RepositoryState) SetPoster(poster eventPoster) {
+	s.poster = poster
+}
+
+// Start performs the initial status observation even while Changes is hidden,
+// so its dirty badge is accurate. History waits until the panel is visible.
+func (s *RepositoryState) Start() {
+	if s == nil || s.started || s.closed {
+		return
+	}
+	s.started = true
+	s.dirty |= RepositoryHistory
+	s.RefreshNow(RepositoryStatus)
+}
+
+func (s *RepositoryState) SetDirs(dirs []string) {
+	if s == nil || s.closed {
+		return
+	}
+	s.dirs = append([]string(nil), dirs...)
+	if s.changes != nil {
+		s.changes.Dirs = append([]string(nil), dirs...)
+		s.changes.multiRoot = len(dirs) > 1
+	}
+	s.lastGroups = make(map[string]changesGroup)
+	s.lastRevisions = make(map[string]string)
+	s.dirty |= RepositoryStatus | RepositoryHistory
+	if s.started {
+		s.RefreshNow(RepositoryStatus)
+	}
+}
+
+func (s *RepositoryState) SetVisible(visible bool) {
+	if s == nil || s.closed || s.visible == visible {
+		return
+	}
+	s.visible = visible
+	if !visible {
+		s.stopPoll()
+		return
+	}
+	// Visibility is a reader request for a current view, not just permission to
+	// poll later. Status lands first; pending history refreshes from that result.
+	s.RefreshNow(RepositoryStatus)
+}
+
+func (s *RepositoryState) InvalidateAll(resources RepositoryResource) {
+	if s == nil || s.closed || resources == 0 {
+		return
+	}
+	s.dirty |= resources
+	if resources&RepositoryStatus != 0 {
+		s.requested++
+		if s.poster == nil {
+			s.startStatus()
+		} else {
+			s.scheduleDebounce()
+		}
+		return
+	}
+	if resources&RepositoryHistory != 0 && s.visible {
+		s.refreshHistory()
+	}
+}
+
+// InvalidatePath ignores writes outside the configured workspace roots. The
+// current scan is multi-root and coalesced, so one relevant path invalidates the
+// complete status resource without spawning a Git process on the caller path.
+func (s *RepositoryState) InvalidatePath(path string, resources RepositoryResource) {
+	if s == nil || path == "" {
+		return
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return
+	}
+	abs = filepath.Clean(abs)
+	for _, dir := range s.dirs {
+		root, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(filepath.Clean(root), abs)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			s.InvalidateAll(resources)
+			return
+		}
+	}
+}
+
+func (s *RepositoryState) RefreshNow(resources RepositoryResource) {
+	if s == nil || s.closed || resources == 0 {
+		return
+	}
+	s.dirty |= resources
+	if resources&RepositoryStatus != 0 {
+		s.requested++
+		s.stopDebounce()
+		if !s.inFlight {
+			s.startStatus()
+		}
+		return
+	}
+	if resources&RepositoryHistory != 0 && s.visible {
+		s.refreshHistory()
+	}
+}
+
+func (s *RepositoryState) startStatus() {
+	if s.closed || s.inFlight {
+		return
+	}
+	s.inFlight = true
+	seq := s.requested
+	dirs := append([]string(nil), s.dirs...)
+	read := s.readStatus
+	ctx, cancel := context.WithTimeout(context.Background(), s.statusWait)
+	s.statusCancel = cancel
+	if s.poster == nil {
+		result := read(ctx, dirs, seq)
+		cancel()
+		s.HandleStatus(result)
+		return
+	}
+	poster := s.poster
+	go func() {
+		result := read(ctx, dirs, seq)
+		cancel()
+		_ = poster.PostEvent(tcell.NewEventInterrupt(result))
+	}()
+}
+
+func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
+	if s == nil || result == nil || s.closed {
+		return
+	}
+	s.inFlight = false
+	s.statusCancel = nil
+	if result.Seq != s.requested {
+		// If the debounce already fired while the older read was in flight,
+		// immediately begin the one required follow-up. Otherwise its timer owns
+		// the trailing edge and will start it.
+		if s.debounceTimer == nil {
+			s.startStatus()
+		}
+		return
+	}
+
+	groups := make([]changesGroup, 0, len(result.Entries))
+	nextGroups := make(map[string]changesGroup, len(result.Entries))
+	nextRevisions := make(map[string]string, len(result.Entries))
+	selectedDir := ""
+	if s.changes != nil {
+		selectedDir = s.changes.selectedGroupDir()
+		if selectedDir == "" && len(result.Entries) > 0 {
+			selectedDir = result.Entries[0].Group.Dir
+		}
+	}
+	revisionChanged := false
+	hadError := false
+	for _, entry := range result.Entries {
+		group := entry.Group
+		if entry.StatusErr != nil {
+			hadError = true
+			if previous, ok := s.lastGroups[group.Dir]; ok {
+				group = previous
+			}
+		}
+		groups = append(groups, group)
+		nextGroups[group.Dir] = group
+		revision := entry.Revision
+		if entry.RevisionErr != nil {
+			revision = s.lastRevisions[group.Dir]
+		}
+		nextRevisions[group.Dir] = revision
+		if previous, ok := s.lastRevisions[group.Dir]; ok && group.Dir == selectedDir && previous != revision {
+			revisionChanged = true
+		}
+	}
+	s.lastGroups = nextGroups
+	s.lastRevisions = nextRevisions
+
+	if s.changes != nil {
+		s.changes.applyWorkingTree(groups)
+	}
+	if !hadError {
+		s.dirty &^= RepositoryStatus
+	}
+	if revisionChanged {
+		s.dirty |= RepositoryHistory
+	}
+	if s.visible {
+		if s.dirty&RepositoryHistory != 0 {
+			s.refreshHistory()
+		} else if s.changes != nil {
+			// Switching the selected workspace root still needs a log read, while
+			// the same root remains guarded by lastLogDir.
+			s.changes.refreshCommitLog()
+		}
+		s.armPoll()
+	}
+}
+
+func (s *RepositoryState) refreshHistory() {
+	if s.changes == nil {
+		return
+	}
+	s.changes.RefreshHistory()
+}
+
+func (s *RepositoryState) HandleHistory(err error) {
+	if s == nil || s.closed {
+		return
+	}
+	if err != nil {
+		s.dirty |= RepositoryHistory
+		return
+	}
+	s.dirty &^= RepositoryHistory
+}
+
+func (s *RepositoryState) scheduleDebounce() {
+	if s.poster == nil || s.closed {
+		return
+	}
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+	}
+	s.debounceGen++
+	gen := s.debounceGen
+	poster := s.poster
+	s.debounceTimer = s.scheduler.AfterFunc(s.debounceWait, func() {
+		_ = poster.PostEvent(tcell.NewEventInterrupt(&repositoryDebounceTick{Gen: gen}))
+	})
+}
+
+func (s *RepositoryState) HandleDebounce(tick *repositoryDebounceTick) {
+	if s == nil || tick == nil || s.closed || tick.Gen != s.debounceGen {
+		return
+	}
+	s.debounceTimer = nil
+	if !s.inFlight && s.dirty&RepositoryStatus != 0 {
+		s.startStatus()
+	}
+}
+
+func (s *RepositoryState) armPoll() {
+	if s.poster == nil || s.closed || !s.visible || s.pollTimer != nil {
+		return
+	}
+	s.pollGen++
+	gen := s.pollGen
+	poster := s.poster
+	s.pollTimer = s.scheduler.AfterFunc(s.pollWait, func() {
+		_ = poster.PostEvent(tcell.NewEventInterrupt(&repositoryPollTick{Gen: gen}))
+	})
+}
+
+func (s *RepositoryState) HandlePoll(tick *repositoryPollTick) {
+	if s == nil || tick == nil || s.closed || tick.Gen != s.pollGen || !s.visible {
+		return
+	}
+	s.pollTimer = nil
+	s.RefreshNow(RepositoryStatus)
+}
+
+func (s *RepositoryState) stopDebounce() {
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+		s.debounceTimer = nil
+	}
+	s.debounceGen++
+}
+
+func (s *RepositoryState) stopPoll() {
+	if s.pollTimer != nil {
+		s.pollTimer.Stop()
+		s.pollTimer = nil
+	}
+	s.pollGen++
+}
+
+func (s *RepositoryState) Close() {
+	if s == nil || s.closed {
+		return
+	}
+	s.closed = true
+	s.stopDebounce()
+	s.stopPoll()
+	if s.statusCancel != nil {
+		s.statusCancel()
+		s.statusCancel = nil
+	}
+	if s.changes != nil {
+		s.changes.CancelHistoryRead()
+	}
+	// A bounded Git read may still finish, but its event is ignored after close.
+	s.requested++
+}
+
+func readRepositoryStatus(ctx context.Context, dirs []string, seq uint64) *RepositoryStatusResult {
+	return &RepositoryStatusResult{Seq: seq, Entries: scanRepositoryStatus(ctx, dirs)}
+}
+
+func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatusEntry {
+	entries := make([]repositoryStatusEntry, 0, len(dirs))
+	seen := make(map[string]bool)
+	for _, dir := range dirs {
+		if root := git.RepoRootContext(ctx, dir); root != "" {
+			dir = root
+		}
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		files, statusErr := git.StatusFilesContext(ctx, dir)
+		var staged, unstaged []git.FileStatus
+		if statusErr == nil {
+			for _, file := range files {
+				if file.Staged {
+					staged = append(staged, file)
+				} else {
+					unstaged = append(unstaged, file)
+				}
+			}
+		}
+		revision, revisionErr := git.RevisionIdentityContext(ctx, dir)
+		entries = append(entries, repositoryStatusEntry{
+			Group: changesGroup{
+				Dir:      dir,
+				Name:     filepath.Base(dir),
+				Staged:   staged,
+				Unstaged: unstaged,
+			},
+			Revision:    revision,
+			StatusErr:   statusErr,
+			RevisionErr: revisionErr,
+		})
+	}
+	return entries
+}
+
+func (a *App) syncRepositoryObservation() {
+	if a == nil || a.Repository == nil || a.Sidebar == nil || a.SplitPanel == nil {
+		return
+	}
+	visible := a.Sidebar.Visible && a.SplitPanel.ShowLeft && a.Sidebar.ActivePanel == "changes"
+	a.Repository.SetVisible(visible)
+}
+
+func (a *App) invalidateRepositoryPath(path string, resources RepositoryResource) {
+	if a != nil && a.Repository != nil {
+		a.Repository.InvalidatePath(path, resources)
+	}
+}
+
+func (a *App) invalidateAllRepositories(resources RepositoryResource) {
+	if a != nil && a.Repository != nil {
+		a.Repository.InvalidateAll(resources)
+	}
+}
+
+func (a *App) postRepositoryInvalidation(path string, resources RepositoryResource) {
+	if a == nil || resources == 0 {
+		return
+	}
+	if a.Screen == nil {
+		if path == "" {
+			a.invalidateAllRepositories(resources)
+		} else {
+			a.invalidateRepositoryPath(path, resources)
+		}
+		return
+	}
+	a.Screen.PostEvent(tcell.NewEventInterrupt(&RepositoryInvalidationRequest{
+		Path: path, Resources: resources,
+	}))
+}
+
+func (a *App) handleRepositoryInvalidation(request *RepositoryInvalidationRequest) {
+	if request.Path == "" {
+		a.invalidateAllRepositories(request.Resources)
+		return
+	}
+	a.invalidateRepositoryPath(request.Path, request.Resources)
+}

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -459,6 +459,7 @@ func (a *App) syncRepositoryObservation() {
 		return
 	}
 	visible := a.Sidebar.Visible && a.SplitPanel.ShowLeft && a.Sidebar.ActivePanel == "changes"
+	visible = visible || a.EditorGroup.ActiveCurrentChangesWidget() != nil
 	a.Repository.SetVisible(visible)
 }
 

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -1,0 +1,326 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+)
+
+type fakeRepositoryTimer struct {
+	fn      func()
+	stopped bool
+}
+
+func (t *fakeRepositoryTimer) Stop() bool {
+	wasActive := !t.stopped
+	t.stopped = true
+	return wasActive
+}
+
+func (t *fakeRepositoryTimer) fire() {
+	if !t.stopped {
+		t.fn()
+	}
+}
+
+func (t *fakeRepositoryTimer) fireLate() { t.fn() }
+
+type fakeRepositoryScheduler struct {
+	timers []*fakeRepositoryTimer
+}
+
+func (s *fakeRepositoryScheduler) AfterFunc(_ time.Duration, fn func()) repositoryTimer {
+	timer := &fakeRepositoryTimer{fn: fn}
+	s.timers = append(s.timers, timer)
+	return timer
+}
+
+func (s *fakeRepositoryScheduler) latest(t *testing.T) *fakeRepositoryTimer {
+	t.Helper()
+	if len(s.timers) == 0 {
+		t.Fatal("no repository timer was scheduled")
+	}
+	return s.timers[len(s.timers)-1]
+}
+
+func repositoryResult(seq uint64, revision string, files ...git.FileStatus) *RepositoryStatusResult {
+	group := changesGroup{Dir: "/repo", Name: "repo"}
+	for _, file := range files {
+		if file.Staged {
+			group.Staged = append(group.Staged, file)
+		} else {
+			group.Unstaged = append(group.Unstaged, file)
+		}
+	}
+	return &RepositoryStatusResult{Seq: seq, Entries: []repositoryStatusEntry{{
+		Group: group, Revision: revision,
+	}}}
+}
+
+func testRepositoryState(changes *ChangesPanel) (*RepositoryState, *fakeRepositoryScheduler, *testPoster) {
+	s := NewRepositoryState(changes, []string{"/repo"})
+	scheduler := &fakeRepositoryScheduler{}
+	poster := newTestPoster()
+	s.scheduler = scheduler
+	s.poster = poster
+	s.started = true
+	return s, scheduler, poster
+}
+
+func TestRepositoryInvalidationsCoalesce(t *testing.T) {
+	s, scheduler, poster := testRepositoryState(nil)
+	var reads atomic.Int32
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		reads.Add(1)
+		return repositoryResult(seq, "head")
+	}
+
+	s.InvalidateAll(RepositoryStatus)
+	s.InvalidateAll(RepositoryStatus)
+	s.InvalidateAll(RepositoryStatus)
+	if len(scheduler.timers) != 3 {
+		t.Fatalf("scheduled %d timers, want three trailing-edge replacements", len(scheduler.timers))
+	}
+	for _, timer := range scheduler.timers[:2] {
+		if !timer.stopped {
+			t.Error("a superseded debounce timer remained active")
+		}
+	}
+
+	scheduler.latest(t).fire()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	if got := reads.Load(); got != 1 {
+		t.Fatalf("status reads = %d, want 1", got)
+	}
+}
+
+func TestRepositoryStateRunsOneFollowUpAfterInFlightInvalidation(t *testing.T) {
+	s, scheduler, poster := testRepositoryState(nil)
+	started := make(chan uint64, 2)
+	release := make(chan struct{}, 2)
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		started <- seq
+		<-release
+		return repositoryResult(seq, "head")
+	}
+
+	s.InvalidateAll(RepositoryStatus)
+	scheduler.latest(t).fire()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	first := <-started
+
+	s.InvalidateAll(RepositoryStatus)
+	s.InvalidateAll(RepositoryStatus)
+	scheduler.latest(t).fire()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	select {
+	case seq := <-started:
+		t.Fatalf("overlapping status read %d started while %d was in flight", seq, first)
+	default:
+	}
+
+	release <- struct{}{}
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	second := <-started
+	if second == first || second != s.requested {
+		t.Fatalf("follow-up seq = %d, first = %d, requested = %d", second, first, s.requested)
+	}
+	release <- struct{}{}
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+}
+
+func TestWorkingTreeStatusDoesNotReloadUnchangedHistory(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.groups = []changesGroup{{Dir: "/repo", Name: "repo"}}
+	cp.lastLogDir = "/repo"
+	cp.logDir = "/repo"
+	s, _, _ := testRepositoryState(cp)
+	s.lastGroups["/repo"] = cp.groups[0]
+	s.lastRevisions["/repo"] = "same"
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryStatus
+	before := cp.logGen
+
+	s.HandleStatus(repositoryResult(1, "same", git.FileStatus{Status: "M", Path: "a.txt"}))
+	if cp.logGen != before {
+		t.Fatalf("working-tree apply changed log generation from %d to %d", before, cp.logGen)
+	}
+	if cp.TotalChanges() != 1 {
+		t.Fatalf("working-tree changes = %d, want 1", cp.TotalChanges())
+	}
+}
+
+func TestStatusFailurePreservesLastGoodSnapshot(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	previous := changesGroup{Dir: "/repo", Name: "repo", Unstaged: []git.FileStatus{{Status: "M", Path: "kept.txt"}}}
+	s, _, _ := testRepositoryState(cp)
+	s.lastGroups["/repo"] = previous
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryStatus
+
+	s.HandleStatus(&RepositoryStatusResult{Seq: 1, Entries: []repositoryStatusEntry{{
+		Group: changesGroup{Dir: "/repo", Name: "repo"}, StatusErr: errors.New("index locked"),
+	}}})
+	if cp.TotalChanges() != 1 || cp.groups[0].Unstaged[0].Path != "kept.txt" {
+		t.Fatalf("failed scan replaced last good state: %+v", cp.groups)
+	}
+	if s.dirty&RepositoryStatus == 0 {
+		t.Error("failed status scan was marked fresh")
+	}
+}
+
+func TestVisibleRepositoryStatePollLifecycle(t *testing.T) {
+	s, scheduler, poster := testRepositoryState(nil)
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		return repositoryResult(seq, "head")
+	}
+
+	s.SetVisible(true)
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	poll := scheduler.latest(t)
+	if poll.stopped {
+		t.Fatal("visible state armed a stopped poll timer")
+	}
+	count := len(scheduler.timers)
+	s.SetVisible(true)
+	if len(scheduler.timers) != count {
+		t.Error("repeated visible state duplicated the poll timer")
+	}
+
+	s.SetVisible(false)
+	if !poll.stopped || s.pollTimer != nil {
+		t.Error("hiding Changes did not cancel polling")
+	}
+	poll.fireLate()
+	s.HandlePoll(poster.await(t).(*repositoryPollTick))
+	if s.inFlight {
+		t.Error("a late hidden poll started a status read")
+	}
+}
+
+func TestShowingChangesDoesNotReloadUnchangedHistory(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.groups = []changesGroup{{Dir: "/repo", Name: "repo"}}
+	cp.buildTree()
+	cp.lastLogDir = "/repo"
+	cp.logDir = "/repo"
+	s, _, poster := testRepositoryState(cp)
+	s.lastGroups["/repo"] = cp.groups[0]
+	s.lastRevisions["/repo"] = "same"
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		return repositoryResult(seq, "same")
+	}
+	before := cp.logGen
+
+	s.SetVisible(true)
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	if cp.logGen != before {
+		t.Fatalf("showing Changes reloaded unchanged history: generation %d -> %d", before, cp.logGen)
+	}
+}
+
+func TestRevisionChangeOnlyReloadsSelectedRoot(t *testing.T) {
+	cp := NewChangesPanel("/repo-a", "/repo-b")
+	cp.groups = []changesGroup{{Dir: "/repo-a", Name: "repo-a"}, {Dir: "/repo-b", Name: "repo-b"}}
+	cp.buildTree()
+	cp.lastLogDir = "/repo-a"
+	cp.logDir = "/repo-a"
+	s, _, _ := testRepositoryState(cp)
+	s.visible = true
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryStatus
+	s.lastGroups["/repo-a"] = cp.groups[0]
+	s.lastGroups["/repo-b"] = cp.groups[1]
+	s.lastRevisions["/repo-a"] = "a-old"
+	s.lastRevisions["/repo-b"] = "b-old"
+	before := cp.logGen
+
+	s.HandleStatus(&RepositoryStatusResult{Seq: 1, Entries: []repositoryStatusEntry{
+		{Group: cp.groups[0], Revision: "a-old"},
+		{Group: cp.groups[1], Revision: "b-new"},
+	}})
+	if cp.logGen != before {
+		t.Fatalf("unselected root revision reloaded selected history: generation %d -> %d", before, cp.logGen)
+	}
+}
+
+func TestSelectedRevisionChangeReloadsHistory(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.groups = []changesGroup{{Dir: "/repo", Name: "repo"}}
+	cp.buildTree()
+	cp.lastLogDir = "/repo"
+	cp.logDir = "/repo"
+	cp.Screen = newTestPoster()
+	s, _, _ := testRepositoryState(cp)
+	s.visible = true
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryStatus
+	s.lastGroups["/repo"] = cp.groups[0]
+	s.lastRevisions["/repo"] = "old"
+	before := cp.logGen
+
+	s.HandleStatus(repositoryResult(1, "new"))
+	if cp.logGen != before+1 {
+		t.Fatalf("selected revision change history generation = %d, want %d", cp.logGen, before+1)
+	}
+	if s.dirty&RepositoryHistory == 0 {
+		t.Fatal("selected revision change was marked fresh before its history result")
+	}
+}
+
+func TestRepositoryStateCloseCancelsInFlightStatus(t *testing.T) {
+	s, _, _ := testRepositoryState(nil)
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	s.statusWait = time.Hour
+	s.readStatus = func(ctx context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		return repositoryResult(seq, "")
+	}
+
+	s.RefreshNow(RepositoryStatus)
+	<-started
+	s.Close()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel the in-flight status context")
+	}
+}
+
+func TestRepositoryStateCloseIgnoresLateTimers(t *testing.T) {
+	s, scheduler, poster := testRepositoryState(nil)
+	var reads atomic.Int32
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		reads.Add(1)
+		return repositoryResult(seq, "head")
+	}
+
+	s.InvalidateAll(RepositoryStatus)
+	debounce := scheduler.latest(t)
+	s.visible = true
+	s.armPoll()
+	poll := scheduler.latest(t)
+	s.Close()
+	debounce.fireLate()
+	poll.fireLate()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	s.HandlePoll(poster.await(t).(*repositoryPollTick))
+	if reads.Load() != 0 {
+		t.Fatalf("late timers started %d reads after close", reads.Load())
+	}
+	if !debounce.stopped || !poll.stopped {
+		t.Error("Close did not stop both timers")
+	}
+}

--- a/internal/app/settings_view.go
+++ b/internal/app/settings_view.go
@@ -101,6 +101,9 @@ func settingsCategories() []settingsCategory {
 			{Label: "Theme", Kind: settingEnum, Options: themeItems,
 				GetString: func(s *config.Settings) string { return s.Theme },
 				SetString: func(s *config.Settings, v string) { s.Theme = v }},
+			{Label: "High contrast diffs", Kind: settingBool,
+				GetBool: func(s *config.Settings) bool { return s.Editor.DiffHighContrast },
+				SetBool: func(s *config.Settings, v bool) { s.Editor.DiffHighContrast = v }},
 			{Label: "Border style", Kind: settingEnum, Options: borderStyleItems,
 				GetString: func(s *config.Settings) string { return s.Editor.BorderStyle },
 				SetString: func(s *config.Settings, v string) { s.Editor.BorderStyle = v }},
@@ -179,7 +182,7 @@ func diffModeItems() []widgets.SelectItem {
 func themeItems() []widgets.SelectItem {
 	names := config.ListThemes()
 	items := make([]widgets.SelectItem, 0, len(names)+1)
-	items = append(items, widgets.SelectItem{ID: "", Label: "Default"})
+	items = append(items, widgets.SelectItem{ID: "", Label: "Built-in Default"})
 	for _, n := range names {
 		items = append(items, widgets.SelectItem{ID: n, Label: n})
 	}

--- a/internal/app/settings_view.go
+++ b/internal/app/settings_view.go
@@ -143,10 +143,13 @@ func settingsCategories() []settingsCategory {
 				GetInt: func(s *config.Settings) int { return s.Autocomplete.Debounce },
 				SetInt: func(s *config.Settings, v int) { s.Autocomplete.Debounce = v }},
 		}},
-		// Explorer, terminal, search and plugin settings are a handful of fields
+		// Git, explorer, terminal, search and plugin settings are a handful of fields
 		// each; separate tabs for them left the strip mostly empty. Labels here
 		// name their area, since the tab title no longer does.
 		{Title: "Advanced", Fields: []settingField{
+			{Label: "Git: file view", Kind: settingEnum, Options: gitFileViewItems,
+				GetString: func(s *config.Settings) string { return s.Git.FileView },
+				SetString: func(s *config.Settings, v string) { s.Git.FileView = v }},
 			{Label: "Explorer: hidden files", Kind: settingBool,
 				GetBool: func(s *config.Settings) bool { return s.Explorer.ShowHidden },
 				SetBool: func(s *config.Settings, v bool) { s.Explorer.ShowHidden = v }},
@@ -176,6 +179,13 @@ func diffModeItems() []widgets.SelectItem {
 	return []widgets.SelectItem{
 		{ID: config.DiffModeSplit, Label: "Split"},
 		{ID: config.DiffModeUnified, Label: "Unified"},
+	}
+}
+
+func gitFileViewItems() []widgets.SelectItem {
+	return []widgets.SelectItem{
+		{ID: config.GitFileViewTree, Label: "Tree"},
+		{ID: config.GitFileViewList, Label: "List"},
 	}
 }
 

--- a/internal/app/settings_view.go
+++ b/internal/app/settings_view.go
@@ -66,6 +66,12 @@ func settingsCategories() []settingsCategory {
 			{Label: "Word wrap", Kind: settingBool,
 				GetBool: func(s *config.Settings) bool { return s.Editor.WordWrap },
 				SetBool: func(s *config.Settings, v bool) { s.Editor.WordWrap = v }},
+			{Label: "Diff mode", Kind: settingEnum, Options: diffModeItems,
+				GetString: func(s *config.Settings) string { return s.Editor.DiffMode },
+				SetString: func(s *config.Settings, v string) { s.Editor.DiffMode = v }},
+			{Label: "Diff word wrap", Kind: settingBool,
+				GetBool: func(s *config.Settings) bool { return s.Editor.DiffWordWrap },
+				SetBool: func(s *config.Settings, v bool) { s.Editor.DiffWordWrap = v }},
 			{Label: "Line numbers", Kind: settingBool,
 				GetBool: func(s *config.Settings) bool { return s.Editor.LineNumbers },
 				SetBool: func(s *config.Settings, v bool) { s.Editor.LineNumbers = v }},
@@ -160,6 +166,13 @@ func settingsCategories() []settingsCategory {
 				GetBool: func(s *config.Settings) bool { return s.DebugMode },
 				SetBool: func(s *config.Settings, v bool) { s.DebugMode = v }},
 		}},
+	}
+}
+
+func diffModeItems() []widgets.SelectItem {
+	return []widgets.SelectItem{
+		{ID: config.DiffModeSplit, Label: "Split"},
+		{ID: config.DiffModeUnified, Label: "Unified"},
 	}
 }
 

--- a/internal/app/settings_view.go
+++ b/internal/app/settings_view.go
@@ -69,6 +69,9 @@ func settingsCategories() []settingsCategory {
 			{Label: "Diff mode", Kind: settingEnum, Options: diffModeItems,
 				GetString: func(s *config.Settings) string { return s.Editor.DiffMode },
 				SetString: func(s *config.Settings, v string) { s.Editor.DiffMode = v }},
+			{Label: "Diff context", Kind: settingEnum, Options: diffContextItems,
+				GetString: func(s *config.Settings) string { return s.Editor.DiffContext },
+				SetString: func(s *config.Settings, v string) { s.Editor.DiffContext = v }},
 			{Label: "Diff word wrap", Kind: settingBool,
 				GetBool: func(s *config.Settings) bool { return s.Editor.DiffWordWrap },
 				SetBool: func(s *config.Settings, v bool) { s.Editor.DiffWordWrap = v }},
@@ -179,6 +182,13 @@ func diffModeItems() []widgets.SelectItem {
 	return []widgets.SelectItem{
 		{ID: config.DiffModeSplit, Label: "Split"},
 		{ID: config.DiffModeUnified, Label: "Unified"},
+	}
+}
+
+func diffContextItems() []widgets.SelectItem {
+	return []widgets.SelectItem{
+		{ID: config.DiffContextChanges, Label: "Changes Only"},
+		{ID: config.DiffContextFull, Label: "Full File"},
 	}
 }
 

--- a/internal/app/sidebar_order.go
+++ b/internal/app/sidebar_order.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"slices"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func (a *App) persistSidebarPanelOrder(ids []string) {
+	a.Settings.Sidebar.PanelOrder = slices.Clone(ids)
+	if err := config.SaveSettings(*a.Settings); err != nil {
+		a.StatusError("Failed to save sidebar order: " + err.Error())
+	}
+}
+
+func (a *App) MoveActiveSidebarPanel(dir int) {
+	a.Sidebar.MoveActivePanel(dir)
+}
+
+func (a *App) sidebarMoveMenuItems() []ui.ContextMenuItem {
+	var items []ui.ContextMenuItem
+	if a.Sidebar.CanMoveActivePanel(-1) {
+		items = append(items, ui.ContextMenuItem{Label: "Move Panel Left", Command: "sidebar.movePanelLeft"})
+	}
+	if a.Sidebar.CanMoveActivePanel(1) {
+		items = append(items, ui.ContextMenuItem{Label: "Move Panel Right", Command: "sidebar.movePanelRight"})
+	}
+	return items
+}

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -26,6 +26,7 @@ func BuildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	m[term.StyleSelection] = base.Reverse(true)
 
 	applyStyleDef(&m, term.StyleStatusBar, theme.StatusBar)
+	applyStyleDef(&m, term.StyleCommitMessage, theme.CommitMessage)
 	applyStyleDef(&m, term.StyleActiveTab, theme.Tabs.Active)
 	applyStyleDef(&m, term.StyleInactiveTab, theme.Tabs.Inactive)
 	selectedTab := theme.Tabs.Selected
@@ -48,6 +49,7 @@ func BuildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	applyStyleDef(&m, term.StyleDiffAdded, theme.Diff.Added)
 	applyStyleDef(&m, term.StyleDiffDeleted, theme.Diff.Deleted)
 	applyStyleDef(&m, term.StyleDiffModified, theme.Diff.Modified)
+	applyStyleDef(&m, term.StyleDiffCollapsed, theme.Diff.Collapsed)
 	applyStyleDef(&m, term.StyleGutterAdded, theme.Diff.GutterAdded)
 	applyStyleDef(&m, term.StyleGutterDeleted, theme.Diff.GutterDeleted)
 	applyStyleDef(&m, term.StyleGutterModified, theme.Diff.GutterModified)

--- a/internal/app/theme_test.go
+++ b/internal/app/theme_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestBuildStyleMapWiresCollapsedDiffStyle(t *testing.T) {
+	theme := config.DefaultTheme()
+	theme.Diff.Collapsed = config.StyleDef{
+		Fg:   "#123456",
+		Bg:   "#654321",
+		Bold: true,
+	}
+
+	styles := BuildStyleMap(theme)
+	collapsed := styles[term.StyleDiffCollapsed]
+	if collapsed == styles[term.StyleDefault] {
+		t.Fatal("collapsed diff style resolved to StyleDefault")
+	}
+	if got := collapsed.GetForeground(); got != tcell.GetColor("#123456") {
+		t.Fatalf("collapsed foreground = %v, want #123456", got)
+	}
+	if got := collapsed.GetBackground(); got != tcell.GetColor("#654321") {
+		t.Fatalf("collapsed background = %v, want #654321", got)
+	}
+	if collapsed.GetAttributes()&tcell.AttrBold == 0 {
+		t.Fatal("collapsed diff style should be bold")
+	}
+}
+
+func TestBuildStyleMapWiresCommitMessageStyle(t *testing.T) {
+	theme := config.DefaultTheme()
+	theme.CommitMessage = config.StyleDef{Fg: "#abcdef", Bg: "#123456", Bold: true}
+
+	styles := BuildStyleMap(theme)
+	message := styles[term.StyleCommitMessage]
+	if got := message.GetForeground(); got != tcell.GetColor("#abcdef") {
+		t.Fatalf("commit message foreground = %v, want #abcdef", got)
+	}
+	if got := message.GetBackground(); got != tcell.GetColor("#123456") {
+		t.Fatalf("commit message background = %v, want #123456", got)
+	}
+	if message.GetAttributes()&tcell.AttrBold == 0 {
+		t.Fatal("commit message style should preserve configured bold")
+	}
+}

--- a/internal/app/watch.go
+++ b/internal/app/watch.go
@@ -46,6 +46,9 @@ func (a *App) SyncWatched() {
 // warned. The recorded disk state of a dirty buffer is deliberately not
 // updated, so the save-time conflict check keeps working.
 func (a *App) HandleFileChanged(path string) {
+	// Repository status changes even when buffer reconciliation later decides
+	// this event is our own save, a deletion, or a dirty-buffer conflict.
+	a.invalidateRepositoryPath(path, RepositoryStatus)
 	buf := a.EditorGroup.BufferForPath(path)
 	if buf == nil {
 		return

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -275,6 +275,8 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	sidebar.AddPanel("search", "Find", search)
 	sidebar.AddPanel("changes", "Changes", changes.Adapter)
 	sidebar.AddPanel("outline", "Outline", symbols.Adapter)
+	sidebar.SetPanelOrder(cfg.Settings.Sidebar.PanelOrder)
+	sidebar.Tabs.Config.Reorderable = true
 	hasFolders := len(ws.Paths()) > 0
 	sidebar.Visible = hasFolders
 	sidebar.Borders = borders

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -210,6 +210,8 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.SyntaxHighlight = cfg.Settings.Editor.IsSyntaxHighlightEnabled()
 	editorGroup.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.Editor.WordWrap = cfg.Settings.Editor.WordWrap
+	editorGroup.DiffMode = configuredDiffMode(cfg.Settings.Editor.DiffMode)
+	editorGroup.DiffWordWrap = cfg.Settings.Editor.DiffWordWrap
 	editorGroup.Editor.AutoDedent = cfg.Settings.Editor.IsAutoDedentEnabled()
 	editorGroup.Editor.AutoIndent = cfg.Settings.Editor.IsAutoIndentEnabled()
 	editorGroup.UndoDeleteCursorStart = cfg.Settings.Editor.UndoDeleteCursorStart

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -211,6 +211,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.Editor.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.DiffMode = configuredDiffMode(cfg.Settings.Editor.DiffMode)
+	editorGroup.DiffContext = configuredDiffContext(cfg.Settings.Editor.DiffContext)
 	editorGroup.DiffWordWrap = cfg.Settings.Editor.DiffWordWrap
 	editorGroup.DiffHighContrast = cfg.Settings.Editor.DiffHighContrast
 	editorGroup.Editor.AutoDedent = cfg.Settings.Editor.IsAutoDedentEnabled()

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -322,6 +322,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		LspNotified:         make(map[string]bool),
 		pluginDetailWidgets: make(map[string]*pluginDetailState),
 	}
+	app.Repository = NewRepositoryState(changes, ws.Paths())
 	app.applyMenuBarVisibility(cfg.Settings.Editor.IsMenuBarVisible())
 	// Rebuild the Diagnostics panel whenever any source (LSP or a plugin)
 	// changes its diagnostics.

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -321,6 +321,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		DocVersions:         make(map[string]int),
 		LspNotified:         make(map[string]bool),
 		pluginDetailWidgets: make(map[string]*pluginDetailState),
+		currentChangesLoads: make(map[string]*currentChangesLoadState),
 	}
 	app.Repository = NewRepositoryState(changes, ws.Paths())
 	app.applyMenuBarVisibility(cfg.Settings.Editor.IsMenuBarVisible())

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -212,6 +212,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	editorGroup.Editor.WordWrap = cfg.Settings.Editor.WordWrap
 	editorGroup.DiffMode = configuredDiffMode(cfg.Settings.Editor.DiffMode)
 	editorGroup.DiffWordWrap = cfg.Settings.Editor.DiffWordWrap
+	editorGroup.DiffHighContrast = cfg.Settings.Editor.DiffHighContrast
 	editorGroup.Editor.AutoDedent = cfg.Settings.Editor.IsAutoDedentEnabled()
 	editorGroup.Editor.AutoIndent = cfg.Settings.Editor.IsAutoIndentEnabled()
 	editorGroup.UndoDeleteCursorStart = cfg.Settings.Editor.UndoDeleteCursorStart

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -265,6 +265,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	search.SetWorkDirs(ws.Paths())
 	search.Debounce.DelayMs = cfg.Settings.Search.Debounce
 	changes := NewChangesPanel(ws.Paths()...)
+	changes.SetFileView(cfg.Settings.Git.FileView)
 	symbols := NewSymbolsPanel()
 
 	explorer := NewNavigationPanel(cfg.Settings.Explorer, ws.Paths()...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,10 @@ func ListThemes() []string {
 
 func LoadTheme(name string) (ThemeConfig, error) {
 	theme := DefaultTheme()
+	if name == "" {
+		theme.ResolveColors()
+		return theme, nil
+	}
 	themeFile := name + ".json"
 
 	if data, err := readFirstTheme(configPaths(), themeFile); err == nil {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -169,7 +169,7 @@ type GitSettings struct {
 }
 
 func DefaultGitSettings() GitSettings {
-	return GitSettings{FileView: GitFileViewTree}
+	return GitSettings{FileView: GitFileViewList}
 }
 
 type SidebarSettings struct {
@@ -316,7 +316,7 @@ func normalizeSettings(s *Settings) {
 		s.Editor.DiffContext = DiffContextChanges
 	}
 	if !slices.Contains(GitFileViews, s.Git.FileView) {
-		s.Git.FileView = GitFileViewTree
+		s.Git.FileView = GitFileViewList
 	}
 	seenPanels := make(map[string]bool)
 	panelOrder := s.Sidebar.PanelOrder[:0]

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -167,6 +167,10 @@ func DefaultGitSettings() GitSettings {
 	return GitSettings{FileView: GitFileViewTree}
 }
 
+type SidebarSettings struct {
+	PanelOrder []string `json:"panelOrder,omitempty"`
+}
+
 func DefaultExplorerSettings() ExplorerSettings {
 	return ExplorerSettings{
 		ShowHidden:     true,
@@ -207,6 +211,7 @@ type Settings struct {
 	LSP          LSPSettings          `json:"lsp"`
 	Autocomplete AutocompleteSettings `json:"autocomplete"`
 	Markdown     MarkdownSettings     `json:"markdown"`
+	Sidebar      SidebarSettings      `json:"sidebar,omitzero"`
 	// Plugins is safe: its only field is a tri-state *bool where nil means the
 	// default, so the zero value and "unset" mean the same thing.
 	Plugins    PluginSettings    `json:"plugins,omitzero"`
@@ -224,6 +229,7 @@ var knownSettingsKeys = map[string]bool{
 	"version": true, "theme": true, "debugMode": true, "editor": true,
 	"search": true, "explorer": true, "git": true, "terminal": true, "lsp": true,
 	"autocomplete": true, "markdown": true, "plugins": true, "formatters": true,
+	"sidebar": true,
 }
 
 func (s Settings) MarshalJSON() ([]byte, error) {
@@ -304,6 +310,16 @@ func normalizeSettings(s *Settings) {
 	if !slices.Contains(GitFileViews, s.Git.FileView) {
 		s.Git.FileView = GitFileViewTree
 	}
+	seenPanels := make(map[string]bool)
+	panelOrder := s.Sidebar.PanelOrder[:0]
+	for _, id := range s.Sidebar.PanelOrder {
+		if id == "" || seenPanels[id] {
+			continue
+		}
+		seenPanels[id] = true
+		panelOrder = append(panelOrder, id)
+	}
+	s.Sidebar.PanelOrder = panelOrder
 }
 
 func LoadSettings() Settings {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -11,14 +11,17 @@ var (
 	GutterStyles = []string{"minimal", "compact", "extended"}
 	BorderStyles = []string{"default", "theme", "rounded", "sharp", "double", "bold", "ascii", "none"}
 	DiffModes    = []string{"split", "unified"}
+	DiffContexts = []string{"changes", "full"}
 	GitFileViews = []string{"tree", "list"}
 )
 
 const (
-	DiffModeSplit   = "split"
-	DiffModeUnified = "unified"
-	GitFileViewTree = "tree"
-	GitFileViewList = "list"
+	DiffModeSplit      = "split"
+	DiffModeUnified    = "unified"
+	DiffContextChanges = "changes"
+	DiffContextFull    = "full"
+	GitFileViewTree    = "tree"
+	GitFileViewList    = "list"
 )
 
 type TerminalSettings struct {
@@ -87,6 +90,7 @@ type EditorSettings struct {
 	InsertSpaces            bool   `json:"insertSpaces"`
 	WordWrap                bool   `json:"wordWrap"`
 	DiffMode                string `json:"diffMode"`
+	DiffContext             string `json:"diffContext"`
 	DiffWordWrap            bool   `json:"diffWordWrap"`
 	DiffHighContrast        bool   `json:"diffHighContrast,omitempty"`
 	LineNumbers             bool   `json:"lineNumbers"`
@@ -136,6 +140,7 @@ func DefaultEditorSettings() EditorSettings {
 		TabSize:                 4,
 		InsertSpaces:            true,
 		DiffMode:                DiffModeSplit,
+		DiffContext:             DiffContextChanges,
 		LineNumbers:             true,
 		InsertFinalNewline:      true,
 		GutterStyle:             "compact",
@@ -306,6 +311,9 @@ func normalizeSettings(s *Settings) {
 	}
 	if !slices.Contains(DiffModes, s.Editor.DiffMode) {
 		s.Editor.DiffMode = DiffModeSplit
+	}
+	if !slices.Contains(DiffContexts, s.Editor.DiffContext) {
+		s.Editor.DiffContext = DiffContextChanges
 	}
 	if !slices.Contains(GitFileViews, s.Git.FileView) {
 		s.Git.FileView = GitFileViewTree

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -10,6 +10,12 @@ import (
 var (
 	GutterStyles = []string{"minimal", "compact", "extended"}
 	BorderStyles = []string{"default", "theme", "rounded", "sharp", "double", "bold", "ascii", "none"}
+	DiffModes    = []string{"split", "unified"}
+)
+
+const (
+	DiffModeSplit   = "split"
+	DiffModeUnified = "unified"
 )
 
 type TerminalSettings struct {
@@ -77,6 +83,8 @@ type EditorSettings struct {
 	TabSize                 int    `json:"tabSize"`
 	InsertSpaces            bool   `json:"insertSpaces"`
 	WordWrap                bool   `json:"wordWrap"`
+	DiffMode                string `json:"diffMode"`
+	DiffWordWrap            bool   `json:"diffWordWrap"`
 	LineNumbers             bool   `json:"lineNumbers"`
 	CursorStyle             string `json:"cursorStyle,omitempty"`
 	FormatOnSave            bool   `json:"formatOnSave"`
@@ -123,6 +131,7 @@ func DefaultEditorSettings() EditorSettings {
 	return EditorSettings{
 		TabSize:                 4,
 		InsertSpaces:            true,
+		DiffMode:                DiffModeSplit,
 		LineNumbers:             true,
 		InsertFinalNewline:      true,
 		GutterStyle:             "compact",
@@ -274,6 +283,9 @@ func normalizeSettings(s *Settings) {
 	}
 	if !slices.Contains(BorderStyles, s.Editor.BorderStyle) {
 		s.Editor.BorderStyle = "default"
+	}
+	if !slices.Contains(DiffModes, s.Editor.DiffMode) {
+		s.Editor.DiffMode = DiffModeSplit
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -11,11 +11,14 @@ var (
 	GutterStyles = []string{"minimal", "compact", "extended"}
 	BorderStyles = []string{"default", "theme", "rounded", "sharp", "double", "bold", "ascii", "none"}
 	DiffModes    = []string{"split", "unified"}
+	GitFileViews = []string{"tree", "list"}
 )
 
 const (
 	DiffModeSplit   = "split"
 	DiffModeUnified = "unified"
+	GitFileViewTree = "tree"
+	GitFileViewList = "list"
 )
 
 type TerminalSettings struct {
@@ -156,6 +159,14 @@ type ExplorerSettings struct {
 	ShowGitIgnored bool `json:"showGitIgnored"`
 }
 
+type GitSettings struct {
+	FileView string `json:"fileView"`
+}
+
+func DefaultGitSettings() GitSettings {
+	return GitSettings{FileView: GitFileViewTree}
+}
+
 func DefaultExplorerSettings() ExplorerSettings {
 	return ExplorerSettings{
 		ShowHidden:     true,
@@ -191,6 +202,7 @@ type Settings struct {
 	Editor       EditorSettings       `json:"editor"`
 	Search       SearchSettings       `json:"search"`
 	Explorer     ExplorerSettings     `json:"explorer"`
+	Git          GitSettings          `json:"git"`
 	Terminal     TerminalSettings     `json:"terminal"`
 	LSP          LSPSettings          `json:"lsp"`
 	Autocomplete AutocompleteSettings `json:"autocomplete"`
@@ -210,7 +222,7 @@ type Settings struct {
 // Any other top-level key is preserved via Settings.Extra.
 var knownSettingsKeys = map[string]bool{
 	"version": true, "theme": true, "debugMode": true, "editor": true,
-	"search": true, "explorer": true, "terminal": true, "lsp": true,
+	"search": true, "explorer": true, "git": true, "terminal": true, "lsp": true,
 	"autocomplete": true, "markdown": true, "plugins": true, "formatters": true,
 }
 
@@ -264,6 +276,7 @@ func DefaultSettings() Settings {
 		Editor:       DefaultEditorSettings(),
 		Search:       DefaultSearchSettings(),
 		Explorer:     DefaultExplorerSettings(),
+		Git:          DefaultGitSettings(),
 		Terminal:     DefaultTerminalSettings(),
 		LSP:          DefaultLSPSettings(),
 		Autocomplete: DefaultAutocompleteSettings(),
@@ -287,6 +300,9 @@ func normalizeSettings(s *Settings) {
 	}
 	if !slices.Contains(DiffModes, s.Editor.DiffMode) {
 		s.Editor.DiffMode = DiffModeSplit
+	}
+	if !slices.Contains(GitFileViews, s.Git.FileView) {
+		s.Git.FileView = GitFileViewTree
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -85,6 +85,7 @@ type EditorSettings struct {
 	WordWrap                bool   `json:"wordWrap"`
 	DiffMode                string `json:"diffMode"`
 	DiffWordWrap            bool   `json:"diffWordWrap"`
+	DiffHighContrast        bool   `json:"diffHighContrast,omitempty"`
 	LineNumbers             bool   `json:"lineNumbers"`
 	CursorStyle             string `json:"cursorStyle,omitempty"`
 	FormatOnSave            bool   `json:"formatOnSave"`

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -23,6 +23,7 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s.Editor.WordWrap = true
 	s.Editor.DiffMode = DiffModeUnified
 	s.Editor.DiffWordWrap = true
+	s.Editor.DiffHighContrast = true
 	enabled := false
 	s.Editor.SyntaxHighlight = &enabled
 	s.Terminal.Shell = "/bin/zsh"
@@ -43,6 +44,9 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if !got.Editor.DiffWordWrap {
 		t.Error("diffWordWrap did not round-trip")
+	}
+	if !got.Editor.DiffHighContrast {
+		t.Error("diffHighContrast did not round-trip")
 	}
 	if got.Editor.IsSyntaxHighlightEnabled() {
 		t.Error("syntaxHighlight=false did not round-trip; tri-state pointer lost")

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -21,6 +21,8 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s := DefaultSettings()
 	s.Editor.TabSize = 7
 	s.Editor.WordWrap = true
+	s.Editor.DiffMode = DiffModeUnified
+	s.Editor.DiffWordWrap = true
 	enabled := false
 	s.Editor.SyntaxHighlight = &enabled
 	s.Terminal.Shell = "/bin/zsh"
@@ -35,6 +37,12 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if !got.Editor.WordWrap {
 		t.Error("wordWrap did not round-trip")
+	}
+	if got.Editor.DiffMode != DiffModeUnified {
+		t.Errorf("diffMode = %q, want %q", got.Editor.DiffMode, DiffModeUnified)
+	}
+	if !got.Editor.DiffWordWrap {
+		t.Error("diffWordWrap did not round-trip")
 	}
 	if got.Editor.IsSyntaxHighlightEnabled() {
 		t.Error("syntaxHighlight=false did not round-trip; tri-state pointer lost")

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -23,6 +23,7 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s.Editor.TabSize = 7
 	s.Editor.WordWrap = true
 	s.Editor.DiffMode = DiffModeUnified
+	s.Editor.DiffContext = DiffContextFull
 	s.Editor.DiffWordWrap = true
 	s.Editor.DiffHighContrast = true
 	s.Git.FileView = GitFileViewList
@@ -44,6 +45,9 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if got.Editor.DiffMode != DiffModeUnified {
 		t.Errorf("diffMode = %q, want %q", got.Editor.DiffMode, DiffModeUnified)
+	}
+	if got.Editor.DiffContext != DiffContextFull {
+		t.Errorf("diffContext = %q, want %q", got.Editor.DiffContext, DiffContextFull)
 	}
 	if !got.Editor.DiffWordWrap {
 		t.Error("diffWordWrap did not round-trip")

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -24,6 +24,7 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s.Editor.DiffMode = DiffModeUnified
 	s.Editor.DiffWordWrap = true
 	s.Editor.DiffHighContrast = true
+	s.Git.FileView = GitFileViewList
 	enabled := false
 	s.Editor.SyntaxHighlight = &enabled
 	s.Terminal.Shell = "/bin/zsh"
@@ -47,6 +48,9 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if !got.Editor.DiffHighContrast {
 		t.Error("diffHighContrast did not round-trip")
+	}
+	if got.Git.FileView != GitFileViewList {
+		t.Errorf("git.fileView = %q, want %q", got.Git.FileView, GitFileViewList)
 	}
 	if got.Editor.IsSyntaxHighlightEnabled() {
 		t.Error("syntaxHighlight=false did not round-trip; tri-state pointer lost")
@@ -104,6 +108,7 @@ func TestNormalizeRejectsUnknownEnumValues(t *testing.T) {
 	s := DefaultSettings()
 	s.Editor.GutterStyle = "bogus"
 	s.Editor.BorderStyle = "bogus"
+	s.Git.FileView = "bogus"
 	normalizeSettings(&s)
 
 	if s.Editor.GutterStyle != "compact" {
@@ -111,6 +116,9 @@ func TestNormalizeRejectsUnknownEnumValues(t *testing.T) {
 	}
 	if s.Editor.BorderStyle != "default" {
 		t.Errorf("borderStyle = %q, want default", s.Editor.BorderStyle)
+	}
+	if s.Git.FileView != GitFileViewTree {
+		t.Errorf("git.fileView = %q, want tree", s.Git.FileView)
 	}
 
 	for _, v := range GutterStyles {
@@ -125,6 +133,13 @@ func TestNormalizeRejectsUnknownEnumValues(t *testing.T) {
 		normalizeSettings(&s)
 		if s.Editor.BorderStyle != v {
 			t.Errorf("normalize rejected valid border style %q", v)
+		}
+	}
+	for _, v := range GitFileViews {
+		s.Git.FileView = v
+		normalizeSettings(&s)
+		if s.Git.FileView != v {
+			t.Errorf("normalize rejected valid git file view %q", v)
 		}
 	}
 }

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -126,8 +126,8 @@ func TestNormalizeRejectsUnknownEnumValues(t *testing.T) {
 	if s.Editor.BorderStyle != "default" {
 		t.Errorf("borderStyle = %q, want default", s.Editor.BorderStyle)
 	}
-	if s.Git.FileView != GitFileViewTree {
-		t.Errorf("git.fileView = %q, want tree", s.Git.FileView)
+	if s.Git.FileView != GitFileViewList {
+		t.Errorf("git.fileView = %q, want list", s.Git.FileView)
 	}
 
 	for _, v := range GutterStyles {

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -25,6 +26,7 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s.Editor.DiffWordWrap = true
 	s.Editor.DiffHighContrast = true
 	s.Git.FileView = GitFileViewList
+	s.Sidebar.PanelOrder = []string{"changes", "explorer", "search"}
 	enabled := false
 	s.Editor.SyntaxHighlight = &enabled
 	s.Terminal.Shell = "/bin/zsh"
@@ -51,6 +53,9 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if got.Git.FileView != GitFileViewList {
 		t.Errorf("git.fileView = %q, want %q", got.Git.FileView, GitFileViewList)
+	}
+	if !slices.Equal(got.Sidebar.PanelOrder, []string{"changes", "explorer", "search"}) {
+		t.Errorf("sidebar.panelOrder = %v", got.Sidebar.PanelOrder)
 	}
 	if got.Editor.IsSyntaxHighlightEnabled() {
 		t.Error("syntaxHighlight=false did not round-trip; tri-state pointer lost")

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -16,6 +16,12 @@ func TestDefaultSettings(t *testing.T) {
 	if !s.Editor.InsertSpaces {
 		t.Fatal("expected InsertSpaces true")
 	}
+	if s.Editor.DiffMode != DiffModeSplit {
+		t.Fatalf("expected DiffMode %q, got %q", DiffModeSplit, s.Editor.DiffMode)
+	}
+	if s.Editor.DiffWordWrap {
+		t.Fatal("expected DiffWordWrap false")
+	}
 }
 
 func TestSettingsPartialJSON(t *testing.T) {
@@ -65,6 +71,24 @@ func TestNormalizeSettingsEmptyGutterStyle(t *testing.T) {
 	normalizeSettings(&s)
 	if s.Editor.GutterStyle != "compact" {
 		t.Errorf("expected empty GutterStyle to become 'compact', got %q", s.Editor.GutterStyle)
+	}
+}
+
+func TestNormalizeSettingsDiffMode(t *testing.T) {
+	for _, mode := range DiffModes {
+		s := DefaultSettings()
+		s.Editor.DiffMode = mode
+		normalizeSettings(&s)
+		if s.Editor.DiffMode != mode {
+			t.Errorf("valid diffMode %q normalized to %q", mode, s.Editor.DiffMode)
+		}
+	}
+
+	s := DefaultSettings()
+	s.Editor.DiffMode = "sideways"
+	normalizeSettings(&s)
+	if s.Editor.DiffMode != DiffModeSplit {
+		t.Errorf("invalid diffMode normalized to %q, want %q", s.Editor.DiffMode, DiffModeSplit)
 	}
 }
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 )
 
@@ -42,6 +43,16 @@ func TestSettingsEmptyJSON(t *testing.T) {
 
 	if s.Editor.TabSize != 4 {
 		t.Fatalf("expected TabSize 4, got %d", s.Editor.TabSize)
+	}
+}
+
+func TestNormalizeSidebarPanelOrder(t *testing.T) {
+	s := DefaultSettings()
+	s.Sidebar.PanelOrder = []string{"changes", "", "explorer", "changes", "plugin.todo"}
+	normalizeSettings(&s)
+	want := []string{"changes", "explorer", "plugin.todo"}
+	if !slices.Equal(s.Sidebar.PanelOrder, want) {
+		t.Fatalf("panelOrder = %v, want %v", s.Sidebar.PanelOrder, want)
 	}
 }
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -20,6 +20,9 @@ func TestDefaultSettings(t *testing.T) {
 	if s.Editor.DiffMode != DiffModeSplit {
 		t.Fatalf("expected DiffMode %q, got %q", DiffModeSplit, s.Editor.DiffMode)
 	}
+	if s.Editor.DiffContext != DiffContextChanges {
+		t.Fatalf("expected DiffContext %q, got %q", DiffContextChanges, s.Editor.DiffContext)
+	}
 	if s.Editor.DiffWordWrap {
 		t.Fatal("expected DiffWordWrap false")
 	}
@@ -100,6 +103,23 @@ func TestNormalizeSettingsDiffMode(t *testing.T) {
 	normalizeSettings(&s)
 	if s.Editor.DiffMode != DiffModeSplit {
 		t.Errorf("invalid diffMode normalized to %q, want %q", s.Editor.DiffMode, DiffModeSplit)
+	}
+}
+
+func TestNormalizeSettingsDiffContext(t *testing.T) {
+	for _, contextMode := range DiffContexts {
+		s := DefaultSettings()
+		s.Editor.DiffContext = contextMode
+		normalizeSettings(&s)
+		if s.Editor.DiffContext != contextMode {
+			t.Errorf("valid diffContext %q normalized to %q", contextMode, s.Editor.DiffContext)
+		}
+	}
+	s := DefaultSettings()
+	s.Editor.DiffContext = "everything"
+	normalizeSettings(&s)
+	if s.Editor.DiffContext != DiffContextChanges {
+		t.Errorf("invalid diffContext normalized to %q, want %q", s.Editor.DiffContext, DiffContextChanges)
 	}
 }
 

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -77,6 +77,7 @@ type DiffStyles struct {
 	Added          StyleDef `json:"added"`
 	Deleted        StyleDef `json:"deleted"`
 	Modified       StyleDef `json:"modified"`
+	Collapsed      StyleDef `json:"collapsed"`
 	GutterAdded    StyleDef `json:"gutterAdded,omitempty"`
 	GutterDeleted  StyleDef `json:"gutterDeleted,omitempty"`
 	GutterModified StyleDef `json:"gutterModified,omitempty"`
@@ -194,27 +195,28 @@ type HoverStyles struct {
 }
 
 type ThemeConfig struct {
-	Default      StyleDef       `json:"default"`
-	Muted        StyleDef       `json:"muted"`
-	Success      StyleDef       `json:"success"`
-	Danger       StyleDef       `json:"danger"`
-	Warning      StyleDef       `json:"warning"`
-	StatusBar    StyleDef       `json:"statusBar"`
-	Tabs         TabStyles      `json:"tabs"`
-	Sidebar      SidebarStyles  `json:"sidebar"`
-	Dialog       DialogStyles   `json:"dialog"`
-	Editor       EditorStyles   `json:"editor"`
-	Menu         MenuStyles     `json:"menu"`
-	Input        InputStyles    `json:"input"`
-	Button       ButtonStyles   `json:"button"`
-	Hover        HoverStyles    `json:"hover"`
-	Border       StyleDef       `json:"border"`
-	BorderActive StyleDef       `json:"borderActive"`
-	Diff         DiffStyles     `json:"diff"`
-	Scrollbar    StyleDef       `json:"scrollbar"`
-	Syntax       SyntaxStyles   `json:"syntax"`
-	Borders      BorderChars    `json:"borders"`
-	Terminal     TerminalColors `json:"terminal,omitempty"`
+	Default       StyleDef       `json:"default"`
+	Muted         StyleDef       `json:"muted"`
+	Success       StyleDef       `json:"success"`
+	Danger        StyleDef       `json:"danger"`
+	Warning       StyleDef       `json:"warning"`
+	StatusBar     StyleDef       `json:"statusBar"`
+	CommitMessage StyleDef       `json:"commitMessage"`
+	Tabs          TabStyles      `json:"tabs"`
+	Sidebar       SidebarStyles  `json:"sidebar"`
+	Dialog        DialogStyles   `json:"dialog"`
+	Editor        EditorStyles   `json:"editor"`
+	Menu          MenuStyles     `json:"menu"`
+	Input         InputStyles    `json:"input"`
+	Button        ButtonStyles   `json:"button"`
+	Hover         HoverStyles    `json:"hover"`
+	Border        StyleDef       `json:"border"`
+	BorderActive  StyleDef       `json:"borderActive"`
+	Diff          DiffStyles     `json:"diff"`
+	Scrollbar     StyleDef       `json:"scrollbar"`
+	Syntax        SyntaxStyles   `json:"syntax"`
+	Borders       BorderChars    `json:"borders"`
+	Terminal      TerminalColors `json:"terminal,omitempty"`
 }
 
 func DefaultTheme() ThemeConfig {
@@ -226,7 +228,8 @@ func DefaultTheme() ThemeConfig {
 		Menu: MenuStyles{
 			Active: StyleDef{Fg: "#ffffff", Bg: "#505050", Bold: true},
 		},
-		StatusBar: StyleDef{},
+		StatusBar:     StyleDef{},
+		CommitMessage: StyleDef{Fg: "#fafafa", Bg: "#2a2f3a"},
 
 		Tabs: TabStyles{
 			Active:   StyleDef{Fg: "#ffffff", Bold: true},
@@ -243,6 +246,9 @@ func DefaultTheme() ThemeConfig {
 		},
 
 		Border: StyleDef{Fg: "#555555"},
+		Diff: DiffStyles{
+			Collapsed: StyleDef{Fg: "#1f1f1f", Bg: "#8ab4d8", Bold: true},
+		},
 
 		Editor: EditorStyles{
 			ActiveLine:    StyleDef{Bg: "#282828"},

--- a/internal/config/theme_test.go
+++ b/internal/config/theme_test.go
@@ -2,6 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/config/themes"
@@ -67,12 +71,102 @@ func TestBundledThemesLoad(t *testing.T) {
 			}
 			th.ResolveColors()
 
+			var explicit ThemeConfig
+			if err := json.Unmarshal(data, &explicit); err != nil {
+				t.Fatalf("failed to inspect %s: %v", name, err)
+			}
+			if explicit.Diff.Collapsed.Fg == "" || explicit.Diff.Collapsed.Bg == "" {
+				t.Errorf("%s: diff.collapsed must define both fg and bg", name)
+			}
+			if !explicit.Diff.Collapsed.Bold {
+				t.Errorf("%s: diff.collapsed must deliberately enable bold", name)
+			}
+			if explicit.CommitMessage.Fg == "" || explicit.CommitMessage.Bg == "" {
+				t.Errorf("%s: commitMessage must define both fg and bg", name)
+			}
+			if strings.HasPrefix(name, "high-contrast-") && !explicit.CommitMessage.Bold {
+				t.Errorf("%s: high-contrast commitMessage must use a strong bold treatment", name)
+			}
+
 			// After resolving, verify critical fields are non-empty
 			if th.Default.Fg == "" {
 				t.Errorf("%s: Default.Fg is empty after resolve", name)
 			}
 		})
 	}
+}
+
+func TestBundledDiffFamilyTextContrast(t *testing.T) {
+	const minimumContrast = 4.5
+	entries, err := themes.FS.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read bundled themes: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		data, err := themes.FS.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		var theme ThemeConfig
+		if err := json.Unmarshal(data, &theme); err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		styles := []struct {
+			name  string
+			style StyleDef
+		}{
+			{name: "commitMessage", style: theme.CommitMessage},
+			{name: "diff.collapsed", style: theme.Diff.Collapsed},
+		}
+		for _, candidate := range styles {
+			styleName, style := candidate.name, candidate.style
+			t.Run(name+"/"+styleName, func(t *testing.T) {
+				ratio, err := styleContrastRatio(style)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Logf("%s %s contrast: %.2f:1", name, styleName, ratio)
+				if ratio < minimumContrast {
+					t.Errorf("contrast %.2f:1 is below %.1f:1 (fg %s, bg %s)", ratio, minimumContrast, style.Fg, style.Bg)
+				}
+			})
+		}
+	}
+}
+
+func styleContrastRatio(style StyleDef) (float64, error) {
+	foreground, err := relativeLuminance(style.Fg)
+	if err != nil {
+		return 0, fmt.Errorf("foreground %q: %w", style.Fg, err)
+	}
+	background, err := relativeLuminance(style.Bg)
+	if err != nil {
+		return 0, fmt.Errorf("background %q: %w", style.Bg, err)
+	}
+	lighter, darker := max(foreground, background), min(foreground, background)
+	return (lighter + 0.05) / (darker + 0.05), nil
+}
+
+func relativeLuminance(color string) (float64, error) {
+	if len(color) != 7 || color[0] != '#' {
+		return 0, fmt.Errorf("want #RRGGBB")
+	}
+	value, err := strconv.ParseUint(color[1:], 16, 24)
+	if err != nil {
+		return 0, fmt.Errorf("want #RRGGBB: %w", err)
+	}
+	linear := func(channel uint64) float64 {
+		srgb := float64(channel) / 255
+		if srgb <= 0.04045 {
+			return srgb / 12.92
+		}
+		return math.Pow((srgb+0.055)/1.055, 2.4)
+	}
+	red := linear((value >> 16) & 0xff)
+	green := linear((value >> 8) & 0xff)
+	blue := linear(value & 0xff)
+	return 0.2126*red + 0.7152*green + 0.0722*blue, nil
 }
 
 func TestResolveColors(t *testing.T) {

--- a/internal/config/theme_test.go
+++ b/internal/config/theme_test.go
@@ -24,6 +24,22 @@ func TestDefaultTheme(t *testing.T) {
 	}
 }
 
+func TestLoadThemeAcceptsAndResolvesBuiltInDefault(t *testing.T) {
+	th, err := LoadTheme("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if th.Syntax.Keyword.Fg == "" {
+		t.Fatal("built-in default lost its syntax palette")
+	}
+	if th.Diff.Added.Bg == "" || th.Diff.Deleted.Bg == "" {
+		t.Fatalf("built-in default diff colors were not resolved: added=%q deleted=%q", th.Diff.Added.Bg, th.Diff.Deleted.Bg)
+	}
+	if th.Diff.GutterAdded.Fg == "" || th.Diff.GutterDeleted.Fg == "" {
+		t.Fatalf("built-in default gutter colors were not resolved: added=%q deleted=%q", th.Diff.GutterAdded.Fg, th.Diff.GutterDeleted.Fg)
+	}
+}
+
 func TestThemePartialJSON(t *testing.T) {
 	th := DefaultTheme()
 	json.Unmarshal([]byte(`{"statusBar": {"fg": "yellow", "bg": "#ff0000"}}`), &th)

--- a/internal/config/themes/aurora.json
+++ b/internal/config/themes/aurora.json
@@ -16,6 +16,10 @@
     "fg": "#00e5ff"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#c8d0e0",
+    "bg": "#121b30"
+  },
   "tabs": {
     "active": {
       "fg": "#ffffff",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#2e2e0a"
+    },
+    "collapsed": {
+      "fg": "#0a0e1a",
+      "bg": "#00e5ff",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/bubblegum.json
+++ b/internal/config/themes/bubblegum.json
@@ -16,6 +16,10 @@
     "fg": "#e06090"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#4a3050",
+    "bg": "#f8d5e7"
+  },
   "tabs": {
     "active": {
       "fg": "#4a3050",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#f5f0d4"
+    },
+    "collapsed": {
+      "fg": "#4a3050",
+      "bg": "#f0c0d8",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/default-dark.json
+++ b/internal/config/themes/default-dark.json
@@ -16,6 +16,10 @@
     "fg": "#555555"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#fafafa",
+    "bg": "#2a2f3a"
+  },
   "tabs": {
     "active": {
       "fg": "#ffffff",
@@ -77,6 +81,11 @@
     },
     "modified": {
       "bg": "#2e2e1e"
+    },
+    "collapsed": {
+      "fg": "#1f1f1f",
+      "bg": "#8ab4d8",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/default-light.json
+++ b/internal/config/themes/default-light.json
@@ -16,6 +16,10 @@
     "fg": "#c0c0c0"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#333333",
+    "bg": "#e8eef7"
+  },
   "tabs": {
     "active": {
       "fg": "#111111",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#f5f5e8"
+    },
+    "collapsed": {
+      "fg": "#ffffff",
+      "bg": "#1e3a5f",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/dracula.json
+++ b/internal/config/themes/dracula.json
@@ -21,6 +21,10 @@
   "statusBar": {
     "fg": "#f8f8f2"
   },
+  "commitMessage": {
+    "fg": "#f8f8f2",
+    "bg": "#343746"
+  },
   "tabs": {
     "active": {
       "fg": "#f8f8f2",
@@ -120,6 +124,11 @@
     },
     "modified": {
       "bg": "#3a3a1e"
+    },
+    "collapsed": {
+      "fg": "#f8f8f2",
+      "bg": "#555972",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/high-contrast-dark.json
+++ b/internal/config/themes/high-contrast-dark.json
@@ -21,6 +21,11 @@
   "statusBar": {
     "fg": "#FFFFFF"
   },
+  "commitMessage": {
+    "fg": "#000000",
+    "bg": "#FFFFFF",
+    "bold": true
+  },
   "tabs": {
     "active": {
       "fg": "#FFFFFF",
@@ -121,6 +126,11 @@
     },
     "modified": {
       "bg": "#333300"
+    },
+    "collapsed": {
+      "fg": "#000000",
+      "bg": "#00FFFF",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/high-contrast-light.json
+++ b/internal/config/themes/high-contrast-light.json
@@ -21,6 +21,11 @@
   "statusBar": {
     "fg": "#000000"
   },
+  "commitMessage": {
+    "fg": "#FFFFFF",
+    "bg": "#000000",
+    "bold": true
+  },
   "tabs": {
     "active": {
       "fg": "#000000",
@@ -121,6 +126,11 @@
     },
     "modified": {
       "bg": "#FFFFCC"
+    },
+    "collapsed": {
+      "fg": "#FFFFFF",
+      "bg": "#0000AA",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/hotline.json
+++ b/internal/config/themes/hotline.json
@@ -16,6 +16,10 @@
     "fg": "#ff00ff"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#e0d8d0",
+    "bg": "#302438"
+  },
   "tabs": {
     "active": {
       "fg": "#ffffff",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#2e2e1e"
+    },
+    "collapsed": {
+      "fg": "#ffffff",
+      "bg": "#7a267a",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/monokai.json
+++ b/internal/config/themes/monokai.json
@@ -16,6 +16,10 @@
     "fg": "#75715e"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#f8f8f2",
+    "bg": "#34352d"
+  },
   "tabs": {
     "active": {
       "fg": "#f8f8f2",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#2e2e1a"
+    },
+    "collapsed": {
+      "fg": "#272822",
+      "bg": "#66d9ef",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/nord.json
+++ b/internal/config/themes/nord.json
@@ -21,6 +21,10 @@
   "statusBar": {
     "fg": "#d8dee9"
   },
+  "commitMessage": {
+    "fg": "#d8dee9",
+    "bg": "#3b4252"
+  },
   "tabs": {
     "active": {
       "fg": "#eceff4",
@@ -120,6 +124,11 @@
     },
     "modified": {
       "bg": "#3b3528"
+    },
+    "collapsed": {
+      "fg": "#2e3440",
+      "bg": "#88c0d0",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/one-dark.json
+++ b/internal/config/themes/one-dark.json
@@ -16,6 +16,10 @@
     "fg": "#4b5263"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#abb2bf",
+    "bg": "#323842"
+  },
   "tabs": {
     "active": {
       "fg": "#d7dae0",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#2e2e1a"
+    },
+    "collapsed": {
+      "fg": "#282c34",
+      "bg": "#61afef",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/rainy-day-dark.json
+++ b/internal/config/themes/rainy-day-dark.json
@@ -21,6 +21,10 @@
   "statusBar": {
     "fg": "#cbd5e1"
   },
+  "commitMessage": {
+    "fg": "#e0e7ff",
+    "bg": "#283852"
+  },
   "tabs": {
     "active": {
       "fg": "#e0e7ff",
@@ -121,6 +125,11 @@
     },
     "modified": {
       "bg": "#2e2e1e"
+    },
+    "collapsed": {
+      "fg": "#e0e7ff",
+      "bg": "#3b5f7a",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/rainy-day.json
+++ b/internal/config/themes/rainy-day.json
@@ -21,6 +21,10 @@
   "statusBar": {
     "fg": "#1e293b"
   },
+  "commitMessage": {
+    "fg": "#1e293b",
+    "bg": "#c6d6ee"
+  },
   "tabs": {
     "active": {
       "fg": "#1e293b",
@@ -121,6 +125,11 @@
     },
     "modified": {
       "bg": "#d8d8a0"
+    },
+    "collapsed": {
+      "fg": "#1e293b",
+      "bg": "#a9c7e8",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/solarized-dark.json
+++ b/internal/config/themes/solarized-dark.json
@@ -16,6 +16,10 @@
     "fg": "#586e75"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#93a1a1",
+    "bg": "#073642"
+  },
   "tabs": {
     "active": {
       "fg": "#93a1a1",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#2e2e0a"
+    },
+    "collapsed": {
+      "fg": "#002b36",
+      "bg": "#2aa198",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/solarized-light.json
+++ b/internal/config/themes/solarized-light.json
@@ -16,6 +16,10 @@
     "fg": "#93a1a1"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#073642",
+    "bg": "#e8dfc7"
+  },
   "tabs": {
     "active": {
       "fg": "#073642",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#f2f2e6"
+    },
+    "collapsed": {
+      "fg": "#fdf6e3",
+      "bg": "#586e75",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/turbo-vision.json
+++ b/internal/config/themes/turbo-vision.json
@@ -22,6 +22,11 @@
     "fg": "#000000",
     "bg": "#00AAAA"
   },
+  "commitMessage": {
+    "fg": "#0000AA",
+    "bg": "#FFFFFF",
+    "bold": true
+  },
   "tabs": {
     "active": {
       "fg": "#FFFFFF",
@@ -141,6 +146,11 @@
     },
     "modified": {
       "bg": "#333300"
+    },
+    "collapsed": {
+      "fg": "#0000AA",
+      "bg": "#55FFFF",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/virtru-dark.json
+++ b/internal/config/themes/virtru-dark.json
@@ -16,6 +16,10 @@
     "fg": "#6e6e6e"
   },
   "statusBar": {},
+  "commitMessage": {
+    "fg": "#fafafa",
+    "bg": "#2a3038"
+  },
   "tabs": {
     "active": {
       "fg": "#fafafa",
@@ -83,6 +87,11 @@
     },
     "modified": {
       "bg": "#2e2e1e"
+    },
+    "collapsed": {
+      "fg": "#1f1f1f",
+      "bg": "#4fc3f7",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/config/themes/zenith.json
+++ b/internal/config/themes/zenith.json
@@ -22,6 +22,10 @@
     "fg": "#abb2bf",
     "bg": "#1e2227"
   },
+  "commitMessage": {
+    "fg": "#c8ccd4",
+    "bg": "#2e3440"
+  },
   "tabs": {
     "active": {
       "fg": "#e2e6ed",
@@ -139,6 +143,11 @@
     },
     "modified": {
       "bg": "#2e2e1e"
+    },
+    "collapsed": {
+      "fg": "#23272e",
+      "bg": "#7ab0df",
+      "bold": true
     }
   },
   "scrollbar": {

--- a/internal/core/diff/diff.go
+++ b/internal/core/diff/diff.go
@@ -12,6 +12,7 @@ const (
 	Context
 	Added
 	Deleted
+	Collapsed
 )
 
 type SideLine struct {

--- a/internal/git/commit_files_test.go
+++ b/internal/git/commit_files_test.go
@@ -1,0 +1,320 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func runOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// buildHistoryRepo produces a repo with, in order: a root commit, a commit on a
+// side branch, a commit on the main line, a true merge of the two, and a rename.
+// It returns the hashes keyed by subject.
+func buildHistoryRepo(t *testing.T) (string, map[string]string) {
+	t.Helper()
+	dir := setupTestRepo(t)
+	// A developer's global commit.gpgsign would block on a passphrase prompt.
+	gitRun(t, dir, "config", "commit.gpgsign", "false")
+	gitRun(t, dir, "checkout", "-q", "-b", "main")
+
+	writeFile(t, dir, "a.txt", "a\n")
+	writeFile(t, dir, "b.txt", "b\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-qm", "root")
+
+	gitRun(t, dir, "checkout", "-q", "-b", "side")
+	writeFile(t, dir, "c.txt", "c\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-qm", "side")
+
+	gitRun(t, dir, "checkout", "-q", "main")
+	writeFile(t, dir, "a.txt", "a\na2\n")
+	gitRun(t, dir, "commit", "-qam", "mainline")
+
+	gitRun(t, dir, "merge", "-q", "--no-ff", "side", "-m", "merge")
+
+	gitRun(t, dir, "mv", "a.txt", "renamed.txt")
+	gitRun(t, dir, "commit", "-qm", "rename")
+
+	hashes := map[string]string{}
+	for _, subject := range []string{"root", "side", "mainline", "merge", "rename"} {
+		out, err := runOutput(dir, "log", "--format=%h", "-1", "--grep", "^"+subject+"$", "--all")
+		if err != nil {
+			t.Fatalf("resolving %q: %v", subject, err)
+		}
+		hashes[subject] = out
+	}
+	return dir, hashes
+}
+
+func paths(files []FileStatus) []string {
+	out := make([]string, len(files))
+	for i, f := range files {
+		out[i] = f.Status + " " + f.Path
+	}
+	return out
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// A merge commit is the case that fails without --diff-merges=first-parent:
+// plain `git show --name-status` prints nothing at all for one. Drop the flag in
+// CommitFiles and this test goes red while every other case here still passes.
+func TestCommitFilesMerge(t *testing.T) {
+	dir, hashes := buildHistoryRepo(t)
+	files, err := CommitFiles(dir, hashes["merge"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"A c.txt"}; !equal(paths(files), want) {
+		t.Errorf("merge commit: got %v, want %v", paths(files), want)
+	}
+}
+
+func TestCommitFilesRootCommit(t *testing.T) {
+	dir, hashes := buildHistoryRepo(t)
+	files, err := CommitFiles(dir, hashes["root"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"A a.txt", "A b.txt"}; !equal(paths(files), want) {
+		t.Errorf("root commit: got %v, want %v", paths(files), want)
+	}
+}
+
+func TestCommitFilesModified(t *testing.T) {
+	dir, hashes := buildHistoryRepo(t)
+	files, err := CommitFiles(dir, hashes["mainline"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"M a.txt"}; !equal(paths(files), want) {
+		t.Errorf("modified: got %v, want %v", paths(files), want)
+	}
+}
+
+// --name-status reports a rename as "R100", with the old and new path as two
+// further records. The similarity score must not reach FileStatus.Status, which
+// the whole UI treats as a single letter.
+func TestCommitFilesRename(t *testing.T) {
+	dir, hashes := buildHistoryRepo(t)
+	files, err := CommitFiles(dir, hashes["rename"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("rename: got %v, want one file", paths(files))
+	}
+	f := files[0]
+	if f.Status != "R" {
+		t.Errorf("status = %q, want %q", f.Status, "R")
+	}
+	if f.Path != "renamed.txt" {
+		t.Errorf("path = %q, want %q", f.Path, "renamed.txt")
+	}
+	if f.OldPath != "a.txt" {
+		t.Errorf("old path = %q, want %q", f.OldPath, "a.txt")
+	}
+}
+
+func TestCommitFilesPathWithSpaces(t *testing.T) {
+	dir := setupTestRepo(t)
+	gitRun(t, dir, "config", "commit.gpgsign", "false")
+	writeFile(t, dir, "my file.txt", "hello\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-qm", "spaces")
+
+	out, err := runOutput(dir, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := CommitFiles(dir, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"A my file.txt"}; !equal(paths(files), want) {
+		t.Errorf("got %v, want %v", paths(files), want)
+	}
+}
+
+func TestCommitFilesUnknownHash(t *testing.T) {
+	dir := setupTestRepo(t)
+	if _, err := CommitFiles(dir, "deadbee"); err == nil {
+		t.Error("expected an error for an unknown hash")
+	}
+}
+
+func TestCommitFileDiffRename(t *testing.T) {
+	dir, hashes := buildHistoryRepo(t)
+	files, err := CommitFiles(dir, hashes["rename"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := CommitFileDiff(dir, hashes["rename"], files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == "" {
+		t.Fatal("rename diff is empty; both sides of the rename must be passed to git")
+	}
+}
+
+func TestCommitFileDiffMerge(t *testing.T) {
+	dir, hashes := buildHistoryRepo(t)
+	out, err := CommitFileDiff(dir, hashes["merge"], FileStatus{Status: "A", Path: "c.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == "" {
+		t.Fatal("merge diff is empty; --diff-merges=first-parent is missing")
+	}
+}
+
+func TestCommitMessageIncludesSubjectAndBody(t *testing.T) {
+	dir := setupTestRepo(t)
+	gitRun(t, dir, "config", "commit.gpgsign", "false")
+	writeFile(t, dir, "message.txt", "content\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-qm", "Detailed subject", "-m", "First body line.\n\nSecond paragraph.")
+
+	message, err := CommitMessage(dir, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "Detailed subject\n\nFirst body line.\n\nSecond paragraph."
+	if message != want {
+		t.Fatalf("CommitMessage() = %q, want %q", message, want)
+	}
+}
+
+// -- only stops option parsing; without --literal-pathspecs these legal file
+// names either match unrelated files or act as pathspec magic and disappear.
+// CommitFiles itself has no input pathspec, while ShowFile uses Git's
+// <ref>:<path> object syntax; exercising both here keeps those distinct forms
+// exact as the diff path is hardened.
+func TestCommitPathsWithPathspecMagicAreLiteral(t *testing.T) {
+	dir := setupTestRepo(t)
+	gitRun(t, dir, "config", "commit.gpgsign", "false")
+	contents := map[string]string{
+		"*.txt":           "literal star\n",
+		":(exclude)*.txt": "literal magic\n",
+		"other.txt":       "unrelated\n",
+	}
+	for path, content := range contents {
+		writeFile(t, dir, path, content)
+	}
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-qm", "pathspec names")
+
+	ref, err := runOutput(dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := CommitFiles(dir, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := make(map[string]FileStatus, len(files))
+	for _, f := range files {
+		byPath[f.Path] = f
+	}
+
+	for _, path := range []string{"*.txt", ":(exclude)*.txt"} {
+		t.Run(path, func(t *testing.T) {
+			status, ok := byPath[path]
+			if !ok {
+				t.Fatalf("CommitFiles lost literal path %q: %+v", path, files)
+			}
+			out, err := CommitFileDiff(dir, ref, status)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Count(out, "diff --git ") != 1 || !strings.Contains(out, "+"+strings.TrimSpace(contents[path])) {
+				t.Fatalf("single-file diff did not select literal path %q:\n%s", path, out)
+			}
+			for other, content := range contents {
+				if other != path && strings.Contains(out, "+"+strings.TrimSpace(content)) {
+					t.Fatalf("diff for %q included unrelated path %q:\n%s", path, other, out)
+				}
+			}
+
+			blob, err := ShowFile(dir, path, ref)
+			if err != nil {
+				t.Fatalf("ShowFile(%q): %v", path, err)
+			}
+			if blob != contents[path] {
+				t.Fatalf("ShowFile(%q) = %q, want %q", path, blob, contents[path])
+			}
+		})
+	}
+}
+
+// The parser is exercised directly because the copy record it must handle is
+// not reachable through CommitFiles: -M asks for renames only, and the flags
+// that do produce a C record either need the source modified in the same commit
+// (-C) or compare against the whole tree (--find-copies-harder).
+func TestParseNameStatusZ(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "M\x00a.txt\x00", []string{"M a.txt"}},
+		{"several", "M\x00a.txt\x00A\x00b.txt\x00D\x00c.txt\x00", []string{"M a.txt", "A b.txt", "D c.txt"}},
+		{"typechange", "T\x00link\x00", []string{"T link"}},
+		{"rename last", "M\x00a.txt\x00R100\x00old\x00new\x00", []string{"M a.txt", "R new"}},
+		// The record after a rename or copy is where an off-by-one shows up:
+		// consume two fields instead of three and every later record shifts.
+		{"rename first", "R100\x00old\x00new\x00M\x00a.txt\x00", []string{"R new", "M a.txt"}},
+		{"copy first", "C085\x00source.txt\x00copy.txt\x00M\x00source.txt\x00", []string{"C copy.txt", "M source.txt"}},
+		{"path with spaces", "A\x00my file.txt\x00", []string{"A my file.txt"}},
+		{"path with a newline", "A\x00two\nlines.txt\x00", []string{"A two\nlines.txt"}},
+		{"leading dash", "A\x00--dash.txt\x00", []string{"A --dash.txt"}},
+		// A stream cut mid-record must drop the partial one, not invent a path.
+		{"truncated pair", "M\x00a.txt\x00A\x00", []string{"M a.txt"}},
+		{"truncated rename", "M\x00a.txt\x00R100\x00old\x00", []string{"M a.txt"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paths(parseNameStatusZ([]byte(tt.in)))
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !equal(got, tt.want) {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The similarity score must not survive into Status: the UI treats it as one
+// letter and would render "R100" as the badge.
+func TestParseNameStatusZDropsSimilarityScore(t *testing.T) {
+	files := parseNameStatusZ([]byte("R100\x00old\x00new\x00"))
+	if len(files) != 1 {
+		t.Fatalf("got %d records, want 1", len(files))
+	}
+	if files[0].Status != "R" {
+		t.Errorf("status = %q, want %q", files[0].Status, "R")
+	}
+	if files[0].OldPath != "old" {
+		t.Errorf("old path = %q, want %q", files[0].OldPath, "old")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -181,6 +181,13 @@ type LogEntry struct {
 	Message string
 }
 
+// LogPage is one stable window into a commit history. HasMore is determined by
+// reading one extra entry, so callers never need a separate count query.
+type LogPage struct {
+	Entries []LogEntry
+	HasMore bool
+}
+
 func Log(dir string, n int) []LogEntry {
 	entries, _ := LogWithError(dir, n)
 	return entries
@@ -193,31 +200,76 @@ func LogWithError(dir string, n int) ([]LogEntry, error) {
 }
 
 func LogWithErrorContext(ctx context.Context, dir string, n int) ([]LogEntry, error) {
-	cmd := exec.CommandContext(ctx, "git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
+	anchor, err := HeadSHAContext(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	page, err := LogPageContext(ctx, dir, anchor, 0, n)
+	return page.Entries, err
+}
+
+// HeadSHAContext resolves HEAD once so subsequent pages can stay anchored to
+// the same history even if new commits arrive while the reader is browsing.
+func HeadSHAContext(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return "", ctx.Err()
 		}
-		head := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "HEAD")
-		if head.Run() != nil && IsRepoContext(ctx, dir) {
-			return nil, nil
+		if IsRepoContext(ctx, dir) {
+			return "", nil
 		}
-		return nil, err
+		return "", err
 	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// LogPageContext reads a page from an immutable anchor. The NUL-delimited
+// format preserves subjects containing spaces.
+func LogPageContext(ctx context.Context, dir, anchor string, skip, limit int) (LogPage, error) {
+	if anchor == "" || limit <= 0 {
+		return LogPage{}, nil
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "log",
+		"-z",
+		fmt.Sprintf("--skip=%d", skip),
+		fmt.Sprintf("--max-count=%d", limit+1),
+		"--format=%H%x00%h%x00%s",
+		anchor,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return LogPage{}, ctx.Err()
+		}
+		return LogPage{}, err
+	}
+	fields := strings.Split(strings.TrimSuffix(string(out), "\x00"), "\x00")
 	var entries []LogEntry
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line == "" {
-			continue
-		}
-		ref, rest, ok := strings.Cut(line, " ")
-		if !ok {
-			continue
-		}
-		hash, msg, _ := strings.Cut(rest, " ")
-		entries = append(entries, LogEntry{Hash: hash, Ref: ref, Message: msg})
+	for len(fields) >= 3 {
+		ref := fields[0]
+		hash := fields[1]
+		entries = append(entries, LogEntry{
+			Ref: ref, Hash: hash, Message: fields[2],
+		})
+		fields = fields[3:]
 	}
-	return entries, nil
+	hasMore := len(entries) > limit
+	if hasMore {
+		entries = entries[:limit]
+	}
+	return LogPage{Entries: entries, HasMore: hasMore}, nil
+}
+
+// CommitAuthoredAt returns the authored timestamp Git recorded for a commit.
+func CommitAuthoredAt(dir, ref string) (time.Time, error) {
+	cmd := exec.Command("git", "-C", dir, "show", "-s", "--format=%aI", ref)
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Parse(time.RFC3339, strings.TrimSpace(string(out)))
 }
 
 // CommitFiles lists the files a commit touched.
@@ -479,8 +531,12 @@ func IgnoredFiles(dir string, paths []string) map[string]bool {
 }
 
 func ShowFile(dir, path, ref string) (string, error) {
+	return ShowFileContext(context.Background(), dir, path, ref)
+}
+
+func ShowFileContext(ctx context.Context, dir, path, ref string) (string, error) {
 	spec := ref + ":" + path
-	cmd := exec.Command("git", "-C", dir, "show", spec)
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "show", spec)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -154,12 +154,16 @@ func BranchName(dir string) string {
 }
 
 type LogEntry struct {
+	// Hash is the abbreviated hash, for display only. Its length depends on
+	// core.abbrev and on how many objects the repo holds, so it is not stable
+	// enough to key anything on — use Ref for that.
 	Hash    string
+	Ref     string
 	Message string
 }
 
 func Log(dir string, n int) []LogEntry {
-	cmd := exec.Command("git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%h %s")
+	cmd := exec.Command("git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil
@@ -169,10 +173,96 @@ func Log(dir string, n int) []LogEntry {
 		if line == "" {
 			continue
 		}
-		hash, msg, _ := strings.Cut(line, " ")
-		entries = append(entries, LogEntry{Hash: hash, Message: msg})
+		ref, rest, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		hash, msg, _ := strings.Cut(rest, " ")
+		entries = append(entries, LogEntry{Hash: hash, Ref: ref, Message: msg})
 	}
 	return entries
+}
+
+// CommitFiles lists the files a commit touched.
+//
+// --diff-merges=first-parent is not cosmetic: `git show --name-status` prints
+// nothing at all for a merge commit, so without it every merge in the log would
+// expand to an empty file list.
+//
+// -M asks for rename detection only. Copies need -C, which finds only copies of
+// files the same commit also modified, or --find-copies-harder, which compares
+// against the whole tree and is far too slow to run from a panel.
+// parseNameStatusZ still handles the copy record, because the format allows one
+// and mis-reading it would shift every record after it.
+func CommitFiles(dir, hash string) ([]FileStatus, error) {
+	cmd := exec.Command("git", "-C", dir, "show", "--name-status",
+		"--diff-merges=first-parent", "-M", "--format=", "-z", hash)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseNameStatusZ(out), nil
+}
+
+// parseNameStatusZ reads `--name-status -z` output. -z drops git's path
+// quoting, so a record is exactly "status<NUL>path<NUL>" — or, for a rename or
+// a copy, "Rxxx<NUL>old<NUL>new<NUL>", where xxx is a similarity score the rest
+// of the app does not want.
+func parseNameStatusZ(out []byte) []FileStatus {
+	fields := strings.Split(strings.TrimSuffix(string(out), "\x00"), "\x00")
+	var files []FileStatus
+	for i := 0; i < len(fields); {
+		code := fields[i]
+		if code == "" {
+			i++
+			continue
+		}
+		st := code[:1]
+		if st == "R" || st == "C" {
+			// A truncated three-field record is dropped rather than read as a
+			// two-field one, which would misalign every record after it.
+			if i+2 >= len(fields) {
+				break
+			}
+			files = append(files, FileStatus{Status: st, OldPath: fields[i+1], Path: fields[i+2]})
+			i += 3
+			continue
+		}
+		if i+1 >= len(fields) {
+			break
+		}
+		files = append(files, FileStatus{Status: st, Path: fields[i+1]})
+		i += 2
+	}
+	return files
+}
+
+// CommitFileDiff returns the diff a single commit applied to one file.
+func CommitFileDiff(dir, hash string, f FileStatus) (string, error) {
+	// -- ends option parsing, but pathspec magic still applies after it. Disable
+	// that separately so legal names such as "*.txt" and ":(exclude)*" select
+	// the one committed path the reader asked for.
+	args := []string{"-C", dir, "--literal-pathspecs", "show", "--diff-merges=first-parent", "-M", "--format=", hash, "--"}
+	if f.OldPath != "" {
+		args = append(args, f.OldPath)
+	}
+	args = append(args, f.Path)
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// CommitMessage returns the complete message for one commit, including its
+// subject and body. The trailing newline Git prints is presentation framing,
+// not part of the message shown in the detail view.
+func CommitMessage(dir, hash string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "show", "-s", "--format=%B", hash).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
 }
 
 type BlameInfo struct {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +18,11 @@ type FileStatus struct {
 }
 
 func RepoRoot(dir string) string {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
+	return RepoRootContext(context.Background(), dir)
+}
+
+func RepoRootContext(ctx context.Context, dir string) string {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -26,13 +31,21 @@ func RepoRoot(dir string) string {
 }
 
 func IsRepo(dir string) bool {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--is-inside-work-tree")
+	return IsRepoContext(context.Background(), dir)
+}
+
+func IsRepoContext(ctx context.Context, dir string) bool {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--is-inside-work-tree")
 	out, err := cmd.Output()
 	return err == nil && strings.TrimSpace(string(out)) == "true"
 }
 
 func StatusFiles(dir string) ([]FileStatus, error) {
-	cmd := exec.Command("git", "-C", dir, "status", "--porcelain", "-u")
+	return StatusFilesContext(context.Background(), dir)
+}
+
+func StatusFilesContext(ctx context.Context, dir string) ([]FileStatus, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "status", "--porcelain", "-u")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -145,12 +158,17 @@ func Push(dir string) error {
 }
 
 func BranchName(dir string) string {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
+	name, _ := BranchNameContext(context.Background(), dir)
+	return name
+}
+
+func BranchNameContext(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(string(out)), nil
 }
 
 type LogEntry struct {
@@ -163,10 +181,28 @@ type LogEntry struct {
 }
 
 func Log(dir string, n int) []LogEntry {
-	cmd := exec.Command("git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
+	entries, _ := LogWithError(dir, n)
+	return entries
+}
+
+// LogWithError distinguishes a legitimate repository with no commits from a
+// transient read failure, so callers can preserve the last good history.
+func LogWithError(dir string, n int) ([]LogEntry, error) {
+	return LogWithErrorContext(context.Background(), dir, n)
+}
+
+func LogWithErrorContext(ctx context.Context, dir string, n int) ([]LogEntry, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
 	out, err := cmd.Output()
 	if err != nil {
-		return nil
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		head := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "HEAD")
+		if head.Run() != nil && IsRepoContext(ctx, dir) {
+			return nil, nil
+		}
+		return nil, err
 	}
 	var entries []LogEntry
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
@@ -180,7 +216,7 @@ func Log(dir string, n int) []LogEntry {
 		hash, msg, _ := strings.Cut(rest, " ")
 		entries = append(entries, LogEntry{Hash: hash, Ref: ref, Message: msg})
 	}
-	return entries
+	return entries, nil
 }
 
 // CommitFiles lists the files a commit touched.
@@ -346,6 +382,38 @@ func HeadSHA(dir string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// RevisionIdentity is a cheap fingerprint for the history surface. Including
+// the branch name catches switching between two branches that currently point
+// at the same commit, while the full object ID catches commits, pulls, resets,
+// and detached-HEAD movement.
+func RevisionIdentity(dir string) string {
+	identity, _ := RevisionIdentityContext(context.Background(), dir)
+	return identity
+}
+
+// RevisionIdentityContext returns a fingerprint that changes for either a new
+// HEAD commit or a branch switch. An unborn repository is a known empty
+// identity rather than a read failure.
+func RevisionIdentityContext(ctx context.Context, dir string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "HEAD", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		head := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "HEAD")
+		if head.Run() != nil && IsRepoContext(ctx, dir) {
+			return "", nil
+		}
+		return "", err
+	}
+	parts := strings.Fields(string(out))
+	if len(parts) < 2 {
+		return "", fmt.Errorf("unexpected revision identity output")
+	}
+	return parts[0] + "\x00" + parts[1], nil
 }
 
 func RemoteURL(dir string) string {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -531,4 +532,49 @@ func DiffRename(dir, oldPath, newPath string) (string, error) {
 		}
 	}
 	return string(out), nil
+}
+
+// DiffWorkingTreeFileContext returns the final working-tree state relative to HEAD,
+// combining staged and unstaged edits into one document. Untracked files are
+// compared with /dev/null so callers can render them as ordinary additions.
+func DiffWorkingTreeFileContext(ctx context.Context, dir string, status FileStatus) (string, error) {
+	path := filepath.Join(dir, status.Path)
+	if status.Status == "?" {
+		return diffFileFromEmptyContext(ctx, dir, path)
+	}
+
+	paths := []string{"--", path}
+	if status.OldPath != "" && status.OldPath != status.Path {
+		paths = []string{"--", filepath.Join(dir, status.OldPath), path}
+	}
+	args := append([]string{"-C", dir, "--literal-pathspecs", "diff", "HEAD"}, paths...)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := cmd.Output()
+	if err == nil {
+		return string(out), nil
+	}
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	// HEAD is absent in an unborn repository. Compare the final worktree file,
+	// not merely its staged snapshot, with the empty tree.
+	head := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "HEAD")
+	if head.Run() != nil && IsRepoContext(ctx, dir) {
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			return "", nil
+		} else if statErr != nil {
+			return "", statErr
+		}
+		return diffFileFromEmptyContext(ctx, dir, path)
+	}
+	return "", err
+}
+
+func diffFileFromEmptyContext(ctx context.Context, dir, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "diff", "--no-index", "--", "/dev/null", path)
+	out, err := cmd.Output()
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return string(out), nil
+	}
+	return string(out), err
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -187,6 +188,39 @@ func TestLogWithErrorDistinguishesEmptyRepoFromFailure(t *testing.T) {
 	}
 	if _, err := LogWithError(t.TempDir(), 10); err == nil {
 		t.Fatal("non-repository log failure was reported as an empty success")
+	}
+}
+
+func TestLogPageStaysAnchoredWhenHeadAdvances(t *testing.T) {
+	dir := setupTestRepo(t)
+	for i := 1; i <= 4; i++ {
+		writeFile(t, dir, "history.txt", fmt.Sprintf("%d\n", i))
+		gitRun(t, dir, "add", "history.txt")
+		gitRun(t, dir, "commit", "-qm", fmt.Sprintf("commit %d", i))
+	}
+
+	anchor, err := HeadSHAContext(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := LogPageContext(context.Background(), dir, anchor, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.HasMore || len(first.Entries) != 2 || first.Entries[0].Message != "commit 4" || first.Entries[1].Message != "commit 3" {
+		t.Fatalf("first page = %+v", first)
+	}
+	// Advance live HEAD after page one. Page two must continue from the saved
+	// anchor, not reinterpret --skip against the now-shifted branch.
+	writeFile(t, dir, "history.txt", "5\n")
+	gitRun(t, dir, "add", "history.txt")
+	gitRun(t, dir, "commit", "-qm", "commit 5")
+	second, err := LogPageContext(context.Background(), dir, anchor, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.HasMore || len(second.Entries) != 2 || second.Entries[0].Message != "commit 2" || second.Entries[1].Message != "commit 1" {
+		t.Fatalf("anchored second page = %+v", second)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -848,3 +848,21 @@ func TestStageReportsError(t *testing.T) {
 		t.Error("expected an error staging a missing path")
 	}
 }
+
+func TestDiffWorkingTreeFileContextUsesFinalContentInUnbornRepository(t *testing.T) {
+	dir := setupTestRepo(t)
+	writeFile(t, dir, "new.txt", "staged version\n")
+	gitRun(t, dir, "-C", dir, "add", "new.txt")
+	writeFile(t, dir, "new.txt", "final working version\n")
+
+	got, err := DiffWorkingTreeFileContext(context.Background(), dir, FileStatus{Status: "M", Path: "new.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "+final working version") {
+		t.Fatalf("diff omitted final working content:\n%s", got)
+	}
+	if strings.Contains(got, "+staged version") {
+		t.Fatalf("diff stopped at staged snapshot:\n%s", got)
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,9 +1,11 @@
 package git
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -137,6 +139,62 @@ func TestStatusFilesEmpty(t *testing.T) {
 	}
 	if len(files) != 0 {
 		t.Errorf("expected no files, got %d: %+v", len(files), files)
+	}
+}
+
+func TestRevisionIdentityTracksHeadAndBranch(t *testing.T) {
+	dir := setupTestRepo(t)
+	writeFile(t, dir, "initial.txt", "hello\n")
+	gitRun(t, dir, "add", "initial.txt")
+	gitRun(t, dir, "commit", "-m", "init")
+
+	initial := RevisionIdentity(dir)
+	if initial == "" {
+		t.Fatal("RevisionIdentity returned an empty identity for a committed repository")
+	}
+
+	gitRun(t, dir, "switch", "-c", "same-head")
+	branched := RevisionIdentity(dir)
+	if branched == initial {
+		t.Fatal("RevisionIdentity did not change when the branch changed at the same commit")
+	}
+	if !strings.HasSuffix(branched, "\x00same-head") {
+		t.Fatalf("RevisionIdentity branch suffix = %q, want same-head", branched)
+	}
+
+	writeFile(t, dir, "initial.txt", "changed\n")
+	gitRun(t, dir, "add", "initial.txt")
+	gitRun(t, dir, "commit", "-m", "change")
+	if committed := RevisionIdentity(dir); committed == branched {
+		t.Fatal("RevisionIdentity did not change when HEAD advanced")
+	}
+}
+
+func TestRevisionIdentityAllowsUnbornRepository(t *testing.T) {
+	dir := setupTestRepo(t)
+	identity, err := RevisionIdentityContext(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unborn repository identity returned an error: %v", err)
+	}
+	if identity != "" {
+		t.Fatalf("unborn repository identity = %q, want empty", identity)
+	}
+}
+
+func TestLogWithErrorDistinguishesEmptyRepoFromFailure(t *testing.T) {
+	if entries, err := LogWithError(setupTestRepo(t), 10); err != nil || len(entries) != 0 {
+		t.Fatalf("empty repository log = (%+v, %v), want empty success", entries, err)
+	}
+	if _, err := LogWithError(t.TempDir(), 10); err == nil {
+		t.Fatal("non-repository log failure was reported as an empty success")
+	}
+}
+
+func TestStatusFilesContextHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := StatusFilesContext(ctx, setupTestRepo(t)); err == nil {
+		t.Fatal("canceled status context returned success")
 	}
 }
 

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -551,6 +551,10 @@ func parseLuaMenuEntries(L *lua.LState, tbl *lua.LTable) []widgets.MenuEntry {
 		if sep := L.GetField(entry, "separator"); sep != lua.LNil {
 			me.Separator = lua.LVAsBool(sep)
 		}
+		if checked := L.GetField(entry, "checked"); checked != lua.LNil {
+			value := lua.LVAsBool(checked)
+			me.Checked = &value
+		}
 		entries = append(entries, me)
 	})
 	return entries

--- a/internal/plugin/panel_widget_test.go
+++ b/internal/plugin/panel_widget_test.go
@@ -176,7 +176,7 @@ func TestTitleWidgetLuaFields(t *testing.T) {
 						icon = "+",
 						padded = true,
 						menu = {
-							{ label = "Refresh", command = "refresh" },
+							{ label = "Refresh", command = "refresh", checked = true },
 						},
 						on_menu = function(cmd) end,
 					})
@@ -215,6 +215,9 @@ func TestTitleWidgetLuaFields(t *testing.T) {
 	}
 	if len(desc.Entries) != 1 || desc.Entries[0].Label != "Refresh" || desc.Entries[0].Command != "refresh" {
 		t.Errorf("expected menu entry Refresh/refresh, got %+v", desc.Entries)
+	}
+	if desc.Entries[0].Checked == nil || !*desc.Entries[0].Checked {
+		t.Errorf("expected checked menu entry, got %+v", desc.Entries[0])
 	}
 	if desc.OnMenu == nil {
 		t.Error("expected on_menu callback to be wired")

--- a/internal/term/screen.go
+++ b/internal/term/screen.go
@@ -5,6 +5,7 @@ type Style int
 const (
 	StyleDefault Style = iota
 	StyleStatusBar
+	StyleCommitMessage
 	StyleActiveTab
 	StyleInactiveTab
 	StyleSidebarSelected
@@ -21,6 +22,7 @@ const (
 	StyleDiffAdded
 	StyleDiffDeleted
 	StyleDiffModified
+	StyleDiffCollapsed
 	StyleScrollbar
 	StyleScrollbarThumb
 	StyleActiveLine

--- a/internal/term/screen_test.go
+++ b/internal/term/screen_test.go
@@ -209,6 +209,7 @@ func TestStyleConstants(t *testing.T) {
 	styles := map[string]Style{
 		"StyleDefault":        StyleDefault,
 		"StyleStatusBar":      StyleStatusBar,
+		"StyleCommitMessage":  StyleCommitMessage,
 		"StyleActiveTab":      StyleActiveTab,
 		"StyleInactiveTab":    StyleInactiveTab,
 		"StyleSelection":      StyleSelection,
@@ -218,6 +219,7 @@ func TestStyleConstants(t *testing.T) {
 		"StyleDiffAdded":      StyleDiffAdded,
 		"StyleDiffDeleted":    StyleDiffDeleted,
 		"StyleDiffModified":   StyleDiffModified,
+		"StyleDiffCollapsed":  StyleDiffCollapsed,
 		"StyleSyntaxComment":  StyleSyntaxComment,
 		"StyleSyntaxString":   StyleSyntaxString,
 		"StyleSyntaxKeyword":  StyleSyntaxKeyword,

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -17,10 +17,12 @@ import (
 // the order Git reports them; a failed or hunk-less diff still gets a heading
 // and an explanatory row so a touched path never silently disappears.
 type CommitDetailFile struct {
-	Path    string
-	OldPath string
-	Diff    diff.FileDiff
-	Error   string
+	Path         string
+	OldPath      string
+	Heading      string
+	HeadingStyle term.Style
+	Diff         diff.FileDiff
+	Error        string
 
 	highlighter *highlight.Highlighter
 	lines       []diff.DiffLine
@@ -64,11 +66,17 @@ type commitDetailControl struct {
 // full-screen cell grid for every changed line on every redraw.
 type CommitDetailWidget struct {
 	BaseWidget
-	Dir     string
-	Ref     string
-	Short   string
-	Loading bool
-	Error   string
+	Dir             string
+	Ref             string
+	Short           string
+	Loading         bool
+	Error           string
+	Header          string
+	EmptyText       string
+	LoadingText     string
+	CurrentChanges  bool
+	HideEmptyNotice bool
+	LoadGen         uint64
 
 	Message string
 	Files   []CommitDetailFile
@@ -124,6 +132,23 @@ func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *Commit
 		Ref:             ref,
 		Short:           short,
 		Loading:         true,
+		Header:          "Commit message",
+		EmptyText:       "No files",
+		LoadingText:     fmt.Sprintf("Loading commit %s…", short),
+		SyntaxHighlight: syntaxHighlight,
+	}
+}
+
+func NewCurrentChangesWidget(dir string, syntaxHighlight bool) *CommitDetailWidget {
+	return &CommitDetailWidget{
+		Dir:             dir,
+		Ref:             "working-tree",
+		Loading:         true,
+		Header:          "Current changes",
+		EmptyText:       "No changes",
+		LoadingText:     "Loading current changes…",
+		CurrentChanges:  true,
+		HideEmptyNotice: true,
 		SyntaxHighlight: syntaxHighlight,
 	}
 }
@@ -195,17 +220,28 @@ func (d *CommitDetailWidget) applyMode(mode DiffMode) {
 }
 
 func (d *CommitDetailWidget) SetDetail(message string, files []CommitDetailFile, errText string) {
+	collapsed := make(map[string]bool)
+	topLine := 0
+	if d.CurrentChanges {
+		topLine = d.TopLine
+		for i, file := range d.Files {
+			if i < len(d.collapsedFiles) && d.collapsedFiles[i] {
+				collapsed[commitDetailFileKey(file)] = true
+			}
+		}
+	}
 	d.Loading = false
 	d.Error = errText
 	d.Message = message
 	d.Files = files
 	d.collapsedFiles = make([]bool, len(files))
 	for i := range d.Files {
+		d.collapsedFiles[i] = collapsed[commitDetailFileKey(d.Files[i])]
 		if d.SyntaxHighlight && d.Files[i].Path != "" {
 			d.Files[i].highlighter = highlight.New(d.Files[i].Path)
 		}
 	}
-	d.TopLine = 0
+	d.TopLine = topLine
 	d.LeftCol = 0
 	d.ClearSelection()
 	d.rebuildRows()
@@ -268,10 +304,17 @@ func (d *CommitDetailWidget) rebuildRows() {
 		return
 	}
 
-	d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageHeaderRow, text: "Commit message", bold: true})
+	header := d.Header
+	if header == "" {
+		header = "Commit message"
+	}
+	d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageHeaderRow, text: header, bold: true})
 	message := strings.TrimRight(d.Message, "\r\n")
 	if message == "" {
 		message = "(No commit message)"
+		if d.CurrentChanges {
+			message = "Working tree clean"
+		}
 	}
 	for i, line := range strings.Split(message, "\n") {
 		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageRow, text: line, bold: i == 0})
@@ -331,10 +374,13 @@ func (d *CommitDetailWidget) rebuildRows() {
 			}
 		}
 	}
-	if len(d.Files) == 0 {
-		const noFiles = "No files"
-		d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: noFiles})
-		d.recordWidth(noFiles)
+	if len(d.Files) == 0 && !d.HideEmptyNotice {
+		emptyText := d.EmptyText
+		if emptyText == "" {
+			emptyText = "No files"
+		}
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: emptyText})
+		d.recordWidth(emptyText)
 	}
 	if maxLine > 0 {
 		d.gutterW = textwidth.String(strconv.Itoa(maxLine)) + 3
@@ -349,10 +395,17 @@ func (d *CommitDetailWidget) recordWidth(text string) {
 }
 
 func commitDetailFileHeading(file CommitDetailFile) string {
+	if file.Heading != "" {
+		return file.Heading
+	}
 	if file.OldPath != "" && file.OldPath != file.Path {
 		return fmt.Sprintf("%s → %s", file.OldPath, file.Path)
 	}
 	return file.Path
+}
+
+func commitDetailFileKey(file CommitDetailFile) string {
+	return file.OldPath + "\x00" + file.Path
 }
 
 func (d *CommitDetailWidget) Render(surface Surface) {
@@ -364,7 +417,11 @@ func (d *CommitDetailWidget) Render(surface Surface) {
 	surface.Fill(term.Cell{Ch: ' ', Style: term.StyleDefault})
 
 	if d.Loading {
-		surface.DrawText(0, 0, fmt.Sprintf("Loading commit %s…", d.Short), w, term.StyleMuted)
+		loadingText := d.LoadingText
+		if loadingText == "" {
+			loadingText = fmt.Sprintf("Loading commit %s…", d.Short)
+		}
+		surface.DrawText(0, 0, loadingText, w, term.StyleMuted)
 		return
 	}
 	if d.Error != "" {
@@ -565,7 +622,11 @@ func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) 
 	for column := 0; column < viewW; column++ {
 		surface.SetCell(column, y, term.Cell{Ch: ' ', Style: term.StyleCommitMessage})
 	}
-	d.drawStaticText(surface, 0, y, viewW, "Commit message", term.StyleCommitMessage, term.StyleCommitMessage, true)
+	header := d.Header
+	if header == "" {
+		header = "Commit message"
+	}
+	d.drawStaticText(surface, 0, y, viewW, header, term.StyleCommitMessage, term.StyleCommitMessage, true)
 	if len(d.Files) == 0 {
 		return
 	}
@@ -575,7 +636,7 @@ func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) 
 	}
 	controlW := textwidth.String(label)
 	controlX := viewW - controlW
-	if controlX <= textwidth.String("Commit message") {
+	if controlX <= textwidth.String(header) {
 		return
 	}
 	d.drawStaticText(surface, controlX, y, controlW, label, term.StyleCommitMessage, term.StyleCommitMessage, true)
@@ -584,20 +645,24 @@ func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) 
 }
 
 func (d *CommitDetailWidget) renderHeading(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	headingStyle := term.StyleDefault
+	if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && d.Files[row.fileIndex].HeadingStyle != 0 {
+		headingStyle = d.Files[row.fileIndex].HeadingStyle
+	}
 	collapsed := row.fileIndex >= 0 && row.fileIndex < len(d.collapsedFiles) && d.collapsedFiles[row.fileIndex]
 	if !visual.continuation {
 		chevron := '▼'
 		if collapsed {
 			chevron = '▶'
 		}
-		surface.SetCell(1, y, term.Cell{Ch: chevron, Style: term.StyleDefault, Bold: true})
+		surface.SetCell(1, y, term.Cell{Ch: chevron, Style: headingStyle, Bold: true})
 	}
 	r := d.GetRect()
 	d.fileControls = append(d.fileControls, commitDetailControl{
 		rect:      Rect{X: r.X, Y: r.Y + y, W: viewW, H: 1},
 		fileIndex: row.fileIndex,
 	})
-	d.drawTextRow(surface, 3, y, viewW-3, row.text, term.StyleDefault, term.StyleDefault, row.bold, visual.leftStart, rowIndex)
+	d.drawTextRow(surface, 3, y, viewW-3, row.text, headingStyle, term.StyleDefault, row.bold, visual.leftStart, rowIndex)
 }
 
 func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
@@ -858,10 +923,14 @@ func (d *CommitDetailWidget) renderStickyHeading(surface Surface, viewW int) {
 	for column := 0; column < viewW; column++ {
 		surface.SetCell(column, 0, term.Cell{Ch: ' ', Style: term.StyleDefault})
 	}
-	surface.SetCell(1, 0, term.Cell{Ch: '▼', Style: term.StyleDefault, Bold: true})
+	headingStyle := d.Files[row.fileIndex].HeadingStyle
+	if headingStyle == 0 {
+		headingStyle = term.StyleDefault
+	}
+	surface.SetCell(1, 0, term.Cell{Ch: '▼', Style: headingStyle, Bold: true})
 	path := truncateCommitDetailPath(commitDetailFileHeading(d.Files[row.fileIndex]), viewW-3)
 	drawTextSegment(surface, 3, 0, viewW-3, path, 0, 0, term.Cell{Ch: ' '}, func(_ int, ch rune) term.Cell {
-		return term.Cell{Ch: ch, Style: term.StyleDefault, Bold: true}
+		return term.Cell{Ch: ch, Style: headingStyle, Bold: true}
 	})
 	r := d.GetRect()
 	d.stickyRect = Rect{X: r.X, Y: r.Y, W: viewW, H: 1}

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -1,0 +1,1071 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/core/highlight"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+	"github.com/gdamore/tcell/v3"
+)
+
+// CommitDetailFile is one file section in a commit detail view. Files remain in
+// the order Git reports them; a failed or hunk-less diff still gets a heading
+// and an explanatory row so a touched path never silently disappears.
+type CommitDetailFile struct {
+	Path    string
+	OldPath string
+	Diff    diff.FileDiff
+	Error   string
+
+	highlighter *highlight.Highlighter
+	lines       []diff.DiffLine
+	unified     []diffUnifiedLine
+}
+
+type commitDetailRowKind uint8
+
+const (
+	commitDetailMessageHeaderRow commitDetailRowKind = iota
+	commitDetailMessageRow
+	commitDetailSpacerRow
+	commitDetailHeadingRow
+	commitDetailNoticeRow
+	commitDetailDiffRow
+)
+
+type commitDetailRow struct {
+	kind      commitDetailRowKind
+	text      string
+	bold      bool
+	fileIndex int
+	lineIndex int
+}
+
+type commitDetailVisualRow struct {
+	row          int
+	leftStart    int
+	rightStart   int
+	continuation bool
+}
+
+type commitDetailControl struct {
+	rect      Rect
+	fileIndex int
+}
+
+// CommitDetailWidget renders an entire commit as one virtualized scrollable
+// document. Unlike stacking several DiffViewWidgets, it owns one vertical
+// viewport and only draws visible rows, so a large commit does not allocate a
+// full-screen cell grid for every changed line on every redraw.
+type CommitDetailWidget struct {
+	BaseWidget
+	Dir     string
+	Ref     string
+	Short   string
+	Loading bool
+	Error   string
+
+	Message string
+	Files   []CommitDetailFile
+
+	SyntaxHighlight bool
+	TopLine         int
+	LeftCol         int
+	wrapMode        DiffWrapMode
+	wrapExplicit    bool
+	mode            DiffMode
+	modeExplicit    bool
+	collapsedFiles  []bool
+
+	rows            []commitDetailRow
+	visualRows      []commitDetailVisualRow
+	visualRowsW     int
+	totalVisualRows int
+	maxLineW        int
+	gutterW         int
+	viewH           int
+	contentW        int
+	scrollbar       Scrollbar
+	hscrollbar      HScrollbar
+	rhscroll        HScrollbar
+
+	// Render owns these layout values. Mouse hit-testing and sticky-heading
+	// controls reuse them rather than trying to reconstruct the viewport.
+	layoutViewW      int
+	layoutLeftStart  int
+	layoutLeftW      int
+	layoutRightStart int
+	layoutRightW     int
+	fileControls     []commitDetailControl
+	topControl       Rect
+	stickyRect       Rect
+	stickyControl    commitDetailControl
+
+	// Selection positions point into logical rows and original, unwrapped text.
+	selecting     bool
+	hasSelection  bool
+	selRight      bool
+	selection     diffTextSelection
+	lastClickTime time.Time
+	lastClickPos  diffSelPos
+}
+
+func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *CommitDetailWidget {
+	return &CommitDetailWidget{
+		Dir:             dir,
+		Ref:             ref,
+		Short:           short,
+		Loading:         true,
+		SyntaxHighlight: syntaxHighlight,
+	}
+}
+
+func (d *CommitDetailWidget) Focusable() bool { return true }
+
+func (d *CommitDetailWidget) IsWrapped() bool { return d.wrapMode == DiffWrapOn }
+
+func (d *CommitDetailWidget) SetWrapped(wrapped bool) {
+	mode := DiffWrapOff
+	if wrapped {
+		mode = DiffWrapOn
+	}
+	d.SetWrapMode(mode)
+}
+
+func (d *CommitDetailWidget) WrapMode() DiffWrapMode { return d.wrapMode }
+
+func (d *CommitDetailWidget) SetWrapMode(mode DiffWrapMode) {
+	d.wrapExplicit = true
+	d.applyWrapMode(mode)
+}
+
+func (d *CommitDetailWidget) ApplyDefaultWrapMode(mode DiffWrapMode) {
+	if d.wrapExplicit {
+		return
+	}
+	d.applyWrapMode(mode)
+}
+
+func (d *CommitDetailWidget) applyWrapMode(mode DiffWrapMode) {
+	if mode == d.wrapMode {
+		return
+	}
+	d.wrapMode = mode
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.visualRowsW = -1
+	d.ClearSelection()
+}
+
+func (d *CommitDetailWidget) Mode() DiffMode { return d.mode }
+
+func (d *CommitDetailWidget) SetMode(mode DiffMode) {
+	d.modeExplicit = true
+	d.applyMode(mode)
+}
+
+func (d *CommitDetailWidget) ApplyDefaultMode(mode DiffMode) {
+	if d.modeExplicit {
+		return
+	}
+	d.applyMode(mode)
+}
+
+func (d *CommitDetailWidget) applyMode(mode DiffMode) {
+	if mode == d.mode {
+		return
+	}
+	d.mode = mode
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+	d.rebuildRows()
+}
+
+func (d *CommitDetailWidget) SetDetail(message string, files []CommitDetailFile, errText string) {
+	d.Loading = false
+	d.Error = errText
+	d.Message = message
+	d.Files = files
+	d.collapsedFiles = make([]bool, len(files))
+	for i := range d.Files {
+		if d.SyntaxHighlight && d.Files[i].Path != "" {
+			d.Files[i].highlighter = highlight.New(d.Files[i].Path)
+		}
+	}
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+	d.rebuildRows()
+}
+
+func (d *CommitDetailWidget) allFilesCollapsed() bool {
+	if len(d.Files) == 0 {
+		return false
+	}
+	for fileIndex := range d.Files {
+		if fileIndex >= len(d.collapsedFiles) || !d.collapsedFiles[fileIndex] {
+			return false
+		}
+	}
+	return true
+}
+
+func (d *CommitDetailWidget) CollapseAllFiles() {
+	d.setAllFilesCollapsed(true)
+}
+
+func (d *CommitDetailWidget) ExpandAllFiles() {
+	d.setAllFilesCollapsed(false)
+}
+
+func (d *CommitDetailWidget) setAllFilesCollapsed(collapsed bool) {
+	if len(d.collapsedFiles) != len(d.Files) {
+		d.collapsedFiles = make([]bool, len(d.Files))
+	}
+	for fileIndex := range d.collapsedFiles {
+		d.collapsedFiles[fileIndex] = collapsed
+	}
+	d.afterCollapseChange()
+}
+
+func (d *CommitDetailWidget) toggleFile(fileIndex int) {
+	if fileIndex < 0 || fileIndex >= len(d.Files) {
+		return
+	}
+	if len(d.collapsedFiles) != len(d.Files) {
+		d.collapsedFiles = make([]bool, len(d.Files))
+	}
+	d.collapsedFiles[fileIndex] = !d.collapsedFiles[fileIndex]
+	d.afterCollapseChange()
+}
+
+func (d *CommitDetailWidget) afterCollapseChange() {
+	d.ClearSelection()
+	d.rebuildRows()
+	d.clampScroll()
+}
+
+func (d *CommitDetailWidget) rebuildRows() {
+	d.rows = nil
+	d.visualRows = nil
+	d.visualRowsW = -1
+	d.maxLineW = 0
+	d.gutterW = 4
+	if d.Error != "" {
+		return
+	}
+
+	d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageHeaderRow, text: "Commit message", bold: true})
+	message := strings.TrimRight(d.Message, "\r\n")
+	if message == "" {
+		message = "(No commit message)"
+	}
+	for i, line := range strings.Split(message, "\n") {
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageRow, text: line, bold: i == 0})
+		d.recordWidth(line)
+	}
+	d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
+
+	maxLine := 0
+	for fileIndex := range d.Files {
+		file := &d.Files[fileIndex]
+		file.lines = compactDiffLines(file.Diff)
+		file.unified = buildUnifiedDiffLines(file.lines)
+		if fileIndex > 0 {
+			d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
+		}
+		heading := commitDetailFileHeading(*file)
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailHeadingRow, text: heading, bold: true, fileIndex: fileIndex})
+		d.recordWidth(heading)
+		if fileIndex < len(d.collapsedFiles) && d.collapsedFiles[fileIndex] {
+			continue
+		}
+
+		switch {
+		case file.Error != "":
+			d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: file.Error, fileIndex: fileIndex})
+			d.recordWidth(file.Error)
+		default:
+			if len(file.lines) == 0 {
+				const noChanges = "No line changes"
+				d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: noChanges, fileIndex: fileIndex})
+				d.recordWidth(noChanges)
+				continue
+			}
+			lineCount := len(file.lines)
+			if d.mode == DiffModeUnified {
+				lineCount = len(file.unified)
+			}
+			for lineIndex := 0; lineIndex < lineCount; lineIndex++ {
+				d.rows = append(d.rows, commitDetailRow{kind: commitDetailDiffRow, fileIndex: fileIndex, lineIndex: lineIndex})
+				if d.mode == DiffModeUnified {
+					line := file.unified[lineIndex].side
+					d.recordWidth(line.Text)
+					if line.Num > maxLine {
+						maxLine = line.Num
+					}
+				} else {
+					line := file.lines[lineIndex]
+					d.recordWidth(line.Left.Text)
+					d.recordWidth(line.Right.Text)
+					if line.Left.Num > maxLine {
+						maxLine = line.Left.Num
+					}
+					if line.Right.Num > maxLine {
+						maxLine = line.Right.Num
+					}
+				}
+			}
+		}
+	}
+	if len(d.Files) == 0 {
+		const noFiles = "No files"
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: noFiles})
+		d.recordWidth(noFiles)
+	}
+	if maxLine > 0 {
+		d.gutterW = textwidth.String(strconv.Itoa(maxLine)) + 3
+	}
+	d.totalVisualRows = len(d.rows)
+}
+
+func (d *CommitDetailWidget) recordWidth(text string) {
+	if width := diffLineVisualWidth(text); width > d.maxLineW {
+		d.maxLineW = width
+	}
+}
+
+func commitDetailFileHeading(file CommitDetailFile) string {
+	if file.OldPath != "" && file.OldPath != file.Path {
+		return fmt.Sprintf("%s → %s", file.OldPath, file.Path)
+	}
+	return file.Path
+}
+
+func (d *CommitDetailWidget) Render(surface Surface) {
+	w, h := surface.Size()
+	r := d.GetRect()
+	if w <= 0 || h <= 0 {
+		return
+	}
+	surface.Fill(term.Cell{Ch: ' ', Style: term.StyleDefault})
+
+	if d.Loading {
+		surface.DrawText(0, 0, fmt.Sprintf("Loading commit %s…", d.Short), w, term.StyleMuted)
+		return
+	}
+	if d.Error != "" {
+		surface.DrawText(0, 0, d.Error, w, term.StyleDanger)
+		return
+	}
+
+	viewW, viewH, showV, showH := d.layout(w, h)
+	d.viewH = viewH
+	leftStart, leftW, rightStart, rightW := d.sideGeometry(viewW)
+	d.layoutViewW = viewW
+	d.layoutLeftStart = leftStart
+	d.layoutLeftW = leftW
+	d.layoutRightStart = rightStart
+	d.layoutRightW = rightW
+	d.fileControls = nil
+	d.topControl = Rect{}
+	d.stickyRect = Rect{}
+	d.stickyControl = commitDetailControl{fileIndex: -1}
+	d.contentW = leftW
+	if d.mode == DiffModeSplit {
+		d.contentW = min(leftW, rightW)
+	}
+	d.clampScroll()
+
+	for screenY := 0; screenY < viewH; screenY++ {
+		rowIndex := d.TopLine + screenY
+		visual := commitDetailVisualRow{row: rowIndex, leftStart: 0, rightStart: 0}
+		if d.IsWrapped() {
+			if rowIndex >= len(d.visualRows) {
+				break
+			}
+			visual = d.visualRows[rowIndex]
+			rowIndex = visual.row
+		} else if rowIndex >= len(d.rows) {
+			break
+		}
+		d.renderRow(surface, rowIndex, d.rows[rowIndex], visual, screenY, viewW)
+	}
+	d.renderStickyHeading(surface, viewW)
+
+	if showV {
+		d.scrollbar.X = r.X + viewW
+		d.scrollbar.Y = r.Y
+		d.scrollbar.Height = viewH
+		d.scrollbar.TotalItems = d.totalVisualRows
+		d.scrollbar.TopItem = d.TopLine
+		d.scrollbar.Render(surface, viewW, 0)
+	} else {
+		d.scrollbar.TotalItems = 0
+	}
+	if showH && viewH < h {
+		d.renderHorizontalScrollbars(surface, r, viewW, viewH)
+	} else {
+		d.hscrollbar.TotalCols = 0
+		d.rhscroll.TotalCols = 0
+	}
+}
+
+func (d *CommitDetailWidget) layout(w, h int) (viewW, viewH int, showV, showH bool) {
+	viewH = h
+	if d.IsWrapped() {
+		showV = d.totalVisualRows > viewH
+	}
+	for range 3 {
+		viewW = w
+		if showV {
+			viewW--
+		}
+		if d.IsWrapped() {
+			if d.visualRowsW != viewW {
+				d.visualRows = d.buildVisualRows(viewW)
+				d.visualRowsW = viewW
+			}
+			d.totalVisualRows = len(d.visualRows)
+			showH = false
+		} else {
+			d.visualRows = nil
+			d.totalVisualRows = len(d.rows)
+			_, leftW, _, rightW := d.sideGeometry(viewW)
+			sideW := leftW
+			if d.mode == DiffModeSplit {
+				sideW = min(leftW, rightW)
+			}
+			showH = sideW > 0 && d.maxLineW > sideW
+		}
+		newViewH := h
+		if showH {
+			newViewH--
+		}
+		newShowV := d.totalVisualRows > newViewH
+		if newViewH == viewH && newShowV == showV {
+			break
+		}
+		viewH = newViewH
+		showV = newShowV
+	}
+	if viewW < 0 {
+		viewW = 0
+	}
+	if viewH < 0 {
+		viewH = 0
+	}
+	return
+}
+
+func (d *CommitDetailWidget) buildVisualRows(viewW int) []commitDetailVisualRow {
+	if viewW <= 0 {
+		return nil
+	}
+	_, leftW, _, rightW := d.sideGeometry(viewW)
+	visualRows := make([]commitDetailVisualRow, 0, len(d.rows))
+	for rowIndex, row := range d.rows {
+		leftStarts := []int{0}
+		rightStarts := []int{0}
+		switch row.kind {
+		case commitDetailMessageHeaderRow, commitDetailSpacerRow:
+			rightStarts = nil
+		case commitDetailHeadingRow:
+			leftStarts = diffWrapStarts(row.text, viewW-3)
+			rightStarts = nil
+		case commitDetailDiffRow:
+			if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && row.lineIndex >= 0 && leftW > 0 {
+				file := &d.Files[row.fileIndex]
+				if d.mode == DiffModeUnified && row.lineIndex < len(file.unified) {
+					leftStarts = diffWrapStarts(file.unified[row.lineIndex].side.Text, leftW)
+					rightStarts = nil
+				} else if d.mode == DiffModeSplit && row.lineIndex < len(file.lines) && rightW > 0 {
+					line := file.lines[row.lineIndex]
+					leftStarts = diffWrapStarts(line.Left.Text, leftW)
+					rightStarts = diffWrapStarts(line.Right.Text, rightW)
+				}
+			}
+		default:
+			leftStarts = diffWrapStarts(row.text, viewW)
+			rightStarts = nil
+		}
+
+		rowCount := len(leftStarts)
+		if len(rightStarts) > rowCount {
+			rowCount = len(rightStarts)
+		}
+		for segment := 0; segment < rowCount; segment++ {
+			leftStart, rightStart := -1, -1
+			if segment < len(leftStarts) {
+				leftStart = leftStarts[segment]
+			}
+			if segment < len(rightStarts) {
+				rightStart = rightStarts[segment]
+			}
+			visualRows = append(visualRows, commitDetailVisualRow{
+				row:          rowIndex,
+				leftStart:    leftStart,
+				rightStart:   rightStart,
+				continuation: segment > 0,
+			})
+		}
+	}
+	return visualRows
+}
+
+// sideGeometry returns the content widths used for every diff row. The parent
+// owns these layout values; row renderers and scrollbar placement reuse them.
+func (d *CommitDetailWidget) sideGeometry(viewW int) (leftStart, leftW, rightStart, rightW int) {
+	if d.mode == DiffModeUnified {
+		return d.gutterW, viewW - d.gutterW, 0, 0
+	}
+	dividerX := (viewW - 1) / 2
+	leftStart = d.gutterW
+	leftW = dividerX - d.gutterW
+	rightStart = dividerX + 1 + d.gutterW
+	rightW = viewW - rightStart
+	return
+}
+
+func (d *CommitDetailWidget) renderRow(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	switch row.kind {
+	case commitDetailMessageHeaderRow:
+		d.renderMessageHeader(surface, y, viewW)
+	case commitDetailSpacerRow:
+		return
+	case commitDetailMessageRow:
+		d.drawTextRow(surface, 0, y, viewW, row.text, term.StyleCommitMessage, term.StyleCommitMessage, row.bold, visual.leftStart, rowIndex)
+	case commitDetailHeadingRow:
+		d.renderHeading(surface, rowIndex, row, visual, y, viewW)
+	case commitDetailNoticeRow:
+		style := term.StyleMuted
+		if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && d.Files[row.fileIndex].Error != "" {
+			style = term.StyleDanger
+		}
+		d.drawTextRow(surface, 0, y, viewW, row.text, style, term.StyleDefault, false, visual.leftStart, rowIndex)
+	case commitDetailDiffRow:
+		d.renderDiffRow(surface, rowIndex, row, visual, y, viewW)
+	}
+}
+
+func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) {
+	for column := 0; column < viewW; column++ {
+		surface.SetCell(column, y, term.Cell{Ch: ' ', Style: term.StyleCommitMessage})
+	}
+	d.drawStaticText(surface, 0, y, viewW, "Commit message", term.StyleCommitMessage, term.StyleCommitMessage, true)
+	if len(d.Files) == 0 {
+		return
+	}
+	label := "Collapse all"
+	if d.allFilesCollapsed() {
+		label = "Expand all"
+	}
+	controlW := textwidth.String(label)
+	controlX := viewW - controlW
+	if controlX <= textwidth.String("Commit message") {
+		return
+	}
+	d.drawStaticText(surface, controlX, y, controlW, label, term.StyleCommitMessage, term.StyleCommitMessage, true)
+	r := d.GetRect()
+	d.topControl = Rect{X: r.X + controlX, Y: r.Y + y, W: controlW, H: 1}
+}
+
+func (d *CommitDetailWidget) renderHeading(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	collapsed := row.fileIndex >= 0 && row.fileIndex < len(d.collapsedFiles) && d.collapsedFiles[row.fileIndex]
+	if !visual.continuation {
+		chevron := '▼'
+		if collapsed {
+			chevron = '▶'
+		}
+		surface.SetCell(1, y, term.Cell{Ch: chevron, Style: term.StyleDefault, Bold: true})
+		r := d.GetRect()
+		d.fileControls = append(d.fileControls, commitDetailControl{
+			rect:      Rect{X: r.X + 1, Y: r.Y + y, W: 1, H: 1},
+			fileIndex: row.fileIndex,
+		})
+	}
+	d.drawTextRow(surface, 3, y, viewW-3, row.text, term.StyleDefault, term.StyleDefault, row.bold, visual.leftStart, rowIndex)
+}
+
+func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	if row.fileIndex < 0 || row.fileIndex >= len(d.Files) {
+		return
+	}
+	file := &d.Files[row.fileIndex]
+	if row.lineIndex < 0 {
+		return
+	}
+	if d.mode == DiffModeUnified {
+		d.renderUnifiedDiffRow(surface, rowIndex, file, row.lineIndex, visual, y, viewW)
+		return
+	}
+	if row.lineIndex >= len(file.lines) {
+		return
+	}
+	line := file.lines[row.lineIndex]
+	leftStart, leftW, rightStart, rightW := d.sideGeometry(viewW)
+	if leftW <= 0 || rightW <= 0 {
+		return
+	}
+	dividerX := (viewW - 1) / 2
+	surface.SetCell(dividerX, y, term.Cell{Ch: '│', Style: term.StyleBorder})
+	leftStyle := diffKindStyle(line.Left.Kind)
+	rightStyle := diffKindStyle(line.Right.Kind)
+	if visual.continuation {
+		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{}, leftStyle)
+		renderDiffGutter(surface, dividerX+1, y, d.gutterW, diff.SideLine{}, rightStyle)
+	} else {
+		renderDiffGutter(surface, 0, y, d.gutterW, line.Left, leftStyle)
+		renderDiffGutter(surface, dividerX+1, y, d.gutterW, line.Right, rightStyle)
+	}
+
+	var leftSpans, rightSpans []highlight.Span
+	if file.highlighter != nil {
+		if line.Left.Text != "" && line.Left.Kind != diff.Collapsed {
+			leftSpans = file.highlighter.HighlightLine(line.Left.Text)
+		}
+		if line.Right.Text != "" && line.Right.Kind != diff.Collapsed {
+			rightSpans = file.highlighter.HighlightLine(line.Right.Text)
+		}
+	}
+	leftScroll := d.LeftCol
+	if d.IsWrapped() {
+		leftScroll = 0
+	}
+	renderDiffText(surface, leftStart, y, leftW, line.Left.Text, leftStyle, leftSpans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
+	renderDiffText(surface, rightStart, y, rightW, line.Right.Text, rightStyle, rightSpans, visual.rightStart, leftScroll, d.selectionDecorator(rowIndex, true))
+}
+
+func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex int, file *CommitDetailFile, lineIndex int, visual commitDetailVisualRow, y, viewW int) {
+	if lineIndex >= len(file.unified) {
+		return
+	}
+	line := file.unified[lineIndex].side
+	contentStart, contentW, _, _ := d.sideGeometry(viewW)
+	if contentW <= 0 {
+		return
+	}
+	style := diffKindStyle(line.Kind)
+	if visual.continuation {
+		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{}, style)
+	} else {
+		renderDiffGutter(surface, 0, y, d.gutterW, line, style)
+	}
+	var spans []highlight.Span
+	if file.highlighter != nil && line.Text != "" && line.Kind != diff.Collapsed {
+		spans = file.highlighter.HighlightLine(line.Text)
+	}
+	leftScroll := d.LeftCol
+	if d.IsWrapped() {
+		leftScroll = 0
+	}
+	renderDiffText(surface, contentStart, y, contentW, line.Text, style, spans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
+}
+
+func (d *CommitDetailWidget) drawText(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool, segmentStart int) {
+	d.drawTextRow(surface, x, y, width, text, style, bg, bold, segmentStart, -1)
+}
+
+func (d *CommitDetailWidget) drawStaticText(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool) {
+	blank := term.Cell{Ch: ' ', Style: style, BgStyle: bg}
+	drawTextSegment(surface, x, y, width, text, 0, 0, blank, func(_ int, ch rune) term.Cell {
+		return term.Cell{Ch: ch, Style: style, BgStyle: bg, Bold: bold}
+	})
+}
+
+func (d *CommitDetailWidget) drawTextRow(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool, segmentStart, rowIndex int) {
+	leftScroll := d.LeftCol
+	if d.IsWrapped() {
+		leftScroll = 0
+	}
+	blank := term.Cell{Ch: ' ', Style: term.StyleDefault, BgStyle: bg}
+	drawTextSegment(surface, x, y, width, text, segmentStart, leftScroll, blank, func(runeIndex int, ch rune) term.Cell {
+		cell := term.Cell{Ch: ch, Style: style, BgStyle: bg, Bold: bold}
+		if rowIndex >= 0 && d.hasSelection && d.selection.Contains(rowIndex, runeIndex) {
+			cell.BgStyle = term.StyleSelection
+		}
+		return cell
+	})
+}
+
+func (d *CommitDetailWidget) selectionDecorator(rowIndex int, right bool) diffCellDecorator {
+	if !d.hasSelection || (d.mode == DiffModeSplit && right != d.selRight) {
+		return nil
+	}
+	return func(runeIndex int, cell term.Cell) term.Cell {
+		if d.selection.Contains(rowIndex, runeIndex) {
+			cell.BgStyle = term.StyleSelection
+		}
+		return cell
+	}
+}
+
+func (d *CommitDetailWidget) rowText(rowIndex int, right bool) (string, bool) {
+	if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return "", false
+	}
+	row := d.rows[rowIndex]
+	switch row.kind {
+	case commitDetailMessageRow, commitDetailHeadingRow, commitDetailNoticeRow:
+		return row.text, true
+	case commitDetailDiffRow:
+		if row.fileIndex < 0 || row.fileIndex >= len(d.Files) || row.lineIndex < 0 {
+			return "", false
+		}
+		file := &d.Files[row.fileIndex]
+		if d.mode == DiffModeUnified {
+			if row.lineIndex >= len(file.unified) {
+				return "", false
+			}
+			return file.unified[row.lineIndex].side.Text, true
+		}
+		if row.lineIndex >= len(file.lines) {
+			return "", false
+		}
+		if right {
+			return file.lines[row.lineIndex].Right.Text, true
+		}
+		return file.lines[row.lineIndex].Left.Text, true
+	default:
+		return "", false
+	}
+}
+
+func (d *CommitDetailWidget) screenToSelection(mx, my int) (pos diffSelPos, right bool, ok bool) {
+	if pointInCommitDetailRect(mx, my, d.stickyRect) {
+		return diffSelPos{}, false, false
+	}
+	r := d.GetRect()
+	localX, localY := mx-r.X, my-r.Y
+	if localX < 0 || localX >= d.layoutViewW || localY < 0 || localY >= d.viewH {
+		return diffSelPos{}, false, false
+	}
+	visualIndex := d.TopLine + localY
+	rowIndex := visualIndex
+	visual := commitDetailVisualRow{row: rowIndex, leftStart: 0, rightStart: 0}
+	if d.IsWrapped() {
+		if visualIndex < 0 || visualIndex >= len(d.visualRows) {
+			return diffSelPos{}, false, false
+		}
+		visual = d.visualRows[visualIndex]
+		rowIndex = visual.row
+	} else if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return diffSelPos{}, false, false
+	}
+	row := d.rows[rowIndex]
+	textX, textW, segmentStart := 0, d.layoutViewW, visual.leftStart
+	switch row.kind {
+	case commitDetailMessageRow, commitDetailNoticeRow:
+	case commitDetailHeadingRow:
+		textX, textW = 3, d.layoutViewW-3
+	case commitDetailDiffRow:
+		if d.mode == DiffModeUnified {
+			textX, textW = d.layoutLeftStart, d.layoutLeftW
+		} else if localX >= d.layoutLeftStart && localX < d.layoutLeftStart+d.layoutLeftW {
+			textX, textW = d.layoutLeftStart, d.layoutLeftW
+			right = false
+		} else if localX >= d.layoutRightStart && localX < d.layoutRightStart+d.layoutRightW {
+			textX, textW = d.layoutRightStart, d.layoutRightW
+			segmentStart = visual.rightStart
+			right = true
+		} else {
+			return diffSelPos{}, false, false
+		}
+	default:
+		return diffSelPos{}, false, false
+	}
+	if textW <= 0 || localX < textX || localX >= textX+textW || segmentStart < 0 {
+		return diffSelPos{}, false, false
+	}
+	text, selectable := d.rowText(rowIndex, right)
+	if !selectable {
+		return diffSelPos{}, false, false
+	}
+	visualCol := localX - textX
+	if !d.IsWrapped() {
+		visualCol += d.LeftCol
+	}
+	return diffSelPos{Line: rowIndex, Col: diffSegmentVisualColToRune(text, segmentStart, visualCol)}, right, true
+}
+
+func (d *CommitDetailWidget) selectionText() string {
+	if !d.hasSelection {
+		return ""
+	}
+	return d.selection.Text(len(d.rows), func(rowIndex int) (string, bool) {
+		return d.rowText(rowIndex, d.selRight)
+	})
+}
+
+func (d *CommitDetailWidget) CopySelection() string {
+	text := d.selectionText()
+	if text != "" {
+		d.ClearSelection()
+	}
+	return text
+}
+
+func (d *CommitDetailWidget) ClearSelection() {
+	d.hasSelection = false
+	d.selecting = false
+}
+
+func (d *CommitDetailWidget) selectWordAt(rowIndex, col int) bool {
+	text, ok := d.rowText(rowIndex, d.selRight)
+	if !ok {
+		return false
+	}
+	return d.selection.SelectWord(rowIndex, col, text)
+}
+
+func (d *CommitDetailWidget) renderStickyHeading(surface Surface, viewW int) {
+	if viewW <= 0 || d.TopLine <= 0 {
+		return
+	}
+	rowIndex := d.TopLine
+	if d.IsWrapped() {
+		if d.TopLine >= len(d.visualRows) {
+			return
+		}
+		rowIndex = d.visualRows[d.TopLine].row
+	}
+	if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return
+	}
+	row := d.rows[rowIndex]
+	if row.kind != commitDetailDiffRow && row.kind != commitDetailNoticeRow {
+		return
+	}
+	if row.fileIndex < 0 || row.fileIndex >= len(d.Files) {
+		return
+	}
+	for column := 0; column < viewW; column++ {
+		surface.SetCell(column, 0, term.Cell{Ch: ' ', Style: term.StyleDefault})
+	}
+	surface.SetCell(1, 0, term.Cell{Ch: '▼', Style: term.StyleDefault, Bold: true})
+	path := truncateCommitDetailPath(commitDetailFileHeading(d.Files[row.fileIndex]), viewW-3)
+	drawTextSegment(surface, 3, 0, viewW-3, path, 0, 0, term.Cell{Ch: ' '}, func(_ int, ch rune) term.Cell {
+		return term.Cell{Ch: ch, Style: term.StyleDefault, Bold: true}
+	})
+	r := d.GetRect()
+	d.stickyRect = Rect{X: r.X, Y: r.Y, W: viewW, H: 1}
+	d.stickyControl = commitDetailControl{
+		rect:      Rect{X: r.X + 1, Y: r.Y, W: 1, H: 1},
+		fileIndex: row.fileIndex,
+	}
+}
+
+func truncateCommitDetailPath(text string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if textwidth.String(text) <= width {
+		return text
+	}
+	runes := []rune(text)
+	tailWidth := 0
+	start := len(runes)
+	for start > 0 {
+		runeWidth := textwidth.Rune(runes[start-1])
+		if tailWidth+runeWidth > width-1 {
+			break
+		}
+		tailWidth += runeWidth
+		start--
+	}
+	return "…" + string(runes[start:])
+}
+
+func (d *CommitDetailWidget) renderHorizontalScrollbars(surface Surface, r Rect, viewW, y int) {
+	leftStart, leftW, rightStart, rightW := d.sideGeometry(viewW)
+	d.hscrollbar.X = r.X + leftStart
+	d.hscrollbar.Y = r.Y + y
+	d.hscrollbar.Width = leftW
+	d.hscrollbar.TotalCols = d.maxLineW
+	d.hscrollbar.LeftCol = d.LeftCol
+	d.hscrollbar.Render(surface, leftStart, y)
+	for column := 0; column < d.gutterW; column++ {
+		surface.SetCell(column, y, term.Cell{Ch: ' '})
+	}
+	if d.mode == DiffModeUnified {
+		d.rhscroll.TotalCols = 0
+		return
+	}
+
+	dividerX := (viewW - 1) / 2
+	d.rhscroll.X = r.X + rightStart
+	d.rhscroll.Y = r.Y + y
+	d.rhscroll.Width = rightW
+	d.rhscroll.TotalCols = d.maxLineW
+	d.rhscroll.LeftCol = d.LeftCol
+	d.rhscroll.Render(surface, rightStart, y)
+
+	surface.SetCell(dividerX, y, term.Cell{Ch: '│', Style: term.StyleBorder})
+	for column := dividerX + 1; column < rightStart; column++ {
+		surface.SetCell(column, y, term.Cell{Ch: ' '})
+	}
+}
+
+func (d *CommitDetailWidget) clampScroll() {
+	maxTop := d.totalVisualRows - d.viewH
+	if maxTop < 0 {
+		maxTop = 0
+	}
+	if d.TopLine < 0 {
+		d.TopLine = 0
+	}
+	if d.TopLine > maxTop {
+		d.TopLine = maxTop
+	}
+	maxLeft := d.maxLineW - d.contentW
+	if d.IsWrapped() {
+		maxLeft = 0
+	}
+	if maxLeft < 0 {
+		maxLeft = 0
+	}
+	if d.LeftCol < 0 {
+		d.LeftCol = 0
+	}
+	if d.LeftCol > maxLeft {
+		d.LeftCol = maxLeft
+	}
+}
+
+func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
+	if newTop, consumed := d.scrollbar.HandleEvent(ev); consumed {
+		d.TopLine = newTop
+		if d.scrollbar.IsDragging() {
+			return EventCaptured
+		}
+		return EventConsumed
+	}
+	if !d.IsWrapped() {
+		if newLeft, consumed := d.hscrollbar.HandleEvent(ev); consumed {
+			d.LeftCol = newLeft
+			if d.hscrollbar.IsDragging() {
+				return EventCaptured
+			}
+			return EventConsumed
+		}
+		if newLeft, consumed := d.rhscroll.HandleEvent(ev); consumed {
+			d.LeftCol = newLeft
+			if d.rhscroll.IsDragging() {
+				return EventCaptured
+			}
+			return EventConsumed
+		}
+	}
+
+	switch event := ev.(type) {
+	case *tcell.EventKey:
+		switch event.Key() {
+		case tcell.KeyUp:
+			d.TopLine--
+		case tcell.KeyDown:
+			d.TopLine++
+		case tcell.KeyLeft:
+			d.LeftCol--
+		case tcell.KeyRight:
+			d.LeftCol++
+		case tcell.KeyPgUp:
+			d.TopLine -= d.viewH
+		case tcell.KeyPgDn:
+			d.TopLine += d.viewH
+		case tcell.KeyHome:
+			d.TopLine = 0
+			d.LeftCol = 0
+		case tcell.KeyEnd:
+			d.TopLine = d.totalVisualRows - d.viewH
+		default:
+			return EventIgnored
+		}
+		d.clampScroll()
+		return EventConsumed
+	case *tcell.EventMouse:
+		buttons := event.Buttons()
+		modifiers := event.Modifiers()
+		switch {
+		case buttons&tcell.WheelUp != 0 && modifiers&tcell.ModShift != 0:
+			d.LeftCol -= 4
+		case buttons&tcell.WheelDown != 0 && modifiers&tcell.ModShift != 0:
+			d.LeftCol += 4
+		case buttons&tcell.WheelUp != 0:
+			d.TopLine -= 3
+		case buttons&tcell.WheelDown != 0:
+			d.TopLine += 3
+		case buttons&tcell.WheelLeft != 0:
+			d.LeftCol -= 4
+		case buttons&tcell.WheelRight != 0:
+			d.LeftCol += 4
+		default:
+			mx, my := event.Position()
+			if buttons&tcell.Button1 != 0 {
+				if pointInCommitDetailRect(mx, my, d.topControl) {
+					if d.allFilesCollapsed() {
+						d.ExpandAllFiles()
+					} else {
+						d.CollapseAllFiles()
+					}
+					return EventConsumed
+				}
+				if pointInCommitDetailRect(mx, my, d.stickyControl.rect) {
+					d.toggleFile(d.stickyControl.fileIndex)
+					return EventConsumed
+				}
+				for _, control := range d.fileControls {
+					if pointInCommitDetailRect(mx, my, control.rect) {
+						d.toggleFile(control.fileIndex)
+						return EventConsumed
+					}
+				}
+				pos, right, ok := d.screenToSelection(mx, my)
+				if ok {
+					if !d.selecting {
+						now := time.Now()
+						isDoubleClick := now.Sub(d.lastClickTime) < DoubleClickMs*time.Millisecond &&
+							pos.Line == d.lastClickPos.Line && pos.Col == d.lastClickPos.Col
+						d.lastClickTime = now
+						d.lastClickPos = pos
+						d.selRight = right
+						if isDoubleClick {
+							if d.selectWordAt(pos.Line, pos.Col) {
+								d.hasSelection = true
+							}
+							return EventConsumed
+						}
+						d.selecting = true
+						d.hasSelection = true
+						d.selection.Anchor = pos
+						d.selection.Current = pos
+					} else {
+						d.selection.Current = pos
+					}
+					return EventCaptured
+				}
+			}
+			if d.selecting && buttons == tcell.ButtonNone {
+				d.selecting = false
+				start, end := d.selection.Range()
+				if start.Line == end.Line && start.Col == end.Col {
+					d.hasSelection = false
+				}
+				return EventConsumed
+			}
+			return EventIgnored
+		}
+		d.clampScroll()
+		return EventConsumed
+	}
+	return EventIgnored
+}
+
+func pointInCommitDetailRect(x, y int, rect Rect) bool {
+	return rect.W > 0 && rect.H > 0 && x >= rect.X && x < rect.X+rect.W && y >= rect.Y && y < rect.Y+rect.H
+}

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -80,6 +80,7 @@ type CommitDetailWidget struct {
 	wrapExplicit    bool
 	mode            DiffMode
 	modeExplicit    bool
+	highContrast    bool
 	collapsedFiles  []bool
 
 	rows            []commitDetailRow
@@ -126,6 +127,10 @@ func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *Commit
 }
 
 func (d *CommitDetailWidget) Focusable() bool { return true }
+
+func (d *CommitDetailWidget) SetDiffHighContrast(enabled bool) { d.highContrast = enabled }
+
+func (d *CommitDetailWidget) DiffHighContrast() bool { return d.highContrast }
 
 func (d *CommitDetailWidget) IsWrapped() bool { return d.wrapMode == DiffWrapOn }
 
@@ -638,8 +643,10 @@ func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row co
 	if d.IsWrapped() {
 		leftScroll = 0
 	}
-	renderDiffText(surface, leftStart, y, leftW, line.Left.Text, leftStyle, leftSpans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
-	renderDiffText(surface, rightStart, y, rightW, line.Right.Text, rightStyle, rightSpans, visual.rightStart, leftScroll, d.selectionDecorator(rowIndex, true))
+	leftForeground := diffKindForeground(line.Left.Kind, d.highContrast)
+	rightForeground := diffKindForeground(line.Right.Kind, d.highContrast)
+	renderDiffText(surface, leftStart, y, leftW, line.Left.Text, leftStyle, leftForeground, leftSpans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
+	renderDiffText(surface, rightStart, y, rightW, line.Right.Text, rightStyle, rightForeground, rightSpans, visual.rightStart, leftScroll, d.selectionDecorator(rowIndex, true))
 }
 
 func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex int, file *CommitDetailFile, lineIndex int, visual commitDetailVisualRow, y, viewW int) {
@@ -665,7 +672,8 @@ func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex int,
 	if d.IsWrapped() {
 		leftScroll = 0
 	}
-	renderDiffText(surface, contentStart, y, contentW, line.Text, style, spans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
+	foreground := diffKindForeground(line.Kind, d.highContrast)
+	renderDiffText(surface, contentStart, y, contentW, line.Text, style, foreground, spans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
 }
 
 func (d *CommitDetailWidget) drawText(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool, segmentStart int) {

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -135,6 +135,9 @@ type CommitDetailWidget struct {
 	lastClickPos      diffSelPos
 	primaryPressed    bool
 	disclosurePressed bool
+	hoveredGapFile    int
+	hoveredGap        int
+	hasHoveredGap     bool
 
 	OnFetchContext func(fileIndex int, file CommitDetailFile)
 }
@@ -149,6 +152,8 @@ func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *Commit
 		EmptyText:       "No files",
 		LoadingText:     fmt.Sprintf("Loading commit %s…", short),
 		SyntaxHighlight: syntaxHighlight,
+		hoveredGapFile:  -1,
+		hoveredGap:      -1,
 	}
 }
 
@@ -158,6 +163,8 @@ func NewCurrentChangesWidget(dir string, syntaxHighlight bool) *CommitDetailWidg
 		Ref:             "working-tree",
 		Loading:         true,
 		Header:          "Current changes",
+		hoveredGapFile:  -1,
+		hoveredGap:      -1,
 		EmptyText:       "No changes",
 		LoadingText:     "Loading current changes…",
 		CurrentChanges:  true,
@@ -784,7 +791,7 @@ func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row co
 		return
 	}
 	if d.mode == DiffModeUnified {
-		d.renderUnifiedDiffRow(surface, rowIndex, file, row.lineIndex, visual, y, viewW)
+		d.renderUnifiedDiffRow(surface, rowIndex, row.fileIndex, file, row.lineIndex, visual, y, viewW)
 		return
 	}
 	if row.lineIndex >= len(file.lines) {
@@ -799,12 +806,16 @@ func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row co
 	surface.SetCell(dividerX, y, term.Cell{Ch: '│', Style: term.StyleBorder})
 	leftStyle := diffKindStyle(line.Left.Kind)
 	rightStyle := diffKindStyle(line.Right.Kind)
+	if gap, ok := file.gapByLine[row.lineIndex]; ok && d.hasHoveredGap && d.hoveredGapFile == row.fileIndex && d.hoveredGap == gap {
+		leftStyle = term.StyleDiffCollapsed
+		rightStyle = term.StyleDiffCollapsed
+	}
 	if visual.continuation {
-		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{}, leftStyle)
-		renderDiffGutter(surface, dividerX+1, y, d.gutterW, diff.SideLine{}, rightStyle)
+		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{})
+		renderDiffGutter(surface, dividerX+1, y, d.gutterW, diff.SideLine{})
 	} else {
-		renderDiffGutter(surface, 0, y, d.gutterW, line.Left, leftStyle)
-		renderDiffGutter(surface, dividerX+1, y, d.gutterW, line.Right, rightStyle)
+		renderDiffGutter(surface, 0, y, d.gutterW, line.Left)
+		renderDiffGutter(surface, dividerX+1, y, d.gutterW, line.Right)
 	}
 
 	var leftSpans, rightSpans []highlight.Span
@@ -826,7 +837,7 @@ func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row co
 	renderDiffText(surface, rightStart, y, rightW, line.Right.Text, rightStyle, rightForeground, rightSpans, visual.rightStart, leftScroll, d.selectionDecorator(rowIndex, true))
 }
 
-func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex int, file *CommitDetailFile, lineIndex int, visual commitDetailVisualRow, y, viewW int) {
+func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex, fileIndex int, file *CommitDetailFile, lineIndex int, visual commitDetailVisualRow, y, viewW int) {
 	if lineIndex >= len(file.unified) {
 		return
 	}
@@ -836,10 +847,14 @@ func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex int,
 		return
 	}
 	style := diffKindStyle(line.Kind)
+	sourceLine := file.unified[lineIndex].sourceLine
+	if gap, ok := file.gapByLine[sourceLine]; ok && d.hasHoveredGap && d.hoveredGapFile == fileIndex && d.hoveredGap == gap {
+		style = term.StyleDiffCollapsed
+	}
 	if visual.continuation {
-		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{}, style)
+		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{})
 	} else {
-		renderDiffGutter(surface, 0, y, d.gutterW, line, style)
+		renderDiffGutter(surface, 0, y, d.gutterW, line)
 	}
 	var spans []highlight.Span
 	if file.highlighter != nil && line.Text != "" && line.Kind != diff.Collapsed {
@@ -1154,6 +1169,7 @@ func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 
 	switch event := ev.(type) {
 	case *tcell.EventKey:
+		d.hasHoveredGap = false
 		switch event.Key() {
 		case tcell.KeyUp:
 			d.TopLine--
@@ -1182,19 +1198,32 @@ func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 		modifiers := event.Modifiers()
 		switch {
 		case buttons&tcell.WheelUp != 0 && modifiers&tcell.ModShift != 0:
+			d.hasHoveredGap = false
 			d.LeftCol -= 4
 		case buttons&tcell.WheelDown != 0 && modifiers&tcell.ModShift != 0:
+			d.hasHoveredGap = false
 			d.LeftCol += 4
 		case buttons&tcell.WheelUp != 0:
+			d.hasHoveredGap = false
 			d.TopLine -= 3
 		case buttons&tcell.WheelDown != 0:
+			d.hasHoveredGap = false
 			d.TopLine += 3
 		case buttons&tcell.WheelLeft != 0:
+			d.hasHoveredGap = false
 			d.LeftCol -= 4
 		case buttons&tcell.WheelRight != 0:
+			d.hasHoveredGap = false
 			d.LeftCol += 4
 		default:
 			mx, my := event.Position()
+			hoveredFile, hoveredGap, overGap := d.contextGapAtScreenY(my)
+			hoverChanged := overGap != d.hasHoveredGap || (overGap && (hoveredFile != d.hoveredGapFile || hoveredGap != d.hoveredGap))
+			d.hasHoveredGap = overGap
+			if overGap {
+				d.hoveredGapFile = hoveredFile
+				d.hoveredGap = hoveredGap
+			}
 			primaryPressed := buttons&tcell.Button1 != 0
 			freshPrimaryPress := primaryPressed && !d.primaryPressed
 			if buttons == tcell.ButtonNone {
@@ -1235,6 +1264,7 @@ func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 						}
 					}
 					if fileIndex, gap, ok := d.contextGapAtScreenY(my); ok {
+						d.hasHoveredGap = false
 						d.requestFileContext(fileIndex, gap)
 						d.disclosurePressed = true
 						return EventConsumed
@@ -1271,6 +1301,9 @@ func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 				if start.Line == end.Line && start.Col == end.Col {
 					d.hasSelection = false
 				}
+				return EventConsumed
+			}
+			if hoverChanged {
 				return EventConsumed
 			}
 			return EventIgnored

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -24,15 +24,23 @@ type CommitDetailFile struct {
 	Diff         diff.FileDiff
 	Error        string
 
-	highlighter *highlight.Highlighter
-	lines       []diff.DiffLine
-	unified     []diffUnifiedLine
+	highlighter    *highlight.Highlighter
+	lines          []diff.DiffLine
+	unified        []diffUnifiedLine
+	oldLines       []string
+	newLines       []string
+	contextLoaded  bool
+	contextLoading bool
+	expandedGaps   map[int]bool
+	gapByLine      map[int]int
+	pendingGap     int
 }
 
 type commitDetailRowKind uint8
 
 const (
 	commitDetailMessageHeaderRow commitDetailRowKind = iota
+	commitDetailMetadataRow
 	commitDetailMessageRow
 	commitDetailSpacerRow
 	commitDetailHeadingRow
@@ -78,8 +86,9 @@ type CommitDetailWidget struct {
 	HideEmptyNotice bool
 	LoadGen         uint64
 
-	Message string
-	Files   []CommitDetailFile
+	Message  string
+	Metadata string
+	Files    []CommitDetailFile
 
 	SyntaxHighlight bool
 	TopLine         int
@@ -88,6 +97,8 @@ type CommitDetailWidget struct {
 	wrapExplicit    bool
 	mode            DiffMode
 	modeExplicit    bool
+	contextMode     DiffContextMode
+	contextExplicit bool
 	highContrast    bool
 	collapsedFiles  []bool
 
@@ -124,6 +135,8 @@ type CommitDetailWidget struct {
 	lastClickPos      diffSelPos
 	primaryPressed    bool
 	disclosurePressed bool
+
+	OnFetchContext func(fileIndex int, file CommitDetailFile)
 }
 
 func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *CommitDetailWidget {
@@ -158,6 +171,42 @@ func (d *CommitDetailWidget) Focusable() bool { return true }
 func (d *CommitDetailWidget) SetDiffHighContrast(enabled bool) { d.highContrast = enabled }
 
 func (d *CommitDetailWidget) DiffHighContrast() bool { return d.highContrast }
+
+func (d *CommitDetailWidget) ContextMode() DiffContextMode { return d.contextMode }
+
+func (d *CommitDetailWidget) SetContextMode(mode DiffContextMode) {
+	d.contextExplicit = true
+	d.applyContextMode(mode)
+}
+
+func (d *CommitDetailWidget) ApplyDefaultContextMode(mode DiffContextMode) {
+	if d.contextExplicit {
+		return
+	}
+	d.applyContextMode(mode)
+}
+
+func (d *CommitDetailWidget) applyContextMode(mode DiffContextMode) {
+	if d.contextMode == mode {
+		return
+	}
+	d.contextMode = mode
+	if mode == DiffContextChangesOnly {
+		for i := range d.Files {
+			clear(d.Files[i].expandedGaps)
+			d.Files[i].pendingGap = -1
+		}
+	}
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+	d.rebuildRows()
+	if mode == DiffContextFullFile {
+		for i := range d.Files {
+			d.requestFileContext(i, -1)
+		}
+	}
+}
 
 func (d *CommitDetailWidget) IsWrapped() bool { return d.wrapMode == DiffWrapOn }
 
@@ -236,6 +285,8 @@ func (d *CommitDetailWidget) SetDetail(message string, files []CommitDetailFile,
 	d.Files = files
 	d.collapsedFiles = make([]bool, len(files))
 	for i := range d.Files {
+		d.Files[i].expandedGaps = make(map[int]bool)
+		d.Files[i].pendingGap = -1
 		d.collapsedFiles[i] = collapsed[commitDetailFileKey(d.Files[i])]
 		if d.SyntaxHighlight && d.Files[i].Path != "" {
 			d.Files[i].highlighter = highlight.New(d.Files[i].Path)
@@ -245,7 +296,55 @@ func (d *CommitDetailWidget) SetDetail(message string, files []CommitDetailFile,
 	d.LeftCol = 0
 	d.ClearSelection()
 	d.rebuildRows()
+	if d.contextMode == DiffContextFullFile {
+		for i := range d.Files {
+			d.requestFileContext(i, -1)
+		}
+	}
 }
+
+func (d *CommitDetailWidget) requestFileContext(fileIndex, gap int) {
+	if fileIndex < 0 || fileIndex >= len(d.Files) {
+		return
+	}
+	file := &d.Files[fileIndex]
+	if file.contextLoaded {
+		if gap >= 0 {
+			file.expandedGaps[gap] = true
+			d.rebuildRows()
+			d.ClearSelection()
+		}
+		return
+	}
+	if gap >= 0 {
+		file.pendingGap = gap
+	}
+	if file.contextLoading || d.OnFetchContext == nil {
+		return
+	}
+	file.contextLoading = true
+	d.OnFetchContext(fileIndex, *file)
+}
+
+func (d *CommitDetailWidget) ApplyFileContext(fileIndex int, key string, oldLines, newLines []string) bool {
+	if fileIndex < 0 || fileIndex >= len(d.Files) || commitDetailFileKey(d.Files[fileIndex]) != key {
+		return false
+	}
+	file := &d.Files[fileIndex]
+	file.oldLines = oldLines
+	file.newLines = newLines
+	file.contextLoaded = true
+	file.contextLoading = false
+	if file.pendingGap >= 0 {
+		file.expandedGaps[file.pendingGap] = true
+		file.pendingGap = -1
+	}
+	d.rebuildRows()
+	d.ClearSelection()
+	return true
+}
+
+func CommitDetailContextKey(file CommitDetailFile) string { return commitDetailFileKey(file) }
 
 func (d *CommitDetailWidget) allFilesCollapsed() bool {
 	if len(d.Files) == 0 {
@@ -309,6 +408,10 @@ func (d *CommitDetailWidget) rebuildRows() {
 		header = "Commit message"
 	}
 	d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageHeaderRow, text: header, bold: true})
+	if d.Metadata != "" {
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMetadataRow, text: d.Metadata})
+		d.recordWidth(d.Metadata)
+	}
 	message := strings.TrimRight(d.Message, "\r\n")
 	if message == "" {
 		message = "(No commit message)"
@@ -325,7 +428,12 @@ func (d *CommitDetailWidget) rebuildRows() {
 	maxLine := 0
 	for fileIndex := range d.Files {
 		file := &d.Files[fileIndex]
-		file.lines = compactDiffLines(file.Diff)
+		if d.contextMode == DiffContextFullFile && file.contextLoaded {
+			file.lines = diff.FullDiffLines(file.oldLines, file.newLines)
+			file.gapByLine = nil
+		} else {
+			file.lines, file.gapByLine = compactDiffLinesWithContext(file.Diff, file.oldLines, file.newLines, file.expandedGaps)
+		}
 		file.unified = buildUnifiedDiffLines(file.lines)
 		if fileIndex > 0 {
 			d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
@@ -601,6 +709,8 @@ func (d *CommitDetailWidget) renderRow(surface Surface, rowIndex int, row commit
 	switch row.kind {
 	case commitDetailMessageHeaderRow:
 		d.renderMessageHeader(surface, y, viewW)
+	case commitDetailMetadataRow:
+		d.drawTextRow(surface, 0, y, viewW, row.text, term.StyleMuted, term.StyleCommitMessage, false, visual.leftStart, rowIndex)
 	case commitDetailSpacerRow:
 		return
 	case commitDetailMessageRow:
@@ -1124,6 +1234,11 @@ func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 							return EventConsumed
 						}
 					}
+					if fileIndex, gap, ok := d.contextGapAtScreenY(my); ok {
+						d.requestFileContext(fileIndex, gap)
+						d.disclosurePressed = true
+						return EventConsumed
+					}
 				}
 				pos, right, ok := d.screenToSelection(mx, my)
 				if ok {
@@ -1164,6 +1279,39 @@ func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventConsumed
 	}
 	return EventIgnored
+}
+
+func (d *CommitDetailWidget) contextGapAtScreenY(screenY int) (fileIndex, gap int, ok bool) {
+	r := d.GetRect()
+	localY := screenY - r.Y
+	if localY < 0 || localY >= d.viewH {
+		return 0, 0, false
+	}
+	visualRow := d.TopLine + localY
+	rowIndex := visualRow
+	if d.IsWrapped() {
+		if visualRow >= len(d.visualRows) {
+			return 0, 0, false
+		}
+		rowIndex = d.visualRows[visualRow].row
+	}
+	if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return 0, 0, false
+	}
+	row := d.rows[rowIndex]
+	if row.kind != commitDetailDiffRow || row.fileIndex < 0 || row.fileIndex >= len(d.Files) {
+		return 0, 0, false
+	}
+	lineIndex := row.lineIndex
+	file := &d.Files[row.fileIndex]
+	if d.mode == DiffModeUnified {
+		if lineIndex < 0 || lineIndex >= len(file.unified) {
+			return 0, 0, false
+		}
+		lineIndex = file.unified[lineIndex].sourceLine
+	}
+	gap, ok = file.gapByLine[lineIndex]
+	return row.fileIndex, gap, ok
 }
 
 func pointInCommitDetailRect(x, y int, rect Rect) bool {

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -108,12 +108,14 @@ type CommitDetailWidget struct {
 	stickyControl    commitDetailControl
 
 	// Selection positions point into logical rows and original, unwrapped text.
-	selecting     bool
-	hasSelection  bool
-	selRight      bool
-	selection     diffTextSelection
-	lastClickTime time.Time
-	lastClickPos  diffSelPos
+	selecting         bool
+	hasSelection      bool
+	selRight          bool
+	selection         diffTextSelection
+	lastClickTime     time.Time
+	lastClickPos      diffSelPos
+	primaryPressed    bool
+	disclosurePressed bool
 }
 
 func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *CommitDetailWidget {
@@ -589,12 +591,12 @@ func (d *CommitDetailWidget) renderHeading(surface Surface, rowIndex int, row co
 			chevron = '▶'
 		}
 		surface.SetCell(1, y, term.Cell{Ch: chevron, Style: term.StyleDefault, Bold: true})
-		r := d.GetRect()
-		d.fileControls = append(d.fileControls, commitDetailControl{
-			rect:      Rect{X: r.X + 1, Y: r.Y + y, W: 1, H: 1},
-			fileIndex: row.fileIndex,
-		})
 	}
+	r := d.GetRect()
+	d.fileControls = append(d.fileControls, commitDetailControl{
+		rect:      Rect{X: r.X, Y: r.Y + y, W: viewW, H: 1},
+		fileIndex: row.fileIndex,
+	})
 	d.drawTextRow(surface, 3, y, viewW-3, row.text, term.StyleDefault, term.StyleDefault, row.bold, visual.leftStart, rowIndex)
 }
 
@@ -864,7 +866,7 @@ func (d *CommitDetailWidget) renderStickyHeading(surface Surface, viewW int) {
 	r := d.GetRect()
 	d.stickyRect = Rect{X: r.X, Y: r.Y, W: viewW, H: 1}
 	d.stickyControl = commitDetailControl{
-		rect:      Rect{X: r.X + 1, Y: r.Y, W: 1, H: 1},
+		rect:      d.stickyRect,
 		fileIndex: row.fileIndex,
 	}
 }
@@ -1014,23 +1016,44 @@ func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 			d.LeftCol += 4
 		default:
 			mx, my := event.Position()
-			if buttons&tcell.Button1 != 0 {
-				if pointInCommitDetailRect(mx, my, d.topControl) {
-					if d.allFilesCollapsed() {
-						d.ExpandAllFiles()
-					} else {
-						d.CollapseAllFiles()
-					}
+			primaryPressed := buttons&tcell.Button1 != 0
+			freshPrimaryPress := primaryPressed && !d.primaryPressed
+			if buttons == tcell.ButtonNone {
+				d.primaryPressed = false
+				if d.disclosurePressed {
+					d.disclosurePressed = false
 					return EventConsumed
 				}
-				if pointInCommitDetailRect(mx, my, d.stickyControl.rect) {
-					d.toggleFile(d.stickyControl.fileIndex)
+			}
+			if primaryPressed {
+				d.primaryPressed = true
+				if d.disclosurePressed {
 					return EventConsumed
 				}
-				for _, control := range d.fileControls {
-					if pointInCommitDetailRect(mx, my, control.rect) {
-						d.toggleFile(control.fileIndex)
+				// A selection drag may cross a heading. Only a fresh press owns the
+				// row-wide disclosure target; otherwise the file would collapse while
+				// the reader was selecting adjacent diff text.
+				if freshPrimaryPress && !d.selecting {
+					if pointInCommitDetailRect(mx, my, d.topControl) {
+						if d.allFilesCollapsed() {
+							d.ExpandAllFiles()
+						} else {
+							d.CollapseAllFiles()
+						}
+						d.disclosurePressed = true
 						return EventConsumed
+					}
+					if pointInCommitDetailRect(mx, my, d.stickyControl.rect) {
+						d.toggleFile(d.stickyControl.fileIndex)
+						d.disclosurePressed = true
+						return EventConsumed
+					}
+					for _, control := range d.fileControls {
+						if pointInCommitDetailRect(mx, my, control.rect) {
+							d.toggleFile(control.fileIndex)
+							d.disclosurePressed = true
+							return EventConsumed
+						}
 					}
 				}
 				pos, right, ok := d.screenToSelection(mx, my)

--- a/internal/ui/commit_detail_widget_test.go
+++ b/internal/ui/commit_detail_widget_test.go
@@ -1,0 +1,549 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestCommitDetailDefaultsRemainInheritedUntilViewOverride(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+
+	detail.ApplyDefaultMode(DiffModeUnified)
+	detail.ApplyDefaultWrapMode(DiffWrapOn)
+	if detail.Mode() != DiffModeUnified || detail.WrapMode() != DiffWrapOn {
+		t.Fatalf("inherited defaults = mode %v wrap %v, want unified/on", detail.Mode(), detail.WrapMode())
+	}
+
+	detail.SetMode(DiffModeSplit)
+	detail.SetWrapMode(DiffWrapOff)
+	detail.ApplyDefaultMode(DiffModeUnified)
+	detail.ApplyDefaultWrapMode(DiffWrapOn)
+	if detail.Mode() != DiffModeSplit || detail.WrapMode() != DiffWrapOff {
+		t.Fatalf("defaults replaced View overrides: mode %v wrap %v", detail.Mode(), detail.WrapMode())
+	}
+}
+
+func TestCommitDetailModeAndWrapDefaultsAreIndependent(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetWrapMode(DiffWrapOn)
+
+	detail.ApplyDefaultMode(DiffModeUnified)
+	detail.ApplyDefaultWrapMode(DiffWrapOff)
+	if detail.Mode() != DiffModeUnified {
+		t.Fatalf("wrap override prevented inherited mode update: %v", detail.Mode())
+	}
+	if detail.WrapMode() != DiffWrapOn {
+		t.Fatalf("wrap default replaced explicit wrapping: %v", detail.WrapMode())
+	}
+}
+
+func commitDetailGridText(cells [][]term.Cell) string {
+	var out strings.Builder
+	for rowIndex, row := range cells {
+		if rowIndex > 0 {
+			out.WriteByte('\n')
+		}
+		for _, cell := range row {
+			if cell.Ch == 0 {
+				out.WriteByte(' ')
+			} else {
+				out.WriteRune(cell.Ch)
+			}
+		}
+	}
+	return out.String()
+}
+
+func TestCommitDetailRendersMessageAndOrderedFileDiffsInOneScroll(t *testing.T) {
+	first := diff.Parse("--- a/first.txt\n+++ b/first.txt\n@@ -1 +1 @@\n-old first\n+new first\n")
+	second := diff.Parse("--- a/second.txt\n+++ b/second.txt\n@@ -1 +1 @@\n-old second\n+new second\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject line\n\nBody paragraph", []CommitDetailFile{
+		{Path: "first.txt", Diff: first},
+		{Path: "second.txt", Diff: second},
+	}, "")
+	detail.SetRect(Rect{X: 0, Y: 0, W: 80, H: 7})
+
+	initial := makeGrid(80, 7)
+	detail.Render(NewRenderSurface(initial, Rect{X: 0, Y: 0, W: 80, H: 7}))
+	initialText := commitDetailGridText(initial)
+	for _, want := range []string{"Subject line", "Body paragraph", "first.txt", "old first", "new first"} {
+		if !strings.Contains(initialText, want) {
+			t.Errorf("initial viewport missing %q:\n%s", want, initialText)
+		}
+	}
+	if strings.Contains(initialText, "second.txt") {
+		t.Fatalf("second file should begin below the initial viewport:\n%s", initialText)
+	}
+
+	detail.HandleEvent(tcell.NewEventKey(tcell.KeyEnd, "", tcell.ModNone))
+	end := makeGrid(80, 7)
+	detail.Render(NewRenderSurface(end, Rect{X: 0, Y: 0, W: 80, H: 7}))
+	endText := commitDetailGridText(end)
+	for _, want := range []string{"second.txt", "old second", "new second"} {
+		if !strings.Contains(endText, want) {
+			t.Errorf("end viewport missing %q:\n%s", want, endText)
+		}
+	}
+
+	firstHeading, secondHeading := -1, -1
+	for index, row := range detail.rows {
+		if row.kind == commitDetailHeadingRow && row.text == "first.txt" {
+			firstHeading = index
+		}
+		if row.kind == commitDetailHeadingRow && row.text == "second.txt" {
+			secondHeading = index
+		}
+	}
+	if firstHeading < 0 || secondHeading <= firstHeading {
+		t.Fatalf("file headings are not in Git order: first=%d second=%d", firstHeading, secondHeading)
+	}
+}
+
+func TestCommitDetailKeepsTouchedFilesWithoutLineHunks(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Rename only", []CommitDetailFile{{
+		Path:    "new.txt",
+		OldPath: "old.txt",
+	}}, "")
+
+	rows := make([]string, 0, len(detail.rows))
+	for _, row := range detail.rows {
+		rows = append(rows, row.text)
+	}
+	joined := strings.Join(rows, "\n")
+	if !strings.Contains(joined, "old.txt → new.txt") || !strings.Contains(joined, "No line changes") {
+		t.Fatalf("hunk-less file disappeared from detail rows:\n%s", joined)
+	}
+}
+
+func TestCommitDetailDoesNotDrawWideRuneAcrossClipEdge(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	cells := makeGrid(3, 1)
+	surface := NewRenderSurface(cells, Rect{X: 0, Y: 0, W: 3, H: 1})
+	detail.drawText(surface, 0, 0, 3, "ab界", term.StyleDefault, term.StyleDefault, false, 0)
+
+	if cells[0][2].Ch != ' ' {
+		t.Fatalf("last clipped cell = %q, want a space instead of wide-rune bleed", cells[0][2].Ch)
+	}
+}
+
+func TestCommitDetailCollapsedSeparatorUsesSharedStyle(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n first\n@@ -20,1 +20,1 @@\n twentieth\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
+
+	separatorRow := -1
+	for rowIndex, row := range detail.rows {
+		if row.kind != commitDetailDiffRow {
+			continue
+		}
+		if detail.Files[row.fileIndex].lines[row.lineIndex].Left.Kind == diff.Collapsed {
+			separatorRow = rowIndex
+			break
+		}
+	}
+	if separatorRow < 0 {
+		t.Fatal("commit detail has no collapsed separator row")
+	}
+
+	const width, height = 60, 8
+	cells := makeGrid(width, height)
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
+	if got := cells[separatorRow][0].Style; got != term.StyleDiffCollapsed {
+		t.Fatalf("collapsed gutter style = %v, want StyleDiffCollapsed", got)
+	}
+	if got := cells[separatorRow][detail.gutterW].Style; got != term.StyleDiffCollapsed {
+		t.Fatalf("collapsed text style = %v, want StyleDiffCollapsed", got)
+	}
+}
+
+func TestCommitDetailWrapsLongDiffRowsWithoutRepeatingGutters(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-left-prefix-LEFT-SUFFIX\n+right-prefix-RIGHT-SUFFIX\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
+	detail.SetWrapped(true)
+
+	const width, height = 30, 8
+	cells := makeGrid(width, height)
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
+	text := commitDetailGridText(cells)
+	if !strings.Contains(text, "LEFT-SUF") || !strings.Contains(text, "RIGHT-SUF") {
+		t.Fatalf("wrapped commit detail should expose both long suffixes:\n%s", text)
+	}
+	if detail.hscrollbar.TotalCols != 0 || detail.rhscroll.TotalCols != 0 {
+		t.Fatalf("wrapped detail retained horizontal scrollbars: %d / %d", detail.hscrollbar.TotalCols, detail.rhscroll.TotalCols)
+	}
+
+	continuation := -1
+	for visualIndex, visual := range detail.visualRows {
+		if visual.continuation && detail.rows[visual.row].kind == commitDetailDiffRow {
+			continuation = visualIndex
+			break
+		}
+	}
+	if continuation < 0 || continuation >= height {
+		t.Fatalf("expected a visible diff continuation, got row %d and map %+v", continuation, detail.visualRows)
+	}
+	if strings.Contains(commitDetailGridText(cells[continuation : continuation+1])[:detail.gutterW], "1") {
+		t.Fatalf("continuation gutter repeated its line number: %q", commitDetailGridText(cells[continuation : continuation+1])[:detail.gutterW])
+	}
+}
+
+func TestCommitDetailUnifiedModeUsesSharedProjection(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,2 +1,2 @@\n-old one\n-old two\n+new one\n+new two\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
+	detail.SetMode(DiffModeUnified)
+
+	if detail.Mode() != DiffModeUnified {
+		t.Fatal("commit detail did not expose unified as its current mode")
+	}
+	got := make([]string, len(detail.Files[0].unified))
+	for i, line := range detail.Files[0].unified {
+		got[i] = line.side.Text
+	}
+	want := []string{"old one", "old two", "new one", "new two"}
+	if len(got) < len(want) || strings.Join(got[:len(want)], "|") != strings.Join(want, "|") {
+		t.Fatalf("commit detail unified order = %v, want %v", got, want)
+	}
+
+	const width, height = 60, 8
+	cells := makeGrid(width, height)
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
+	text := commitDetailGridText(cells)
+	oldOne, oldTwo := strings.Index(text, "old one"), strings.Index(text, "old two")
+	newOne, newTwo := strings.Index(text, "new one"), strings.Index(text, "new two")
+	if oldOne < 0 || oldTwo < oldOne || newOne < oldTwo || newTwo < newOne {
+		t.Fatalf("commit detail did not render removals before additions:\n%s", text)
+	}
+}
+
+func TestCommitDetailUnifiedWrapUsesFullContentWidth(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-left-prefix-LEFT-SUFFIX\n+right-prefix-RIGHT-SUFFIX\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
+	detail.SetMode(DiffModeUnified)
+	detail.SetWrapMode(DiffWrapOn)
+
+	const width, height = 30, 8
+	cells := makeGrid(width, height)
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
+	text := commitDetailGridText(cells)
+	for _, suffix := range []string{"LEFT-SUFFIX", "RIGHT-SUFFIX"} {
+		if !strings.Contains(text, suffix) {
+			t.Fatalf("unified wrapped detail missing %q:\n%s", suffix, text)
+		}
+	}
+	if detail.hscrollbar.TotalCols != 0 || detail.rhscroll.TotalCols != 0 {
+		t.Fatalf("unified wrapped detail retained horizontal scrollbars: %d / %d", detail.hscrollbar.TotalCols, detail.rhscroll.TotalCols)
+	}
+}
+
+func TestCommitDetailWrappedSelectionCopiesOriginalText(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-abcdefghijklmno\n+ABCDEFGHIJKLMNO\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
+	detail.SetWrapped(true)
+
+	const width, height = 24, 10
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
+
+	var segments []int
+	for visualIndex, visual := range detail.visualRows {
+		row := detail.rows[visual.row]
+		if row.kind == commitDetailDiffRow && row.lineIndex == 0 {
+			segments = append(segments, visualIndex)
+		}
+	}
+	if len(segments) < 3 {
+		t.Fatalf("expected three wrapped segments, got %v", detail.visualRows)
+	}
+	detail.HandleEvent(tcell.NewEventMouse(detail.layoutLeftStart+2, segments[0], tcell.Button1, tcell.ModNone))
+	detail.HandleEvent(tcell.NewEventMouse(detail.layoutLeftStart+1, segments[2], tcell.Button1, tcell.ModNone))
+	detail.HandleEvent(tcell.NewEventMouse(detail.layoutLeftStart+1, segments[2], tcell.ButtonNone, tcell.ModNone))
+
+	selected := makeGrid(width, height)
+	detail.Render(NewRenderSurface(selected, Rect{W: width, H: height}))
+	foundSelection := false
+	for _, row := range selected {
+		for _, cell := range row {
+			if cell.BgStyle == term.StyleSelection {
+				foundSelection = true
+			}
+		}
+	}
+	if !foundSelection {
+		t.Fatal("shared diff decorator did not paint commit-detail selection")
+	}
+	if got := detail.CopySelection(); got != "cdefghijklmno" {
+		t.Fatalf("wrapped copy = %q, want original unwrapped text", got)
+	}
+}
+
+func TestCommitDetailCollapseRebuildsExtentAndClearsSelection(t *testing.T) {
+	first := diff.Parse("--- a/first.txt\n+++ b/first.txt\n@@ -1 +1 @@\n-old first\n+new first\n")
+	second := diff.Parse("--- a/second.txt\n+++ b/second.txt\n@@ -1 +1 @@\n-old second\n+new second\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "first.txt", Diff: first}, {Path: "second.txt", Diff: second}}, "")
+	expandedRows := len(detail.rows)
+	detail.hasSelection = true
+	detail.selection.Anchor = diffSelPos{Line: 1, Col: 0}
+	detail.selection.Current = diffSelPos{Line: 1, Col: 1}
+	detail.TopLine = expandedRows
+
+	detail.CollapseAllFiles()
+	if !detail.allFilesCollapsed() {
+		t.Fatal("collapse-all left an expanded file")
+	}
+	if detail.hasSelection {
+		t.Fatal("collapse retained a selection whose logical rows were rebuilt")
+	}
+	for _, row := range detail.rows {
+		if row.kind == commitDetailDiffRow || row.kind == commitDetailNoticeRow {
+			t.Fatalf("collapsed detail retained content row %+v", row)
+		}
+	}
+	if len(detail.rows) >= expandedRows {
+		t.Fatalf("collapsed rows = %d, want fewer than expanded %d", len(detail.rows), expandedRows)
+	}
+
+	const width, height = 50, 6
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
+	if detail.TopLine > max(0, detail.totalVisualRows-detail.viewH) {
+		t.Fatalf("collapse left TopLine %d beyond extent %d", detail.TopLine, detail.totalVisualRows-detail.viewH)
+	}
+	if detail.scrollbar.TotalItems != 0 && detail.scrollbar.TotalItems != len(detail.rows) {
+		t.Fatalf("collapsed scrollbar extent = %d, want %d", detail.scrollbar.TotalItems, len(detail.rows))
+	}
+
+	detail.ExpandAllFiles()
+	if detail.allFilesCollapsed() || len(detail.rows) != expandedRows {
+		t.Fatalf("expand-all restored %d rows, want %d", len(detail.rows), expandedRows)
+	}
+}
+
+func TestCommitDetailSelectionCrossesCollapsedFileBoundary(t *testing.T) {
+	files := []CommitDetailFile{
+		{Path: "first.txt", Diff: diff.Parse("--- a/first.txt\n+++ b/first.txt\n@@ -1 +1 @@\n-old first\n+new first\n")},
+		{Path: "second.txt", Diff: diff.Parse("--- a/second.txt\n+++ b/second.txt\n@@ -1 +1 @@\n-old second\n+new second\n")},
+		{Path: "third.txt", Diff: diff.Parse("--- a/third.txt\n+++ b/third.txt\n@@ -1 +1 @@\n-old third\n+new third\n")},
+	}
+	for _, tc := range []struct {
+		name    string
+		mode    DiffMode
+		wrapped bool
+		want    string
+	}{
+		{name: "split", mode: DiffModeSplit, want: "old first\n\n\nsecond.txt\n\nthird.txt\nold third"},
+		{name: "unified", mode: DiffModeUnified, want: "old first\nnew first\n\n\nsecond.txt\n\nthird.txt\nold third\nnew third"},
+		{name: "wrapped", mode: DiffModeSplit, wrapped: true, want: "old first\n\n\nsecond.txt\n\nthird.txt\nold third"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+			detail.SetDetail("Subject", files, "")
+			detail.SetMode(tc.mode)
+			detail.SetWrapped(tc.wrapped)
+			detail.toggleFile(1)
+
+			startRow, endRow := -1, -1
+			for rowIndex, row := range detail.rows {
+				if row.kind != commitDetailDiffRow {
+					continue
+				}
+				text, selectable := detail.rowText(rowIndex, false)
+				if !selectable || text == "" {
+					continue
+				}
+				if row.fileIndex == 0 && startRow < 0 {
+					startRow = rowIndex
+				}
+				if row.fileIndex == 2 {
+					endRow = rowIndex
+				}
+			}
+			if startRow < 0 || endRow < 0 {
+				t.Fatalf("missing boundary diff rows: start=%d end=%d rows=%+v", startRow, endRow, detail.rows)
+			}
+			endText, ok := detail.rowText(endRow, false)
+			if !ok {
+				t.Fatalf("end row %d has no selectable text", endRow)
+			}
+			detail.hasSelection = true
+			detail.selection.Anchor = diffSelPos{Line: startRow, Col: 0}
+			detail.selection.Current = diffSelPos{Line: endRow, Col: len([]rune(endText))}
+
+			got := detail.CopySelection()
+			if got != tc.want {
+				t.Fatalf("copy across collapsed boundary = %q, want %q", got, tc.want)
+			}
+			if strings.Contains(got, "old second") || strings.Contains(got, "new second") {
+				t.Fatalf("copy included collapsed file contents: %q", got)
+			}
+		})
+	}
+}
+
+func TestCommitDetailHeadingControlCollapsesOnlyItsFile(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.txt\n+++ b/test.txt\n@@ -1 +1 @@\n-old\n+new\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "first.txt", Diff: fileDiff}, {Path: "second.txt", Diff: fileDiff}}, "")
+	const width, height = 60, 12
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
+	if len(detail.fileControls) < 2 {
+		t.Fatalf("rendered controls = %v, want one per heading", detail.fileControls)
+	}
+	control := detail.fileControls[0]
+	detail.HandleEvent(tcell.NewEventMouse(control.rect.X, control.rect.Y, tcell.Button1, tcell.ModNone))
+	if !detail.collapsedFiles[0] || detail.collapsedFiles[1] {
+		t.Fatalf("per-file collapse state = %v, want [true false]", detail.collapsedFiles)
+	}
+}
+
+func TestCommitDetailTopControlCollapsesAndExpandsAllFiles(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.txt\n+++ b/test.txt\n@@ -1 +1 @@\n-old\n+new\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "first.txt", Diff: fileDiff}, {Path: "second.txt", Diff: fileDiff}}, "")
+	const width, height = 60, 12
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
+	if detail.topControl.W == 0 {
+		t.Fatal("commit header did not expose collapse-all control")
+	}
+	detail.HandleEvent(tcell.NewEventMouse(detail.topControl.X, detail.topControl.Y, tcell.Button1, tcell.ModNone))
+	if !detail.allFilesCollapsed() {
+		t.Fatalf("top control did not collapse all files: %v", detail.collapsedFiles)
+	}
+
+	detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
+	detail.HandleEvent(tcell.NewEventMouse(detail.topControl.X, detail.topControl.Y, tcell.Button1, tcell.ModNone))
+	if detail.allFilesCollapsed() {
+		t.Fatalf("top control did not expand all files: %v", detail.collapsedFiles)
+	}
+}
+
+func TestCommitDetailMessageUsesDedicatedStyle(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.SetDetail("Subject\nBody", nil, "")
+	const width, height = 30, 5
+	cells := makeGrid(width, height)
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
+	for _, row := range []int{0, 1, 2} {
+		if got := cells[row][0].Style; got != term.StyleCommitMessage {
+			t.Fatalf("message row %d style = %v, want StyleCommitMessage", row, got)
+		}
+	}
+}
+
+func TestCommitDetailStickyHeadingIsSelectionInertButControlRemainsClickable(t *testing.T) {
+	var patch strings.Builder
+	patch.WriteString("--- a/file.go\n+++ b/file.go\n@@ -1,8 +1,8 @@\n")
+	for i := 1; i <= 8; i++ {
+		patch.WriteString("-old line ")
+		patch.WriteString(strconv.Itoa(i))
+		patch.WriteByte('\n')
+	}
+	for i := 1; i <= 8; i++ {
+		patch.WriteString("+new line ")
+		patch.WriteString(strconv.Itoa(i))
+		patch.WriteByte('\n')
+	}
+	fileDiff := diff.Parse(patch.String())
+	const longPath = "very/long/component/path/whose/filename-survives.go"
+
+	for _, tc := range []struct {
+		name    string
+		mode    DiffMode
+		wrapped bool
+	}{{"split", DiffModeSplit, false}, {"unified", DiffModeUnified, false}, {"wrapped", DiffModeSplit, true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+			detail.SetDetail("Subject", []CommitDetailFile{{Path: longPath, Diff: fileDiff}}, "")
+			detail.SetMode(tc.mode)
+			detail.SetWrapped(tc.wrapped)
+			const width, height = 32, 5
+			detail.SetRect(Rect{W: width, H: height})
+			detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
+
+			firstDiffVisual := -1
+			if detail.IsWrapped() {
+				for visualIndex, visual := range detail.visualRows {
+					if detail.rows[visual.row].kind == commitDetailDiffRow {
+						firstDiffVisual = visualIndex
+						break
+					}
+				}
+			} else {
+				for rowIndex, row := range detail.rows {
+					if row.kind == commitDetailDiffRow {
+						firstDiffVisual = rowIndex
+						break
+					}
+				}
+			}
+			if firstDiffVisual < 0 {
+				t.Fatal("detail has no diff row")
+			}
+			detail.TopLine = firstDiffVisual
+			cells := makeGrid(width, height)
+			detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
+			firstRow := commitDetailGridText(cells[:1])
+			if !strings.HasPrefix(firstRow, " ▼ …") || !strings.Contains(firstRow, "filename-survives.go") {
+				t.Fatalf("sticky heading did not preserve the path tail:\n%s", firstRow)
+			}
+			selectionX := detail.layoutLeftStart + 1
+			if pos, _, ok := detail.screenToSelection(selectionX, 0); ok {
+				t.Fatalf("sticky row exposed covered diff position %+v", pos)
+			}
+			if result := detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.Button1, tcell.ModNone)); result != EventIgnored {
+				t.Fatalf("sticky text press result = %v, want ignored", result)
+			}
+			if detail.hasSelection || detail.selecting {
+				t.Fatal("sticky text press started a selection")
+			}
+
+			start, _, ok := detail.screenToSelection(selectionX, 1)
+			if !ok {
+				t.Fatal("row below sticky heading is not selectable")
+			}
+			detail.HandleEvent(tcell.NewEventMouse(selectionX, 1, tcell.Button1, tcell.ModNone))
+			detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.Button1, tcell.ModNone))
+			if detail.selection.Current != start {
+				t.Fatalf("drag across sticky row moved selection to covered content: got %+v want %+v", detail.selection.Current, start)
+			}
+			detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.ButtonNone, tcell.ModNone))
+
+			control := detail.stickyControl
+			if result := detail.HandleEvent(tcell.NewEventMouse(control.rect.X, control.rect.Y, tcell.Button1, tcell.ModNone)); result != EventConsumed {
+				t.Fatalf("sticky collapse result = %v, want consumed", result)
+			}
+			if !detail.collapsedFiles[control.fileIndex] {
+				t.Fatal("sticky collapse control did not collapse its file")
+			}
+		})
+	}
+}
+
+func TestTruncateCommitDetailPathUsesDisplayWidthAndKeepsTail(t *testing.T) {
+	got := truncateCommitDetailPath("prefix/界/filename.go", 12)
+	if textwidth.String(got) > 12 {
+		t.Fatalf("truncated path width = %d, want <= 12: %q", textwidth.String(got), got)
+	}
+	if !strings.HasPrefix(got, "…") || !strings.HasSuffix(got, "filename.go") {
+		t.Fatalf("left-truncated path = %q, want ellipsis and filename tail", got)
+	}
+}

--- a/internal/ui/commit_detail_widget_test.go
+++ b/internal/ui/commit_detail_widget_test.go
@@ -29,6 +29,40 @@ func TestCommitDetailDefaultsRemainInheritedUntilViewOverride(t *testing.T) {
 	}
 }
 
+func TestCurrentChangesUsesNativeHeaderAndPreservesCollapseOnRefresh(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	first := CommitDetailFile{Path: "first.go", Heading: "M  first.go · unstaged"}
+	second := CommitDetailFile{Path: "second.go", Heading: "A  second.go · staged"}
+	detail.SetDetail("2 files · +1 −1", []CommitDetailFile{first, second}, "")
+	detail.toggleFile(1)
+	detail.TopLine = 3
+
+	detail.SetDetail("2 files · +2 −1", []CommitDetailFile{second, first}, "")
+	if detail.Header != "Current changes" || !detail.CurrentChanges {
+		t.Fatalf("current change-set identity = (%q, %v)", detail.Header, detail.CurrentChanges)
+	}
+	if !detail.collapsedFiles[0] || detail.collapsedFiles[1] {
+		t.Fatalf("collapse state did not follow file identity: %v", detail.collapsedFiles)
+	}
+	if detail.TopLine != 3 {
+		t.Fatalf("refresh reset scroll to %d", detail.TopLine)
+	}
+	if got := detail.rows[0].text; got != "Current changes" {
+		t.Fatalf("document header = %q", got)
+	}
+}
+
+func TestCurrentChangesCleanStateHasOneMessage(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	detail.SetDetail("Working tree clean", nil, "")
+	if len(detail.rows) != 3 {
+		t.Fatalf("clean current changes rendered redundant rows: %+v", detail.rows)
+	}
+	if detail.rows[1].text != "Working tree clean" {
+		t.Fatalf("clean state message = %q", detail.rows[1].text)
+	}
+}
+
 func TestCommitDetailModeAndWrapDefaultsAreIndependent(t *testing.T) {
 	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
 	detail.SetWrapMode(DiffWrapOn)

--- a/internal/ui/commit_detail_widget_test.go
+++ b/internal/ui/commit_detail_widget_test.go
@@ -185,7 +185,7 @@ func TestCommitDetailDoesNotDrawWideRuneAcrossClipEdge(t *testing.T) {
 	}
 }
 
-func TestCommitDetailCollapsedSeparatorUsesSharedStyle(t *testing.T) {
+func TestCommitDetailCollapsedSeparatorUsesSharedQuietAndHoverStyles(t *testing.T) {
 	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n first\n@@ -20,1 +20,1 @@\n twentieth\n")
 	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
 	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
@@ -208,11 +208,19 @@ func TestCommitDetailCollapsedSeparatorUsesSharedStyle(t *testing.T) {
 	cells := makeGrid(width, height)
 	detail.SetRect(Rect{W: width, H: height})
 	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
-	if got := cells[separatorRow][0].Style; got != term.StyleDiffCollapsed {
-		t.Fatalf("collapsed gutter style = %v, want StyleDiffCollapsed", got)
+	if got := cells[separatorRow][detail.gutterW-1]; got.Ch != '▶' || got.Style != term.StyleLineNumber {
+		t.Fatalf("collapsed gutter cell = %+v, want line-number disclosure triangle", got)
 	}
+	if got := cells[separatorRow][detail.gutterW]; got.Style != term.StyleMuted || got.BgStyle != 0 {
+		t.Fatalf("collapsed text cell = %+v, want muted text on inherited background", got)
+	}
+
+	if result := detail.HandleEvent(tcell.NewEventMouse(detail.gutterW, separatorRow, tcell.ButtonNone, tcell.ModNone)); result != EventConsumed {
+		t.Fatalf("collapsed separator hover result = %v, want EventConsumed for redraw", result)
+	}
+	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
 	if got := cells[separatorRow][detail.gutterW].Style; got != term.StyleDiffCollapsed {
-		t.Fatalf("collapsed text style = %v, want StyleDiffCollapsed", got)
+		t.Fatalf("hovered collapsed text style = %v, want StyleDiffCollapsed", got)
 	}
 }
 

--- a/internal/ui/commit_detail_widget_test.go
+++ b/internal/ui/commit_detail_widget_test.go
@@ -407,10 +407,19 @@ func TestCommitDetailHeadingControlCollapsesOnlyItsFile(t *testing.T) {
 		t.Fatalf("rendered controls = %v, want one per heading", detail.fileControls)
 	}
 	control := detail.fileControls[0]
-	detail.HandleEvent(tcell.NewEventMouse(control.rect.X, control.rect.Y, tcell.Button1, tcell.ModNone))
+	if control.rect.W != detail.layoutViewW {
+		t.Fatalf("heading hit target width = %d, want full row %d", control.rect.W, detail.layoutViewW)
+	}
+	titleX := control.rect.X + 6
+	detail.HandleEvent(tcell.NewEventMouse(titleX, control.rect.Y, tcell.Button1, tcell.ModNone))
 	if !detail.collapsedFiles[0] || detail.collapsedFiles[1] {
 		t.Fatalf("per-file collapse state = %v, want [true false]", detail.collapsedFiles)
 	}
+	detail.HandleEvent(tcell.NewEventMouse(titleX+3, control.rect.Y, tcell.Button1, tcell.ModNone))
+	if !detail.collapsedFiles[0] {
+		t.Fatal("held movement across a heading toggled disclosure a second time")
+	}
+	detail.HandleEvent(tcell.NewEventMouse(titleX+3, control.rect.Y, tcell.ButtonNone, tcell.ModNone))
 }
 
 func TestCommitDetailTopControlCollapsesAndExpandsAllFiles(t *testing.T) {
@@ -424,12 +433,14 @@ func TestCommitDetailTopControlCollapsesAndExpandsAllFiles(t *testing.T) {
 		t.Fatal("commit header did not expose collapse-all control")
 	}
 	detail.HandleEvent(tcell.NewEventMouse(detail.topControl.X, detail.topControl.Y, tcell.Button1, tcell.ModNone))
+	detail.HandleEvent(tcell.NewEventMouse(detail.topControl.X, detail.topControl.Y, tcell.ButtonNone, tcell.ModNone))
 	if !detail.allFilesCollapsed() {
 		t.Fatalf("top control did not collapse all files: %v", detail.collapsedFiles)
 	}
 
 	detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
 	detail.HandleEvent(tcell.NewEventMouse(detail.topControl.X, detail.topControl.Y, tcell.Button1, tcell.ModNone))
+	detail.HandleEvent(tcell.NewEventMouse(detail.topControl.X, detail.topControl.Y, tcell.ButtonNone, tcell.ModNone))
 	if detail.allFilesCollapsed() {
 		t.Fatalf("top control did not expand all files: %v", detail.collapsedFiles)
 	}
@@ -509,11 +520,23 @@ func TestCommitDetailStickyHeadingIsSelectionInertButControlRemainsClickable(t *
 			if pos, _, ok := detail.screenToSelection(selectionX, 0); ok {
 				t.Fatalf("sticky row exposed covered diff position %+v", pos)
 			}
-			if result := detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.Button1, tcell.ModNone)); result != EventIgnored {
-				t.Fatalf("sticky text press result = %v, want ignored", result)
+			if result := detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.Button1, tcell.ModNone)); result != EventConsumed {
+				t.Fatalf("sticky title press result = %v, want consumed", result)
 			}
+			if !detail.collapsedFiles[0] {
+				t.Fatal("sticky title press did not collapse its file")
+			}
+			detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.ButtonNone, tcell.ModNone))
+			detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.Button1, tcell.ModNone))
+			if detail.collapsedFiles[0] {
+				t.Fatal("second sticky title press did not expand its file")
+			}
+			detail.HandleEvent(tcell.NewEventMouse(selectionX, 0, tcell.ButtonNone, tcell.ModNone))
+			detail.TopLine = firstDiffVisual
+			cells = makeGrid(width, height)
+			detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
 			if detail.hasSelection || detail.selecting {
-				t.Fatal("sticky text press started a selection")
+				t.Fatal("sticky title press started a selection")
 			}
 
 			start, _, ok := detail.screenToSelection(selectionX, 1)

--- a/internal/ui/commit_detail_widget_test.go
+++ b/internal/ui/commit_detail_widget_test.go
@@ -157,6 +157,23 @@ func TestCommitDetailKeepsTouchedFilesWithoutLineHunks(t *testing.T) {
 	}
 }
 
+func TestCommitDetailRendersAuthoredMetadataBelowHeader(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	detail.Metadata = "Authored Aug 21, 2026 at 5:42 PM -0400"
+	detail.SetDetail("Subject", nil, "")
+	if len(detail.rows) < 3 || detail.rows[1].kind != commitDetailMetadataRow || detail.rows[1].text != detail.Metadata {
+		t.Fatalf("metadata row = %+v", detail.rows)
+	}
+
+	const width, height = 60, 5
+	cells := makeGrid(width, height)
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(cells, Rect{W: width, H: height}))
+	if text := commitDetailGridText(cells); !strings.Contains(text, detail.Metadata) {
+		t.Fatalf("rendered detail missing metadata:\n%s", text)
+	}
+}
+
 func TestCommitDetailDoesNotDrawWideRuneAcrossClipEdge(t *testing.T) {
 	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
 	cells := makeGrid(3, 1)
@@ -196,6 +213,51 @@ func TestCommitDetailCollapsedSeparatorUsesSharedStyle(t *testing.T) {
 	}
 	if got := cells[separatorRow][detail.gutterW].Style; got != term.StyleDiffCollapsed {
 		t.Fatalf("collapsed text style = %v, want StyleDiffCollapsed", got)
+	}
+}
+
+func TestCommitDetailCollapsedSeparatorClickLoadsAndExpandsOnlyThatGap(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n line 1\n@@ -20,1 +20,1 @@\n line 20\n")
+	detail := NewCommitDetailWidget("/repo", "full-hash", "abc1234", false)
+	requested := -1
+	detail.OnFetchContext = func(fileIndex int, _ CommitDetailFile) { requested = fileIndex }
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
+
+	separatorRow := -1
+	for rowIndex, row := range detail.rows {
+		if row.kind == commitDetailDiffRow && detail.Files[row.fileIndex].lines[row.lineIndex].Left.Kind == diff.Collapsed {
+			separatorRow = rowIndex
+			break
+		}
+	}
+	if separatorRow < 0 {
+		t.Fatal("commit detail has no context gap")
+	}
+	const width, height = 60, 12
+	detail.SetRect(Rect{W: width, H: height})
+	detail.Render(NewRenderSurface(makeGrid(width, height), Rect{W: width, H: height}))
+	if got := detail.HandleEvent(tcell.NewEventMouse(width-2, separatorRow, tcell.Button1, tcell.ModNone)); got != EventConsumed {
+		t.Fatalf("context gap click = %v", got)
+	}
+	if requested != 0 || detail.Files[0].pendingGap != 0 {
+		t.Fatalf("context request = file %d gap %d", requested, detail.Files[0].pendingGap)
+	}
+
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = "line " + strconv.Itoa(i+1)
+	}
+	key := CommitDetailContextKey(detail.Files[0])
+	if !detail.ApplyFileContext(0, key, lines, lines) {
+		t.Fatal("matching file context was rejected")
+	}
+	if !detail.Files[0].expandedGaps[0] || len(detail.Files[0].lines) <= 2 {
+		t.Fatalf("gap was not expanded: expanded=%v lines=%d", detail.Files[0].expandedGaps, len(detail.Files[0].lines))
+	}
+	for _, line := range detail.Files[0].lines {
+		if line.Left.Kind == diff.Collapsed || line.Right.Kind == diff.Collapsed {
+			t.Fatal("expanded gap retained a collapsed separator")
+		}
 	}
 }
 

--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -8,10 +8,13 @@ import (
 
 type ContentSplitWidget struct {
 	BaseWidget
-	Top               Widget
-	Bottom            Widget
-	ShowBottom        bool
-	BottomH           int
+	Top        Widget
+	Bottom     Widget
+	ShowBottom bool
+	BottomH    int
+	// BottomRatio supplies a responsive height while BottomH is unset. A manual
+	// divider drag clears the ratio and records an explicit BottomH instead.
+	BottomRatio       float64
 	MinTopH           int
 	MinBottomH        int
 	Borders           *term.BorderSet
@@ -60,6 +63,13 @@ func (cs *ContentSplitWidget) constrainedBottomHeight(totalH, requested int) int
 	return min(max(requested, minBottom), maxBottom)
 }
 
+func (cs *ContentSplitWidget) requestedBottomHeight(totalH int) int {
+	if cs.BottomH <= 0 && cs.BottomRatio > 0 {
+		return int(float64(totalH) * cs.BottomRatio)
+	}
+	return cs.BottomH
+}
+
 func (cs *ContentSplitWidget) Render(surface Surface) {
 	w, h := surface.Size()
 	r := cs.GetRect()
@@ -85,7 +95,7 @@ func (cs *ContentSplitWidget) Render(surface Surface) {
 	bs := term.StyleBorder
 
 	// One row belongs to the divider; the rest is divided between the children.
-	bottomH := cs.constrainedBottomHeight(h, cs.BottomH)
+	bottomH := cs.constrainedBottomHeight(h, cs.requestedBottomHeight(h))
 	divY := h - bottomH - 1
 	topH := divY
 
@@ -131,6 +141,7 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 		if pressed {
 			newH := r.Y + r.H - my - 1
 			newH = cs.constrainedBottomHeight(r.H, newH)
+			cs.BottomRatio = 0
 			if cs.OnResize != nil {
 				cs.OnResize(newH)
 			}
@@ -154,7 +165,7 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 
 	if cs.ShowBottom {
-		bottomH := cs.constrainedBottomHeight(r.H, cs.BottomH)
+		bottomH := cs.constrainedBottomHeight(r.H, cs.requestedBottomHeight(r.H))
 		divY := r.Y + r.H - bottomH - 1
 
 		// r.W-1: exclude last column to avoid colliding with editor scrollbar
@@ -219,6 +230,6 @@ func (cs *ContentSplitWidget) DividerScreenY() int {
 		return -1
 	}
 	r := cs.GetRect()
-	bottomH := cs.constrainedBottomHeight(r.H, cs.BottomH)
+	bottomH := cs.constrainedBottomHeight(r.H, cs.requestedBottomHeight(r.H))
 	return r.Y + r.H - bottomH - 1
 }

--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -12,6 +12,8 @@ type ContentSplitWidget struct {
 	Bottom            Widget
 	ShowBottom        bool
 	BottomH           int
+	MinTopH           int
+	MinBottomH        int
 	Borders           *term.BorderSet
 	OnResize          func(height int)
 	OnBottomClick     func()
@@ -20,6 +22,17 @@ type ContentSplitWidget struct {
 	dragging          bool
 	wasPressed        bool
 	capturedChild     Widget
+}
+
+func (cs *ContentSplitWidget) WidgetChildren() []Widget {
+	children := make([]Widget, 0, 2)
+	if cs.Top != nil {
+		children = append(children, cs.Top)
+	}
+	if cs.Bottom != nil {
+		children = append(children, cs.Bottom)
+	}
+	return children
 }
 
 func NewContentSplitWidget() *ContentSplitWidget {
@@ -31,9 +44,28 @@ func NewContentSplitWidget() *ContentSplitWidget {
 
 func (cs *ContentSplitWidget) Focusable() bool { return false }
 
+// constrainedBottomHeight applies both child minimums to a requested bottom
+// height. If the available area cannot hold both, the top minimum wins; there
+// is no layout that can satisfy both, and preserving the primary surface keeps
+// the divider reachable when the terminal grows again.
+func (cs *ContentSplitWidget) constrainedBottomHeight(totalH, requested int) int {
+	if totalH <= 1 {
+		return 0
+	}
+	maxBottom := totalH - 1 - max(cs.MinTopH, 0)
+	if maxBottom < 0 {
+		maxBottom = 0
+	}
+	minBottom := min(max(cs.MinBottomH, 0), maxBottom)
+	return min(max(requested, minBottom), maxBottom)
+}
+
 func (cs *ContentSplitWidget) Render(surface Surface) {
 	w, h := surface.Size()
 	r := cs.GetRect()
+	if w <= 0 || h <= 0 {
+		return
+	}
 
 	if !cs.ShowBottom || cs.Bottom == nil {
 		if cs.RightBorderStartY != nil {
@@ -52,15 +84,9 @@ func (cs *ContentSplitWidget) Render(surface Surface) {
 	}
 	bs := term.StyleBorder
 
-	// 1 row for divider + bottomH for content
-	needed := cs.BottomH + 1
-	if needed > h {
-		needed = h
-	}
-	divY := h - needed
-	if divY < 0 {
-		divY = 0
-	}
+	// One row belongs to the divider; the rest is divided between the children.
+	bottomH := cs.constrainedBottomHeight(h, cs.BottomH)
+	divY := h - bottomH - 1
 	topH := divY
 
 	if cs.RightBorderStartY != nil {
@@ -80,7 +106,7 @@ func (cs *ContentSplitWidget) Render(surface Surface) {
 	}
 
 	// Bottom content
-	bottomContentH := h - divY - 1
+	bottomContentH := bottomH
 	if cs.Bottom != nil && bottomContentH > 0 {
 		cs.Bottom.SetRect(Rect{X: r.X, Y: r.Y + divY + 1, W: r.W, H: bottomContentH})
 		bottomSurface := surface.Sub(Rect{X: 0, Y: divY + 1, W: w, H: bottomContentH})
@@ -104,6 +130,7 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 	if cs.dragging {
 		if pressed {
 			newH := r.Y + r.H - my - 1
+			newH = cs.constrainedBottomHeight(r.H, newH)
 			if cs.OnResize != nil {
 				cs.OnResize(newH)
 			}
@@ -127,14 +154,8 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 
 	if cs.ShowBottom {
-		needed := cs.BottomH + 1
-		if needed > r.H {
-			needed = r.H
-		}
-		divY := r.Y + r.H - needed
-		if divY < r.Y {
-			divY = r.Y
-		}
+		bottomH := cs.constrainedBottomHeight(r.H, cs.BottomH)
+		divY := r.Y + r.H - bottomH - 1
 
 		// r.W-1: exclude last column to avoid colliding with editor scrollbar
 		// For divY+1 (tab bar row), let the bottom panel handle clicks first
@@ -198,9 +219,6 @@ func (cs *ContentSplitWidget) DividerScreenY() int {
 		return -1
 	}
 	r := cs.GetRect()
-	needed := cs.BottomH + 1
-	if needed > r.H {
-		needed = r.H
-	}
-	return r.Y + r.H - needed
+	bottomH := cs.constrainedBottomHeight(r.H, cs.BottomH)
+	return r.Y + r.H - bottomH - 1
 }

--- a/internal/ui/content_split_test.go
+++ b/internal/ui/content_split_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestContentSplitDragRespectsChildMinimumHeights(t *testing.T) {
+	top := &mockWidget{}
+	bottom := &mockWidget{}
+	cs := NewContentSplitWidget()
+	cs.Top = top
+	cs.Bottom = bottom
+	cs.ShowBottom = true
+	cs.BottomH = 8
+	cs.MinTopH = 5
+	cs.MinBottomH = 4
+	cs.SetRect(Rect{X: 3, Y: 2, W: 30, H: 20})
+	cs.OnResize = func(height int) { cs.BottomH = height }
+
+	render := func() {
+		cs.Render(NewRenderSurface(makeGrid(30, 20), Rect{X: 3, Y: 2, W: 30, H: 20}))
+	}
+	drag := func(fromY, toY int) {
+		t.Helper()
+		if got := cs.HandleEvent(tcell.NewEventMouse(5, fromY, tcell.Button1, tcell.ModNone)); got != EventCaptured {
+			t.Fatalf("drag start result = %v, want captured", got)
+		}
+		if got := cs.HandleEvent(tcell.NewEventMouse(5, toY, tcell.Button1, tcell.ModNone)); got != EventCaptured {
+			t.Fatalf("drag move result = %v, want captured", got)
+		}
+		cs.HandleEvent(tcell.NewEventMouse(5, toY, tcell.ButtonNone, tcell.ModNone))
+		render()
+	}
+
+	render()
+	drag(cs.DividerScreenY(), 21)
+	if cs.BottomH != 4 {
+		t.Errorf("bottom height after downward drag = %d, want minimum 4", cs.BottomH)
+	}
+	if got := bottom.GetRect().H; got != 4 {
+		t.Errorf("rendered bottom height = %d, want 4", got)
+	}
+
+	drag(cs.DividerScreenY(), 2)
+	if cs.BottomH != 14 {
+		t.Errorf("bottom height after upward drag = %d, want maximum 14", cs.BottomH)
+	}
+	if got := top.GetRect().H; got != 5 {
+		t.Errorf("rendered top height = %d, want minimum 5", got)
+	}
+}
+
+func TestContentSplitExposesChildrenInLayoutOrder(t *testing.T) {
+	top := &mockWidget{}
+	bottom := &mockWidget{}
+	cs := NewContentSplitWidget()
+	cs.Top = top
+	cs.Bottom = bottom
+
+	children := cs.WidgetChildren()
+	if len(children) != 2 || children[0] != top || children[1] != bottom {
+		t.Fatalf("children = %#v, want top then bottom", children)
+	}
+}

--- a/internal/ui/content_split_test.go
+++ b/internal/ui/content_split_test.go
@@ -64,3 +64,27 @@ func TestContentSplitExposesChildrenInLayoutOrder(t *testing.T) {
 		t.Fatalf("children = %#v, want top then bottom", children)
 	}
 }
+
+func TestContentSplitRatioTracksAvailableHeightUntilResized(t *testing.T) {
+	top := &mockWidget{}
+	bottom := &mockWidget{}
+	cs := NewContentSplitWidget()
+	cs.Top = top
+	cs.Bottom = bottom
+	cs.ShowBottom = true
+	cs.BottomH = 0
+	cs.BottomRatio = 0.5
+
+	render := func(height int) {
+		cs.SetRect(Rect{W: 30, H: height})
+		cs.Render(NewRenderSurface(makeGrid(30, height), Rect{W: 30, H: height}))
+	}
+	render(20)
+	if bottom.GetRect().H != 10 || top.GetRect().H != 9 {
+		t.Fatalf("20-row half split = top %d bottom %d, want 9/10 around divider", top.GetRect().H, bottom.GetRect().H)
+	}
+	render(30)
+	if bottom.GetRect().H != 15 || top.GetRect().H != 14 {
+		t.Fatalf("30-row half split = top %d bottom %d, want 14/15 around divider", top.GetRect().H, bottom.GetRect().H)
+	}
+}

--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -12,6 +13,7 @@ type ContextMenuItem struct {
 	Command  string
 	IsSep    bool
 	Checked  int // 0 = no indicator, 1 = unchecked, 2 = checked
+	Submenu  []ContextMenuItem
 }
 
 const (
@@ -34,6 +36,9 @@ type ContextMenuWidget struct {
 	OnDismiss      func()
 	OnNavigate     func(dir int)
 	OnMouseOutside func(ev tcell.Event)
+	Submenu        *ContextMenuWidget
+	parent         *ContextMenuWidget
+	submenuIndex   int
 	firstEvent     bool
 }
 
@@ -65,6 +70,15 @@ func (c *ContextMenuWidget) hasCheckedItems() bool {
 	return false
 }
 
+func (c *ContextMenuWidget) hasSubmenus() bool {
+	for _, it := range c.Items {
+		if len(it.Submenu) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *ContextMenuWidget) menuWidth() int {
 	maxLabel := 0
 	maxShort := 0
@@ -72,11 +86,11 @@ func (c *ContextMenuWidget) menuWidth() int {
 		if it.IsSep {
 			continue
 		}
-		lr := len([]rune(it.Label))
+		lr := textwidth.String(it.Label)
 		if lr > maxLabel {
 			maxLabel = lr
 		}
-		sr := len([]rune(it.Shortcut))
+		sr := textwidth.String(it.Shortcut)
 		if sr > maxShort {
 			maxShort = sr
 		}
@@ -87,6 +101,9 @@ func (c *ContextMenuWidget) menuWidth() int {
 	}
 	if maxShort > 0 {
 		w += maxShort + 2
+	}
+	if c.hasSubmenus() {
+		w += 2
 	}
 	if w < 15 {
 		w = 15
@@ -114,6 +131,13 @@ func (c *ContextMenuWidget) Render(surface Surface) {
 	if y < 0 {
 		y = 0
 	}
+
+	c.renderAt(surface, x, y, sw, sh)
+}
+
+func (c *ContextMenuWidget) renderAt(surface Surface, x, y, sw, sh int) {
+	menuW := c.menuWidth()
+	menuH := len(c.Items) + 2
 
 	b := term.SingleBorderSet()
 	if c.Borders != nil {
@@ -151,13 +175,36 @@ func (c *ContextMenuWidget) Render(surface Surface) {
 			if i == c.Selected {
 				shortStyle = style
 			}
-			shortRunes := []rune(it.Shortcut)
-			sx := x + menuW - 2 - len(shortRunes)
+			sx := x + menuW - 2 - textwidth.String(it.Shortcut)
 			surface.DrawText(sx, row, it.Shortcut, x+menuW-1, shortStyle)
+		}
+		if len(it.Submenu) > 0 {
+			surface.SetCell(x+menuW-2, row, term.Cell{Ch: '›', Style: style})
 		}
 	}
 
 	c.storeRect(x, y, menuW, menuH)
+
+	if c.Submenu == nil {
+		return
+	}
+	childW := c.Submenu.menuWidth()
+	childH := len(c.Submenu.Items) + 2
+	childX := x + menuW - 1
+	if childX+childW > sw {
+		childX = x - childW + 1
+	}
+	if childX < 0 {
+		childX = 0
+	}
+	childY := y + 1 + c.submenuIndex
+	if childY+childH > sh {
+		childY = sh - childH
+	}
+	if childY < 0 {
+		childY = 0
+	}
+	c.Submenu.renderAt(surface, childX, childY, sw, sh)
 }
 
 func (c *ContextMenuWidget) storeRect(x, y, w, h int) {
@@ -167,6 +214,7 @@ func (c *ContextMenuWidget) storeRect(x, y, w, h int) {
 func (c *ContextMenuWidget) HandleEvent(ev tcell.Event) EventResult {
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
+		active := c.activeMenu()
 		switch tev.Key() {
 		case tcell.KeyEscape:
 			if c.OnDismiss != nil {
@@ -174,25 +222,33 @@ func (c *ContextMenuWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 			return EventConsumed
 		case tcell.KeyUp:
-			c.moveSelection(-1)
+			active.moveSelection(-1)
 			return EventConsumed
 		case tcell.KeyDown:
-			c.moveSelection(1)
+			active.moveSelection(1)
 			return EventConsumed
 		case tcell.KeyLeft:
-			if c.OnNavigate != nil {
+			if active.parent != nil {
+				active.parent.Submenu = nil
+			} else if c.OnNavigate != nil {
 				c.OnNavigate(-1)
 			}
 			return EventConsumed
 		case tcell.KeyRight:
-			if c.OnNavigate != nil {
+			if active.openSelectedSubmenu() {
+				return EventConsumed
+			}
+			if active.parent == nil && c.OnNavigate != nil {
 				c.OnNavigate(1)
 			}
 			return EventConsumed
 		case tcell.KeyEnter:
-			if c.Selected >= 0 && c.Selected < len(c.Items) && !c.Items[c.Selected].IsSep {
-				if c.OnExec != nil {
-					c.OnExec(c.Items[c.Selected].Command)
+			if active.Selected >= 0 && active.Selected < len(active.Items) && !active.Items[active.Selected].IsSep {
+				if active.openSelectedSubmenu() {
+					return EventConsumed
+				}
+				if c.OnExec != nil && active.Items[active.Selected].Command != "" {
+					c.OnExec(active.Items[active.Selected].Command)
 				}
 			}
 			return EventConsumed
@@ -200,46 +256,97 @@ func (c *ContextMenuWidget) HandleEvent(ev tcell.Event) EventResult {
 	case *tcell.EventMouse:
 		btn := tev.Buttons()
 		mx, my := tev.Position()
-		r := c.GetRect()
 
 		if c.firstEvent {
 			c.firstEvent = false
 			return EventConsumed
 		}
 
+		menu := c.menuAt(mx, my)
 		if btn&tcell.Button1 != 0 {
-			if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
+			if menu == nil {
 				if c.OnDismiss != nil {
 					c.OnDismiss()
 				}
 				return EventConsumed
 			}
-			itemIdx := my - r.Y - 1
-			if itemIdx >= 0 && itemIdx < len(c.Items) && !c.Items[itemIdx].IsSep {
-				c.Selected = itemIdx
-				if c.OnExec != nil {
-					c.OnExec(c.Items[c.Selected].Command)
+			itemIdx := my - menu.GetRect().Y - 1
+			if itemIdx >= 0 && itemIdx < len(menu.Items) && !menu.Items[itemIdx].IsSep {
+				menu.selectItem(itemIdx)
+				if menu.openSelectedSubmenu() {
+					return EventConsumed
+				}
+				if c.OnExec != nil && menu.Items[menu.Selected].Command != "" {
+					c.OnExec(menu.Items[menu.Selected].Command)
 				}
 			}
 			return EventConsumed
 		}
 
 		if btn == tcell.ButtonNone {
-			if mx < r.X || mx >= r.X+r.W || my < r.Y || my >= r.Y+r.H {
+			if menu == nil {
 				c.Selected = -1
 				if c.OnMouseOutside != nil {
 					c.OnMouseOutside(ev)
 				}
 				return EventConsumed
 			}
-			itemIdx := my - r.Y - 1
-			if itemIdx >= 0 && itemIdx < len(c.Items) && !c.Items[itemIdx].IsSep {
-				c.Selected = itemIdx
+			itemIdx := my - menu.GetRect().Y - 1
+			if itemIdx >= 0 && itemIdx < len(menu.Items) && !menu.Items[itemIdx].IsSep {
+				menu.selectItem(itemIdx)
+				menu.openSelectedSubmenu()
 			}
 			return EventConsumed
 		}
 	}
 	return EventConsumed
+}
+
+func (c *ContextMenuWidget) activeMenu() *ContextMenuWidget {
+	if c.Submenu != nil {
+		return c.Submenu.activeMenu()
+	}
+	return c
+}
+
+func (c *ContextMenuWidget) menuAt(x, y int) *ContextMenuWidget {
+	if c.Submenu != nil {
+		if menu := c.Submenu.menuAt(x, y); menu != nil {
+			return menu
+		}
+	}
+	r := c.GetRect()
+	if x >= r.X && x < r.X+r.W && y >= r.Y && y < r.Y+r.H {
+		return c
+	}
+	return nil
+}
+
+func (c *ContextMenuWidget) selectItem(index int) {
+	if c.Selected != index {
+		c.Selected = index
+		c.Submenu = nil
+	}
+}
+
+func (c *ContextMenuWidget) openSelectedSubmenu() bool {
+	if c.Selected < 0 || c.Selected >= len(c.Items) {
+		return false
+	}
+	items := c.Items[c.Selected].Submenu
+	if len(items) == 0 {
+		return false
+	}
+	if c.Submenu != nil && c.submenuIndex == c.Selected {
+		return true
+	}
+	child := NewContextMenuWidget(items, 0, 0)
+	child.Borders = c.Borders
+	child.parent = c
+	child.firstEvent = false
+	c.Submenu = child
+	c.submenuIndex = c.Selected
+	return true
 }
 
 func (c *ContextMenuWidget) moveSelection(dir int) {
@@ -252,6 +359,7 @@ func (c *ContextMenuWidget) moveSelection(dir int) {
 		next = (next + dir + n) % n
 		if !c.Items[next].IsSep {
 			c.Selected = next
+			c.Submenu = nil
 			return
 		}
 	}

--- a/internal/ui/contextmenu_widget_test.go
+++ b/internal/ui/contextmenu_widget_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestContextMenuKeyboardNavigatesSubmenu(t *testing.T) {
+	var executed string
+	menu := NewContextMenuWidget([]ContextMenuItem{
+		{Label: "Git Files", Submenu: []ContextMenuItem{
+			{Label: "Tree", Command: "tree"},
+			{Label: "List", Command: "list"},
+		}},
+	}, 2, 1)
+	menu.OnExec = func(command string) { executed = command }
+	menu.Render(NewRenderSurface(makeGrid(50, 15), Rect{W: 50, H: 15}))
+
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyRight, "", 0))
+	if menu.Submenu == nil {
+		t.Fatal("Right should open the selected submenu")
+	}
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyDown, "", 0))
+	if menu.Submenu.Selected != 1 {
+		t.Fatalf("submenu selection = %d, want 1", menu.Submenu.Selected)
+	}
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyLeft, "", 0))
+	if menu.Submenu != nil {
+		t.Fatal("Left should return to the parent menu")
+	}
+
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", 0))
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyDown, "", 0))
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", 0))
+	if executed != "list" {
+		t.Fatalf("executed %q, want list", executed)
+	}
+}
+
+func TestContextMenuHoverOpensSubmenuAndFlipsAtRightEdge(t *testing.T) {
+	var executed string
+	menu := NewContextMenuWidget([]ContextMenuItem{
+		{Label: "Diff View", Submenu: []ContextMenuItem{
+			{Label: "Split", Command: "split"},
+			{Label: "Unified", Command: "unified"},
+		}},
+	}, 31, 1)
+	menu.OnExec = func(command string) { executed = command }
+	menu.firstEvent = false
+	surface := NewRenderSurface(makeGrid(36, 15), Rect{W: 36, H: 15})
+	menu.Render(surface)
+
+	r := menu.GetRect()
+	menu.HandleEvent(tcell.NewEventMouse(r.X+2, r.Y+1, tcell.ButtonNone, 0))
+	if menu.Submenu == nil {
+		t.Fatal("hover should open a submenu")
+	}
+	menu.Render(surface)
+	childRect := menu.Submenu.GetRect()
+	if childRect.X >= r.X {
+		t.Fatalf("submenu x = %d, parent x = %d; expected it to flip left", childRect.X, r.X)
+	}
+
+	menu.HandleEvent(tcell.NewEventMouse(childRect.X+2, childRect.Y+2, tcell.Button1, 0))
+	if executed != "unified" {
+		t.Fatalf("executed %q, want unified", executed)
+	}
+}
+
+func TestContextMenuWidthUsesDisplayColumns(t *testing.T) {
+	menu := NewContextMenuWidget([]ContextMenuItem{{Label: "界界界界界界界界界界界界"}}, 0, 0)
+	if got := menu.menuWidth(); got < 30 {
+		t.Fatalf("menu width = %d, want at least 30 display columns", got)
+	}
+}

--- a/internal/ui/diff_render.go
+++ b/internal/ui/diff_render.go
@@ -1,0 +1,223 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/core/highlight"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+)
+
+const diffTabWidth = 4
+
+// DiffMode is the reader-selected projection for every diff surface. Keeping
+// this as a value rather than a boolean lets menus and other controls inspect
+// and set a specific mode without reverse-engineering toggle state.
+type DiffMode uint8
+
+const (
+	DiffModeSplit DiffMode = iota
+	DiffModeUnified
+)
+
+func (m DiffMode) Toggle() DiffMode {
+	if m == DiffModeUnified {
+		return DiffModeSplit
+	}
+	return DiffModeUnified
+}
+
+// DiffWrapMode is the explicit line-wrapping state shared by diff surfaces.
+type DiffWrapMode uint8
+
+const (
+	DiffWrapOff DiffWrapMode = iota
+	DiffWrapOn
+)
+
+func (m DiffWrapMode) Toggle() DiffWrapMode {
+	if m == DiffWrapOn {
+		return DiffWrapOff
+	}
+	return DiffWrapOn
+}
+
+// DiffModeSurface is implemented by every diff-reading surface so commands,
+// menus, and the tab control all inspect and update the same presentation
+// state. SetMode and SetWrapMode are reader overrides; ApplyDefaultMode and
+// ApplyDefaultWrapMode only update properties that still inherit Options.
+type DiffModeSurface interface {
+	Mode() DiffMode
+	SetMode(DiffMode)
+	ApplyDefaultMode(DiffMode)
+	WrapMode() DiffWrapMode
+	SetWrapMode(DiffWrapMode)
+	ApplyDefaultWrapMode(DiffWrapMode)
+}
+
+// diffUnifiedLine points back to its source split row so search and selection
+// can keep using their original indexes after projection.
+type diffUnifiedLine struct {
+	sourceLine int
+	right      bool
+	side       diff.SideLine
+}
+
+// buildUnifiedDiffLines is shared by file diffs and each file section in a
+// commit detail. A contiguous change block is projected as all removals then
+// all additions; unchanged and collapsed rows appear once.
+func buildUnifiedDiffLines(lines []diff.DiffLine) []diffUnifiedLine {
+	var unified []diffUnifiedLine
+	for i := 0; i < len(lines); {
+		if lines[i].Left.Kind == diff.Deleted || lines[i].Right.Kind == diff.Added {
+			end := i
+			for end < len(lines) && (lines[end].Left.Kind == diff.Deleted || lines[end].Right.Kind == diff.Added) {
+				end++
+			}
+			for source := i; source < end; source++ {
+				if lines[source].Left.Kind == diff.Deleted {
+					unified = append(unified, diffUnifiedLine{sourceLine: source, side: lines[source].Left})
+				}
+			}
+			for source := i; source < end; source++ {
+				if lines[source].Right.Kind == diff.Added {
+					unified = append(unified, diffUnifiedLine{sourceLine: source, right: true, side: lines[source].Right})
+				}
+			}
+			i = end
+			continue
+		}
+
+		side := lines[i].Left
+		if side.Text == "" && lines[i].Right.Text != "" {
+			side = lines[i].Right
+		}
+		unified = append(unified, diffUnifiedLine{sourceLine: i, side: side})
+		i++
+	}
+	return unified
+}
+
+type diffCellDecorator func(runeIndex int, cell term.Cell) term.Cell
+
+func diffKindStyle(kind diff.LineKind) term.Style {
+	switch kind {
+	case diff.Added:
+		return term.StyleDiffAdded
+	case diff.Deleted:
+		return term.StyleDiffDeleted
+	case diff.Collapsed:
+		return term.StyleDiffCollapsed
+	default:
+		return term.StyleDefault
+	}
+}
+
+func diffLineVisualWidth(text string) int {
+	width := 0
+	for _, ch := range text {
+		if ch == '\t' {
+			width = ((width / diffTabWidth) + 1) * diffTabWidth
+		} else {
+			width += textwidth.Rune(ch)
+		}
+	}
+	return width
+}
+
+func diffWrapStarts(text string, width int) []int {
+	return wrapLineSegments([]rune(text), width, diffTabWidth)
+}
+
+func renderDiffGutter(surface Surface, x, y, width int, line diff.SideLine, baseStyle term.Style) {
+	number := ""
+	if line.Num > 0 {
+		number = fmt.Sprintf("%d", line.Num)
+	}
+	text := " " + fmt.Sprintf("%*s", width-3, number) + "  "
+	style := term.StyleLineNumber
+	if baseStyle == term.StyleDiffCollapsed {
+		style = baseStyle
+	}
+	for column, ch := range []rune(text) {
+		if column >= width {
+			break
+		}
+		surface.SetCell(x+column, y, term.Cell{Ch: ch, Style: style})
+	}
+}
+
+func renderDiffText(surface Surface, x, y, width int, text string, baseStyle term.Style, spans []highlight.Span, segmentStart, leftVisualCol int, decorate diffCellDecorator) {
+	fullBaseStyle := baseStyle == term.StyleDiffCollapsed
+	blank := term.Cell{Ch: ' '}
+	if fullBaseStyle {
+		blank.Style = baseStyle
+	} else if baseStyle != term.StyleDefault {
+		blank.BgStyle = baseStyle
+	}
+
+	drawTextSegment(surface, x, y, width, text, segmentStart, leftVisualCol, blank, func(runeIndex int, ch rune) term.Cell {
+		style := term.StyleDefault
+		if fullBaseStyle {
+			style = baseStyle
+		}
+		for _, span := range spans {
+			if runeIndex >= span.Start && runeIndex < span.End {
+				style = span.Style
+				break
+			}
+		}
+		cell := term.Cell{Ch: ch, Style: style}
+		if !fullBaseStyle && baseStyle != term.StyleDefault {
+			cell.BgStyle = baseStyle
+		}
+		if decorate != nil {
+			cell = decorate(runeIndex, cell)
+		}
+		return cell
+	})
+}
+
+// drawTextSegment draws one horizontally clipped or wrapped segment. Rune
+// indexes remain indexes into the original text so syntax, search, and
+// selection spans do not need their own wrapping logic.
+func drawTextSegment(surface Surface, x, y, width int, text string, segmentStart, leftVisualCol int, blank term.Cell, cellAt func(runeIndex int, ch rune) term.Cell) {
+	for column := 0; column < width; column++ {
+		surface.SetCell(x+column, y, blank)
+	}
+	if segmentStart < 0 {
+		return
+	}
+
+	runes := []rune(text)
+	visualColumn := 0
+	for runeIndex := segmentStart; runeIndex < len(runes); runeIndex++ {
+		ch := runes[runeIndex]
+		cell := cellAt(runeIndex, ch)
+		if ch == '\t' {
+			nextStop := ((visualColumn / diffTabWidth) + 1) * diffTabWidth
+			for tabColumn := visualColumn; tabColumn < nextStop; tabColumn++ {
+				drawColumn := tabColumn - leftVisualCol
+				if drawColumn >= 0 && drawColumn < width {
+					cell.Ch = ' '
+					surface.SetCell(x+drawColumn, y, cell)
+				}
+			}
+			visualColumn = nextStop
+		} else {
+			runeWidth := textwidth.Rune(ch)
+			drawColumn := visualColumn - leftVisualCol
+			if drawColumn >= 0 && drawColumn < width {
+				if runeWidth > 1 && drawColumn == width-1 {
+					cell.Ch = ' '
+				}
+				surface.SetCell(x+drawColumn, y, cell)
+			}
+			visualColumn += runeWidth
+		}
+		if visualColumn-leftVisualCol >= width {
+			break
+		}
+	}
+}

--- a/internal/ui/diff_render.go
+++ b/internal/ui/diff_render.go
@@ -44,8 +44,8 @@ func (m DiffWrapMode) Toggle() DiffWrapMode {
 }
 
 // DiffModeSurface is implemented by every diff-reading surface so commands,
-// menus, and the tab control all inspect and update the same presentation
-// state. SetMode and SetWrapMode are reader overrides; ApplyDefaultMode and
+// menus, settings, and the tab control update the same presentation state.
+// SetMode and SetWrapMode are reader overrides; ApplyDefaultMode and
 // ApplyDefaultWrapMode only update properties that still inherit Options.
 type DiffModeSurface interface {
 	Mode() DiffMode
@@ -54,6 +54,7 @@ type DiffModeSurface interface {
 	WrapMode() DiffWrapMode
 	SetWrapMode(DiffWrapMode)
 	ApplyDefaultWrapMode(DiffWrapMode)
+	SetDiffHighContrast(bool)
 }
 
 // diffUnifiedLine points back to its source split row so search and selection
@@ -114,6 +115,20 @@ func diffKindStyle(kind diff.LineKind) term.Style {
 	}
 }
 
+func diffKindForeground(kind diff.LineKind, highContrast bool) term.Style {
+	if !highContrast {
+		return term.StyleDefault
+	}
+	switch kind {
+	case diff.Added:
+		return term.StyleGutterAdded
+	case diff.Deleted:
+		return term.StyleGutterDeleted
+	default:
+		return term.StyleDefault
+	}
+}
+
 func diffLineVisualWidth(text string) int {
 	width := 0
 	for _, ch := range text {
@@ -135,11 +150,19 @@ func renderDiffGutter(surface Surface, x, y, width int, line diff.SideLine, base
 	if line.Num > 0 {
 		number = fmt.Sprintf("%d", line.Num)
 	}
-	text := " " + fmt.Sprintf("%*s", width-3, number) + "  "
+	marker := ' '
 	style := term.StyleLineNumber
-	if baseStyle == term.StyleDiffCollapsed {
+	switch line.Kind {
+	case diff.Added:
+		marker = '+'
+		style = term.StyleGutterAdded
+	case diff.Deleted:
+		marker = '-'
+		style = term.StyleGutterDeleted
+	case diff.Collapsed:
 		style = baseStyle
 	}
+	text := fmt.Sprintf("%*s %c", width-2, number, marker)
 	for column, ch := range []rune(text) {
 		if column >= width {
 			break
@@ -148,7 +171,10 @@ func renderDiffGutter(surface Surface, x, y, width int, line diff.SideLine, base
 	}
 }
 
-func renderDiffText(surface Surface, x, y, width int, text string, baseStyle term.Style, spans []highlight.Span, segmentStart, leftVisualCol int, decorate diffCellDecorator) {
+func renderDiffText(surface Surface, x, y, width int, text string, baseStyle, foregroundStyle term.Style, spans []highlight.Span, segmentStart, leftVisualCol int, decorate diffCellDecorator) {
+	if foregroundStyle != term.StyleDefault {
+		spans = nil
+	}
 	fullBaseStyle := baseStyle == term.StyleDiffCollapsed
 	blank := term.Cell{Ch: ' '}
 	if fullBaseStyle {
@@ -158,7 +184,7 @@ func renderDiffText(surface Surface, x, y, width int, text string, baseStyle ter
 	}
 
 	drawTextSegment(surface, x, y, width, text, segmentStart, leftVisualCol, blank, func(runeIndex int, ch rune) term.Cell {
-		style := term.StyleDefault
+		style := foregroundStyle
 		if fullBaseStyle {
 			style = baseStyle
 		}

--- a/internal/ui/diff_render.go
+++ b/internal/ui/diff_render.go
@@ -126,13 +126,16 @@ func diffKindStyle(kind diff.LineKind) term.Style {
 	case diff.Deleted:
 		return term.StyleDiffDeleted
 	case diff.Collapsed:
-		return term.StyleDiffCollapsed
+		return term.StyleDefault
 	default:
 		return term.StyleDefault
 	}
 }
 
 func diffKindForeground(kind diff.LineKind, highContrast bool) term.Style {
+	if kind == diff.Collapsed {
+		return term.StyleMuted
+	}
 	if !highContrast {
 		return term.StyleDefault
 	}
@@ -162,7 +165,7 @@ func diffWrapStarts(text string, width int) []int {
 	return wrapLineSegments([]rune(text), width, diffTabWidth)
 }
 
-func renderDiffGutter(surface Surface, x, y, width int, line diff.SideLine, baseStyle term.Style) {
+func renderDiffGutter(surface Surface, x, y, width int, line diff.SideLine) {
 	number := ""
 	if line.Num > 0 {
 		number = fmt.Sprintf("%d", line.Num)
@@ -177,7 +180,7 @@ func renderDiffGutter(surface Surface, x, y, width int, line diff.SideLine, base
 		marker = '-'
 		style = term.StyleGutterDeleted
 	case diff.Collapsed:
-		style = baseStyle
+		marker = '▶'
 	}
 	text := fmt.Sprintf("%*s %c", width-2, number, marker)
 	for column, ch := range []rune(text) {

--- a/internal/ui/diff_render.go
+++ b/internal/ui/diff_render.go
@@ -43,6 +43,23 @@ func (m DiffWrapMode) Toggle() DiffWrapMode {
 	return DiffWrapOn
 }
 
+// DiffContextMode controls how much unchanged file content a diff surface
+// shows. ChangesOnly keeps Git's compact hunks; FullFile includes every line.
+type DiffContextMode uint8
+
+const (
+	DiffContextChangesOnly DiffContextMode = iota
+	DiffContextFullFile
+)
+
+// DiffContextSurface is separate from DiffModeSurface because some diff
+// readers can project split/unified and wrapping without owning full blobs.
+type DiffContextSurface interface {
+	ContextMode() DiffContextMode
+	SetContextMode(DiffContextMode)
+	ApplyDefaultContextMode(DiffContextMode)
+}
+
 // DiffModeSurface is implemented by every diff-reading surface so commands,
 // menus, settings, and the tab control update the same presentation state.
 // SetMode and SetWrapMode are reader overrides; ApplyDefaultMode and

--- a/internal/ui/diff_selection.go
+++ b/internal/ui/diff_selection.go
@@ -1,0 +1,102 @@
+package ui
+
+import (
+	"strings"
+	"unicode"
+)
+
+type diffSelPos struct {
+	Line int
+	Col  int
+}
+
+// diffTextSelection stores positions in logical, unwrapped text. Diff surfaces
+// provide their own line lookup so split panes and commit-detail document rows
+// can share selection mechanics without coupling their different row models.
+type diffTextSelection struct {
+	Anchor  diffSelPos
+	Current diffSelPos
+}
+
+type diffSelectionTextAt func(line int) (text string, selectable bool)
+
+func (s diffTextSelection) Range() (start, end diffSelPos) {
+	if s.Anchor.Line < s.Current.Line ||
+		(s.Anchor.Line == s.Current.Line && s.Anchor.Col <= s.Current.Col) {
+		return s.Anchor, s.Current
+	}
+	return s.Current, s.Anchor
+}
+
+func (s diffTextSelection) Contains(line, col int) bool {
+	start, end := s.Range()
+	if line < start.Line || line > end.Line {
+		return false
+	}
+	if start.Line == end.Line {
+		return col >= start.Col && col < end.Col
+	}
+	if line == start.Line {
+		return col >= start.Col
+	}
+	if line == end.Line {
+		return col < end.Col
+	}
+	return true
+}
+
+func (s diffTextSelection) Text(lineCount int, textAt diffSelectionTextAt) string {
+	start, end := s.Range()
+	if lineCount <= 0 || end.Line < 0 || start.Line >= lineCount {
+		return ""
+	}
+	firstLine := max(0, start.Line)
+	lastLine := min(end.Line, lineCount-1)
+	lines := make([]string, 0, lastLine-firstLine+1)
+	for line := firstLine; line <= lastLine; line++ {
+		text, selectable := textAt(line)
+		if !selectable {
+			if line != start.Line && line != end.Line {
+				lines = append(lines, "")
+			}
+			continue
+		}
+		runes := []rune(text)
+		startCol, endCol := 0, len(runes)
+		if line == start.Line {
+			startCol = min(max(0, start.Col), len(runes))
+		}
+		if line == end.Line {
+			endCol = min(max(0, end.Col), len(runes))
+		}
+		if startCol < endCol {
+			lines = append(lines, string(runes[startCol:endCol]))
+		} else {
+			lines = append(lines, "")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (s *diffTextSelection) SelectWord(line, col int, text string) bool {
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return false
+	}
+	col = min(max(0, col), len(runes)-1)
+	isWord := func(ch rune) bool {
+		return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_'
+	}
+	start, end := col, col
+	if isWord(runes[col]) {
+		for start > 0 && isWord(runes[start-1]) {
+			start--
+		}
+		for end < len(runes)-1 && isWord(runes[end+1]) {
+			end++
+		}
+	}
+	s.Anchor = diffSelPos{Line: line, Col: start}
+	s.Current = diffSelPos{Line: line, Col: end + 1}
+	return true
+}

--- a/internal/ui/diff_selection_test.go
+++ b/internal/ui/diff_selection_test.go
@@ -1,0 +1,134 @@
+package ui
+
+import "testing"
+
+func TestDiffTextSelectionContainsBoundaries(t *testing.T) {
+	t.Run("single line is half open", func(t *testing.T) {
+		selection := diffTextSelection{
+			Anchor:  diffSelPos{Line: 3, Col: 2},
+			Current: diffSelPos{Line: 3, Col: 5},
+		}
+		assertDiffSelectionContains(t, selection,
+			[]diffSelPos{{Line: 3, Col: 2}, {Line: 3, Col: 3}, {Line: 3, Col: 4}},
+			[]diffSelPos{{Line: 3, Col: 1}, {Line: 3, Col: 5}},
+		)
+	})
+
+	t.Run("single character contains only that cell", func(t *testing.T) {
+		selection := diffTextSelection{
+			Anchor:  diffSelPos{Line: 1, Col: 4},
+			Current: diffSelPos{Line: 1, Col: 5},
+		}
+		assertDiffSelectionContains(t, selection,
+			[]diffSelPos{{Line: 1, Col: 4}},
+			[]diffSelPos{{Line: 1, Col: 3}, {Line: 1, Col: 5}},
+		)
+	})
+
+	t.Run("multiple lines use partial edges and full middle rows", func(t *testing.T) {
+		selection := diffTextSelection{
+			Anchor:  diffSelPos{Line: 2, Col: 3},
+			Current: diffSelPos{Line: 4, Col: 2},
+		}
+		assertDiffSelectionContains(t, selection,
+			[]diffSelPos{
+				{Line: 2, Col: 3}, {Line: 2, Col: 8},
+				{Line: 3, Col: 0}, {Line: 3, Col: 20},
+				{Line: 4, Col: 0}, {Line: 4, Col: 1},
+			},
+			[]diffSelPos{{Line: 2, Col: 2}, {Line: 4, Col: 2}, {Line: 5, Col: 0}},
+		)
+	})
+
+	t.Run("reversed selection normalizes through range", func(t *testing.T) {
+		selection := diffTextSelection{
+			Anchor:  diffSelPos{Line: 4, Col: 2},
+			Current: diffSelPos{Line: 2, Col: 3},
+		}
+		start, end := selection.Range()
+		if start != (diffSelPos{Line: 2, Col: 3}) || end != (diffSelPos{Line: 4, Col: 2}) {
+			t.Fatalf("range = %v..%v, want 2:3..4:2", start, end)
+		}
+		assertDiffSelectionContains(t, selection,
+			[]diffSelPos{{Line: 2, Col: 3}, {Line: 3, Col: 0}, {Line: 4, Col: 1}},
+			[]diffSelPos{{Line: 2, Col: 2}, {Line: 4, Col: 2}},
+		)
+	})
+}
+
+func assertDiffSelectionContains(t *testing.T, selection diffTextSelection, included, excluded []diffSelPos) {
+	t.Helper()
+	for _, point := range included {
+		if !selection.Contains(point.Line, point.Col) {
+			t.Errorf("selection %v..%v should contain %+v", selection.Anchor, selection.Current, point)
+		}
+	}
+	for _, point := range excluded {
+		if selection.Contains(point.Line, point.Col) {
+			t.Errorf("selection %v..%v should not contain %+v", selection.Anchor, selection.Current, point)
+		}
+	}
+}
+
+func TestDiffTextSelectionSelectWordBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		col   int
+		start int
+		end   int
+	}{
+		{name: "first character", col: 0, start: 0, end: 5},
+		{name: "last character", col: 4, start: 0, end: 5},
+		{name: "whitespace", col: 5, start: 5, end: 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var selection diffTextSelection
+			if !selection.SelectWord(7, tc.col, "alpha beta") {
+				t.Fatal("SelectWord rejected non-empty text")
+			}
+			start, end := selection.Range()
+			if start != (diffSelPos{Line: 7, Col: tc.start}) || end != (diffSelPos{Line: 7, Col: tc.end}) {
+				t.Fatalf("word range = %v..%v, want 7:%d..7:%d", start, end, tc.start, tc.end)
+			}
+		})
+	}
+}
+
+func TestDiffTextSelectionMechanics(t *testing.T) {
+	selection := diffTextSelection{
+		Anchor:  diffSelPos{Line: 2, Col: 3},
+		Current: diffSelPos{Line: 0, Col: 1},
+	}
+	start, end := selection.Range()
+	if start != (diffSelPos{Line: 0, Col: 1}) || end != (diffSelPos{Line: 2, Col: 3}) {
+		t.Fatalf("range = %v..%v, want 0:1..2:3", start, end)
+	}
+	for _, point := range []diffSelPos{{Line: 0, Col: 1}, {Line: 1, Col: 0}, {Line: 2, Col: 2}} {
+		if !selection.Contains(point.Line, point.Col) {
+			t.Errorf("selection should contain %+v", point)
+		}
+	}
+	for _, point := range []diffSelPos{{Line: 0, Col: 0}, {Line: 2, Col: 3}, {Line: 3, Col: 0}} {
+		if selection.Contains(point.Line, point.Col) {
+			t.Errorf("selection should not contain %+v", point)
+		}
+	}
+
+	lines := []struct {
+		text       string
+		selectable bool
+	}{{"zero", true}, {"hidden", false}, {"twofold", true}}
+	if got := selection.Text(len(lines), func(line int) (string, bool) {
+		return lines[line].text, lines[line].selectable
+	}); got != "ero\n\ntwo" {
+		t.Fatalf("text = %q, want selected source text with an intermediate blank row", got)
+	}
+
+	if !selection.SelectWord(4, 5, "alpha_beta + gamma") {
+		t.Fatal("word selection rejected non-empty text")
+	}
+	start, end = selection.Range()
+	if start != (diffSelPos{Line: 4, Col: 0}) || end != (diffSelPos{Line: 4, Col: 10}) {
+		t.Fatalf("word range = %v..%v, want 4:0..4:10", start, end)
+	}
+}

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -56,16 +56,23 @@ type DiffViewWidget struct {
 	searchActiveSideIdx int
 
 	// diff view modes and their projected rows
-	extended     bool
-	wrapMode     DiffWrapMode
-	wrapExplicit bool
-	mode         DiffMode
-	modeExplicit bool
-	highContrast bool
-	fileDiff     diff.FileDiff
-	oldLines     []string
-	newLines     []string
-	unifiedLines []diffUnifiedLine
+	extended        bool
+	wrapMode        DiffWrapMode
+	wrapExplicit    bool
+	mode            DiffMode
+	modeExplicit    bool
+	contextMode     DiffContextMode
+	contextExplicit bool
+	contextLoaded   bool
+	expandedGaps    map[int]bool
+	gapByLine       map[int]int
+	pendingGap      int
+	primaryPressed  bool
+	highContrast    bool
+	fileDiff        diff.FileDiff
+	oldLines        []string
+	newLines        []string
+	unifiedLines    []diffUnifiedLine
 
 	OnFetchExtended func(dv *DiffViewWidget)
 	Loading         bool
@@ -84,6 +91,14 @@ func NewDiffViewWidget(filePath string, fd diff.FileDiff, oldLines, newLines []s
 		oldLines:            oldLines,
 		newLines:            newLines,
 		extended:            extended,
+		contextMode:         DiffContextChangesOnly,
+		contextExplicit:     extended,
+		contextLoaded:       oldLines != nil || newLines != nil,
+		expandedGaps:        make(map[int]bool),
+		pendingGap:          -1,
+	}
+	if extended {
+		dv.contextMode = DiffContextFullFile
 	}
 	dv.rebuildLines()
 	return dv
@@ -98,7 +113,25 @@ func (d *DiffViewWidget) SetNewLines(lines []string) {
 }
 
 func (d *DiffViewWidget) IsExtended() bool {
-	return d.extended
+	return d.contextMode == DiffContextFullFile
+}
+
+func (d *DiffViewWidget) ContextMode() DiffContextMode { return d.contextMode }
+
+func (d *DiffViewWidget) SetContextMode(mode DiffContextMode) {
+	d.contextExplicit = true
+	d.applyContextMode(mode)
+}
+
+func (d *DiffViewWidget) ApplyDefaultContextMode(mode DiffContextMode) {
+	if d.contextExplicit {
+		return
+	}
+	d.applyContextMode(mode)
+}
+
+func (d *DiffViewWidget) applyContextMode(mode DiffContextMode) {
+	d.applyExtended(mode == DiffContextFullFile)
 }
 
 func (d *DiffViewWidget) IsWrapped() bool {
@@ -179,13 +212,26 @@ func (d *DiffViewWidget) applyMode(mode DiffMode) {
 }
 
 func (d *DiffViewWidget) SetExtended(extended bool) {
-	if extended && len(d.oldLines) == 0 && d.OnFetchExtended != nil {
+	d.contextExplicit = true
+	d.applyExtended(extended)
+}
+
+func (d *DiffViewWidget) applyExtended(extended bool) {
+	if extended && !d.contextLoaded && d.OnFetchExtended != nil {
 		d.Loading = true
 		d.extended = true
+		d.contextMode = DiffContextFullFile
 		d.OnFetchExtended(d)
 		return
 	}
 	d.extended = extended
+	if extended {
+		d.contextMode = DiffContextFullFile
+	} else {
+		d.contextMode = DiffContextChangesOnly
+		d.pendingGap = -1
+		clear(d.expandedGaps)
+	}
 	d.rebuildLines()
 	d.TopLine = 0
 	d.wrapTopOffset = 0
@@ -196,6 +242,13 @@ func (d *DiffViewWidget) SetExtended(extended bool) {
 
 func (d *DiffViewWidget) FinishLoading() {
 	d.Loading = false
+	d.contextLoaded = true
+	if d.pendingGap >= 0 {
+		d.expandedGaps[d.pendingGap] = true
+		d.pendingGap = -1
+		d.extended = false
+		d.contextMode = DiffContextChangesOnly
+	}
 	d.rebuildLines()
 	d.TopLine = 0
 	d.wrapTopOffset = 0
@@ -205,10 +258,11 @@ func (d *DiffViewWidget) FinishLoading() {
 }
 
 func (d *DiffViewWidget) rebuildLines() {
-	if d.extended && len(d.oldLines) > 0 {
+	if d.extended && d.contextLoaded {
 		d.Lines = diff.FullDiffLines(d.oldLines, d.newLines)
+		d.gapByLine = nil
 	} else {
-		d.Lines = compactDiffLines(d.fileDiff)
+		d.Lines, d.gapByLine = compactDiffLinesWithContext(d.fileDiff, d.oldLines, d.newLines, d.expandedGaps)
 	}
 	d.unifiedLines = buildUnifiedDiffLines(d.Lines)
 	maxW := 0
@@ -221,6 +275,47 @@ func (d *DiffViewWidget) rebuildLines() {
 		}
 	}
 	d.maxLineW = maxW
+}
+
+func (d *DiffViewWidget) expandContextGap(gap int) {
+	if gap < 0 || d.expandedGaps[gap] {
+		return
+	}
+	if !d.contextLoaded && d.OnFetchExtended != nil {
+		d.pendingGap = gap
+		d.Loading = true
+		d.OnFetchExtended(d)
+		return
+	}
+	if !d.contextLoaded {
+		return
+	}
+	d.expandedGaps[gap] = true
+	d.rebuildLines()
+	d.ClearSearch()
+	d.ClearSelection()
+}
+
+func (d *DiffViewWidget) screenSourceLine(my int) int {
+	r := d.GetRect()
+	localY := my - r.Y
+	if localY < 0 || localY >= d.viewH {
+		return -1
+	}
+	line := d.TopLine + localY
+	if d.IsWrapped() {
+		if localY >= len(d.wrapMap) {
+			return -1
+		}
+		line = d.wrapMap[localY].line
+	}
+	if d.IsUnified() {
+		if line < 0 || line >= len(d.unifiedLines) {
+			return -1
+		}
+		return d.unifiedLines[line].sourceLine
+	}
+	return line
 }
 
 func (d *DiffViewWidget) Focusable() bool { return true }
@@ -851,7 +946,18 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		}
 		mx, my := tev.Position()
+		if btn == tcell.ButtonNone {
+			d.primaryPressed = false
+		}
 		if btn&tcell.Button1 != 0 {
+			freshPress := !d.primaryPressed
+			d.primaryPressed = true
+			if freshPress {
+				if gap, ok := d.gapByLine[d.screenSourceLine(my)]; ok {
+					d.expandContextGap(gap)
+					return EventConsumed
+				}
+			}
 			pos, right, ok := d.screenToSel(mx, my)
 			if ok {
 				if !d.selecting {

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -1,11 +1,8 @@
 package ui
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 	"time"
-	"unicode"
 
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/core/highlight"
@@ -19,24 +16,20 @@ type diffMergedRef struct {
 	sideIdx int
 }
 
-type diffSelPos struct {
-	Line int
-	Col  int
-}
-
 type DiffViewWidget struct {
 	BaseWidget
-	FilePath    string
-	Lines       []diff.DiffLine
-	Highlighter *highlight.Highlighter
-	TopLine     int
-	LeftCol     int
-	maxLineW    int
-	viewH       int
-	contentW    int
-	scrollbar   Scrollbar
-	hscrollbar  HScrollbar
-	rhscrollbar HScrollbar
+	FilePath        string
+	Lines           []diff.DiffLine
+	Highlighter     *highlight.Highlighter
+	TopLine         int
+	LeftCol         int
+	maxLineW        int
+	viewH           int
+	contentW        int
+	totalVisualRows int
+	scrollbar       Scrollbar
+	hscrollbar      HScrollbar
+	rhscrollbar     HScrollbar
 
 	// layout cache for mouse hit-testing
 	layoutDividerX   int
@@ -45,13 +38,14 @@ type DiffViewWidget struct {
 	layoutRightStart int
 	layoutRightW     int
 	layoutGutterW    int
+	wrapMap          []diffWrapEntry
+	wrapTopOffset    int
 
 	// selection state
 	selecting     bool
 	hasSelection  bool
 	selRight      bool
-	selAnchor     diffSelPos
-	selCurrent    diffSelPos
+	selection     diffTextSelection
 	lastClickTime time.Time
 	lastClickPos  diffSelPos
 
@@ -61,11 +55,16 @@ type DiffViewWidget struct {
 	searchActiveRight   bool
 	searchActiveSideIdx int
 
-	// extended diff mode
-	extended bool
-	fileDiff diff.FileDiff
-	oldLines []string
-	newLines []string
+	// diff view modes and their projected rows
+	extended     bool
+	wrapMode     DiffWrapMode
+	wrapExplicit bool
+	mode         DiffMode
+	modeExplicit bool
+	fileDiff     diff.FileDiff
+	oldLines     []string
+	newLines     []string
+	unifiedLines []diffUnifiedLine
 
 	OnFetchExtended func(dv *DiffViewWidget)
 	Loading         bool
@@ -97,6 +96,83 @@ func (d *DiffViewWidget) IsExtended() bool {
 	return d.extended
 }
 
+func (d *DiffViewWidget) IsWrapped() bool {
+	return d.wrapMode == DiffWrapOn
+}
+
+func (d *DiffViewWidget) SetWrapped(wrapped bool) {
+	mode := DiffWrapOff
+	if wrapped {
+		mode = DiffWrapOn
+	}
+	d.SetWrapMode(mode)
+}
+
+func (d *DiffViewWidget) WrapMode() DiffWrapMode { return d.wrapMode }
+
+func (d *DiffViewWidget) SetWrapMode(mode DiffWrapMode) {
+	d.wrapExplicit = true
+	d.applyWrapMode(mode)
+}
+
+func (d *DiffViewWidget) ApplyDefaultWrapMode(mode DiffWrapMode) {
+	if d.wrapExplicit {
+		return
+	}
+	d.applyWrapMode(mode)
+}
+
+func (d *DiffViewWidget) applyWrapMode(mode DiffWrapMode) {
+	if mode == d.wrapMode {
+		return
+	}
+	d.wrapMode = mode
+	d.TopLine = 0
+	d.wrapTopOffset = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+}
+
+func (d *DiffViewWidget) IsUnified() bool {
+	return d.mode == DiffModeUnified
+}
+
+func (d *DiffViewWidget) SetUnified(unified bool) {
+	mode := DiffModeSplit
+	if unified {
+		mode = DiffModeUnified
+	}
+	d.SetMode(mode)
+}
+
+func (d *DiffViewWidget) Mode() DiffMode { return d.mode }
+
+func (d *DiffViewWidget) SetMode(mode DiffMode) {
+	d.modeExplicit = true
+	d.applyMode(mode)
+}
+
+func (d *DiffViewWidget) ApplyDefaultMode(mode DiffMode) {
+	if d.modeExplicit {
+		return
+	}
+	d.applyMode(mode)
+}
+
+func (d *DiffViewWidget) applyMode(mode DiffMode) {
+	if mode == d.mode {
+		return
+	}
+	d.mode = mode
+	d.TopLine = 0
+	d.wrapTopOffset = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+	if len(d.SearchMatchesLeft) > 0 || len(d.SearchMatchesRight) > 0 {
+		d.SetSearchMatches(d.SearchMatchesLeft, d.SearchMatchesRight)
+	}
+}
+
 func (d *DiffViewWidget) SetExtended(extended bool) {
 	if extended && len(d.oldLines) == 0 && d.OnFetchExtended != nil {
 		d.Loading = true
@@ -107,6 +183,7 @@ func (d *DiffViewWidget) SetExtended(extended bool) {
 	d.extended = extended
 	d.rebuildLines()
 	d.TopLine = 0
+	d.wrapTopOffset = 0
 	d.LeftCol = 0
 	d.ClearSearch()
 	d.ClearSelection()
@@ -116,6 +193,7 @@ func (d *DiffViewWidget) FinishLoading() {
 	d.Loading = false
 	d.rebuildLines()
 	d.TopLine = 0
+	d.wrapTopOffset = 0
 	d.LeftCol = 0
 	d.ClearSearch()
 	d.ClearSelection()
@@ -125,14 +203,15 @@ func (d *DiffViewWidget) rebuildLines() {
 	if d.extended && len(d.oldLines) > 0 {
 		d.Lines = diff.FullDiffLines(d.oldLines, d.newLines)
 	} else {
-		d.Lines = d.fileDiff.AllLines()
+		d.Lines = compactDiffLines(d.fileDiff)
 	}
+	d.unifiedLines = buildUnifiedDiffLines(d.Lines)
 	maxW := 0
 	for _, dl := range d.Lines {
-		if lw := len([]rune(dl.Left.Text)); lw > maxW {
+		if lw := diffLineVisualWidth(dl.Left.Text); lw > maxW {
 			maxW = lw
 		}
-		if rw := len([]rune(dl.Right.Text)); rw > maxW {
+		if rw := diffLineVisualWidth(dl.Right.Text); rw > maxW {
 			maxW = rw
 		}
 	}
@@ -179,6 +258,22 @@ func (d *DiffViewWidget) ApplySearchHighlight(query string, opts SearchOptions) 
 }
 
 func (d *DiffViewWidget) ScrollToLine(line int) {
+	if d.IsUnified() {
+		line = d.unifiedIndexForSearchLine(line)
+	}
+	if d.IsWrapped() && d.viewH > 0 {
+		target := 0
+		if d.IsUnified() {
+			target = unifiedLineToVisualRow(d.unifiedLines, line, d.layoutLeftW)
+		} else {
+			target = diffLineToVisualRow(d.Lines, line, d.layoutLeftW, d.layoutRightW)
+		}
+		top := d.topVisualRow()
+		if target < top || target >= top+d.viewH {
+			d.setTopVisualRow(target - d.viewH/2)
+		}
+		return
+	}
 	if d.viewH <= 0 {
 		d.TopLine = line
 		return
@@ -188,7 +283,11 @@ func (d *DiffViewWidget) ScrollToLine(line int) {
 		if d.TopLine < 0 {
 			d.TopLine = 0
 		}
-		max := len(d.Lines) - d.viewH
+		lineCount := len(d.Lines)
+		if d.IsUnified() {
+			lineCount = len(d.unifiedLines)
+		}
+		max := lineCount - d.viewH
 		if max < 0 {
 			max = 0
 		}
@@ -217,12 +316,24 @@ func (d *DiffViewWidget) SetSearchMatches(left, right []FindMatch) []FindMatch {
 	}
 	var entries []entry
 	for i, m := range left {
-		entries = append(entries, entry{m, false, i})
+		if !d.IsUnified() || d.unifiedIndexForSource(m.Line, false) >= 0 {
+			entries = append(entries, entry{m, false, i})
+		}
 	}
 	for i, m := range right {
-		entries = append(entries, entry{m, true, i})
+		if !d.IsUnified() || d.unifiedIndexForSource(m.Line, true) >= 0 {
+			entries = append(entries, entry{m, true, i})
+		}
 	}
 	sort.Slice(entries, func(i, j int) bool {
+		if d.IsUnified() {
+			leftIndex := d.unifiedIndexForSource(entries[i].match.Line, entries[i].isRight)
+			rightIndex := d.unifiedIndexForSource(entries[j].match.Line, entries[j].isRight)
+			if leftIndex != rightIndex {
+				return leftIndex < rightIndex
+			}
+			return entries[i].match.Col < entries[j].match.Col
+		}
 		if entries[i].match.Line != entries[j].match.Line {
 			return entries[i].match.Line < entries[j].match.Line
 		}
@@ -270,7 +381,8 @@ func (d *DiffViewWidget) gutterWidth() int {
 }
 
 func (d *DiffViewWidget) Render(surface Surface) {
-	w, h := surface.Size()
+	originalW, originalH := surface.Size()
+	w, h := originalW, originalH
 	r := d.GetRect()
 
 	if d.Loading {
@@ -285,24 +397,51 @@ func (d *DiffViewWidget) Render(surface Surface) {
 
 	gutterW := d.gutterWidth()
 
-	showVScroll := len(d.Lines) > h
-	contentW := (w-1)/2 - gutterW
-	showHScroll := d.maxLineW > contentW
-
-	if showHScroll {
-		h--
-	}
-	if showVScroll {
-		w--
+	showVScroll, showHScroll := false, false
+	var dividerX, leftStart, leftW, rightStart, rightW int
+	for range 3 {
+		w, h = originalW, originalH
+		if showVScroll {
+			w--
+		}
+		leftStart = gutterW
+		if d.IsUnified() {
+			dividerX = -1
+			leftW = w - gutterW
+			rightStart, rightW = 0, 0
+		} else {
+			dividerX = (w - 1) / 2
+			leftW = dividerX - gutterW
+			rightStart = dividerX + 1 + gutterW
+			rightW = w - rightStart
+		}
+		if leftW < 1 || (!d.IsUnified() && rightW < 1) {
+			return
+		}
+		showHScroll = !d.IsWrapped() && d.maxLineW > leftW
+		if showHScroll {
+			h--
+		}
+		totalRows := len(d.Lines)
+		if d.IsUnified() {
+			totalRows = len(d.unifiedLines)
+		}
+		if d.IsWrapped() {
+			if d.IsUnified() {
+				totalRows = totalUnifiedVisualRows(d.unifiedLines, leftW)
+			} else {
+				totalRows = totalDiffVisualRows(d.Lines, leftW, rightW)
+			}
+		}
+		newShowVScroll := totalRows > h
+		if newShowVScroll == showVScroll {
+			d.totalVisualRows = totalRows
+			break
+		}
+		showVScroll = newShowVScroll
 	}
 
 	d.viewH = h
-
-	dividerX := (w - 1) / 2
-	leftStart := gutterW
-	leftW := dividerX - gutterW
-	rightStart := dividerX + 1 + gutterW
-	rightW := w - rightStart
 	d.contentW = leftW
 
 	d.layoutDividerX = dividerX
@@ -312,12 +451,39 @@ func (d *DiffViewWidget) Render(surface Surface) {
 	d.layoutRightW = rightW
 	d.layoutGutterW = gutterW
 
-	if leftW < 1 || rightW < 1 {
-		return
+	if d.IsWrapped() {
+		d.setTopVisualRow(d.topVisualRow())
+		if d.IsUnified() {
+			d.wrapMap = buildUnifiedWrapMap(d.unifiedLines, d.TopLine, d.wrapTopOffset, h, leftW)
+		} else {
+			d.wrapMap = buildDiffWrapMap(d.Lines, d.TopLine, d.wrapTopOffset, h, leftW, rightW)
+		}
+	} else {
+		d.wrapMap = nil
+		d.wrapTopOffset = 0
+		if d.IsUnified() {
+			d.totalVisualRows = len(d.unifiedLines)
+		} else {
+			d.totalVisualRows = len(d.Lines)
+		}
+		d.setTopVisualRow(d.TopLine)
 	}
 
 	for y := 0; y < h; y++ {
+		if d.IsUnified() {
+			d.renderUnifiedRow(surface, y, w, gutterW, leftStart, leftW)
+			continue
+		}
 		idx := d.TopLine + y
+		leftSegment, rightSegment := 0, 0
+		continuation := false
+		if d.IsWrapped() {
+			entry := d.wrapMap[y]
+			idx = entry.line
+			leftSegment = entry.leftStart
+			rightSegment = entry.rightStart
+			continuation = entry.continuation
+		}
 		surface.SetCell(dividerX, y, term.Cell{Ch: '│', Style: term.StyleBorder})
 
 		if idx >= len(d.Lines) {
@@ -332,18 +498,23 @@ func (d *DiffViewWidget) Render(surface Surface) {
 
 		dl := d.Lines[idx]
 
-		leftStyle := kindToStyle(dl.Left.Kind)
-		rightStyle := kindToStyle(dl.Right.Kind)
+		leftStyle := diffKindStyle(dl.Left.Kind)
+		rightStyle := diffKindStyle(dl.Right.Kind)
 
-		d.renderGutter(surface, 0, y, gutterW, dl.Left, leftStyle)
-		d.renderGutter(surface, dividerX+1, y, gutterW, dl.Right, rightStyle)
+		if continuation {
+			renderDiffGutter(surface, 0, y, gutterW, diff.SideLine{}, leftStyle)
+			renderDiffGutter(surface, dividerX+1, y, gutterW, diff.SideLine{}, rightStyle)
+		} else {
+			renderDiffGutter(surface, 0, y, gutterW, dl.Left, leftStyle)
+			renderDiffGutter(surface, dividerX+1, y, gutterW, dl.Right, rightStyle)
+		}
 
 		var leftSpans, rightSpans []highlight.Span
 		if d.Highlighter != nil {
-			if dl.Left.Text != "" {
+			if dl.Left.Text != "" && dl.Left.Kind != diff.Collapsed {
 				leftSpans = d.Highlighter.HighlightLine(dl.Left.Text)
 			}
-			if dl.Right.Text != "" {
+			if dl.Right.Text != "" && dl.Right.Kind != diff.Collapsed {
 				rightSpans = d.Highlighter.HighlightLine(dl.Right.Text)
 			}
 		}
@@ -355,16 +526,20 @@ func (d *DiffViewWidget) Render(surface Surface) {
 		if d.searchActiveRight {
 			rightActive = d.searchActiveSideIdx
 		}
-		d.renderSide(surface, leftStart, y, leftW, dl.Left.Text, leftStyle, leftSpans, idx, d.SearchMatchesLeft, leftActive, !d.selRight)
-		d.renderSide(surface, rightStart, y, rightW, dl.Right.Text, rightStyle, rightSpans, idx, d.SearchMatchesRight, rightActive, d.selRight)
+		leftScroll, rightScroll := d.LeftCol, d.LeftCol
+		if d.IsWrapped() {
+			leftScroll, rightScroll = 0, 0
+		}
+		d.renderSide(surface, leftStart, y, leftW, dl.Left.Text, leftStyle, leftSpans, idx, idx, d.SearchMatchesLeft, leftActive, !d.selRight, leftSegment, leftScroll)
+		d.renderSide(surface, rightStart, y, rightW, dl.Right.Text, rightStyle, rightSpans, idx, idx, d.SearchMatchesRight, rightActive, d.selRight, rightSegment, rightScroll)
 	}
 
 	if showVScroll {
 		d.scrollbar.X = r.X + w
 		d.scrollbar.Y = r.Y
 		d.scrollbar.Height = h
-		d.scrollbar.TotalItems = len(d.Lines)
-		d.scrollbar.TopItem = d.TopLine
+		d.scrollbar.TotalItems = d.totalVisualRows
+		d.scrollbar.TopItem = d.topVisualRow()
 		d.scrollbar.Render(surface, w, 0)
 	}
 
@@ -379,127 +554,154 @@ func (d *DiffViewWidget) Render(surface Surface) {
 		for x := 0; x < gutterW; x++ {
 			surface.SetCell(x, h, term.Cell{Ch: ' '})
 		}
-		surface.SetCell(dividerX, h, term.Cell{Ch: '│', Style: term.StyleBorder})
-		for x := dividerX + 1; x < rightStart; x++ {
-			surface.SetCell(x, h, term.Cell{Ch: ' '})
-		}
-
-		d.rhscrollbar.X = r.X + rightStart
-		d.rhscrollbar.Y = r.Y + h
-		d.rhscrollbar.Width = rightW
-		d.rhscrollbar.TotalCols = d.maxLineW
-		d.rhscrollbar.LeftCol = d.LeftCol
-		d.rhscrollbar.Render(surface, rightStart, h)
-	}
-}
-
-func (d *DiffViewWidget) renderGutter(surface Surface, x, y, w int, sl diff.SideLine, style term.Style) {
-	num := ""
-	if sl.Num > 0 {
-		num = fmt.Sprintf("%d", sl.Num)
-	}
-	padded := " " + fmt.Sprintf("%*s", w-3, num) + "  "
-	for i, ch := range []rune(padded) {
-		if i >= w {
-			break
-		}
-		surface.SetCell(x+i, y, term.Cell{Ch: ch, Style: term.StyleLineNumber})
-	}
-}
-
-func (d *DiffViewWidget) renderSide(surface Surface, x, y, w int, text string, baseStyle term.Style, spans []highlight.Span, lineIdx int, matches []FindMatch, activeIdx int, selSide bool) {
-	runes := []rune(text)
-	for i := 0; i < w; i++ {
-		colIdx := d.LeftCol + i
-		ch := ' '
-		if colIdx < len(runes) {
-			ch = runes[colIdx]
-		}
-		style := term.StyleDefault
-		for _, sp := range spans {
-			if colIdx >= sp.Start && colIdx < sp.End {
-				style = sp.Style
-				break
+		if !d.IsUnified() {
+			surface.SetCell(dividerX, h, term.Cell{Ch: '│', Style: term.StyleBorder})
+			for x := dividerX + 1; x < rightStart; x++ {
+				surface.SetCell(x, h, term.Cell{Ch: ' '})
 			}
+
+			d.rhscrollbar.X = r.X + rightStart
+			d.rhscrollbar.Y = r.Y + h
+			d.rhscrollbar.Width = rightW
+			d.rhscrollbar.TotalCols = d.maxLineW
+			d.rhscrollbar.LeftCol = d.LeftCol
+			d.rhscrollbar.Render(surface, rightStart, h)
 		}
+	}
+}
+
+func (d *DiffViewWidget) renderUnifiedRow(surface Surface, y, w, gutterW, contentStart, contentW int) {
+	displayIndex := d.TopLine + y
+	segmentStart := 0
+	continuation := false
+	if d.IsWrapped() {
+		entry := d.wrapMap[y]
+		displayIndex = entry.line
+		segmentStart = entry.leftStart
+		continuation = entry.continuation
+	}
+	if displayIndex >= len(d.unifiedLines) {
+		for x := 0; x < w; x++ {
+			surface.SetCell(x, y, term.Cell{Ch: ' '})
+		}
+		return
+	}
+
+	line := d.unifiedLines[displayIndex]
+	baseStyle := diffKindStyle(line.side.Kind)
+	if continuation {
+		renderDiffGutter(surface, 0, y, gutterW, diff.SideLine{}, baseStyle)
+	} else {
+		renderDiffGutter(surface, 0, y, gutterW, line.side, baseStyle)
+	}
+
+	var spans []highlight.Span
+	if d.Highlighter != nil && line.side.Text != "" && line.side.Kind != diff.Collapsed {
+		spans = d.Highlighter.HighlightLine(line.side.Text)
+	}
+	matches, active := d.SearchMatchesLeft, -1
+	if line.right {
+		matches = d.SearchMatchesRight
+		if d.searchActiveRight {
+			active = d.searchActiveSideIdx
+		}
+	} else if !d.searchActiveRight {
+		active = d.searchActiveSideIdx
+	}
+	leftScroll := d.LeftCol
+	if d.IsWrapped() {
+		leftScroll = 0
+	}
+	d.renderSide(surface, contentStart, y, contentW, line.side.Text, baseStyle, spans, line.sourceLine, displayIndex, matches, active, true, segmentStart, leftScroll)
+}
+
+func (d *DiffViewWidget) renderSide(surface Surface, x, y, w int, text string, baseStyle term.Style, spans []highlight.Span, matchLineIdx, selectionLineIdx int, matches []FindMatch, activeIdx int, selSide bool, segmentStart, leftVisualCol int) {
+	renderDiffText(surface, x, y, w, text, baseStyle, spans, segmentStart, leftVisualCol, func(colIdx int, cell term.Cell) term.Cell {
 		for mi, m := range matches {
-			if m.Line == lineIdx && colIdx >= m.Col && colIdx < m.Col+m.Len {
+			if m.Line == matchLineIdx && colIdx >= m.Col && colIdx < m.Col+m.Len {
 				if mi == activeIdx {
-					style = term.StyleSearchActive
+					cell.Style = term.StyleSearchActive
 				} else {
-					style = term.StyleSearchMatch
+					cell.Style = term.StyleSearchMatch
 				}
+				cell.BgStyle = 0
 				break
 			}
 		}
-		cell := term.Cell{Ch: ch, Style: style}
-		if selSide && d.isCellSelected(lineIdx, colIdx) {
+		if selSide && d.hasSelection && d.selection.Contains(selectionLineIdx, colIdx) {
 			cell.BgStyle = term.StyleSelection
-		} else if style != term.StyleSearchMatch && style != term.StyleSearchActive && baseStyle != term.StyleDefault {
-			cell.BgStyle = baseStyle
 		}
-		surface.SetCell(x+i, y, cell)
-	}
-}
-
-func kindToStyle(k diff.LineKind) term.Style {
-	switch k {
-	case diff.Added:
-		return term.StyleDiffAdded
-	case diff.Deleted:
-		return term.StyleDiffDeleted
-	default:
-		return term.StyleDefault
-	}
-}
-
-func (d *DiffViewWidget) selectionRange() (start, end diffSelPos) {
-	a, b := d.selAnchor, d.selCurrent
-	if a.Line < b.Line || (a.Line == b.Line && a.Col <= b.Col) {
-		return a, b
-	}
-	return b, a
-}
-
-func (d *DiffViewWidget) isCellSelected(line, col int) bool {
-	if !d.hasSelection {
-		return false
-	}
-	start, end := d.selectionRange()
-	if line < start.Line || line > end.Line {
-		return false
-	}
-	if start.Line == end.Line {
-		return col >= start.Col && col < end.Col
-	}
-	if line == start.Line {
-		return col >= start.Col
-	}
-	if line == end.Line {
-		return col < end.Col
-	}
-	return true
+		return cell
+	})
 }
 
 func (d *DiffViewWidget) screenToSel(mx, my int) (pos diffSelPos, right bool, ok bool) {
 	r := d.GetRect()
 	localX := mx - r.X
 	localY := my - r.Y
+	if localY < 0 || localY >= d.viewH {
+		return diffSelPos{}, false, false
+	}
 	line := d.TopLine + localY
+	leftStart, rightStart := 0, 0
+	if d.IsWrapped() {
+		if localY >= len(d.wrapMap) {
+			return diffSelPos{}, false, false
+		}
+		entry := d.wrapMap[localY]
+		line = entry.line
+		leftStart = entry.leftStart
+		rightStart = entry.rightStart
+	}
+	if d.IsUnified() {
+		if line < 0 || line >= len(d.unifiedLines) {
+			return diffSelPos{}, false, false
+		}
+		if localX < d.layoutLeftStart || localX >= d.layoutLeftStart+d.layoutLeftW || leftStart < 0 {
+			return diffSelPos{}, false, false
+		}
+		displayLine := d.unifiedLines[line]
+		visualCol := localX - d.layoutLeftStart
+		if !d.IsWrapped() {
+			visualCol += d.LeftCol
+		}
+		col := diffSegmentVisualColToRune(displayLine.side.Text, leftStart, visualCol)
+		return diffSelPos{Line: line, Col: col}, displayLine.right, true
+	}
+	if line < 0 || line >= len(d.Lines) {
+		return diffSelPos{}, false, false
+	}
 
 	if localX >= d.layoutLeftStart && localX < d.layoutLeftStart+d.layoutLeftW {
-		col := d.LeftCol + (localX - d.layoutLeftStart)
+		if leftStart < 0 {
+			return diffSelPos{}, false, false
+		}
+		visualCol := localX - d.layoutLeftStart
+		if !d.IsWrapped() {
+			visualCol += d.LeftCol
+		}
+		col := diffSegmentVisualColToRune(d.Lines[line].Left.Text, leftStart, visualCol)
 		return diffSelPos{Line: line, Col: col}, false, true
 	}
 	if localX >= d.layoutRightStart && localX < d.layoutRightStart+d.layoutRightW {
-		col := d.LeftCol + (localX - d.layoutRightStart)
+		if rightStart < 0 {
+			return diffSelPos{}, false, false
+		}
+		visualCol := localX - d.layoutRightStart
+		if !d.IsWrapped() {
+			visualCol += d.LeftCol
+		}
+		col := diffSegmentVisualColToRune(d.Lines[line].Right.Text, rightStart, visualCol)
 		return diffSelPos{Line: line, Col: col}, true, true
 	}
 	return diffSelPos{}, false, false
 }
 
 func (d *DiffViewWidget) CopySelection() string {
-	text := d.selectedText()
+	if !d.hasSelection {
+		return ""
+	}
+	text := d.selection.Text(d.selectionLineCount(), d.selectionTextAt)
 	if text != "" {
 		d.ClearSelection()
 	}
@@ -511,79 +713,31 @@ func (d *DiffViewWidget) ClearSelection() {
 	d.selecting = false
 }
 
-func (d *DiffViewWidget) selectedText() string {
-	if !d.hasSelection {
-		return ""
+func (d *DiffViewWidget) selectionLineCount() int {
+	if d.IsUnified() {
+		return len(d.unifiedLines)
 	}
-	start, end := d.selectionRange()
-	var lines []string
-	for i := start.Line; i <= end.Line && i < len(d.Lines); i++ {
-		var text string
-		if d.selRight {
-			text = d.Lines[i].Right.Text
-		} else {
-			text = d.Lines[i].Left.Text
-		}
-		runes := []rune(text)
-		startCol := 0
-		endCol := len(runes)
-		if i == start.Line {
-			startCol = start.Col
-		}
-		if i == end.Line {
-			endCol = end.Col
-		}
-		if startCol > len(runes) {
-			startCol = len(runes)
-		}
-		if endCol > len(runes) {
-			endCol = len(runes)
-		}
-		if startCol < endCol {
-			lines = append(lines, string(runes[startCol:endCol]))
-		} else {
-			lines = append(lines, "")
-		}
-	}
-	return strings.Join(lines, "\n")
+	return len(d.Lines)
 }
 
-func (d *DiffViewWidget) selectWord(line, col int) {
-	if line < 0 || line >= len(d.Lines) {
-		return
+func (d *DiffViewWidget) selectionTextAt(line int) (string, bool) {
+	if line < 0 || line >= d.selectionLineCount() {
+		return "", false
 	}
-	var text string
+	if d.IsUnified() {
+		return d.unifiedLines[line].side.Text, true
+	}
 	if d.selRight {
-		text = d.Lines[line].Right.Text
-	} else {
-		text = d.Lines[line].Left.Text
+		return d.Lines[line].Right.Text, true
 	}
-	runes := []rune(text)
-	if len(runes) == 0 {
-		return
-	}
-	if col >= len(runes) {
-		col = len(runes) - 1
-	}
-	isWord := func(r rune) bool {
-		return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
-	}
-	start, end := col, col
-	if isWord(runes[col]) {
-		for start > 0 && isWord(runes[start-1]) {
-			start--
-		}
-		for end < len(runes)-1 && isWord(runes[end+1]) {
-			end++
-		}
-	}
-	end++
-	d.hasSelection = true
-	d.selAnchor = diffSelPos{Line: line, Col: start}
-	d.selCurrent = diffSelPos{Line: line, Col: end}
+	return d.Lines[line].Left.Text, true
 }
 
 func (d *DiffViewWidget) clampLeftCol() {
+	if d.IsWrapped() {
+		d.LeftCol = 0
+		return
+	}
 	max := d.maxLineW - d.contentW
 	if max < 0 {
 		max = 0
@@ -604,37 +758,33 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		return EventConsumed
 	}
-	if newLeft, consumed := d.hscrollbar.HandleEvent(ev); consumed {
-		d.LeftCol = newLeft
-		if d.hscrollbar.IsDragging() {
-			return EventCaptured
+	if !d.IsWrapped() {
+		if newLeft, consumed := d.hscrollbar.HandleEvent(ev); consumed {
+			d.LeftCol = newLeft
+			if d.hscrollbar.IsDragging() {
+				return EventCaptured
+			}
+			return EventConsumed
 		}
-		return EventConsumed
-	}
-	if newLeft, consumed := d.rhscrollbar.HandleEvent(ev); consumed {
-		d.LeftCol = newLeft
-		if d.rhscrollbar.IsDragging() {
-			return EventCaptured
+		if !d.IsUnified() {
+			if newLeft, consumed := d.rhscrollbar.HandleEvent(ev); consumed {
+				d.LeftCol = newLeft
+				if d.rhscrollbar.IsDragging() {
+					return EventCaptured
+				}
+				return EventConsumed
+			}
 		}
-		return EventConsumed
 	}
 
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
 		switch tev.Key() {
 		case tcell.KeyUp:
-			if d.TopLine > 0 {
-				d.TopLine--
-			}
+			d.scrollVertical(-1)
 			return EventConsumed
 		case tcell.KeyDown:
-			max := len(d.Lines) - d.viewH
-			if max < 0 {
-				max = 0
-			}
-			if d.TopLine < max {
-				d.TopLine++
-			}
+			d.scrollVertical(1)
 			return EventConsumed
 		case tcell.KeyLeft:
 			if d.LeftCol > 0 {
@@ -646,31 +796,18 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			d.clampLeftCol()
 			return EventConsumed
 		case tcell.KeyPgUp:
-			d.TopLine -= d.viewH
-			if d.TopLine < 0 {
-				d.TopLine = 0
-			}
+			d.scrollVertical(-d.viewH)
 			return EventConsumed
 		case tcell.KeyPgDn:
-			max := len(d.Lines) - d.viewH
-			if max < 0 {
-				max = 0
-			}
-			d.TopLine += d.viewH
-			if d.TopLine > max {
-				d.TopLine = max
-			}
+			d.scrollVertical(d.viewH)
 			return EventConsumed
 		case tcell.KeyHome:
 			d.TopLine = 0
+			d.wrapTopOffset = 0
 			d.LeftCol = 0
 			return EventConsumed
 		case tcell.KeyEnd:
-			max := len(d.Lines) - d.viewH
-			if max < 0 {
-				max = 0
-			}
-			d.TopLine = max
+			d.setTopVisualRow(d.totalVisualRows)
 			return EventConsumed
 		}
 	case *tcell.EventMouse:
@@ -683,10 +820,7 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 					d.LeftCol = 0
 				}
 			} else {
-				d.TopLine -= 3
-				if d.TopLine < 0 {
-					d.TopLine = 0
-				}
+				d.scrollVertical(-3)
 			}
 			return EventConsumed
 		}
@@ -695,14 +829,7 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 				d.LeftCol += 4
 				d.clampLeftCol()
 			} else {
-				max := len(d.Lines) - d.viewH
-				if max < 0 {
-					max = 0
-				}
-				d.TopLine += 3
-				if d.TopLine > max {
-					d.TopLine = max
-				}
+				d.scrollVertical(3)
 			}
 			return EventConsumed
 		}
@@ -730,22 +857,26 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 					d.lastClickPos = pos
 					d.selRight = right
 					if isDoubleClick {
-						d.selectWord(pos.Line, pos.Col)
+						if text, selectable := d.selectionTextAt(pos.Line); selectable {
+							if d.selection.SelectWord(pos.Line, pos.Col, text) {
+								d.hasSelection = true
+							}
+						}
 						return EventConsumed
 					}
 					d.selecting = true
 					d.hasSelection = true
-					d.selAnchor = pos
-					d.selCurrent = pos
+					d.selection.Anchor = pos
+					d.selection.Current = pos
 				} else {
-					d.selCurrent = pos
+					d.selection.Current = pos
 				}
 				return EventCaptured
 			}
 		}
 		if d.selecting && btn == tcell.ButtonNone {
 			d.selecting = false
-			start, end := d.selectionRange()
+			start, end := d.selection.Range()
 			if start.Line == end.Line && start.Col == end.Col {
 				d.hasSelection = false
 			}

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -67,6 +67,8 @@ type DiffViewWidget struct {
 	expandedGaps    map[int]bool
 	gapByLine       map[int]int
 	pendingGap      int
+	hoveredGap      int
+	hasHoveredGap   bool
 	primaryPressed  bool
 	highContrast    bool
 	fileDiff        diff.FileDiff
@@ -96,6 +98,7 @@ func NewDiffViewWidget(filePath string, fd diff.FileDiff, oldLines, newLines []s
 		contextLoaded:       oldLines != nil || newLines != nil,
 		expandedGaps:        make(map[int]bool),
 		pendingGap:          -1,
+		hoveredGap:          -1,
 	}
 	if extended {
 		dv.contextMode = DiffContextFullFile
@@ -278,6 +281,7 @@ func (d *DiffViewWidget) rebuildLines() {
 }
 
 func (d *DiffViewWidget) expandContextGap(gap int) {
+	d.hasHoveredGap = false
 	if gap < 0 || d.expandedGaps[gap] {
 		return
 	}
@@ -600,13 +604,17 @@ func (d *DiffViewWidget) Render(surface Surface) {
 
 		leftStyle := diffKindStyle(dl.Left.Kind)
 		rightStyle := diffKindStyle(dl.Right.Kind)
+		if gap, ok := d.gapByLine[idx]; ok && d.hasHoveredGap && gap == d.hoveredGap {
+			leftStyle = term.StyleDiffCollapsed
+			rightStyle = term.StyleDiffCollapsed
+		}
 
 		if continuation {
-			renderDiffGutter(surface, 0, y, gutterW, diff.SideLine{}, leftStyle)
-			renderDiffGutter(surface, dividerX+1, y, gutterW, diff.SideLine{}, rightStyle)
+			renderDiffGutter(surface, 0, y, gutterW, diff.SideLine{})
+			renderDiffGutter(surface, dividerX+1, y, gutterW, diff.SideLine{})
 		} else {
-			renderDiffGutter(surface, 0, y, gutterW, dl.Left, leftStyle)
-			renderDiffGutter(surface, dividerX+1, y, gutterW, dl.Right, rightStyle)
+			renderDiffGutter(surface, 0, y, gutterW, dl.Left)
+			renderDiffGutter(surface, dividerX+1, y, gutterW, dl.Right)
 		}
 
 		var leftSpans, rightSpans []highlight.Span
@@ -689,10 +697,13 @@ func (d *DiffViewWidget) renderUnifiedRow(surface Surface, y, w, gutterW, conten
 
 	line := d.unifiedLines[displayIndex]
 	baseStyle := diffKindStyle(line.side.Kind)
+	if gap, ok := d.gapByLine[line.sourceLine]; ok && d.hasHoveredGap && gap == d.hoveredGap {
+		baseStyle = term.StyleDiffCollapsed
+	}
 	if continuation {
-		renderDiffGutter(surface, 0, y, gutterW, diff.SideLine{}, baseStyle)
+		renderDiffGutter(surface, 0, y, gutterW, diff.SideLine{})
 	} else {
-		renderDiffGutter(surface, 0, y, gutterW, line.side, baseStyle)
+		renderDiffGutter(surface, 0, y, gutterW, line.side)
 	}
 
 	var spans []highlight.Span
@@ -879,6 +890,7 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
+		d.hasHoveredGap = false
 		switch tev.Key() {
 		case tcell.KeyUp:
 			d.scrollVertical(-1)
@@ -914,6 +926,7 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 		btn := tev.Buttons()
 		mod := tev.Modifiers()
 		if btn&tcell.WheelUp != 0 {
+			d.hasHoveredGap = false
 			if mod&tcell.ModShift != 0 {
 				d.LeftCol -= 4
 				if d.LeftCol < 0 {
@@ -925,6 +938,7 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		}
 		if btn&tcell.WheelDown != 0 {
+			d.hasHoveredGap = false
 			if mod&tcell.ModShift != 0 {
 				d.LeftCol += 4
 				d.clampLeftCol()
@@ -934,6 +948,7 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		}
 		if btn&tcell.WheelLeft != 0 {
+			d.hasHoveredGap = false
 			d.LeftCol -= 4
 			if d.LeftCol < 0 {
 				d.LeftCol = 0
@@ -941,11 +956,18 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		}
 		if btn&tcell.WheelRight != 0 {
+			d.hasHoveredGap = false
 			d.LeftCol += 4
 			d.clampLeftCol()
 			return EventConsumed
 		}
 		mx, my := tev.Position()
+		hoveredGap, overGap := d.gapByLine[d.screenSourceLine(my)]
+		hoverChanged := overGap != d.hasHoveredGap || (overGap && hoveredGap != d.hoveredGap)
+		d.hasHoveredGap = overGap
+		if overGap {
+			d.hoveredGap = hoveredGap
+		}
 		if btn == tcell.ButtonNone {
 			d.primaryPressed = false
 		}
@@ -991,6 +1013,9 @@ func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			if start.Line == end.Line && start.Col == end.Col {
 				d.hasSelection = false
 			}
+		}
+		if hoverChanged {
+			return EventConsumed
 		}
 	}
 	return EventIgnored

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -61,6 +61,7 @@ type DiffViewWidget struct {
 	wrapExplicit bool
 	mode         DiffMode
 	modeExplicit bool
+	highContrast bool
 	fileDiff     diff.FileDiff
 	oldLines     []string
 	newLines     []string
@@ -69,6 +70,10 @@ type DiffViewWidget struct {
 	OnFetchExtended func(dv *DiffViewWidget)
 	Loading         bool
 }
+
+func (d *DiffViewWidget) SetDiffHighContrast(enabled bool) { d.highContrast = enabled }
+
+func (d *DiffViewWidget) DiffHighContrast() bool { return d.highContrast }
 
 func NewDiffViewWidget(filePath string, fd diff.FileDiff, oldLines, newLines []string, extended bool) *DiffViewWidget {
 	dv := &DiffViewWidget{
@@ -530,8 +535,8 @@ func (d *DiffViewWidget) Render(surface Surface) {
 		if d.IsWrapped() {
 			leftScroll, rightScroll = 0, 0
 		}
-		d.renderSide(surface, leftStart, y, leftW, dl.Left.Text, leftStyle, leftSpans, idx, idx, d.SearchMatchesLeft, leftActive, !d.selRight, leftSegment, leftScroll)
-		d.renderSide(surface, rightStart, y, rightW, dl.Right.Text, rightStyle, rightSpans, idx, idx, d.SearchMatchesRight, rightActive, d.selRight, rightSegment, rightScroll)
+		d.renderSide(surface, leftStart, y, leftW, dl.Left.Text, leftStyle, diffKindForeground(dl.Left.Kind, d.highContrast), leftSpans, idx, idx, d.SearchMatchesLeft, leftActive, !d.selRight, leftSegment, leftScroll)
+		d.renderSide(surface, rightStart, y, rightW, dl.Right.Text, rightStyle, diffKindForeground(dl.Right.Kind, d.highContrast), rightSpans, idx, idx, d.SearchMatchesRight, rightActive, d.selRight, rightSegment, rightScroll)
 	}
 
 	if showVScroll {
@@ -612,11 +617,11 @@ func (d *DiffViewWidget) renderUnifiedRow(surface Surface, y, w, gutterW, conten
 	if d.IsWrapped() {
 		leftScroll = 0
 	}
-	d.renderSide(surface, contentStart, y, contentW, line.side.Text, baseStyle, spans, line.sourceLine, displayIndex, matches, active, true, segmentStart, leftScroll)
+	d.renderSide(surface, contentStart, y, contentW, line.side.Text, baseStyle, diffKindForeground(line.side.Kind, d.highContrast), spans, line.sourceLine, displayIndex, matches, active, true, segmentStart, leftScroll)
 }
 
-func (d *DiffViewWidget) renderSide(surface Surface, x, y, w int, text string, baseStyle term.Style, spans []highlight.Span, matchLineIdx, selectionLineIdx int, matches []FindMatch, activeIdx int, selSide bool, segmentStart, leftVisualCol int) {
-	renderDiffText(surface, x, y, w, text, baseStyle, spans, segmentStart, leftVisualCol, func(colIdx int, cell term.Cell) term.Cell {
+func (d *DiffViewWidget) renderSide(surface Surface, x, y, w int, text string, baseStyle, foregroundStyle term.Style, spans []highlight.Span, matchLineIdx, selectionLineIdx int, matches []FindMatch, activeIdx int, selSide bool, segmentStart, leftVisualCol int) {
+	renderDiffText(surface, x, y, w, text, baseStyle, foregroundStyle, spans, segmentStart, leftVisualCol, func(colIdx int, cell term.Cell) term.Cell {
 		for mi, m := range matches {
 			if m.Line == matchLineIdx && colIdx >= m.Col && colIdx < m.Col+m.Len {
 				if mi == activeIdx {

--- a/internal/ui/diff_widget_compact.go
+++ b/internal/ui/diff_widget_compact.go
@@ -1,0 +1,73 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+)
+
+func compactDiffLines(fileDiff diff.FileDiff) []diff.DiffLine {
+	var lines []diff.DiffLine
+	for i, hunk := range fileDiff.Hunks {
+		if i > 0 {
+			leftDistance := hunkLineDistance(fileDiff.Hunks[i-1], hunk, false)
+			rightDistance := hunkLineDistance(fileDiff.Hunks[i-1], hunk, true)
+			if leftDistance <= 0 {
+				leftDistance = rightDistance
+			}
+			if rightDistance <= 0 {
+				rightDistance = leftDistance
+			}
+
+			if leftDistance > 0 || rightDistance > 0 {
+				leftLabel, rightLabel := hunk.Header, hunk.Header
+				if leftDistance > 0 {
+					leftLabel = collapsedDistanceLabel(leftDistance)
+				}
+				if rightDistance > 0 {
+					rightLabel = collapsedDistanceLabel(rightDistance)
+				}
+				lines = append(lines, diff.DiffLine{
+					Left:  diff.SideLine{Kind: diff.Collapsed, Text: leftLabel},
+					Right: diff.SideLine{Kind: diff.Collapsed, Text: rightLabel},
+				})
+			}
+		}
+		lines = append(lines, hunk.Lines...)
+	}
+	return lines
+}
+
+func hunkLineDistance(previous, next diff.Hunk, right bool) int {
+	previousLine := 0
+	for _, line := range previous.Lines {
+		num := line.Left.Num
+		if right {
+			num = line.Right.Num
+		}
+		if num > previousLine {
+			previousLine = num
+		}
+	}
+
+	nextLine := 0
+	for _, line := range next.Lines {
+		num := line.Left.Num
+		if right {
+			num = line.Right.Num
+		}
+		if num > 0 {
+			nextLine = num
+			break
+		}
+	}
+	return nextLine - previousLine - 1
+}
+
+func collapsedDistanceLabel(distance int) string {
+	unit := "lines"
+	if distance == 1 {
+		unit = "line"
+	}
+	return fmt.Sprintf("⋯ %d %s ⋯", distance, unit)
+}

--- a/internal/ui/diff_widget_compact.go
+++ b/internal/ui/diff_widget_compact.go
@@ -6,8 +6,12 @@ import (
 	"github.com/eugenioenko/ttt/internal/core/diff"
 )
 
-func compactDiffLines(fileDiff diff.FileDiff) []diff.DiffLine {
+// compactDiffLinesWithContext keeps Git's hunk projection but can replace an
+// individual collapsed separator with the omitted unchanged rows. The map
+// identifies which rendered rows remain expandable.
+func compactDiffLinesWithContext(fileDiff diff.FileDiff, oldLines, newLines []string, expanded map[int]bool) ([]diff.DiffLine, map[int]int) {
 	var lines []diff.DiffLine
+	gaps := make(map[int]int)
 	for i, hunk := range fileDiff.Hunks {
 		if i > 0 {
 			leftDistance := hunkLineDistance(fileDiff.Hunks[i-1], hunk, false)
@@ -20,6 +24,12 @@ func compactDiffLines(fileDiff diff.FileDiff) []diff.DiffLine {
 			}
 
 			if leftDistance > 0 || rightDistance > 0 {
+				gap := i - 1
+				if expanded[gap] && (oldLines != nil || newLines != nil) {
+					lines = append(lines, expandedHunkGap(fileDiff.Hunks[i-1], hunk, oldLines, newLines)...)
+					lines = append(lines, hunk.Lines...)
+					continue
+				}
 				leftLabel, rightLabel := hunk.Header, hunk.Header
 				if leftDistance > 0 {
 					leftLabel = collapsedDistanceLabel(leftDistance)
@@ -27,6 +37,7 @@ func compactDiffLines(fileDiff diff.FileDiff) []diff.DiffLine {
 				if rightDistance > 0 {
 					rightLabel = collapsedDistanceLabel(rightDistance)
 				}
+				gaps[len(lines)] = gap
 				lines = append(lines, diff.DiffLine{
 					Left:  diff.SideLine{Kind: diff.Collapsed, Text: leftLabel},
 					Right: diff.SideLine{Kind: diff.Collapsed, Text: rightLabel},
@@ -35,7 +46,70 @@ func compactDiffLines(fileDiff diff.FileDiff) []diff.DiffLine {
 		}
 		lines = append(lines, hunk.Lines...)
 	}
+	return lines, gaps
+}
+
+func expandedHunkGap(previous, next diff.Hunk, oldLines, newLines []string) []diff.DiffLine {
+	previousLeft, previousRight := hunkLastNumbers(previous)
+	nextLeft, nextRight := hunkFirstNumbers(next)
+	leftCount := nextLeft - previousLeft - 1
+	rightCount := nextRight - previousRight - 1
+	if leftCount < 0 {
+		leftCount = 0
+	}
+	if rightCount < 0 {
+		rightCount = 0
+	}
+	count := max(leftCount, rightCount)
+	lines := make([]diff.DiffLine, 0, count)
+	for offset := 1; offset <= count; offset++ {
+		line := diff.DiffLine{}
+		if offset <= leftCount {
+			num := previousLeft + offset
+			line.Left = diff.SideLine{Num: num, Text: lineAt(oldLines, num), Kind: diff.Context}
+		} else {
+			line.Left = diff.SideLine{Kind: diff.Blank}
+		}
+		if offset <= rightCount {
+			num := previousRight + offset
+			line.Right = diff.SideLine{Num: num, Text: lineAt(newLines, num), Kind: diff.Context}
+		} else {
+			line.Right = diff.SideLine{Kind: diff.Blank}
+		}
+		lines = append(lines, line)
+	}
 	return lines
+}
+
+func hunkLastNumbers(hunk diff.Hunk) (left, right int) {
+	for _, line := range hunk.Lines {
+		if line.Left.Num > left {
+			left = line.Left.Num
+		}
+		if line.Right.Num > right {
+			right = line.Right.Num
+		}
+	}
+	return left, right
+}
+
+func hunkFirstNumbers(hunk diff.Hunk) (left, right int) {
+	for _, line := range hunk.Lines {
+		if left == 0 && line.Left.Num > 0 {
+			left = line.Left.Num
+		}
+		if right == 0 && line.Right.Num > 0 {
+			right = line.Right.Num
+		}
+	}
+	return left, right
+}
+
+func lineAt(lines []string, oneBased int) string {
+	if oneBased <= 0 || oneBased > len(lines) {
+		return ""
+	}
+	return lines[oneBased-1]
 }
 
 func hunkLineDistance(previous, next diff.Hunk, right bool) int {

--- a/internal/ui/diff_widget_test.go
+++ b/internal/ui/diff_widget_test.go
@@ -13,17 +13,20 @@ func TestDiffWidgetDefaultsRemainInheritedUntilViewOverride(t *testing.T) {
 	dv := NewDiffViewWidget("test.go", diff.FileDiff{}, nil, nil, false)
 
 	dv.ApplyDefaultMode(DiffModeUnified)
+	dv.ApplyDefaultContextMode(DiffContextFullFile)
 	dv.ApplyDefaultWrapMode(DiffWrapOn)
-	if dv.Mode() != DiffModeUnified || dv.WrapMode() != DiffWrapOn {
-		t.Fatalf("inherited defaults = mode %v wrap %v, want unified/on", dv.Mode(), dv.WrapMode())
+	if dv.Mode() != DiffModeUnified || dv.ContextMode() != DiffContextFullFile || dv.WrapMode() != DiffWrapOn {
+		t.Fatalf("inherited defaults = mode %v context %v wrap %v, want unified/full/on", dv.Mode(), dv.ContextMode(), dv.WrapMode())
 	}
 
 	dv.SetMode(DiffModeSplit)
+	dv.SetContextMode(DiffContextChangesOnly)
 	dv.SetWrapMode(DiffWrapOff)
 	dv.ApplyDefaultMode(DiffModeUnified)
+	dv.ApplyDefaultContextMode(DiffContextFullFile)
 	dv.ApplyDefaultWrapMode(DiffWrapOn)
-	if dv.Mode() != DiffModeSplit || dv.WrapMode() != DiffWrapOff {
-		t.Fatalf("defaults replaced View overrides: mode %v wrap %v", dv.Mode(), dv.WrapMode())
+	if dv.Mode() != DiffModeSplit || dv.ContextMode() != DiffContextChangesOnly || dv.WrapMode() != DiffWrapOff {
+		t.Fatalf("defaults replaced View overrides: mode %v context %v wrap %v", dv.Mode(), dv.ContextMode(), dv.WrapMode())
 	}
 }
 
@@ -317,6 +320,31 @@ func TestDiffWidgetCollapsedSeparatorUsesSingularLine(t *testing.T) {
 
 	if got := dv.Lines[1].Left.Text; got != "⋯ 1 line ⋯" {
 		t.Fatalf("separator = %q, want singular distance", got)
+	}
+}
+
+func TestDiffWidgetCollapsedSeparatorClickExpandsOnlyThatGap(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n first\n@@ -8,1 +8,1 @@\n eighth\n")
+	oldLines := []string{"first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth"}
+	newLines := append([]string(nil), oldLines...)
+	dv := NewDiffViewWidget("test.go", fd, oldLines, newLines, false)
+
+	const width, height = 60, 8
+	grid := makeGrid(width, height)
+	dv.SetRect(Rect{W: width, H: height})
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+	if got := dv.Lines[1].Left.Text; got != "⋯ 6 lines ⋯" {
+		t.Fatalf("precondition separator = %q", got)
+	}
+
+	if result := dv.HandleEvent(tcell.NewEventMouse(width-2, 1, tcell.Button1, 0)); result != EventConsumed {
+		t.Fatalf("collapsed row click result = %v", result)
+	}
+	if len(dv.Lines) < 8 || dv.Lines[1].Left.Text != "second" || dv.Lines[6].Right.Text != "seventh" {
+		t.Fatalf("expanded gap lines = %+v", dv.Lines)
+	}
+	if dv.ContextMode() != DiffContextChangesOnly {
+		t.Fatalf("one expanded gap changed global context mode to %v", dv.ContextMode())
 	}
 }
 

--- a/internal/ui/diff_widget_test.go
+++ b/internal/ui/diff_widget_test.go
@@ -356,3 +356,52 @@ func TestDiffWidgetCollapsedSeparatorUsesDedicatedStyle(t *testing.T) {
 		t.Fatalf("collapsed separator gutter style = %v, want StyleDiffCollapsed", gutterCell.Style)
 	}
 }
+
+func TestDiffGutterMarksAndColorsChangedLines(t *testing.T) {
+	grid := makeGrid(10, 2)
+	surface := NewRenderSurface(grid, Rect{W: 10, H: 2})
+	renderDiffGutter(surface, 0, 0, 5, diff.SideLine{Num: 12, Kind: diff.Deleted}, term.StyleDiffDeleted)
+	renderDiffGutter(surface, 0, 1, 5, diff.SideLine{Num: 13, Kind: diff.Added}, term.StyleDiffAdded)
+
+	if got := commitDetailGridText(grid); !strings.Contains(got, "12 -") || !strings.Contains(got, "13 +") {
+		t.Fatalf("changed gutters do not show line markers:\n%s", got)
+	}
+	for column := 0; column < 5; column++ {
+		if grid[0][column].Style != term.StyleGutterDeleted {
+			t.Fatalf("deleted gutter column %d style = %v, want StyleGutterDeleted", column, grid[0][column].Style)
+		}
+		if grid[1][column].Style != term.StyleGutterAdded {
+			t.Fatalf("added gutter column %d style = %v, want StyleGutterAdded", column, grid[1][column].Style)
+		}
+	}
+}
+
+func TestDiffWidgetHighContrastUsesSemanticChangeForegrounds(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-var oldValue = 1\n+var newValue = 2\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+
+	const width, height = 60, 2
+	standard := makeGrid(width, height)
+	dv.SetRect(Rect{W: width, H: height})
+	dv.Render(NewRenderSurface(standard, Rect{W: width, H: height}))
+	if got := standard[0][dv.layoutLeftStart].Style; got != term.StyleSyntaxKeyword {
+		t.Fatalf("standard diff text style = %v, want syntax keyword", got)
+	}
+
+	dv.SetDiffHighContrast(true)
+	grid := makeGrid(width, height)
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+
+	if got := grid[0][dv.layoutLeftStart].Style; got != term.StyleGutterDeleted {
+		t.Fatalf("deleted text style = %v, want semantic deleted foreground", got)
+	}
+	if got := grid[0][dv.layoutRightStart].Style; got != term.StyleGutterAdded {
+		t.Fatalf("added text style = %v, want semantic added foreground", got)
+	}
+	if got := grid[0][dv.layoutLeftStart].BgStyle; got != term.StyleDiffDeleted {
+		t.Fatalf("deleted text background = %v, want StyleDiffDeleted", got)
+	}
+	if got := grid[0][dv.layoutRightStart].BgStyle; got != term.StyleDiffAdded {
+		t.Fatalf("added text background = %v, want StyleDiffAdded", got)
+	}
+}

--- a/internal/ui/diff_widget_test.go
+++ b/internal/ui/diff_widget_test.go
@@ -360,7 +360,7 @@ func TestDiffWidgetCollapsedSeparatorOmitsAdjacentLines(t *testing.T) {
 	}
 }
 
-func TestDiffWidgetCollapsedSeparatorUsesDedicatedStyle(t *testing.T) {
+func TestDiffWidgetCollapsedSeparatorIsQuietUntilHovered(t *testing.T) {
 	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n first\n@@ -20,1 +20,1 @@\n twentieth\n")
 	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
 
@@ -371,25 +371,31 @@ func TestDiffWidgetCollapsedSeparatorUsesDedicatedStyle(t *testing.T) {
 
 	separatorRow := 1
 	contentCell := grid[separatorRow][dv.layoutLeftStart]
-	if contentCell.Style != term.StyleDiffCollapsed {
-		t.Fatalf("collapsed separator style = %v, want StyleDiffCollapsed", contentCell.Style)
+	if contentCell.Style != term.StyleMuted || contentCell.BgStyle != 0 {
+		t.Fatalf("collapsed separator cell = %+v, want muted text on inherited background", contentCell)
 	}
-	if contentCell.Style == term.StyleDefault {
-		t.Fatal("collapsed separator must not resolve to StyleDefault")
+	gutterCell := grid[separatorRow][dv.layoutGutterW-1]
+	if gutterCell.Ch != '▶' || gutterCell.Style != term.StyleLineNumber {
+		t.Fatalf("collapsed separator gutter cell = %+v, want line-number disclosure triangle", gutterCell)
 	}
-	if contentCell.BgStyle != 0 {
-		t.Fatalf("collapsed separator should use its full style, got BgStyle %v", contentCell.BgStyle)
+
+	if result := dv.HandleEvent(tcell.NewEventMouse(dv.layoutLeftStart, separatorRow, tcell.ButtonNone, tcell.ModNone)); result != EventConsumed {
+		t.Fatalf("collapsed separator hover result = %v, want EventConsumed for redraw", result)
 	}
-	if gutterCell := grid[separatorRow][0]; gutterCell.Style != term.StyleDiffCollapsed {
-		t.Fatalf("collapsed separator gutter style = %v, want StyleDiffCollapsed", gutterCell.Style)
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+	if got := grid[separatorRow][dv.layoutLeftStart].Style; got != term.StyleDiffCollapsed {
+		t.Fatalf("hovered separator style = %v, want StyleDiffCollapsed", got)
+	}
+	if got := grid[separatorRow][dv.layoutGutterW-1]; got.Ch != '▶' || got.Style != term.StyleLineNumber {
+		t.Fatalf("hovered separator gutter cell = %+v, want stable line-number disclosure triangle", got)
 	}
 }
 
 func TestDiffGutterMarksAndColorsChangedLines(t *testing.T) {
 	grid := makeGrid(10, 2)
 	surface := NewRenderSurface(grid, Rect{W: 10, H: 2})
-	renderDiffGutter(surface, 0, 0, 5, diff.SideLine{Num: 12, Kind: diff.Deleted}, term.StyleDiffDeleted)
-	renderDiffGutter(surface, 0, 1, 5, diff.SideLine{Num: 13, Kind: diff.Added}, term.StyleDiffAdded)
+	renderDiffGutter(surface, 0, 0, 5, diff.SideLine{Num: 12, Kind: diff.Deleted})
+	renderDiffGutter(surface, 0, 1, 5, diff.SideLine{Num: 13, Kind: diff.Added})
 
 	if got := commitDetailGridText(grid); !strings.Contains(got, "12 -") || !strings.Contains(got, "13 +") {
 		t.Fatalf("changed gutters do not show line markers:\n%s", got)

--- a/internal/ui/diff_widget_test.go
+++ b/internal/ui/diff_widget_test.go
@@ -1,10 +1,45 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v3"
 )
+
+func TestDiffWidgetDefaultsRemainInheritedUntilViewOverride(t *testing.T) {
+	dv := NewDiffViewWidget("test.go", diff.FileDiff{}, nil, nil, false)
+
+	dv.ApplyDefaultMode(DiffModeUnified)
+	dv.ApplyDefaultWrapMode(DiffWrapOn)
+	if dv.Mode() != DiffModeUnified || dv.WrapMode() != DiffWrapOn {
+		t.Fatalf("inherited defaults = mode %v wrap %v, want unified/on", dv.Mode(), dv.WrapMode())
+	}
+
+	dv.SetMode(DiffModeSplit)
+	dv.SetWrapMode(DiffWrapOff)
+	dv.ApplyDefaultMode(DiffModeUnified)
+	dv.ApplyDefaultWrapMode(DiffWrapOn)
+	if dv.Mode() != DiffModeSplit || dv.WrapMode() != DiffWrapOff {
+		t.Fatalf("defaults replaced View overrides: mode %v wrap %v", dv.Mode(), dv.WrapMode())
+	}
+}
+
+func TestDiffWidgetModeAndWrapDefaultsAreIndependent(t *testing.T) {
+	dv := NewDiffViewWidget("test.go", diff.FileDiff{}, nil, nil, false)
+	dv.SetMode(DiffModeUnified)
+
+	dv.ApplyDefaultMode(DiffModeSplit)
+	dv.ApplyDefaultWrapMode(DiffWrapOn)
+	if dv.Mode() != DiffModeUnified {
+		t.Fatalf("mode default replaced explicit unified mode: %v", dv.Mode())
+	}
+	if dv.WrapMode() != DiffWrapOn {
+		t.Fatalf("mode override prevented inherited wrap update: %v", dv.WrapMode())
+	}
+}
 
 func TestDiffWidgetLeftRightLines(t *testing.T) {
 	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,3 +1,3 @@\n hello world\n-old line\n+new line\n context\n")
@@ -122,5 +157,202 @@ func TestDiffWidgetSearchContext(t *testing.T) {
 	total := len(leftMatches) + len(rightMatches)
 	if total == 0 {
 		t.Errorf("expected matches for 'hello' in context lines, got none. Left: %v, Right: %v", dv.LeftLines(), dv.RightLines())
+	}
+}
+
+func TestDiffWidgetWrapRendersContinuationWithoutLineNumber(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-abcdefghijklmno\n+ABCDEFGHIJKLMNO\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+	dv.SetWrapped(true)
+
+	const width, height = 30, 4
+	grid := makeGrid(width, height)
+	dv.SetRect(Rect{W: width, H: height})
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+
+	row := func(y int) string {
+		var b strings.Builder
+		for _, cell := range grid[y] {
+			if cell.Ch == 0 {
+				b.WriteRune(' ')
+			} else {
+				b.WriteRune(cell.Ch)
+			}
+		}
+		return b.String()
+	}
+	if !strings.Contains(row(0), "abcdefghij") || !strings.Contains(row(1), "klmno") {
+		t.Fatalf("expected the long line to wrap across rows, got:\n%s\n%s", row(0), row(1))
+	}
+	if strings.Contains(row(1)[:4], "1") {
+		t.Fatalf("continuation gutter must not repeat the line number, got %q", row(1)[:4])
+	}
+}
+
+func TestDiffWidgetWrappedSelectionCopiesOriginalText(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-abcdefghij\n+ABCDEFGHIJ\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+	dv.SetWrapped(true)
+
+	const width, height = 24, 4
+	grid := make([][]term.Cell, height)
+	for y := range grid {
+		grid[y] = make([]term.Cell, width)
+	}
+	dv.SetRect(Rect{W: width, H: height})
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+
+	// The left pane is seven columns wide at this size. Select from rune 2 on
+	// the first visual row through rune 10 on its continuation row.
+	dv.HandleEvent(tcell.NewEventMouse(6, 0, tcell.Button1, tcell.ModNone))
+	dv.HandleEvent(tcell.NewEventMouse(7, 1, tcell.Button1, tcell.ModNone))
+	dv.HandleEvent(tcell.NewEventMouse(7, 1, tcell.ButtonNone, tcell.ModNone))
+
+	if got := dv.CopySelection(); got != "cdefghij" {
+		t.Fatalf("wrapped copy = %q, want original unwrapped text %q", got, "cdefghij")
+	}
+}
+
+func TestDiffWidgetFullwidthWrapAndHorizontalExtent(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-界界a\n+界界b\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+
+	// Each side is five terminal columns wide (2 + 2 + 1), despite containing
+	// only three runes. The unwrapped scrollbar must expose that full extent.
+	if dv.maxLineW != 5 {
+		t.Fatalf("fullwidth line extent = %d, want 5 terminal columns", dv.maxLineW)
+	}
+	const width, height = 15, 4 // three content columns per side
+	grid := makeGrid(width, height)
+	dv.SetRect(Rect{W: width, H: height})
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+	if dv.hscrollbar.TotalCols != 5 || dv.rhscrollbar.TotalCols != 5 {
+		t.Fatalf("horizontal extents = %d / %d, want 5 / 5", dv.hscrollbar.TotalCols, dv.rhscrollbar.TotalCols)
+	}
+
+	// At three columns, only one double-width rune fits on each row. A
+	// rune-count implementation would keep all three runes on one row.
+	dv.SetWrapped(true)
+	grid = makeGrid(width, height)
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+	if len(dv.wrapMap) < 2 {
+		t.Fatalf("expected a continuation row, got wrap map %v", dv.wrapMap)
+	}
+	first, continuation := dv.wrapMap[0], dv.wrapMap[1]
+	if first.line != 0 || first.leftStart != 0 || first.rightStart != 0 {
+		t.Fatalf("first fullwidth segment = %+v, want rune offset 0 on both sides", first)
+	}
+	if continuation.line != 0 || continuation.leftStart != 1 || continuation.rightStart != 1 {
+		t.Fatalf("fullwidth continuation = %+v, want rune offset 1 on both sides", continuation)
+	}
+}
+
+func TestDiffWidgetUnifiedOrdersRemovedBeforeAdded(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,2 +1,2 @@\n-old one\n-old two\n+new one\n+new two\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+	dv.SetUnified(true)
+
+	if !dv.IsUnified() {
+		t.Fatal("unified mode should be enabled")
+	}
+	got := make([]string, len(dv.unifiedLines))
+	for i, line := range dv.unifiedLines {
+		got[i] = line.side.Text
+	}
+	want := []string{"old one", "old two", "new one", "new two"}
+	if len(got) < len(want) || strings.Join(got[:len(want)], "|") != strings.Join(want, "|") {
+		t.Fatalf("unified order = %v, want %v", got, want)
+	}
+}
+
+func TestDiffWidgetUnifiedSelectionAndSearchUseProjectedLines(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-old value\n+new value\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+	dv.SetUnified(true)
+	dv.ApplySearchHighlight("new", SearchOptions{})
+
+	if len(dv.SearchMatchesRight) != 1 {
+		t.Fatalf("unified search should retain the added-side match, got %v", dv.SearchMatchesRight)
+	}
+	const width, height = 40, 4
+	grid := makeGrid(width, height)
+	dv.SetRect(Rect{W: width, H: height})
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+	foundSearchStyle := false
+	for _, row := range grid {
+		for _, cell := range row {
+			if cell.Style == term.StyleSearchMatch {
+				foundSearchStyle = true
+			}
+		}
+	}
+	if !foundSearchStyle {
+		t.Fatal("unified rendering should draw the projected search match")
+	}
+
+	dv.hasSelection = true
+	dv.selection.Anchor = diffSelPos{Line: 0, Col: 0}
+	dv.selection.Current = diffSelPos{Line: 1, Col: len([]rune("new value"))}
+	if got := dv.CopySelection(); got != "old value\nnew value" {
+		t.Fatalf("unified copy = %q, want stacked original lines", got)
+	}
+}
+
+func TestDiffWidgetCollapsedSeparatorShowsLineDistance(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -22,3 +22,3 @@\n line 22\n line 23\n line 24\n@@ -356,2 +356,2 @@\n line 356\n line 357\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+
+	if len(dv.Lines) < 4 {
+		t.Fatalf("expected two hunks and a separator, got %v", dv.Lines)
+	}
+	separator := dv.Lines[3]
+	if separator.Left.Text != "⋯ 331 lines ⋯" || separator.Right.Text != "⋯ 331 lines ⋯" {
+		t.Fatalf("separator = %q / %q, want collapsed distance", separator.Left.Text, separator.Right.Text)
+	}
+}
+
+func TestDiffWidgetCollapsedSeparatorUsesSingularLine(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -24,1 +24,1 @@\n line 24\n@@ -26,1 +26,1 @@\n line 26\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+
+	if got := dv.Lines[1].Left.Text; got != "⋯ 1 line ⋯" {
+		t.Fatalf("separator = %q, want singular distance", got)
+	}
+}
+
+func TestDiffWidgetCollapsedSeparatorOmitsAdjacentLines(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -24,1 +24,1 @@\n line 24\n@@ -25,1 +25,1 @@\n line 25\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+
+	if len(dv.Lines) != 3 {
+		t.Fatalf("lines = %d, want adjacent diff rows with no separator: %v", len(dv.Lines), dv.Lines)
+	}
+	if dv.Lines[0].Left.Text != "line 24" || dv.Lines[1].Left.Text != "line 25" {
+		t.Fatalf("adjacent rows shifted: %q then %q", dv.Lines[0].Left.Text, dv.Lines[1].Left.Text)
+	}
+}
+
+func TestDiffWidgetCollapsedSeparatorUsesDedicatedStyle(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n first\n@@ -20,1 +20,1 @@\n twentieth\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+
+	const width, height = 50, 5
+	grid := makeGrid(width, height)
+	dv.SetRect(Rect{W: width, H: height})
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+
+	separatorRow := 1
+	contentCell := grid[separatorRow][dv.layoutLeftStart]
+	if contentCell.Style != term.StyleDiffCollapsed {
+		t.Fatalf("collapsed separator style = %v, want StyleDiffCollapsed", contentCell.Style)
+	}
+	if contentCell.Style == term.StyleDefault {
+		t.Fatal("collapsed separator must not resolve to StyleDefault")
+	}
+	if contentCell.BgStyle != 0 {
+		t.Fatalf("collapsed separator should use its full style, got BgStyle %v", contentCell.BgStyle)
+	}
+	if gutterCell := grid[separatorRow][0]; gutterCell.Style != term.StyleDiffCollapsed {
+		t.Fatalf("collapsed separator gutter style = %v, want StyleDiffCollapsed", gutterCell.Style)
 	}
 }

--- a/internal/ui/diff_widget_unified.go
+++ b/internal/ui/diff_widget_unified.go
@@ -1,0 +1,89 @@
+package ui
+
+func (d *DiffViewWidget) unifiedIndexForSource(sourceLine int, right bool) int {
+	for i, line := range d.unifiedLines {
+		if line.sourceLine == sourceLine && line.right == right {
+			return i
+		}
+	}
+	return -1
+}
+
+func (d *DiffViewWidget) unifiedIndexForSearchLine(sourceLine int) int {
+	if index := d.unifiedIndexForSource(sourceLine, d.searchActiveRight); index >= 0 {
+		return index
+	}
+	for i, line := range d.unifiedLines {
+		if line.sourceLine == sourceLine {
+			return i
+		}
+	}
+	return sourceLine
+}
+
+func unifiedLineVisualRows(line diffUnifiedLine, width int) int {
+	return len(diffWrapStarts(line.side.Text, width))
+}
+
+func totalUnifiedVisualRows(lines []diffUnifiedLine, width int) int {
+	total := 0
+	for _, line := range lines {
+		total += unifiedLineVisualRows(line, width)
+	}
+	return total
+}
+
+func unifiedLineToVisualRow(lines []diffUnifiedLine, line, width int) int {
+	row := 0
+	for i := 0; i < line && i < len(lines); i++ {
+		row += unifiedLineVisualRows(lines[i], width)
+	}
+	return row
+}
+
+func unifiedVisualRowToTop(lines []diffUnifiedLine, target, width int) (line, offset int) {
+	if target <= 0 {
+		return 0, 0
+	}
+	row := 0
+	for i, displayLine := range lines {
+		rows := unifiedLineVisualRows(displayLine, width)
+		if row+rows > target {
+			return i, target - row
+		}
+		row += rows
+	}
+	if len(lines) == 0 {
+		return 0, 0
+	}
+	last := len(lines) - 1
+	return last, unifiedLineVisualRows(lines[last], width) - 1
+}
+
+func buildUnifiedWrapMap(lines []diffUnifiedLine, topLine, topOffset, height, width int) []diffWrapEntry {
+	entries := make([]diffWrapEntry, 0, height)
+	line := topLine
+	for len(entries) < height {
+		if line >= len(lines) {
+			entries = append(entries, diffWrapEntry{line: line, leftStart: -1, rightStart: -1})
+			line++
+			continue
+		}
+
+		starts := diffWrapStarts(lines[line].side.Text, width)
+		startRow := 0
+		if line == topLine && topOffset < len(starts) {
+			startRow = topOffset
+		}
+		for row := startRow; row < len(starts) && len(entries) < height; row++ {
+			entries = append(entries, diffWrapEntry{
+				line:         line,
+				leftStart:    starts[row],
+				rightStart:   -1,
+				continuation: row > 0,
+			})
+		}
+		line++
+	}
+	return entries
+}

--- a/internal/ui/diff_widget_wrap.go
+++ b/internal/ui/diff_widget_wrap.go
@@ -1,0 +1,143 @@
+package ui
+
+import (
+	"github.com/eugenioenko/ttt/internal/core/diff"
+)
+
+type diffWrapEntry struct {
+	line         int
+	leftStart    int
+	rightStart   int
+	continuation bool
+}
+
+func diffLineVisualRows(line diff.DiffLine, leftW, rightW int) int {
+	leftRows := len(diffWrapStarts(line.Left.Text, leftW))
+	rightRows := len(diffWrapStarts(line.Right.Text, rightW))
+	if rightRows > leftRows {
+		return rightRows
+	}
+	return leftRows
+}
+
+func totalDiffVisualRows(lines []diff.DiffLine, leftW, rightW int) int {
+	total := 0
+	for _, line := range lines {
+		total += diffLineVisualRows(line, leftW, rightW)
+	}
+	return total
+}
+
+func diffLineToVisualRow(lines []diff.DiffLine, line, leftW, rightW int) int {
+	row := 0
+	for i := 0; i < line && i < len(lines); i++ {
+		row += diffLineVisualRows(lines[i], leftW, rightW)
+	}
+	return row
+}
+
+func diffVisualRowToTop(lines []diff.DiffLine, target, leftW, rightW int) (line, offset int) {
+	if target <= 0 {
+		return 0, 0
+	}
+	row := 0
+	for i, dl := range lines {
+		rows := diffLineVisualRows(dl, leftW, rightW)
+		if row+rows > target {
+			return i, target - row
+		}
+		row += rows
+	}
+	if len(lines) == 0 {
+		return 0, 0
+	}
+	return len(lines) - 1, diffLineVisualRows(lines[len(lines)-1], leftW, rightW) - 1
+}
+
+func buildDiffWrapMap(lines []diff.DiffLine, topLine, topOffset, height, leftW, rightW int) []diffWrapEntry {
+	entries := make([]diffWrapEntry, 0, height)
+	line := topLine
+	for len(entries) < height {
+		if line >= len(lines) {
+			entries = append(entries, diffWrapEntry{line: line, leftStart: -1, rightStart: -1})
+			line++
+			continue
+		}
+
+		leftStarts := diffWrapStarts(lines[line].Left.Text, leftW)
+		rightStarts := diffWrapStarts(lines[line].Right.Text, rightW)
+		rows := len(leftStarts)
+		if len(rightStarts) > rows {
+			rows = len(rightStarts)
+		}
+		startRow := 0
+		if line == topLine && topOffset < rows {
+			startRow = topOffset
+		}
+		for row := startRow; row < rows && len(entries) < height; row++ {
+			leftStart, rightStart := -1, -1
+			if row < len(leftStarts) {
+				leftStart = leftStarts[row]
+			}
+			if row < len(rightStarts) {
+				rightStart = rightStarts[row]
+			}
+			entries = append(entries, diffWrapEntry{
+				line:         line,
+				leftStart:    leftStart,
+				rightStart:   rightStart,
+				continuation: row > 0,
+			})
+		}
+		line++
+	}
+	return entries
+}
+
+func diffSegmentVisualColToRune(text string, startCol, visualCol int) int {
+	if startCol < 0 {
+		return 0
+	}
+	runes := []rune(text)
+	if startCol >= len(runes) {
+		return len(runes)
+	}
+	return startCol + visualColToBufCol(string(runes[startCol:]), visualCol, diffTabWidth)
+}
+
+func (d *DiffViewWidget) topVisualRow() int {
+	if !d.IsWrapped() {
+		return d.TopLine
+	}
+	if d.IsUnified() {
+		return unifiedLineToVisualRow(d.unifiedLines, d.TopLine, d.layoutLeftW) + d.wrapTopOffset
+	}
+	return diffLineToVisualRow(d.Lines, d.TopLine, d.layoutLeftW, d.layoutRightW) + d.wrapTopOffset
+}
+
+func (d *DiffViewWidget) setTopVisualRow(row int) {
+	maxTop := d.totalVisualRows - d.viewH
+	if maxTop < 0 {
+		maxTop = 0
+	}
+	if row < 0 {
+		row = 0
+	}
+	if row > maxTop {
+		row = maxTop
+	}
+	if d.IsWrapped() {
+		if d.IsUnified() {
+			d.TopLine, d.wrapTopOffset = unifiedVisualRowToTop(d.unifiedLines, row, d.layoutLeftW)
+		} else {
+			d.TopLine, d.wrapTopOffset = diffVisualRowToTop(d.Lines, row, d.layoutLeftW, d.layoutRightW)
+		}
+	} else {
+		d.TopLine = row
+		d.wrapTopOffset = 0
+	}
+}
+
+func (d *DiffViewWidget) scrollVertical(rows int) {
+	d.setTopVisualRow(d.topVisualRow() + rows)
+}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -82,6 +82,7 @@ type EditorGroupWidget struct {
 	GutterStyle             string
 	WordWrap                bool
 	DiffMode                DiffMode
+	DiffContext             DiffContextMode
 	DiffWordWrap            bool
 	DiffHighContrast        bool
 	SyntaxHighlight         bool
@@ -455,6 +456,9 @@ func (g *EditorGroupWidget) OpenDiffTab(tabName, title, path string, fd diff.Fil
 // in View.
 func (g *EditorGroupWidget) ApplyDiffDefaults(surface DiffModeSurface) {
 	surface.ApplyDefaultMode(g.DiffMode)
+	if contextSurface, ok := surface.(DiffContextSurface); ok {
+		contextSurface.ApplyDefaultContextMode(g.DiffContext)
+	}
 	wrapMode := DiffWrapOff
 	if g.DiffWordWrap {
 		wrapMode = DiffWrapOn
@@ -465,14 +469,26 @@ func (g *EditorGroupWidget) ApplyDiffDefaults(surface DiffModeSurface) {
 
 // SetDiffDefaults updates the defaults used by future diff surfaces and
 // refreshes every open surface that still inherits either property.
-func (g *EditorGroupWidget) SetDiffDefaults(mode DiffMode, wordWrap bool) {
+func (g *EditorGroupWidget) SetDiffDefaults(mode DiffMode, contextMode DiffContextMode, wordWrap bool) {
 	g.DiffMode = mode
+	g.DiffContext = contextMode
 	g.DiffWordWrap = wordWrap
 	for _, tab := range g.tabs {
 		if surface, ok := tab.Content.(DiffModeSurface); ok {
 			g.ApplyDiffDefaults(surface)
 		}
 	}
+}
+
+func (g *EditorGroupWidget) ActiveDiffContextSurface() DiffContextSurface {
+	t := g.activeTab()
+	if t == nil || t.Content == nil {
+		return nil
+	}
+	if surface, ok := t.Content.(DiffContextSurface); ok {
+		return surface
+	}
+	return nil
 }
 
 func (g *EditorGroupWidget) SetDiffHighContrast(enabled bool) {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -136,6 +136,9 @@ func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool
 	tabBar.OnTabClick = func(index int) {
 		g.SwitchTab(index)
 	}
+	tabBar.OnTabReorder = func(from, to int) {
+		g.MoveTab(from, to)
+	}
 	tabBar.OnNextTab = func() { g.NextTab() }
 	tabBar.OnPrevTab = func() { g.PrevTab() }
 	tabBar.OnDoubleClick = func() { g.NewFile() }
@@ -248,6 +251,56 @@ func (g *EditorGroupWidget) TogglePinTab() {
 
 func (g *EditorGroupWidget) IsActiveTabPinned() bool {
 	return g.active < g.pinnedCount
+}
+
+// MoveTab reorders a tab without changing its pinned state or the active
+// document. Dragging a preview is an explicit placement action, so the preview
+// becomes a regular tab instead of remaining eligible for replacement.
+func (g *EditorGroupWidget) MoveTab(from, to int) bool {
+	if from < 0 || from >= len(g.tabs) || to < 0 || to >= len(g.tabs) {
+		return false
+	}
+	if from < g.pinnedCount {
+		to = min(to, g.pinnedCount-1)
+	} else {
+		to = max(to, g.pinnedCount)
+	}
+	if from == to {
+		return false
+	}
+
+	tab := g.tabs[from]
+	tab.Preview = false
+	g.tabs = append(g.tabs[:from], g.tabs[from+1:]...)
+	g.tabs = slices.Insert(g.tabs, to, tab)
+	switch {
+	case g.active == from:
+		g.active = to
+	case from < g.active && to >= g.active:
+		g.active--
+	case from > g.active && to <= g.active:
+		g.active++
+	}
+	g.syncTabs()
+	return true
+}
+
+func (g *EditorGroupWidget) CanMoveActiveTab(direction int) bool {
+	to := g.active + direction
+	if direction == 0 || to < 0 || to >= len(g.tabs) {
+		return false
+	}
+	if g.active < g.pinnedCount {
+		return to < g.pinnedCount
+	}
+	return to >= g.pinnedCount
+}
+
+func (g *EditorGroupWidget) MoveActiveTab(direction int) bool {
+	if !g.CanMoveActiveTab(direction) {
+		return false
+	}
+	return g.MoveTab(g.active, g.active+direction)
 }
 
 func (g *EditorGroupWidget) OpenFile(path string) {
@@ -1905,8 +1958,8 @@ func (g *EditorGroupWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 	result := g.TabBar.HandleEvent(ev)
 	slog.Debug("editorGroup", "tabBarResult", result)
-	if result == EventConsumed {
-		return EventConsumed
+	if result != EventIgnored {
+		return result
 	}
 	t := g.activeTab()
 	if t == nil {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1894,25 +1894,6 @@ func (g *EditorGroupWidget) syncTabs() {
 		})
 	}
 	g.TabBar.SetTabs(uiTabs)
-	g.TabBar.Controls = nil
-	if surface := g.ActiveDiffModeSurface(); surface != nil {
-		g.TabBar.Controls = []TabBarControl{
-			{
-				Label:  "Split",
-				Active: surface.Mode() == DiffModeSplit,
-				OnClick: func() {
-					surface.SetMode(DiffModeSplit)
-				},
-			},
-			{
-				Label:  "Unified",
-				Active: surface.Mode() == DiffModeUnified,
-				OnClick: func() {
-					surface.SetMode(DiffModeUnified)
-				},
-			},
-		}
-	}
 }
 
 func (g *EditorGroupWidget) Render(surface Surface) {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -642,6 +642,14 @@ func (g *EditorGroupWidget) ActiveCommitDetailWidget() *CommitDetailWidget {
 	return nil
 }
 
+func (g *EditorGroupWidget) ActiveCurrentChangesWidget() *CommitDetailWidget {
+	detail := g.ActiveCommitDetailWidget()
+	if detail != nil && detail.CurrentChanges {
+		return detail
+	}
+	return nil
+}
+
 func (g *EditorGroupWidget) ActiveDiffModeSurface() DiffModeSurface {
 	if diffView := g.ActiveDiffWidget(); diffView != nil {
 		return diffView
@@ -675,6 +683,14 @@ func (g *EditorGroupWidget) CommitDetailWidgetByTab(tabName string) *CommitDetai
 			}
 			return nil
 		}
+	}
+	return nil
+}
+
+func (g *EditorGroupWidget) CurrentChangesWidgetByTab(tabName string) *CommitDetailWidget {
+	detail := g.CommitDetailWidgetByTab(tabName)
+	if detail != nil && detail.CurrentChanges {
+		return detail
 	}
 	return nil
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -969,15 +969,15 @@ func (g *EditorGroupWidget) Save() bool {
 	return true
 }
 
-func (g *EditorGroupWidget) SaveAs(path string) {
+func (g *EditorGroupWidget) SaveAs(path string) bool {
 	t := g.activeTab()
 	if t == nil || t.Content != nil {
-		return
+		return false
 	}
 	g.applySaveCleanups(t)
 	if err := t.Buf.SaveFile(path); err != nil {
 		g.reportError(fmt.Sprintf("Failed to save %s: %v", path, err))
-		return
+		return false
 	}
 	if t.Undo != nil {
 		t.Undo.MarkSaved()
@@ -990,6 +990,7 @@ func (g *EditorGroupWidget) SaveAs(path string) {
 		t.Highlighter = nil
 	}
 	g.syncTabs()
+	return true
 }
 
 // RenamePath repoints open tabs after a path is renamed on disk. oldPath may be

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -83,6 +83,7 @@ type EditorGroupWidget struct {
 	WordWrap                bool
 	DiffMode                DiffMode
 	DiffWordWrap            bool
+	DiffHighContrast        bool
 	SyntaxHighlight         bool
 	BracketPairColorization bool
 	BracketColorStyles      []term.Style
@@ -406,6 +407,7 @@ func (g *EditorGroupWidget) ApplyDiffDefaults(surface DiffModeSurface) {
 		wrapMode = DiffWrapOn
 	}
 	surface.ApplyDefaultWrapMode(wrapMode)
+	surface.SetDiffHighContrast(g.DiffHighContrast)
 }
 
 // SetDiffDefaults updates the defaults used by future diff surfaces and
@@ -416,6 +418,15 @@ func (g *EditorGroupWidget) SetDiffDefaults(mode DiffMode, wordWrap bool) {
 	for _, tab := range g.tabs {
 		if surface, ok := tab.Content.(DiffModeSurface); ok {
 			g.ApplyDiffDefaults(surface)
+		}
+	}
+}
+
+func (g *EditorGroupWidget) SetDiffHighContrast(enabled bool) {
+	g.DiffHighContrast = enabled
+	for _, tab := range g.tabs {
+		if surface, ok := tab.Content.(DiffModeSurface); ok {
+			surface.SetDiffHighContrast(enabled)
 		}
 	}
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -59,9 +59,9 @@ type editorTab struct {
 	Folds       *fold.State
 	TabSize     int
 	UseTabs     bool
-	Content Widget
-	Preview bool
-	Virtual bool
+	Content     Widget
+	Preview     bool
+	Virtual     bool
 	LineChanges []diff.LineChangeKind
 	ReadOnly    bool
 }
@@ -81,6 +81,8 @@ type EditorGroupWidget struct {
 	LineNumbers             bool
 	GutterStyle             string
 	WordWrap                bool
+	DiffMode                DiffMode
+	DiffWordWrap            bool
 	SyntaxHighlight         bool
 	BracketPairColorization bool
 	BracketColorStyles      []term.Style
@@ -93,10 +95,13 @@ type EditorGroupWidget struct {
 	OnFileChange            func(path, lang, text string)
 	OnFileClose             func(path, lang string)
 	OnContentTabClose       func(id string)
-	OnError                 func(msg string)
-	OnNotify                func(msg string)
-	pendingNotify           []string
-	focused                 bool
+	// OnActiveContentChange fires after a tab switch or an in-place replacement
+	// changes what the editor group is showing.
+	OnActiveContentChange func()
+	OnError               func(msg string)
+	OnNotify              func(msg string)
+	pendingNotify         []string
+	focused               bool
 	// diagSources holds diagnostics keyed by source ("lsp", "plugin:<name>")
 	// then by file path. Merged per-path into each tab's Diagnostics.
 	diagSources map[string]map[string][]Diagnostic
@@ -196,6 +201,12 @@ func (g *EditorGroupWidget) notify(msg string) {
 	}
 }
 
+func (g *EditorGroupWidget) activeContentChanged() {
+	if g.OnActiveContentChange != nil {
+		g.OnActiveContentChange()
+	}
+}
+
 func (g *EditorGroupWidget) FlushNotifications() {
 	if g.OnNotify == nil {
 		return
@@ -241,11 +252,15 @@ func (g *EditorGroupWidget) IsActiveTabPinned() bool {
 func (g *EditorGroupWidget) OpenFile(path string) {
 	for i := range g.tabs {
 		if g.tabs[i].FilePath == path {
+			wasActive := i == g.active
 			g.tabs[i].Preview = false
 			if g.tabs[i].Buf != nil && !g.tabs[i].Buf.Dirty {
 				g.tabs[i].Buf.LoadFile(path)
 			}
 			g.SwitchTab(i)
+			if wasActive {
+				g.activeContentChanged()
+			}
 			return
 		}
 	}
@@ -299,6 +314,7 @@ func (g *EditorGroupWidget) OpenFile(path string) {
 	if t := g.activeTab(); t != nil && t.Preview && t.Content == nil && t.Buf != nil && !t.Buf.Dirty {
 		g.tabs[g.active] = newTab
 		g.syncTabs()
+		g.activeContentChanged()
 	} else {
 		g.tabs = append(g.tabs, newTab)
 		g.SwitchTab(len(g.tabs) - 1)
@@ -341,37 +357,80 @@ func (g *EditorGroupWidget) nextUntitledName() string {
 }
 
 func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, newLines []string, extended bool) {
-	tabName := path + " (diff)"
+	g.OpenDiffTab(path+" (diff)", "", path, fd, oldLines, newLines, extended)
+}
+
+// OpenDiffTab opens a diff under an explicit tab key and label. Callers that can
+// produce several diffs of the same file — one per commit, say — need their own
+// key, or the second one would replace the first under an identical label.
+// path is still the real file path so the highlighter picks the right language.
+func (g *EditorGroupWidget) OpenDiffTab(tabName, title, path string, fd diff.FileDiff, oldLines, newLines []string, extended bool) {
 	for i, t := range g.tabs {
 		if t.FilePath == tabName {
+			wasActive := i == g.active
 			dw := NewDiffViewWidget(path, fd, oldLines, newLines, extended)
+			g.ApplyDiffDefaults(dw)
 			if !g.SyntaxHighlight {
 				dw.Highlighter = nil
 			}
 			t.Content = dw
+			t.Title = title
 			g.tabs[i] = t
 			g.SwitchTab(i)
+			if wasActive {
+				g.activeContentChanged()
+			}
 			return
 		}
 	}
 	widget := NewDiffViewWidget(path, fd, oldLines, newLines, extended)
+	g.ApplyDiffDefaults(widget)
 	if !g.SyntaxHighlight {
 		widget.Highlighter = nil
 	}
 	g.tabs = append(g.tabs, editorTab{
 		FilePath: tabName,
+		Title:    title,
 		Content:  widget,
 	})
 	g.SwitchTab(len(g.tabs) - 1)
 }
 
+// ApplyDiffDefaults initializes or refreshes a reading surface. Each property
+// follows the current Options default until the reader overrides that property
+// in View.
+func (g *EditorGroupWidget) ApplyDiffDefaults(surface DiffModeSurface) {
+	surface.ApplyDefaultMode(g.DiffMode)
+	wrapMode := DiffWrapOff
+	if g.DiffWordWrap {
+		wrapMode = DiffWrapOn
+	}
+	surface.ApplyDefaultWrapMode(wrapMode)
+}
+
+// SetDiffDefaults updates the defaults used by future diff surfaces and
+// refreshes every open surface that still inherits either property.
+func (g *EditorGroupWidget) SetDiffDefaults(mode DiffMode, wordWrap bool) {
+	g.DiffMode = mode
+	g.DiffWordWrap = wordWrap
+	for _, tab := range g.tabs {
+		if surface, ok := tab.Content.(DiffModeSurface); ok {
+			g.ApplyDiffDefaults(surface)
+		}
+	}
+}
+
 func (g *EditorGroupWidget) OpenPluginTab(id, title string, content Widget) {
 	for i, t := range g.tabs {
 		if t.FilePath == id {
+			wasActive := i == g.active
 			t.Content = content
 			t.Title = title
 			g.tabs[i] = t
 			g.SwitchTab(i)
+			if wasActive {
+				g.activeContentChanged()
+			}
 			return
 		}
 	}
@@ -386,6 +445,7 @@ func (g *EditorGroupWidget) OpenPluginTab(id, title string, content Widget) {
 func (g *EditorGroupWidget) ClosePluginTab(id string) {
 	for i, t := range g.tabs {
 		if t.FilePath == id {
+			wasActive := i == g.active
 			if t.Content != nil && g.OnContentTabClose != nil {
 				g.OnContentTabClose(t.FilePath)
 			}
@@ -408,6 +468,9 @@ func (g *EditorGroupWidget) ClosePluginTab(id string) {
 				g.active = len(g.tabs) - 1
 			}
 			g.syncTabs()
+			if wasActive {
+				g.activeContentChanged()
+			}
 			return
 		}
 	}
@@ -504,11 +567,47 @@ func (g *EditorGroupWidget) ActiveDiffWidget() *DiffViewWidget {
 	return nil
 }
 
+func (g *EditorGroupWidget) ActiveCommitDetailWidget() *CommitDetailWidget {
+	t := g.activeTab()
+	if t == nil || t.Content == nil {
+		return nil
+	}
+	if detail, ok := t.Content.(*CommitDetailWidget); ok {
+		return detail
+	}
+	return nil
+}
+
+func (g *EditorGroupWidget) ActiveDiffModeSurface() DiffModeSurface {
+	if diffView := g.ActiveDiffWidget(); diffView != nil {
+		return diffView
+	}
+	if detail := g.ActiveCommitDetailWidget(); detail != nil {
+		return detail
+	}
+	return nil
+}
+
 func (g *EditorGroupWidget) DiffWidgetByTab(tabName string) *DiffViewWidget {
 	for _, t := range g.tabs {
 		if t.FilePath == tabName {
 			if dv, ok := t.Content.(*DiffViewWidget); ok {
 				return dv
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// CommitDetailWidgetByTab returns a still-open commit detail tab. Async detail
+// results use this as their identity check: if the reader closed the loading
+// tab before Git finished, the result is dropped instead of reopening it.
+func (g *EditorGroupWidget) CommitDetailWidgetByTab(tabName string) *CommitDetailWidget {
+	for _, t := range g.tabs {
+		if t.FilePath == tabName {
+			if detail, ok := t.Content.(*CommitDetailWidget); ok {
+				return detail
 			}
 			return nil
 		}
@@ -568,6 +667,7 @@ func (g *EditorGroupWidget) SetUseTabs(useTabs bool) {
 
 func (g *EditorGroupWidget) SwitchTab(idx int) {
 	if idx >= 0 && idx < len(g.tabs) {
+		changed := idx != g.active
 		if t := g.activeTab(); t != nil && t.Content != nil {
 			if setter, ok := t.Content.(interface{ SetFocused(bool) }); ok {
 				setter.SetFocused(false)
@@ -582,6 +682,9 @@ func (g *EditorGroupWidget) SwitchTab(idx int) {
 					setter.SetFocused(true)
 				}
 			}
+		}
+		if changed {
+			g.activeContentChanged()
 		}
 	}
 }
@@ -634,6 +737,7 @@ func (g *EditorGroupWidget) CloseTab() {
 		g.active = len(g.tabs) - 1
 	}
 	g.syncTabs()
+	g.activeContentChanged()
 }
 
 func (g *EditorGroupWidget) CloseOtherTabs() {
@@ -705,6 +809,7 @@ func (g *EditorGroupWidget) HasDirtyOtherTabs() bool {
 }
 
 func (g *EditorGroupWidget) CloseAllTabs() {
+	activeChanged := g.pinnedCount == 0 || g.active != 0
 	kept := slices.Clone(g.tabs[:g.pinnedCount])
 	if len(kept) == 0 {
 		kept = []editorTab{{
@@ -721,9 +826,13 @@ func (g *EditorGroupWidget) CloseAllTabs() {
 	g.tabs = kept
 	g.active = 0
 	g.syncTabs()
+	if activeChanged {
+		g.activeContentChanged()
+	}
 }
 
 func (g *EditorGroupWidget) CloseAllSaved() {
+	activeFile := g.ActiveFilePath()
 	var kept []editorTab
 	for i := range g.tabs {
 		if i < g.pinnedCount || (g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty) {
@@ -739,6 +848,9 @@ func (g *EditorGroupWidget) CloseAllSaved() {
 		g.active = len(g.tabs) - 1
 	}
 	g.syncTabs()
+	if g.ActiveFilePath() != activeFile {
+		g.activeContentChanged()
+	}
 }
 
 func (g *EditorGroupWidget) HasDirtyTabs() bool {
@@ -932,8 +1044,12 @@ func (g *EditorGroupWidget) OpenFileReadOnly(path, title string) {
 func (g *EditorGroupWidget) OpenBufferReadOnly(title, filePath string, lines []string) {
 	for i := range g.tabs {
 		if g.tabs[i].Title == title && g.tabs[i].ReadOnly {
+			wasActive := i == g.active
 			g.tabs[i].Buf.Lines = lines
 			g.SwitchTab(i)
+			if wasActive {
+				g.activeContentChanged()
+			}
 			return
 		}
 	}
@@ -1567,6 +1683,12 @@ func (g *EditorGroupWidget) Copy() {
 		}
 		return
 	}
+	if detail, ok := t.Content.(*CommitDetailWidget); ok {
+		if text := detail.CopySelection(); text != "" {
+			clipboard.Set(text)
+		}
+		return
+	}
 	if t.Content != nil {
 		// Non-editor tab (settings UI, plugin panel, ...): no buffer to copy from.
 		return
@@ -1675,6 +1797,25 @@ func (g *EditorGroupWidget) syncTabs() {
 		})
 	}
 	g.TabBar.SetTabs(uiTabs)
+	g.TabBar.Controls = nil
+	if surface := g.ActiveDiffModeSurface(); surface != nil {
+		g.TabBar.Controls = []TabBarControl{
+			{
+				Label:  "Split",
+				Active: surface.Mode() == DiffModeSplit,
+				OnClick: func() {
+					surface.SetMode(DiffModeSplit)
+				},
+			},
+			{
+				Label:  "Unified",
+				Active: surface.Mode() == DiffModeUnified,
+				OnClick: func() {
+					surface.SetMode(DiffModeUnified)
+				},
+			},
+		}
+	}
 }
 
 func (g *EditorGroupWidget) Render(surface Surface) {

--- a/internal/ui/editor_group_tab_reorder_test.go
+++ b/internal/ui/editor_group_tab_reorder_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/buffer"
+	"github.com/eugenioenko/ttt/internal/core/cursor"
+	"github.com/eugenioenko/ttt/internal/core/selection"
+	"github.com/eugenioenko/ttt/internal/core/undo"
+	"github.com/eugenioenko/ttt/internal/view"
+)
+
+func reorderTestTab(path string, preview bool) editorTab {
+	return editorTab{
+		FilePath: path,
+		Buf:      &buffer.Buffer{Lines: []string{""}},
+		Cur:      &cursor.Cursor{},
+		Vp:       &view.Viewport{},
+		Undo:     &undo.UndoStack{},
+		Sel:      &selection.Selection{},
+		Preview:  preview,
+	}
+}
+
+func tabPaths(g *EditorGroupWidget) []string {
+	paths := make([]string, len(g.tabs))
+	for i := range g.tabs {
+		paths[i] = g.tabs[i].FilePath
+	}
+	return paths
+}
+
+func TestEditorGroupMoveTabPreservesActiveDocumentAndCommitsPreview(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, true, "relative")
+	g.tabs = []editorTab{
+		reorderTestTab("one.go", true),
+		reorderTestTab("two.go", false),
+		reorderTestTab("three.go", false),
+	}
+	g.active = 1
+
+	if !g.MoveTab(0, 2) {
+		t.Fatal("MoveTab should reorder distinct unpinned positions")
+	}
+	want := []string{"two.go", "three.go", "one.go"}
+	if got := tabPaths(g); !slices.Equal(got, want) {
+		t.Fatalf("tab order = %v, want %v", got, want)
+	}
+	if g.active != 0 || g.tabs[g.active].FilePath != "two.go" {
+		t.Fatalf("active tab = %d %q, want two.go at 0", g.active, g.tabs[g.active].FilePath)
+	}
+	if g.tabs[2].Preview {
+		t.Fatal("dragged preview should become a regular tab")
+	}
+}
+
+func TestEditorGroupMoveTabKeepsPinnedBoundary(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, true, "relative")
+	g.tabs = []editorTab{
+		reorderTestTab("pin-one.go", false),
+		reorderTestTab("pin-two.go", false),
+		reorderTestTab("one.go", false),
+		reorderTestTab("two.go", false),
+	}
+	g.pinnedCount = 2
+	g.active = 2
+
+	if g.MoveTab(2, 0) {
+		t.Fatal("unpinned tab should not cross into the pinned block")
+	}
+	if g.MoveTab(1, 3) {
+		t.Fatal("pinned tab should not cross into the unpinned block")
+	}
+	if !g.MoveTab(0, 1) {
+		t.Fatal("pinned tabs should reorder within their block")
+	}
+	want := []string{"pin-two.go", "pin-one.go", "one.go", "two.go"}
+	if got := tabPaths(g); !slices.Equal(got, want) {
+		t.Fatalf("tab order = %v, want %v", got, want)
+	}
+	if g.active != 2 || !g.CanMoveActiveTab(1) || g.CanMoveActiveTab(-1) {
+		t.Fatalf("active movement availability is wrong: active=%d left=%v right=%v",
+			g.active, g.CanMoveActiveTab(-1), g.CanMoveActiveTab(1))
+	}
+}

--- a/internal/ui/palette_help.go
+++ b/internal/ui/palette_help.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/command"
+)
+
+type paletteItemKind uint8
+
+// Help favors trustworthy results over fuzzy recall. Weak character-order
+// coincidences remain below the absolute floor, while the relative floor keeps
+// secondary metadata associations from trailing a much stronger title match.
+const (
+	paletteHelpScoreFloor          = 200
+	paletteHelpRelativeNumerator   = 3
+	paletteHelpRelativeDenominator = 4
+)
+
+const (
+	paletteCommandItem paletteItemKind = iota
+	paletteHelpTopicItem
+)
+
+type paletteHelpTopic struct {
+	ID              string
+	Title           string
+	Description     string
+	CommandPrefixes []string
+	CommandIDs      []string
+	ChordsOnly      bool
+}
+
+// paletteHelpTopics is a deliberately curated new-user onramp. Command titles
+// and shortcuts remain derived from the command registry and keybinding config;
+// only this small orientation layer is authored by hand and maintained here.
+var paletteHelpTopics = []paletteHelpTopic{
+	{
+		ID:              "workspace",
+		Title:           "Workspace map",
+		Description:     "Understand folders, tabs, and editor groups",
+		CommandPrefixes: []string{"workspace.", "file.", "tab.", "focus."},
+		CommandIDs:      []string{"command.palette"},
+	},
+	{
+		ID:              "panels",
+		Title:           "Sidebar and panels",
+		Description:     "Use Explorer, Search, Changes, and Output",
+		CommandPrefixes: []string{"sidebar.", "panel.", "output."},
+		CommandIDs:      []string{"explorer.help", "search.help", "changes.help"},
+	},
+	{
+		ID:              "navigation",
+		Title:           "Navigate files",
+		Description:     "Open files, switch tabs, and move focus",
+		CommandPrefixes: []string{"file.", "tab.", "focus."},
+		CommandIDs:      []string{"editor.goToLine", "command.palette"},
+	},
+	{
+		ID:              "changes",
+		Title:           "Review changes",
+		Description:     "Review, stage, and commit workspace changes",
+		CommandPrefixes: []string{"changes.", "git.", "pr."},
+		CommandIDs:      []string{"sidebar.changes", "changes.help"},
+	},
+	{
+		ID:              "terminal",
+		Title:           "Integrated terminal",
+		Description:     "Open shells without leaving the editor",
+		CommandPrefixes: []string{"terminal."},
+		CommandIDs:      []string{"focus.terminal"},
+	},
+	{
+		ID:          "chords",
+		Title:       "Keybinding chords",
+		Description: "Use multi-step chords and edit shortcuts",
+		CommandIDs:  []string{"view.keybindings", "keybindings.open"},
+		ChordsOnly:  true,
+	},
+}
+
+func buildPaletteHelpItems(commands []command.Command) ([]PaletteItem, []PaletteItem) {
+	topics := make([]PaletteItem, 0, len(paletteHelpTopics))
+	for _, topic := range paletteHelpTopics {
+		topics = append(topics, PaletteItem{
+			Label:       topic.Title,
+			ID:          "help:" + topic.ID,
+			Description: topic.Description,
+			kind:        paletteHelpTopicItem,
+			topicID:     topic.ID,
+			searchText:  []string{topic.Title, topic.Description, topic.ID},
+		})
+	}
+
+	items := make([]PaletteItem, 0, len(commands))
+	for _, cmd := range commands {
+		description := paletteCommandDescription(cmd.ID)
+		searchText := []string{cmd.Title, cmd.ID, cmd.Shortcut, description}
+		searchText = append(searchText, cmd.Keywords...)
+		items = append(items, PaletteItem{
+			Label:       cmd.Title,
+			Detail:      cmd.Shortcut,
+			ID:          cmd.ID,
+			Description: description,
+			kind:        paletteCommandItem,
+			searchText:  searchText,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Label < items[j].Label
+	})
+	return topics, items
+}
+
+func paletteCommandDescription(id string) string {
+	switch {
+	case strings.HasPrefix(id, "workspace."):
+		return "Manage folders and saved workspaces"
+	case strings.HasPrefix(id, "file."):
+		return "Create, open, save, or find a file"
+	case strings.HasPrefix(id, "tab."), strings.HasPrefix(id, "focus."):
+		return "Move between open files and editor groups"
+	case strings.HasPrefix(id, "sidebar."), strings.HasPrefix(id, "panel."), strings.HasPrefix(id, "output."):
+		return "Show, hide, or focus an editor panel"
+	case strings.HasPrefix(id, "changes."), strings.HasPrefix(id, "git."), strings.HasPrefix(id, "pr."):
+		return "Inspect or act on version-control changes"
+	case strings.HasPrefix(id, "terminal."):
+		return "Use the integrated terminal"
+	case strings.HasPrefix(id, "settings."), strings.HasPrefix(id, "theme."), strings.HasPrefix(id, "options."), strings.HasPrefix(id, "keybindings."):
+		return "Customize behavior and shortcuts"
+	default:
+		return "Run this editor command"
+	}
+}
+
+func paletteHelpTopicByID(id string) (paletteHelpTopic, bool) {
+	for _, topic := range paletteHelpTopics {
+		if topic.ID == id {
+			return topic, true
+		}
+	}
+	return paletteHelpTopic{}, false
+}
+
+func paletteTopicMatchesCommand(topic paletteHelpTopic, item PaletteItem) bool {
+	for _, id := range topic.CommandIDs {
+		if item.ID == id {
+			return true
+		}
+	}
+	for _, prefix := range topic.CommandPrefixes {
+		if strings.HasPrefix(item.ID, prefix) {
+			return true
+		}
+	}
+	return topic.ChordsOnly && strings.Contains(item.Detail, " ")
+}
+
+func scorePaletteHelpItem(query string, item PaletteItem) (bool, int) {
+	bestOK, bestScore := fuzzyMatch(query, item.Label)
+	for _, text := range item.searchText {
+		if ok, score := fuzzyMatch(query, text); ok {
+			if text != item.Label {
+				score /= 2
+			}
+			if !bestOK || score > bestScore {
+				bestOK = true
+				bestScore = score
+			}
+		}
+	}
+	return bestOK, bestScore
+}

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -19,12 +21,17 @@ const (
 	paletteCommandMode paletteMode = iota
 	paletteFileMode
 	paletteGoToLineMode
+	paletteHelpMode
 )
 
 type PaletteItem struct {
-	Label  string
-	Detail string
-	ID     string
+	Label       string
+	Detail      string
+	ID          string
+	Description string
+	kind        paletteItemKind
+	topicID     string
+	searchText  []string
 }
 
 type paletteFile struct {
@@ -43,6 +50,10 @@ type SelectDialogWidget struct {
 	inputY            int
 	mode              paletteMode
 	files             []paletteFile
+	helpTopics        []PaletteItem
+	helpCommands      []PaletteItem
+	activeHelpTopic   string
+	helpQuery         string
 	OnExecute         func(id string)
 	OnOpenFile        func(path string)
 	OnGoToLine        func(line int)
@@ -63,6 +74,7 @@ func NewSelectDialogWidget(commands []command.Command) *SelectDialogWidget {
 	p := &SelectDialogWidget{
 		Commands: commands,
 	}
+	p.helpTopics, p.helpCommands = buildPaletteHelpItems(commands)
 	p.Input = NewInputWidget()
 	p.Input.Prefix = " "
 	p.Input.SetText(">")
@@ -115,9 +127,6 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 	sw, sh := surface.Size()
 
 	boxW := sw * 6 / 10 // 60% of terminal width
-	if boxW > 60 {
-		boxW = 60
-	}
 	if boxW < 40 {
 		boxW = 40
 	}
@@ -129,9 +138,18 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 		boxH = 3
 	} else {
 		maxItems := 10
-		boxH = 4 + len(p.Items)
-		if boxH > maxItems+4 {
-			boxH = maxItems + 4
+		chromeRows := 4
+		if p.mode == paletteHelpMode {
+			// Help reserves one divider and one detail row beneath the list.
+			chromeRows += 2
+		}
+		itemRows := len(p.Items)
+		if p.mode == paletteHelpMode && p.helpQuery != "" && itemRows == 0 {
+			itemRows = 1
+		}
+		boxH = chromeRows + itemRows
+		if boxH > maxItems+chromeRows {
+			boxH = maxItems + chromeRows
 		}
 	}
 	if boxH > sh-2 {
@@ -169,6 +187,9 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 	}
 
 	visibleItems := boxH - 4
+	if p.mode == paletteHelpMode {
+		visibleItems -= 2
+	}
 	p.visibleItems = visibleItems
 	p.ensureVisible(visibleItems)
 	showScroll := len(p.Items) > visibleItems
@@ -197,32 +218,84 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 		}
 
 		surface.ClearRect(boxX+1, y, contentRight-boxX-1, 1, style)
-		surface.DrawText(boxX+2, y, item.Label, contentRight-1, style)
-
-		if item.Detail != "" {
-			detailStyle := term.StyleMuted
-			if idx == p.Selected {
-				detailStyle = style
-			}
-			labelEnd := boxX + 2 + len([]rune(item.Label))
-			minGap := 3
-			availStart := labelEnd + minGap
-			availW := contentRight - 1 - availStart
-			if availW > 0 {
-				detail := item.Detail
-				detailRunes := []rune(detail)
-				if len(detailRunes) > availW {
-					detail = "…" + string(detailRunes[len(detailRunes)-availW+1:])
-				}
-				sx := contentRight - 1 - len([]rune(detail))
-				surface.DrawText(sx, y, detail, contentRight-1, detailStyle)
-			}
-		}
+		p.renderItemRow(surface, y, contentRight, item, style, idx == p.Selected)
+	}
+	if p.mode == paletteHelpMode && p.helpQuery != "" && len(p.Items) == 0 && visibleItems > 0 {
+		y := boxY + 3
+		message := fmt.Sprintf("No help entries match %q", p.helpQuery)
+		surface.DrawText(boxX+2, y, message, contentRight-1, term.StyleMuted)
 	}
 
 	if showScroll {
 		p.scrollbar.Render(surface, p.scrollbar.X, p.scrollbar.Y)
 	}
+
+	if p.mode == paletteHelpMode {
+		dividerY := boxY + boxH - 3
+		for x := boxX + 1; x < boxX+boxW-1; x++ {
+			surface.SetCell(x, dividerY, term.Cell{Ch: b.Horizontal, Style: term.StyleBorder})
+		}
+		detailY := boxY + boxH - 2
+		surface.ClearRect(boxX+1, detailY, boxW-2, 1, term.StyleDefault)
+		if p.Selected >= 0 && p.Selected < len(p.Items) {
+			description := p.Items[p.Selected].Description
+			surface.DrawText(boxX+2, detailY, description, boxX+boxW-2, term.StyleMuted)
+		} else if p.helpQuery != "" {
+			surface.DrawText(boxX+2, detailY, "Try > for all commands", boxX+boxW-2, term.StyleMuted)
+		}
+	}
+}
+
+func (p *SelectDialogWidget) renderItemRow(surface Surface, y, contentRight int, item PaletteItem, style term.Style, selected bool) {
+	detail := item.Detail
+	detailStyle := term.StyleMuted
+	if selected {
+		detailStyle = style
+	}
+
+	// Help commands reserve room for their derived shortcut. Other modes keep
+	// their existing preference for the complete label and add detail only if it
+	// fits after the columns DrawText actually consumed.
+	if p.mode == paletteHelpMode && item.kind == paletteCommandItem && detail != "" {
+		detailW := textwidth.String(detail)
+		detailX := contentRight - 1 - detailW
+		if detailX > p.boxX+4 {
+			surface.DrawText(p.boxX+2, y, item.Label, detailX-2, style)
+			surface.DrawText(detailX, y, detail, contentRight-1, detailStyle)
+			return
+		}
+	}
+
+	labelEnd := surface.DrawText(p.boxX+2, y, item.Label, contentRight-1, style)
+	if detail == "" {
+		return
+	}
+	availStart := labelEnd + 3
+	availW := contentRight - 1 - availStart
+	if availW <= 0 {
+		return
+	}
+	detail = truncatePaletteDetail(detail, availW)
+	detailX := contentRight - 1 - textwidth.String(detail)
+	surface.DrawText(detailX, y, detail, contentRight-1, detailStyle)
+}
+
+func truncatePaletteDetail(detail string, availW int) string {
+	if textwidth.String(detail) <= availW {
+		return detail
+	}
+	runes := []rune(detail)
+	tailW := 0
+	i := len(runes)
+	for i > 0 {
+		width := textwidth.Rune(runes[i-1])
+		if tailW+width > availW-1 {
+			break
+		}
+		tailW += width
+		i--
+	}
+	return "…" + string(runes[i:])
 }
 
 func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -287,16 +360,7 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 				clickedIdx := p.scrollOffset + (my - itemsStartY)
 				if clickedIdx >= 0 && clickedIdx < len(p.Items) {
 					p.Selected = clickedIdx
-					item := p.Items[p.Selected]
-					if p.mode == paletteCommandMode {
-						if p.OnExecute != nil {
-							p.OnExecute(item.ID)
-						}
-					} else {
-						if p.OnOpenFile != nil {
-							p.OnOpenFile(item.ID)
-						}
-					}
+					p.activateItem(p.Items[p.Selected])
 				}
 			}
 		}
@@ -311,6 +375,11 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 
 	switch kev.Key() {
 	case tcell.KeyEscape:
+		if p.mode == paletteHelpMode && p.activeHelpTopic != "" {
+			p.activeHelpTopic = ""
+			p.Input.SetText("?")
+			return EventConsumed
+		}
 		if p.OnDismiss != nil {
 			p.OnDismiss()
 		}
@@ -326,16 +395,7 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 				}
 			}
 		} else if p.Selected >= 0 && p.Selected < len(p.Items) {
-			item := p.Items[p.Selected]
-			if p.mode == paletteCommandMode {
-				if p.OnExecute != nil {
-					p.OnExecute(item.ID)
-				}
-			} else {
-				if p.OnOpenFile != nil {
-					p.OnOpenFile(item.ID)
-				}
-			}
+			p.activateItem(p.Items[p.Selected])
 		}
 	case tcell.KeyUp:
 		if p.Selected > 0 {
@@ -352,10 +412,37 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		p.notifySelectionChange()
 	default:
+		if kev.Key() == tcell.KeyRune && kev.Str() == "?" && p.mode == paletteCommandMode && p.Input.Text == ">" {
+			p.Input.SetText("?")
+			return EventConsumed
+		}
 		p.Input.HandleEvent(ev)
 	}
 
 	return EventConsumed
+}
+
+func (p *SelectDialogWidget) activateItem(item PaletteItem) {
+	if p.mode == paletteHelpMode {
+		if item.kind == paletteHelpTopicItem {
+			p.activeHelpTopic = item.topicID
+			p.Input.SetText("?")
+			return
+		}
+		if p.OnExecute != nil {
+			p.OnExecute(item.ID)
+		}
+		return
+	}
+	if p.mode == paletteCommandMode {
+		if p.OnExecute != nil {
+			p.OnExecute(item.ID)
+		}
+		return
+	}
+	if p.OnOpenFile != nil {
+		p.OnOpenFile(item.ID)
+	}
 }
 
 func (p *SelectDialogWidget) ensureVisible(visibleItems int) {
@@ -380,18 +467,91 @@ func (p *SelectDialogWidget) filter() {
 	text := p.Input.Text
 	if strings.HasPrefix(text, ">") {
 		p.mode = paletteCommandMode
+		p.activeHelpTopic = ""
 		query := strings.TrimLeft(text[1:], " ")
 		p.filterCommands(query)
 	} else if strings.HasPrefix(text, ":") {
 		p.mode = paletteGoToLineMode
+		p.activeHelpTopic = ""
 		p.Items = nil
 		p.Selected = 0
 		p.scrollOffset = 0
+	} else if strings.HasPrefix(text, "?") {
+		p.mode = paletteHelpMode
+		query := strings.TrimSpace(text[1:])
+		p.filterHelp(query)
 	} else {
 		p.mode = paletteFileMode
+		p.activeHelpTopic = ""
 		p.filterFiles(text)
 	}
 	p.notifySelectionChange()
+}
+
+func (p *SelectDialogWidget) filterHelp(query string) {
+	p.helpQuery = query
+	if p.activeHelpTopic != "" {
+		topic, ok := paletteHelpTopicByID(p.activeHelpTopic)
+		if !ok {
+			p.activeHelpTopic = ""
+		} else {
+			candidates := make([]PaletteItem, 0, len(p.helpCommands))
+			for _, item := range p.helpCommands {
+				if paletteTopicMatchesCommand(topic, item) {
+					candidates = append(candidates, item)
+				}
+			}
+			p.Items = filterPaletteHelpCandidates(query, candidates)
+			p.Selected = 0
+			p.scrollOffset = 0
+			return
+		}
+	}
+
+	if query == "" {
+		p.Items = append(p.Items[:0], p.helpTopics...)
+	} else {
+		candidates := make([]PaletteItem, 0, len(p.helpTopics)+len(p.helpCommands))
+		candidates = append(candidates, p.helpTopics...)
+		candidates = append(candidates, p.helpCommands...)
+		p.Items = filterPaletteHelpCandidates(query, candidates)
+	}
+	p.Selected = 0
+	p.scrollOffset = 0
+}
+
+func filterPaletteHelpCandidates(query string, candidates []PaletteItem) []PaletteItem {
+	if query == "" {
+		return append([]PaletteItem(nil), candidates...)
+	}
+	type scored struct {
+		item  PaletteItem
+		score int
+	}
+	matches := make([]scored, 0, len(candidates))
+	bestScore := 0
+	for _, item := range candidates {
+		if ok, score := scorePaletteHelpItem(query, item); ok {
+			matches = append(matches, scored{item: item, score: score})
+			if score > bestScore {
+				bestScore = score
+			}
+		}
+	}
+	relevanceFloor := bestScore * paletteHelpRelativeNumerator / paletteHelpRelativeDenominator
+	if relevanceFloor < paletteHelpScoreFloor {
+		relevanceFloor = paletteHelpScoreFloor
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return matches[i].score > matches[j].score
+	})
+	items := make([]PaletteItem, 0, len(matches))
+	for _, match := range matches {
+		if match.score >= relevanceFloor {
+			items = append(items, match.item)
+		}
+	}
+	return items
 }
 
 func (p *SelectDialogWidget) filterCommands(query string) {

--- a/internal/ui/selectdialog_widget_test.go
+++ b/internal/ui/selectdialog_widget_test.go
@@ -1,11 +1,41 @@
 package ui
 
 import (
-	"github.com/eugenioenko/ttt/internal/command"
+	"strings"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
 
 	"github.com/gdamore/tcell/v3"
 )
+
+func defaultShortcut(commandID string) string {
+	for _, binding := range config.DefaultKeybindings() {
+		if binding.Command == commandID {
+			return binding.Key
+		}
+	}
+	return ""
+}
+
+func helpTestCommands() []command.Command {
+	return []command.Command{
+		{
+			ID:       "file.quickOpen",
+			Title:    "Open Anything From the Workspace",
+			Shortcut: defaultShortcut("file.quickOpen"),
+			Keywords: []string{"file", "navigate", "open"},
+		},
+		{
+			ID:       "sidebar.search",
+			Title:    "Search Everywhere",
+			Shortcut: defaultShortcut("sidebar.search"),
+			Keywords: []string{"sidebar", "search", "workspace"},
+		},
+		{ID: "tab.closeAllSaved", Title: "Close All Saved Tabs"},
+	}
+}
 
 func testCommands() []command.Command {
 	return []command.Command{
@@ -345,5 +375,139 @@ func TestPaletteTitleMatchRanksAboveKeywordOnly(t *testing.T) {
 	}
 	if p.Items[0].ID != "settings" {
 		t.Fatalf("expected title match 'Preferences: Open Settings' (id=settings) to rank first, got id=%s (%s)", p.Items[0].ID, p.Items[0].Label)
+	}
+}
+
+func TestPaletteHelpStartsWithOrientationTopics(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+
+	// A question mark typed into the initial command prompt switches prefixes;
+	// the user should not have to erase ">" first.
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "?", tcell.ModNone))
+
+	if p.Input.Text != "?" {
+		t.Fatalf("expected question-mark prefix, got %q", p.Input.Text)
+	}
+	if len(p.Items) == 0 {
+		t.Fatal("expected orientation topics")
+	}
+	for _, item := range p.Items {
+		if item.ID == "file.quickOpen" || item.ID == "sidebar.search" {
+			t.Fatalf("empty help should show topics, not command %q", item.ID)
+		}
+	}
+	if p.Items[0].Description == "" {
+		t.Fatal("expected the selected topic to have orientation detail")
+	}
+}
+
+func TestPaletteHelpSearchDerivesCommandsAndShortcuts(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "?", tcell.ModNone))
+	for _, r := range "Open Anything" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone))
+	}
+
+	if len(p.Items) == 0 {
+		t.Fatal("expected command search result")
+	}
+	got := p.Items[0]
+	if got.ID != "file.quickOpen" {
+		t.Fatalf("expected derived command ID, got %q", got.ID)
+	}
+	if got.Label != "Open Anything From the Workspace" {
+		t.Fatalf("expected registered title, got %q", got.Label)
+	}
+	if got.Detail != defaultShortcut("file.quickOpen") {
+		t.Fatalf("expected shortcut derived from DefaultKeybindings, got %q", got.Detail)
+	}
+}
+
+func TestPaletteHelpTopicDrillsIntoCommands(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "?", tcell.ModNone))
+
+	// The first topic is the workspace orientation topic. Enter reveals the
+	// commands related to that topic instead of trying to execute the topic.
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+
+	if len(p.Items) == 0 {
+		t.Fatal("expected commands after entering a help topic")
+	}
+	foundQuickOpen := false
+	for _, item := range p.Items {
+		if item.ID == "file.quickOpen" {
+			foundQuickOpen = true
+		}
+	}
+	if !foundQuickOpen {
+		t.Fatal("workspace topic should drill into the derived quick-open command")
+	}
+}
+
+func TestPaletteHelpRelevanceFloorRejectsFuzzyNoise(t *testing.T) {
+	commands := []command.Command{
+		{ID: "editor.undo", Title: "Undo", Shortcut: defaultShortcut("editor.undo")},
+		{ID: "multicursor.undoCursor", Title: "Undo Last Cursor", Shortcut: defaultShortcut("multicursor.undoCursor")},
+		{ID: "changes.discard", Title: "Git: Discard Changes", Keywords: []string{"git", "changes", "revert", "restore", "undo"}},
+		{ID: "sourceAction.formatDocument", Title: "Source Action: Format Document"},
+		{ID: "about", Title: "About TTT Editor"},
+		{ID: "multicursor.selectNext", Title: "Add Next Occurrence"},
+		{ID: "editor.indentation", Title: "Change Indentation"},
+	}
+	p := NewSelectDialogWidget(commands)
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "?", tcell.ModNone))
+	for _, r := range "undo" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone))
+	}
+
+	if len(p.Items) != 2 {
+		labels := make([]string, len(p.Items))
+		for i, item := range p.Items {
+			labels[i] = item.Label
+		}
+		t.Fatalf("expected only two relevant undo matches, got %d: %v", len(p.Items), labels)
+	}
+	if p.Items[0].ID != "editor.undo" || p.Items[1].ID != "multicursor.undoCursor" {
+		t.Fatalf("unexpected undo result order: %q, %q", p.Items[0].ID, p.Items[1].ID)
+	}
+
+	// A metadata match remains discoverable when it is the best available
+	// evidence; the relative floor only suppresses it beside stronger titles.
+	p.Input.SetText("?revert")
+	if len(p.Items) != 1 || p.Items[0].ID != "changes.discard" {
+		t.Fatalf("expected exact keyword-only match, got %#v", p.Items)
+	}
+}
+
+func TestPaletteHelpNoMatchesRendersGuidance(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "?", tcell.ModNone))
+	for _, r := range "qxzvjk" {
+		p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone))
+	}
+	if len(p.Items) != 0 {
+		t.Fatalf("expected no matches, got %d", len(p.Items))
+	}
+
+	cells := makeGrid(80, 24)
+	p.Render(NewRenderSurface(cells, Rect{X: 0, Y: 0, W: 80, H: 24}))
+	var rendered strings.Builder
+	for _, row := range cells {
+		for _, cell := range row {
+			if cell.Ch == 0 {
+				rendered.WriteByte(' ')
+			} else {
+				rendered.WriteRune(cell.Ch)
+			}
+		}
+		rendered.WriteByte('\n')
+	}
+	text := rendered.String()
+	if !strings.Contains(text, `No help entries match "qxzvjk"`) {
+		t.Fatalf("missing no-results message:\n%s", text)
+	}
+	if !strings.Contains(text, "Try > for all commands") {
+		t.Fatalf("missing command-mode hint:\n%s", text)
 	}
 }

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -59,8 +59,13 @@ func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
 		_, my := tev.Position()
 		r := s.GetRect()
 		if my == r.Y {
-			if s.Tabs.HandleEvent(ev) == EventConsumed {
-				return EventConsumed
+			result := s.Tabs.HandleEvent(ev)
+			if result == EventCaptured {
+				s.capturedChild = s.Tabs
+				return EventCaptured
+			}
+			if result == EventConsumed {
+				return result
 			}
 			return EventIgnored
 		}

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -9,8 +9,9 @@ import (
 type SidebarWidget struct {
 	BaseWidget
 	TabbedPanel
-	Visible bool
-	Borders *term.BorderSet
+	Visible       bool
+	Borders       *term.BorderSet
+	capturedChild Widget
 }
 
 func NewSidebarWidget() *SidebarWidget {
@@ -46,6 +47,14 @@ func (s *SidebarWidget) Render(surface Surface) {
 }
 
 func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
+	if s.capturedChild != nil {
+		result := s.capturedChild.HandleEvent(ev)
+		if tev, ok := ev.(*tcell.EventMouse); ok && tev.Buttons() == tcell.ButtonNone {
+			s.capturedChild = nil
+		}
+		return result
+	}
+
 	if tev, ok := ev.(*tcell.EventMouse); ok {
 		_, my := tev.Position()
 		r := s.GetRect()
@@ -58,7 +67,11 @@ func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 	active := s.ActiveWidget()
 	if active != nil {
-		return active.HandleEvent(ev)
+		result := active.HandleEvent(ev)
+		if result == EventCaptured {
+			s.capturedChild = active
+		}
+		return result
 	}
 	return EventIgnored
 }

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/textwidth"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -42,6 +43,7 @@ type TabBarWidget struct {
 	OnTabClick       func(index int)
 	OnTabClose       func(index int)
 	OnTabUnpin       func(index int)
+	OnTabReorder     func(from, to int)
 	OnTabRightClick  func(index, screenX, screenY int)
 	OnPrevTab        func()
 	OnNextTab        func()
@@ -58,6 +60,7 @@ type TabBarWidget struct {
 	closeDownY       int
 	wasPressed       bool
 	lastClickTime    int64
+	drag             widgets.TabDragState
 }
 
 func NewTabBarWidget() *TabBarWidget {
@@ -172,7 +175,7 @@ func (t *TabBarWidget) Render(surface Surface) {
 	}
 
 	// Scroll to keep active tab visible within the inner zone
-	if activeIdx >= 0 {
+	if activeIdx >= 0 && !t.drag.Active() {
 		s := spans[activeIdx]
 		if s.end-t.ScrollOffset > innerW {
 			t.ScrollOffset = s.end - innerW
@@ -291,6 +294,12 @@ func (t *TabBarWidget) Render(surface Surface) {
 		moreSurface := surface.Sub(Rect{X: w - 4, Y: 1, W: 3, H: 1})
 		t.MoreButton.Render(moreSurface)
 	}
+
+	if x := t.dropIndicatorX(); x >= innerLeft && x < innerRight {
+		for y := 0; y < 3; y++ {
+			surface.SetCell(x, y, term.Cell{Ch: '│', Style: term.StyleBorderActive})
+		}
+	}
 }
 
 func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -303,6 +312,22 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	btn := mev.Buttons()
 
 	slog.Debug("tabBar", "mx", mx, "my", my, "btn", btn, "rect", r, "hasMore", t.MoreButton != nil)
+
+	if btn == tcell.ButtonNone && t.drag.Active() {
+		t.wasPressed = false
+		from, to, dragged := t.drag.End()
+		if dragged && from != to && t.OnTabReorder != nil {
+			t.OnTabReorder(from, to)
+		}
+		return EventConsumed
+	}
+	if t.drag.Active() && btn&tcell.Button1 != 0 {
+		t.autoScrollDrag(mx)
+		if t.drag.Update(mx, t.dropTargetAt(mx)) {
+			t.closeDownX = -1
+		}
+		return EventCaptured
+	}
 
 	if t.MoreButton != nil {
 		if t.MoreButton.HandleEvent(ev) == EventConsumed {
@@ -415,6 +440,10 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 			if t.OnTabClick != nil {
 				t.OnTabClick(i)
 			}
+			if t.OnTabReorder != nil {
+				t.drag.Begin(i, mx)
+				return EventCaptured
+			}
 			return EventConsumed
 		}
 	}
@@ -427,4 +456,56 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		t.lastClickTime = now
 	}
 	return EventConsumed
+}
+
+func (t *TabBarWidget) dropTargetAt(screenX int) int {
+	localX := screenX - t.GetRect().X - t.renderArrowW + t.ScrollOffset
+	last := -1
+	for i, span := range t.tabSpans {
+		last = i
+		if localX < span.start+(span.end-span.start)/2 {
+			return i
+		}
+	}
+	return last
+}
+
+func (t *TabBarWidget) dropIndicatorX() int {
+	if !t.drag.Dragging() || t.drag.From() == t.drag.Target() {
+		return -1
+	}
+	target := t.drag.Target()
+	if target < 0 || target >= len(t.tabSpans) {
+		return -1
+	}
+	span := t.tabSpans[target]
+	logicalX := span.end - 1
+	if target < t.drag.From() {
+		logicalX = span.start
+	}
+	return logicalX - t.ScrollOffset + t.renderArrowW
+}
+
+func (t *TabBarWidget) autoScrollDrag(screenX int) {
+	if t.renderArrowW == 0 {
+		return
+	}
+	r := t.GetRect()
+	innerW := t.renderInnerRight - t.renderArrowW
+	if innerW < 1 {
+		return
+	}
+	const scrollStep = 3
+	if screenX <= r.X+t.renderArrowW {
+		t.ScrollOffset -= scrollStep
+	} else if screenX >= r.X+t.renderInnerRight-1 {
+		t.ScrollOffset += scrollStep
+	}
+	maxScroll := t.totalTabWidth - innerW
+	if t.ScrollOffset > maxScroll {
+		t.ScrollOffset = maxScroll
+	}
+	if t.ScrollOffset < 0 {
+		t.ScrollOffset = 0
+	}
 }

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -24,6 +24,15 @@ type Tab struct {
 	Pinned   bool
 }
 
+// TabBarControl is a compact, directly clickable mode choice rendered beside
+// the tabs. The marker is textual as well as styled so the active choice stays
+// inspectable in monochrome terminals and screenshots.
+type TabBarControl struct {
+	Label   string
+	Active  bool
+	OnClick func()
+}
+
 type TabBarWidget struct {
 	BaseWidget
 	Tabs             []Tab
@@ -37,7 +46,9 @@ type TabBarWidget struct {
 	OnPrevTab        func()
 	OnNextTab        func()
 	OnDoubleClick    func()
+	Controls         []TabBarControl
 	tabSpans         []tabSpan
+	controlSpans     []MenuItemSpan
 	renderArrowW     int // arrow-gutter width from the last Render, reused by HandleEvent
 	renderInnerRight int // right edge of the tab zone from the last Render, reused by HandleEvent
 	hasOverflowLeft  bool
@@ -73,6 +84,15 @@ func (t *TabBarWidget) tabLabel(tab Tab) string {
 	}
 	label += " "
 	return label
+}
+
+func (t *TabBarWidget) controlsWidth() int {
+	width := 0
+	for _, control := range t.Controls {
+		// Surrounding spaces plus the radio marker and its following space.
+		width += textwidth.String(control.Label) + 4
+	}
+	return width
 }
 
 // drawTabLabel draws a tab label from x, advancing by each rune's display width
@@ -131,14 +151,20 @@ func (t *TabBarWidget) Render(surface Surface) {
 	if t.MoreButton != nil && w >= 5 {
 		moreW = 4
 	}
-	hasOverflow := pos > w-moreW
+	controlsW := t.controlsWidth()
+	// On narrow tab bars, keep the tab usable rather than squeezing it behind
+	// the mode control. The View menu and keyboard command remain available.
+	if controlsW > 0 && w-moreW-controlsW < 12 {
+		controlsW = 0
+	}
+	hasOverflow := pos > w-moreW-controlsW
 	arrowW := 0
 	if hasOverflow {
 		arrowW = 3 // " ◀ " or " ▶ "
 	}
 	innerLeft := arrowW
 	t.renderArrowW = arrowW
-	innerRight := w - moreW - arrowW
+	innerRight := w - moreW - controlsW - arrowW
 	t.renderInnerRight = innerRight
 	innerW := innerRight - innerLeft
 	if innerW < 1 {
@@ -239,6 +265,26 @@ func (t *TabBarWidget) Render(surface Surface) {
 		surface.SetCell(innerRight+1, 1, term.Cell{Ch: '▶', Style: term.StyleMuted})
 	}
 
+	t.controlSpans = nil
+	if controlsW > 0 {
+		x := w - moreW - controlsW
+		for _, control := range t.Controls {
+			start := x
+			style := term.StyleInactiveTab
+			marker := '○'
+			if control.Active {
+				style = term.StyleActiveTab
+				marker = '●'
+			}
+			label := " " + string(marker) + " " + control.Label + " "
+			for _, ch := range label {
+				surface.SetCell(x, 1, term.Cell{Ch: ch, Style: style})
+				x += textwidth.Rune(ch)
+			}
+			t.controlSpans = append(t.controlSpans, MenuItemSpan{Start: start, End: x})
+		}
+	}
+
 	if t.MoreButton != nil && w >= 5 {
 		r := t.GetRect()
 		t.MoreButton.SetRect(Rect{X: r.X + w - 4, Y: r.Y + 1, W: 3, H: 1})
@@ -321,6 +367,18 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	t.wasPressed = true
 	if !freshClick {
 		return EventConsumed
+	}
+
+	if my == r.Y+1 {
+		localX := mx - r.X
+		for i, span := range t.controlSpans {
+			if localX >= span.Start && localX < span.End {
+				if i < len(t.Controls) && t.Controls[i].OnClick != nil {
+					t.Controls[i].OnClick()
+				}
+				return EventConsumed
+			}
+		}
 	}
 
 	// Clicks in the reserved ◀/▶ arrow columns are consumed here so they never

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -25,15 +25,6 @@ type Tab struct {
 	Pinned   bool
 }
 
-// TabBarControl is a compact, directly clickable mode choice rendered beside
-// the tabs. The marker is textual as well as styled so the active choice stays
-// inspectable in monochrome terminals and screenshots.
-type TabBarControl struct {
-	Label   string
-	Active  bool
-	OnClick func()
-}
-
 type TabBarWidget struct {
 	BaseWidget
 	Tabs             []Tab
@@ -48,9 +39,7 @@ type TabBarWidget struct {
 	OnPrevTab        func()
 	OnNextTab        func()
 	OnDoubleClick    func()
-	Controls         []TabBarControl
 	tabSpans         []tabSpan
-	controlSpans     []MenuItemSpan
 	renderArrowW     int // arrow-gutter width from the last Render, reused by HandleEvent
 	renderInnerRight int // right edge of the tab zone from the last Render, reused by HandleEvent
 	hasOverflowLeft  bool
@@ -87,15 +76,6 @@ func (t *TabBarWidget) tabLabel(tab Tab) string {
 	}
 	label += " "
 	return label
-}
-
-func (t *TabBarWidget) controlsWidth() int {
-	width := 0
-	for _, control := range t.Controls {
-		// Surrounding spaces plus the radio marker and its following space.
-		width += textwidth.String(control.Label) + 4
-	}
-	return width
 }
 
 // drawTabLabel draws a tab label from x, advancing by each rune's display width
@@ -154,20 +134,14 @@ func (t *TabBarWidget) Render(surface Surface) {
 	if t.MoreButton != nil && w >= 5 {
 		moreW = 4
 	}
-	controlsW := t.controlsWidth()
-	// On narrow tab bars, keep the tab usable rather than squeezing it behind
-	// the mode control. The View menu and keyboard command remain available.
-	if controlsW > 0 && w-moreW-controlsW < 12 {
-		controlsW = 0
-	}
-	hasOverflow := pos > w-moreW-controlsW
+	hasOverflow := pos > w-moreW
 	arrowW := 0
 	if hasOverflow {
 		arrowW = 3 // " ◀ " or " ▶ "
 	}
 	innerLeft := arrowW
 	t.renderArrowW = arrowW
-	innerRight := w - moreW - controlsW - arrowW
+	innerRight := w - moreW - arrowW
 	t.renderInnerRight = innerRight
 	innerW := innerRight - innerLeft
 	if innerW < 1 {
@@ -266,26 +240,6 @@ func (t *TabBarWidget) Render(surface Surface) {
 	}
 	if t.hasOverflowRight {
 		surface.SetCell(innerRight+1, 1, term.Cell{Ch: '▶', Style: term.StyleMuted})
-	}
-
-	t.controlSpans = nil
-	if controlsW > 0 {
-		x := w - moreW - controlsW
-		for _, control := range t.Controls {
-			start := x
-			style := term.StyleInactiveTab
-			marker := '○'
-			if control.Active {
-				style = term.StyleActiveTab
-				marker = '●'
-			}
-			label := " " + string(marker) + " " + control.Label + " "
-			for _, ch := range label {
-				surface.SetCell(x, 1, term.Cell{Ch: ch, Style: style})
-				x += textwidth.Rune(ch)
-			}
-			t.controlSpans = append(t.controlSpans, MenuItemSpan{Start: start, End: x})
-		}
 	}
 
 	if t.MoreButton != nil && w >= 5 {
@@ -392,18 +346,6 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	t.wasPressed = true
 	if !freshClick {
 		return EventConsumed
-	}
-
-	if my == r.Y+1 {
-		localX := mx - r.X
-		for i, span := range t.controlSpans {
-			if localX >= span.Start && localX < span.End {
-				if i < len(t.Controls) && t.Controls[i].OnClick != nil {
-					t.Controls[i].OnClick()
-				}
-				return EventConsumed
-			}
-		}
 	}
 
 	// Clicks in the reserved ◀/▶ arrow columns are consumed here so they never

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -123,6 +123,62 @@ func TestTabBarOverflowScrollLeft(t *testing.T) {
 	}
 }
 
+func TestTabBarDragReordersWithThemedIndicator(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{
+		{Name: "one.go", Active: true},
+		{Name: "two.go"},
+		{Name: "three.go"},
+	})
+	tb.SetRect(Rect{X: 4, Y: 2, W: 50, H: 3})
+	grid := makeGrid(50, 3)
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 50, H: 3}))
+
+	fromX := tb.GetRect().X + tb.tabSpans[0].start + 2
+	toX := tb.GetRect().X + tb.tabSpans[2].end - 2
+	var gotFrom, gotTo = -1, -1
+	tb.OnTabReorder = func(from, to int) { gotFrom, gotTo = from, to }
+
+	if got := tb.HandleEvent(tcell.NewEventMouse(fromX, 3, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down = %v, want captured", got)
+	}
+	if got := tb.HandleEvent(tcell.NewEventMouse(toX, 3, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("drag = %v, want captured", got)
+	}
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 50, H: 3}))
+	indicatorX := tb.dropIndicatorX()
+	if indicatorX < 0 || grid[1][indicatorX].Ch != '│' || grid[1][indicatorX].Style != term.StyleBorderActive {
+		t.Fatal("drag should render a themed drop indicator")
+	}
+	tb.HandleEvent(tcell.NewEventMouse(toX, 3, tcell.ButtonNone, 0))
+	if gotFrom != 0 || gotTo != 2 {
+		t.Fatalf("reorder = %d -> %d, want 0 -> 2", gotFrom, gotTo)
+	}
+}
+
+func TestTabBarDragAutoScrollsOverflow(t *testing.T) {
+	tb := NewTabBarWidget()
+	tabs := make([]Tab, 10)
+	for i := range tabs {
+		tabs[i] = Tab{Name: fmt.Sprintf("file-%d.go", i), Active: i == 0}
+	}
+	tb.SetTabs(tabs)
+	tb.SetRect(Rect{X: 0, Y: 0, W: 30, H: 3})
+	grid := makeGrid(30, 3)
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 30, H: 3}))
+	tb.OnTabReorder = func(_, _ int) {}
+
+	startX := tb.renderArrowW + 2
+	tb.HandleEvent(tcell.NewEventMouse(startX, 1, tcell.Button1, 0))
+	for range 3 {
+		tb.HandleEvent(tcell.NewEventMouse(tb.renderInnerRight-1, 1, tcell.Button1, 0))
+		tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 30, H: 3}))
+	}
+	if tb.ScrollOffset == 0 {
+		t.Fatal("dragging at the right edge should scroll hidden tabs into view")
+	}
+}
+
 // renderInMoreButtonWindow sizes the bar to exactly the total tab width with a
 // MoreButton present, so tabs overflow the inner zone but not the full width —
 // the #354 window. Returns the rendered grid and the bar width.

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/term"
@@ -37,6 +38,36 @@ func TestTabBarRender(t *testing.T) {
 	// Row 2: baseline with gap
 	if grid[2][0].Ch != '┘' {
 		t.Fatalf("expected BottomRight at row 2 col 0, got '%c'", grid[2][0].Ch)
+	}
+}
+
+func TestTabBarModeControlsExposeAndSetCurrentChoice(t *testing.T) {
+	selected := ""
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{{Name: "change.diff", Active: true}})
+	tb.Controls = []TabBarControl{
+		{Label: "Split", Active: true, OnClick: func() { selected = "split" }},
+		{Label: "Unified", OnClick: func() { selected = "unified" }},
+	}
+	tb.SetRect(Rect{X: 0, Y: 0, W: 60, H: 3})
+	grid := makeGrid(60, 3)
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 60, H: 3}))
+
+	var row strings.Builder
+	for _, cell := range grid[1] {
+		row.WriteRune(cell.Ch)
+	}
+	if !strings.Contains(row.String(), "● Split") || !strings.Contains(row.String(), "○ Unified") {
+		t.Fatalf("mode control does not expose active choice: %q", row.String())
+	}
+	if len(tb.controlSpans) != 2 {
+		t.Fatalf("mode control spans = %v, want two", tb.controlSpans)
+	}
+	span := tb.controlSpans[1]
+	x := span.Start + (span.End-span.Start)/2
+	tb.HandleEvent(tcell.NewEventMouse(x, 1, tcell.Button1, tcell.ModNone))
+	if selected != "unified" {
+		t.Fatalf("click selected %q, want unified", selected)
 	}
 }
 

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/term"
@@ -38,36 +37,6 @@ func TestTabBarRender(t *testing.T) {
 	// Row 2: baseline with gap
 	if grid[2][0].Ch != '┘' {
 		t.Fatalf("expected BottomRight at row 2 col 0, got '%c'", grid[2][0].Ch)
-	}
-}
-
-func TestTabBarModeControlsExposeAndSetCurrentChoice(t *testing.T) {
-	selected := ""
-	tb := NewTabBarWidget()
-	tb.SetTabs([]Tab{{Name: "change.diff", Active: true}})
-	tb.Controls = []TabBarControl{
-		{Label: "Split", Active: true, OnClick: func() { selected = "split" }},
-		{Label: "Unified", OnClick: func() { selected = "unified" }},
-	}
-	tb.SetRect(Rect{X: 0, Y: 0, W: 60, H: 3})
-	grid := makeGrid(60, 3)
-	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 60, H: 3}))
-
-	var row strings.Builder
-	for _, cell := range grid[1] {
-		row.WriteRune(cell.Ch)
-	}
-	if !strings.Contains(row.String(), "● Split") || !strings.Contains(row.String(), "○ Unified") {
-		t.Fatalf("mode control does not expose active choice: %q", row.String())
-	}
-	if len(tb.controlSpans) != 2 {
-		t.Fatalf("mode control spans = %v, want two", tb.controlSpans)
-	}
-	span := tb.controlSpans[1]
-	x := span.Start + (span.End-span.Start)/2
-	tb.HandleEvent(tcell.NewEventMouse(x, 1, tcell.Button1, tcell.ModNone))
-	if selected != "unified" {
-		t.Fatalf("click selected %q, want unified", selected)
 	}
 }
 

--- a/internal/ui/tabbed_panel.go
+++ b/internal/ui/tabbed_panel.go
@@ -1,6 +1,9 @@
 package ui
 
 import (
+	"slices"
+	"sort"
+
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/widgets"
 )
@@ -12,11 +15,13 @@ type panelEntry struct {
 }
 
 type TabbedPanel struct {
-	ActivePanel   string
-	Tabs          *widgets.TabsWidget
-	OnPanelChange func(id string)
+	ActivePanel    string
+	Tabs           *widgets.TabsWidget
+	OnPanelChange  func(id string)
+	OnPanelReorder func(ids []string)
 
-	panels []panelEntry
+	panels         []panelEntry
+	preferredOrder []string
 }
 
 func NewTabbedPanel() TabbedPanel {
@@ -31,6 +36,9 @@ func (tp *TabbedPanel) InitTabClick() {
 			tp.SetActivePanel(tp.panels[index].ID)
 		}
 	}
+	tp.Tabs.Config.OnReorder = func(from, to int) {
+		tp.MovePanel(from, to)
+	}
 }
 
 func (tp *TabbedPanel) AddPanel(id, title string, w Widget) {
@@ -38,7 +46,77 @@ func (tp *TabbedPanel) AddPanel(id, title string, w Widget) {
 	if tp.ActivePanel == "" {
 		tp.ActivePanel = id
 	}
+	tp.applyPreferredOrder()
 	tp.syncTabs()
+}
+
+func (tp *TabbedPanel) SetPanelOrder(order []string) {
+	tp.preferredOrder = slices.Clone(order)
+	tp.applyPreferredOrder()
+	tp.syncTabs()
+}
+
+func (tp *TabbedPanel) applyPreferredOrder() {
+	if len(tp.preferredOrder) == 0 || len(tp.panels) < 2 {
+		return
+	}
+	rank := make(map[string]int, len(tp.preferredOrder))
+	for i, id := range tp.preferredOrder {
+		if _, exists := rank[id]; !exists {
+			rank[id] = i
+		}
+	}
+	sort.SliceStable(tp.panels, func(i, j int) bool {
+		ri, iKnown := rank[tp.panels[i].ID]
+		rj, jKnown := rank[tp.panels[j].ID]
+		switch {
+		case iKnown && jKnown:
+			return ri < rj
+		case iKnown:
+			return true
+		case jKnown:
+			return false
+		default:
+			return false
+		}
+	})
+}
+
+func (tp *TabbedPanel) MovePanel(from, to int) bool {
+	if from < 0 || from >= len(tp.panels) || to < 0 || to >= len(tp.panels) || from == to {
+		return false
+	}
+	panel := tp.panels[from]
+	tp.panels = append(tp.panels[:from], tp.panels[from+1:]...)
+	tp.panels = slices.Insert(tp.panels, to, panel)
+	tp.preferredOrder = tp.PanelIDs()
+	tp.syncTabs()
+	if tp.OnPanelReorder != nil {
+		tp.OnPanelReorder(tp.PanelIDs())
+	}
+	return true
+}
+
+func (tp *TabbedPanel) ActivePanelIndex() int {
+	for i, panel := range tp.panels {
+		if panel.ID == tp.ActivePanel {
+			return i
+		}
+	}
+	return -1
+}
+
+func (tp *TabbedPanel) CanMoveActivePanel(dir int) bool {
+	idx := tp.ActivePanelIndex()
+	return idx >= 0 && idx+dir >= 0 && idx+dir < len(tp.panels)
+}
+
+func (tp *TabbedPanel) MoveActivePanel(dir int) bool {
+	idx := tp.ActivePanelIndex()
+	if idx < 0 {
+		return false
+	}
+	return tp.MovePanel(idx, idx+dir)
 }
 
 func (tp *TabbedPanel) RemovePanel(id string) {

--- a/internal/ui/tabbed_panel_test.go
+++ b/internal/ui/tabbed_panel_test.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestTabbedPanelAppliesSavedOrderAsPanelsArrive(t *testing.T) {
+	tp := NewTabbedPanel()
+	tp.InitTabClick()
+	tp.SetPanelOrder([]string{"changes", "plugin.todo", "explorer"})
+	tp.AddPanel("explorer", "Explore", &mockWidget{})
+	tp.AddPanel("search", "Find", &mockWidget{})
+	tp.AddPanel("changes", "Changes", &mockWidget{})
+	if got := tp.PanelIDs(); !slices.Equal(got, []string{"changes", "explorer", "search"}) {
+		t.Fatalf("core panel order = %v", got)
+	}
+	tp.AddPanel("plugin.todo", "Todo", &mockWidget{})
+	if got := tp.PanelIDs(); !slices.Equal(got, []string{"changes", "plugin.todo", "explorer", "search"}) {
+		t.Fatalf("late plugin panel order = %v", got)
+	}
+	if tp.ActivePanel != "explorer" {
+		t.Fatalf("active panel changed to %q", tp.ActivePanel)
+	}
+}
+
+func TestTabbedPanelMovePreservesActiveIdentity(t *testing.T) {
+	tp := NewTabbedPanel()
+	tp.InitTabClick()
+	for _, id := range []string{"explorer", "search", "changes"} {
+		tp.AddPanel(id, id, &mockWidget{})
+	}
+	tp.SetActivePanel("changes")
+	var reported []string
+	tp.OnPanelReorder = func(ids []string) { reported = ids }
+	if !tp.MovePanel(2, 0) {
+		t.Fatal("MovePanel returned false")
+	}
+	want := []string{"changes", "explorer", "search"}
+	if !slices.Equal(tp.PanelIDs(), want) || !slices.Equal(reported, want) {
+		t.Fatalf("order = %v, reported = %v, want %v", tp.PanelIDs(), reported, want)
+	}
+	if tp.ActivePanel != "changes" || tp.ActivePanelIndex() != 0 {
+		t.Fatalf("active panel = %q at %d", tp.ActivePanel, tp.ActivePanelIndex())
+	}
+}

--- a/internal/ui/tree_widget_adapter.go
+++ b/internal/ui/tree_widget_adapter.go
@@ -7,9 +7,10 @@ import (
 
 type WidgetAdapter struct {
 	BaseWidget
-	W      widgets.Widget
-	focus  *widgets.FocusManager
-	popups []widgets.PopupRenderer
+	W            widgets.Widget
+	focus        *widgets.FocusManager
+	popups       []widgets.PopupRenderer
+	rootCaptured bool
 }
 
 func NewWidgetAdapter(w widgets.Widget) *WidgetAdapter {
@@ -69,6 +70,13 @@ func (a *WidgetAdapter) wireTabbedCallbacks(w widgets.Widget) {
 	case *widgets.ScrollViewWidget:
 		if v.Child != nil {
 			a.wireTabbedCallbacks(v.Child)
+		}
+	case *ContentSplitWidget:
+		if v.Top != nil {
+			a.wireTabbedCallbacks(v.Top)
+		}
+		if v.Bottom != nil {
+			a.wireTabbedCallbacks(v.Bottom)
 		}
 	}
 }
@@ -143,6 +151,18 @@ func (a *WidgetAdapter) CursorPosition() (int, int, bool) {
 }
 
 func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
+	// A container that captured a mouse press owns the rest of that gesture.
+	// Running focus hit-testing first would let a child under the pointer steal
+	// a drag as it crossed the child (for example, a split divider crossing an
+	// input row).
+	if tev, ok := ev.(*tcell.EventMouse); ok && a.rootCaptured {
+		result := a.W.HandleEvent(ev)
+		if tev.Buttons() == tcell.ButtonNone {
+			a.rootCaptured = false
+		}
+		return result
+	}
+
 	// Popups are painted over the tree, so they must claim clicks over the rows
 	// they cover before those rows get a chance at them.
 	if tev, ok := ev.(*tcell.EventMouse); ok {
@@ -153,5 +173,9 @@ func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
 	if result := a.focus.HandleEvent(ev); result != EventIgnored {
 		return result
 	}
-	return a.W.HandleEvent(ev)
+	result := a.W.HandleEvent(ev)
+	if result == EventCaptured {
+		a.rootCaptured = true
+	}
+	return result
 }

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -67,18 +67,116 @@ func (fm *FocusManager) FocusNext() {
 	if len(fm.items) == 0 {
 		return
 	}
-	fm.setFocus((fm.focused + 1) % len(fm.items))
+	if next := fm.adjacentRendered(1); next >= 0 && next != fm.focused {
+		fm.setFocus(next)
+	}
 }
 
 func (fm *FocusManager) FocusPrev() {
 	if len(fm.items) == 0 {
 		return
 	}
-	next := fm.focused - 1
-	if next < 0 {
-		next = len(fm.items) - 1
+	if next := fm.adjacentRendered(-1); next >= 0 && next != fm.focused {
+		fm.setFocus(next)
 	}
-	fm.setFocus(next)
+}
+
+// hasRenderedGeometry uses layout rects rather than widget existence or a
+// visibility flag. Before the root has been laid out there is no geometry to
+// judge, so structural focus collection keeps its existing initialization
+// behavior. Once rendered, a zero-area child or one fully clipped by a layout
+// ancestor does not participate in keyboard traversal. Scroll-view clipping is
+// intentionally excluded so offscreen content remains eligible for
+// ScrollIntoView.
+func (fm *FocusManager) hasRenderedGeometry(item FocusableWidget) bool {
+	if fm.root == nil {
+		return true
+	}
+	rootRect := fm.root.GetRect()
+	if rootRect.W <= 0 || rootRect.H <= 0 {
+		return true
+	}
+	path := make([]Widget, 0, 4)
+	if !collectWidgetPath(fm.root, item, &path) {
+		return false
+	}
+	for _, widget := range path {
+		r := widget.GetRect()
+		if r.W <= 0 || r.H <= 0 {
+			return false
+		}
+	}
+	visible := item.GetRect()
+	for i := len(path) - 2; i >= 0; i-- {
+		if _, scrolls := path[i].(*ScrollViewWidget); scrolls {
+			// Content outside this viewport can become visible by scrolling;
+			// continue clipping from the viewport itself so an outer layout can
+			// still exclude the entire scroll view.
+			visible = path[i].GetRect()
+			continue
+		}
+		visible = intersectRects(visible, path[i].GetRect())
+		if visible.W <= 0 || visible.H <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func collectWidgetPath(widget, target Widget, path *[]Widget) bool {
+	*path = append(*path, widget)
+	if widget == target {
+		return true
+	}
+	if container, ok := widget.(ContainerWidget); ok {
+		for _, child := range container.WidgetChildren() {
+			if collectWidgetPath(child, target, path) {
+				return true
+			}
+		}
+	}
+	*path = (*path)[:len(*path)-1]
+	return false
+}
+
+func (fm *FocusManager) renderedItemCount() int {
+	count := 0
+	for _, item := range fm.items {
+		if fm.hasRenderedGeometry(item) {
+			count++
+		}
+	}
+	return count
+}
+
+func (fm *FocusManager) adjacentRendered(step int) int {
+	if len(fm.items) == 0 {
+		return -1
+	}
+	index := fm.focused
+	if index < 0 || index >= len(fm.items) {
+		if step > 0 {
+			index = -1
+		} else {
+			index = 0
+		}
+	}
+	for range len(fm.items) {
+		index = (index + step + len(fm.items)) % len(fm.items)
+		if fm.hasRenderedGeometry(fm.items[index]) {
+			return index
+		}
+	}
+	return -1
+}
+
+func (fm *FocusManager) ensureFocusedRendered() {
+	if fm.focused >= 0 && fm.focused < len(fm.items) && fm.hasRenderedGeometry(fm.items[fm.focused]) {
+		return
+	}
+	if next := fm.adjacentRendered(1); next >= 0 {
+		fm.setFocus(next)
+	}
 }
 
 // Items are collected pre-order, so a click inside a focusable container (a
@@ -209,14 +307,15 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 	}
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
-		if tev.Key() == tcell.KeyTab && len(fm.items) > 1 {
+		if tev.Key() == tcell.KeyTab && fm.renderedItemCount() > 1 {
 			fm.FocusNext()
 			return EventConsumed
 		}
-		if tev.Key() == tcell.KeyBacktab && len(fm.items) > 1 {
+		if tev.Key() == tcell.KeyBacktab && fm.renderedItemCount() > 1 {
 			fm.FocusPrev()
 			return EventConsumed
 		}
+		fm.ensureFocusedRendered()
 		if fw := fm.Focused(); fw != nil {
 			return fw.HandleEvent(ev)
 		}

--- a/internal/widgets/focus_test.go
+++ b/internal/widgets/focus_test.go
@@ -80,6 +80,52 @@ func TestFocusManagerTabCycle(t *testing.T) {
 	}
 }
 
+func TestFocusManagerSkipsFocusableChildWithNoRenderedGeometry(t *testing.T) {
+	first := NewButtonWidget(ButtonConfig{Label: "First"})
+	second := NewButtonWidget(ButtonConfig{Label: "Second"})
+	clipped := NewButtonWidget(ButtonConfig{Label: "Clipped"})
+	stack := NewVStackWidget(first, second, clipped)
+
+	fm := NewFocusManager()
+	fm.SetActive(true)
+	fm.Collect(stack)
+	renderWidget(stack, 0, 0, 20, 3)
+	renderWidget(stack, 0, 0, 20, 2)
+	if r := clipped.GetRect(); r.W <= 0 || r.H <= 0 || r.Y < stack.GetRect().H {
+		t.Fatalf("clipped child rect = %+v, want stale positive geometry outside shrunken stack %+v", r, stack.GetRect())
+	}
+
+	fm.HandleEvent(tabEvent())
+	if fm.Focused() != Widget(second) {
+		t.Fatalf("first Tab focus = %T, want second visible button", fm.Focused())
+	}
+	fm.HandleEvent(tabEvent())
+	if fm.Focused() != Widget(first) {
+		t.Fatalf("second Tab focus = %T, want wrap past clipped button", fm.Focused())
+	}
+}
+
+func TestFocusManagerKeepsOffscreenScrollContentEligible(t *testing.T) {
+	first := NewButtonWidget(ButtonConfig{Label: "First"})
+	second := NewButtonWidget(ButtonConfig{Label: "Second"})
+	content := NewVStackWidget(first, second)
+	scroll := NewScrollViewWidget(content)
+
+	fm := NewFocusManager()
+	fm.SetActive(true)
+	fm.Collect(scroll)
+	renderWidget(scroll, 0, 0, 20, 1)
+	if VisibleRect(scroll, second) != (Rect{}) {
+		t.Fatalf("second button should begin outside the scroll viewport, got %+v", VisibleRect(scroll, second))
+	}
+
+	fm.HandleEvent(tabEvent())
+	fm.HandleEvent(tabEvent())
+	if fm.Focused() != Widget(second) {
+		t.Fatalf("focus = %T, want offscreen button retained for scroll-into-view", fm.Focused())
+	}
+}
+
 func TestFocusManagerShiftTab(t *testing.T) {
 	b1 := NewButtonWidget(ButtonConfig{Label: "&Run"})
 	b2 := NewButtonWidget(ButtonConfig{Label: "&Stop"})

--- a/internal/widgets/tab_drag.go
+++ b/internal/widgets/tab_drag.go
@@ -1,0 +1,61 @@
+package widgets
+
+const TabDragThreshold = 2
+
+// TabDragState owns only the pointer gesture. The widget that contains the
+// canonical tabs remains responsible for translating the reported from/to
+// indices into an actual reorder.
+type TabDragState struct {
+	pressedIndex int
+	targetIndex  int
+	pressX       int
+	active       bool
+	dragging     bool
+}
+
+func (d *TabDragState) Begin(index, screenX int) {
+	d.pressedIndex = index
+	d.targetIndex = index
+	d.pressX = screenX
+	d.active = true
+	d.dragging = false
+}
+
+func (d *TabDragState) Update(screenX, targetIndex int) bool {
+	if !d.active {
+		return false
+	}
+	distance := screenX - d.pressX
+	if distance < 0 {
+		distance = -distance
+	}
+	if !d.dragging && distance >= TabDragThreshold {
+		d.dragging = true
+	}
+	if d.dragging && targetIndex >= 0 {
+		d.targetIndex = targetIndex
+	}
+	return d.dragging
+}
+
+func (d *TabDragState) End() (from, to int, dragged bool) {
+	if !d.active {
+		return 0, 0, false
+	}
+	from, to, dragged = d.pressedIndex, d.targetIndex, d.dragging
+	d.Cancel()
+	return from, to, dragged
+}
+
+func (d *TabDragState) Cancel() {
+	d.pressedIndex = 0
+	d.targetIndex = 0
+	d.pressX = 0
+	d.active = false
+	d.dragging = false
+}
+
+func (d *TabDragState) Active() bool   { return d.active }
+func (d *TabDragState) Dragging() bool { return d.dragging }
+func (d *TabDragState) From() int      { return d.pressedIndex }
+func (d *TabDragState) Target() int    { return d.targetIndex }

--- a/internal/widgets/tab_drag_test.go
+++ b/internal/widgets/tab_drag_test.go
@@ -1,0 +1,21 @@
+package widgets
+
+import "testing"
+
+func TestTabDragStateRequiresIntentionalMovement(t *testing.T) {
+	var drag TabDragState
+	drag.Begin(1, 10)
+	if drag.Update(11, 2) {
+		t.Fatal("one-column jitter should not start a drag")
+	}
+	if !drag.Update(12, 2) {
+		t.Fatal("two-column movement should start a drag")
+	}
+	from, to, dragged := drag.End()
+	if !dragged || from != 1 || to != 2 {
+		t.Fatalf("drag result = %d -> %d, dragged=%v", from, to, dragged)
+	}
+	if drag.Active() {
+		t.Fatal("End should reset the gesture")
+	}
+}

--- a/internal/widgets/tabs.go
+++ b/internal/widgets/tabs.go
@@ -18,12 +18,14 @@ type TabAction struct {
 }
 
 type TabsConfig struct {
-	Items      []TabItem   `json:"items"`
-	Actions    []TabAction `json:"-"`
-	Style      term.Style  `json:"-"`
-	Align      string      `json:"align,omitempty"`
-	OnTabClick func(index int)
-	OnOverflow func(screenX, screenY int)
+	Items       []TabItem   `json:"items"`
+	Actions     []TabAction `json:"-"`
+	Style       term.Style  `json:"-"`
+	Align       string      `json:"align,omitempty"`
+	Reorderable bool        `json:"-"`
+	OnTabClick  func(index int)
+	OnOverflow  func(screenX, screenY int)
+	OnReorder   func(from, to int)
 }
 
 type TabsWidget struct {
@@ -36,6 +38,7 @@ type TabsWidget struct {
 	wasPressed  bool
 	focused     bool
 	selected    int
+	drag        TabDragState
 }
 
 func NewTabsWidget(config TabsConfig) *TabsWidget {
@@ -247,6 +250,10 @@ func (t *TabsWidget) Render(surface Surface) {
 		ax++
 		t.actionSpans = append(t.actionSpans, [2]int{startX, startX + aw})
 	}
+
+	if x := t.dropIndicatorX(); x >= 0 && x < w {
+		inner.SetCell(x, 0, term.Cell{Ch: '│', Style: term.StyleBorderActive})
+	}
 }
 
 func (t *TabsWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -318,17 +325,34 @@ func (t *TabsWidget) handleKey(ev *tcell.EventKey) EventResult {
 
 func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 	pressed := mev.Buttons()&tcell.Button1 != 0
+	mx, my := mev.Position()
+	r := t.GetRect()
+	lx := mx - r.X - t.Box.MarginLeft - t.Box.PaddingLeft
+
+	if mev.Buttons() == tcell.ButtonNone {
+		t.wasPressed = false
+		if t.drag.Active() {
+			from, to, dragged := t.drag.End()
+			if dragged && from != to && t.Config.OnReorder != nil {
+				t.Config.OnReorder(from, to)
+			}
+			return EventConsumed
+		}
+		return EventIgnored
+	}
+	if t.drag.Active() && pressed {
+		t.drag.Update(mx, t.dropTargetAt(lx))
+		return EventCaptured
+	}
+
 	freshClick := pressed && !t.wasPressed
 	t.wasPressed = pressed
 	if !freshClick {
 		return EventIgnored
 	}
-	mx, my := mev.Position()
-	r := t.GetRect()
 	if my < r.Y || my >= r.Y+r.H || mx < r.X || mx >= r.X+r.W {
 		return EventIgnored
 	}
-	lx := mx - r.X - t.Box.MarginLeft - t.Box.PaddingLeft
 
 	for i, span := range t.actionSpans {
 		if lx >= span[0] && lx < span[1] {
@@ -350,8 +374,44 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 			if t.Config.OnTabClick != nil {
 				t.Config.OnTabClick(i)
 			}
+			if t.Config.Reorderable && t.Config.OnReorder != nil {
+				t.drag.Begin(i, mx)
+				return EventCaptured
+			}
 			return EventConsumed
 		}
 	}
 	return EventIgnored
+}
+
+func (t *TabsWidget) dropTargetAt(localX int) int {
+	last := -1
+	for i, span := range t.tabSpans {
+		if span[1] <= span[0] {
+			continue
+		}
+		last = i
+		if localX < span[0]+(span[1]-span[0])/2 {
+			return i
+		}
+	}
+	return last
+}
+
+func (t *TabsWidget) dropIndicatorX() int {
+	if !t.drag.Dragging() || t.drag.From() == t.drag.Target() {
+		return -1
+	}
+	target := t.drag.Target()
+	if target < 0 || target >= len(t.tabSpans) {
+		return -1
+	}
+	span := t.tabSpans[target]
+	if span[1] <= span[0] {
+		return -1
+	}
+	if target < t.drag.From() {
+		return span[0]
+	}
+	return span[1] - 1
 }

--- a/internal/widgets/tabs_test.go
+++ b/internal/widgets/tabs_test.go
@@ -3,6 +3,9 @@ package widgets
 import (
 	"strings"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v3"
 )
 
 func tabsRowText(s *testSurface, y int) string {
@@ -114,5 +117,62 @@ func TestTabsHiddenTabsNotClickable(t *testing.T) {
 		if span[0] != 0 || span[1] != 0 {
 			t.Fatalf("hidden tab %d should have zero span, got %v", idx, span)
 		}
+	}
+}
+
+func TestTabsDragReordersVisibleHeaders(t *testing.T) {
+	var from, to = -1, -1
+	tw := NewTabsWidget(TabsConfig{
+		Items: []TabItem{
+			{ID: "explorer", Label: "Explore", Active: true},
+			{ID: "search", Label: "Find"},
+			{ID: "changes", Label: "Changes"},
+		},
+		Reorderable: true,
+		OnReorder: func(f, target int) {
+			from, to = f, target
+		},
+	})
+	s := renderWidget(tw, 0, 0, 40, 1)
+	start := tw.tabSpans[0][0] + 2
+	end := tw.tabSpans[2][0] + 2
+	if got := tw.HandleEvent(tcell.NewEventMouse(start, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down result = %v, want EventCaptured", got)
+	}
+	tw.HandleEvent(tcell.NewEventMouse(end, 0, tcell.Button1, 0))
+	tw.Render(s)
+	foundIndicator := false
+	for _, cell := range s.cells[0] {
+		if cell.Ch == '│' && cell.Style == term.StyleBorderActive {
+			foundIndicator = true
+		}
+	}
+	if !foundIndicator {
+		t.Fatal("drag should render a themed drop indicator")
+	}
+	tw.HandleEvent(tcell.NewEventMouse(end, 0, tcell.ButtonNone, 0))
+	if from != 0 || to != 2 {
+		t.Fatalf("reorder = %d -> %d, want 0 -> 2", from, to)
+	}
+}
+
+func TestTabsClickJitterDoesNotReorder(t *testing.T) {
+	clicked, reordered := -1, false
+	tw := NewTabsWidget(TabsConfig{
+		Items:       []TabItem{{ID: "a", Label: "Alpha"}, {ID: "b", Label: "Beta"}},
+		Reorderable: true,
+		OnTabClick:  func(i int) { clicked = i },
+		OnReorder:   func(_, _ int) { reordered = true },
+	})
+	renderWidget(tw, 0, 0, 30, 1)
+	x := tw.tabSpans[0][0] + 2
+	tw.HandleEvent(tcell.NewEventMouse(x, 0, tcell.Button1, 0))
+	tw.HandleEvent(tcell.NewEventMouse(x+1, 0, tcell.Button1, 0))
+	tw.HandleEvent(tcell.NewEventMouse(x+1, 0, tcell.ButtonNone, 0))
+	if clicked != 0 {
+		t.Fatalf("clicked = %d, want 0", clicked)
+	}
+	if reordered {
+		t.Fatal("one-column jitter reordered a tab")
 	}
 }

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -144,6 +144,84 @@ func (t *TreeWidget) SetActiveID(id string) {
 	t.Config.ActiveID = id
 }
 
+// CollapseAll closes every materialized branch while preserving the selected
+// node when it remains visible. A selection hidden inside a collapsed branch
+// falls back to the first visible row instead of drifting to an unrelated row
+// at the same numeric index.
+func (t *TreeWidget) CollapseAll() {
+	selectedID := t.selectedID()
+	setTreeExpanded(t.Config.Items, false)
+	t.flatten()
+	t.restoreVisibleSelection(selectedID)
+}
+
+// ExpandAll opens every branch currently represented in the model. Lazy trees
+// load one newly revealed level, but deliberately do not recurse into those new
+// children in the same event; doing so could synchronously traverse an entire
+// filesystem from one menu click.
+func (t *TreeWidget) ExpandAll() {
+	t.ExpandAllWhere(func(*TreeNode) bool { return true })
+}
+
+// ExpandAllWhere is the filtered form used by trees that expose branches
+// which are valid to open manually but unsuitable for bulk traversal (for
+// example hidden or gitignored directories in Explorer).
+func (t *TreeWidget) ExpandAllWhere(include func(*TreeNode) bool) {
+	selectedID := t.selectedID()
+	nodes := materializedTreeNodes(t.Config.Items)
+	for _, node := range nodes {
+		if !node.isExpandable() || !include(node) {
+			continue
+		}
+		node.Expanded = true
+		if len(node.Children) == 0 && t.Config.OnExpand != nil {
+			t.Config.OnExpand(node)
+		}
+	}
+	t.flatten()
+	t.restoreVisibleSelection(selectedID)
+}
+
+func (t *TreeWidget) selectedID() string {
+	if node := t.Selected(); node != nil {
+		return node.ID
+	}
+	return ""
+}
+
+func (t *TreeWidget) restoreVisibleSelection(id string) {
+	t.selected = 0
+	if id == "" {
+		t.clampSelected()
+		return
+	}
+	for i, node := range t.flatList {
+		if node.ID == id {
+			t.selected = i
+			return
+		}
+	}
+	t.clampSelected()
+}
+
+func setTreeExpanded(nodes []*TreeNode, expanded bool) {
+	for _, node := range nodes {
+		if node.isExpandable() {
+			node.Expanded = expanded
+		}
+		setTreeExpanded(node.Children, expanded)
+	}
+}
+
+func materializedTreeNodes(nodes []*TreeNode) []*TreeNode {
+	var result []*TreeNode
+	for _, node := range nodes {
+		result = append(result, node)
+		result = append(result, materializedTreeNodes(node.Children)...)
+	}
+	return result
+}
+
 func (t *TreeWidget) Reload() {
 	expanded := map[string]bool{}
 	t.CollectExpanded(expanded)

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -17,10 +17,16 @@ type TreeNode struct {
 	Actions    []Action    `json:"actions,omitempty"`
 	Muted      bool        `json:"-"`
 	Expandable bool        `json:"-"`
+	// TruncateLeft overrides TreeConfig.TruncateLeft for this node, so one tree
+	// can hold both prose that reads from the left and paths whose tail matters.
+	TruncateLeft bool `json:"-"`
 
 	Expanded bool `json:"-"`
 	depth    int
 	parent   *TreeNode
+	// chevronX is the screen column Render assigned to this row's disclosure
+	// control. Mouse handling reuses it instead of duplicating the layout math.
+	chevronX int
 }
 
 type Action struct {
@@ -32,6 +38,9 @@ type MenuEntry struct {
 	Label     string `json:"label"`
 	Command   string `json:"command"`
 	Separator bool   `json:"separator,omitempty"`
+	// Checked is optional so existing menus retain their indicator-free layout;
+	// non-nil false reserves an unchecked indicator and true draws the check.
+	Checked *bool `json:"checked,omitempty"`
 }
 
 type TreeConfig struct {
@@ -49,8 +58,13 @@ type TreeConfig struct {
 	OnMenu     func(entries []MenuEntry, node *TreeNode, screenX, screenY int)
 	OnExpand   func(node *TreeNode)
 	OnSelect   func(node *TreeNode)
+	OnFocus    func()
 	OnKey      func(ev *tcell.EventKey, node *TreeNode) bool
 	RenderItem func(surface Surface, node *TreeNode, idx, y, w int, selected bool)
+	// ActivateExpandable separates a row's disclosure control from activation.
+	// When set, the rendered chevron still expands/collapses, while Enter or a
+	// click elsewhere on an expandable row invokes OnCommand("activate", node).
+	ActivateExpandable bool
 }
 
 type TreeWidget struct {
@@ -86,9 +100,14 @@ func (t *TreeWidget) Width() int  { return 0 }
 // ContentHeight reports visible rows so scroll views can measure the tree.
 func (t *TreeWidget) ContentHeight() int { return len(t.flatList) + t.BoxOverheadH() }
 
-func (t *TreeWidget) Focusable() bool   { return true }
-func (t *TreeWidget) SetFocused(f bool) { t.focused = f }
-func (t *TreeWidget) IsFocused() bool   { return t.focused }
+func (t *TreeWidget) Focusable() bool { return true }
+func (t *TreeWidget) SetFocused(f bool) {
+	t.focused = f
+	if f && t.Config.OnFocus != nil {
+		t.Config.OnFocus()
+	}
+}
+func (t *TreeWidget) IsFocused() bool { return t.focused }
 
 func (t *TreeWidget) Selected() *TreeNode {
 	if t.selected >= 0 && t.selected < len(t.flatList) {
@@ -314,6 +333,7 @@ func (t *TreeWidget) rightSideWidth(node *TreeNode) int {
 }
 
 func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) {
+	node.chevronX = -1
 	if t.Config.RenderItem != nil {
 		t.Config.RenderItem(surface, node, idx, y, w, idx == t.selected)
 		return
@@ -333,7 +353,6 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 	maxX := w - 2 - t.rightSideWidth(node)
 
 	x := node.depth * t.Config.Indent
-
 	hasChildren := len(node.Children) > 0 || node.Expandable
 	if hasChildren {
 		chevron := '▶'
@@ -342,6 +361,7 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		}
 		if x < w {
 			surface.SetCell(x, y, term.Cell{Ch: chevron, Style: style})
+			node.chevronX = t.contentX + x
 		}
 		x++
 		if x < w {
@@ -370,7 +390,7 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		labelStyle = term.StyleMuted
 	}
 	labelRunes := []rune(node.Label)
-	if t.Config.TruncateLeft {
+	if t.Config.TruncateLeft || node.TruncateLeft {
 		labelRunes = truncateRunesLeft(labelRunes, maxX-x)
 	}
 	x = drawRunesClipped(surface, x, y, maxX, labelRunes, labelStyle)
@@ -540,7 +560,15 @@ func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {
 		}
 
 		if !t.Config.SelectOnClick {
-			t.ActivateSelected()
+			if t.Config.ActivateExpandable && node.isExpandable() {
+				if mx == node.chevronX {
+					t.toggleExpandedSelected()
+				} else if t.Config.OnCommand != nil {
+					t.Config.OnCommand("activate", node)
+				}
+			} else {
+				t.ActivateSelected()
+			}
 		}
 		return EventConsumed
 	}
@@ -573,7 +601,11 @@ func (t *TreeWidget) handleKey(ev *tcell.EventKey) EventResult {
 			}
 			return EventConsumed
 		}
-		t.ActivateSelected()
+		if t.Config.ActivateExpandable {
+			t.activateSelectedNode()
+		} else {
+			t.ActivateSelected()
+		}
 		return EventConsumed
 	case tcell.KeyRune:
 		if t.Config.OnKey != nil && t.Config.OnKey(ev, t.Selected()) {
@@ -641,14 +673,34 @@ func (t *TreeWidget) ActivateSelected() {
 	}
 	node := t.flatList[t.selected]
 	if node.isExpandable() {
-		node.Expanded = !node.Expanded
-		if node.Expanded && t.Config.OnExpand != nil {
-			t.Config.OnExpand(node)
-		}
-		t.flatten()
+		t.toggleExpandedSelected()
 	} else if t.Config.OnCommand != nil {
 		t.Config.OnCommand("activate", node)
 	}
+}
+
+// toggleExpandedSelected changes only disclosure state. It is separate from
+// activation for trees whose expandable rows also represent openable content.
+func (t *TreeWidget) toggleExpandedSelected() {
+	if t.selected < 0 || t.selected >= len(t.flatList) {
+		return
+	}
+	node := t.flatList[t.selected]
+	if !node.isExpandable() {
+		return
+	}
+	node.Expanded = !node.Expanded
+	if node.Expanded && t.Config.OnExpand != nil {
+		t.Config.OnExpand(node)
+	}
+	t.flatten()
+}
+
+func (t *TreeWidget) activateSelectedNode() {
+	if t.selected < 0 || t.selected >= len(t.flatList) || t.Config.OnCommand == nil {
+		return
+	}
+	t.Config.OnCommand("activate", t.flatList[t.selected])
 }
 
 func (t *TreeWidget) collapseOrParent() {

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -1262,6 +1262,61 @@ func TestTreeCollectRestoreExpanded(t *testing.T) {
 	}
 }
 
+func TestTreeExpandAndCollapseAllPreserveVisibleSelection(t *testing.T) {
+	root := &TreeNode{
+		ID:         "root",
+		Label:      "Root",
+		Expandable: true,
+		Expanded:   true,
+		Children: []*TreeNode{{
+			ID:         "child",
+			Label:      "Child",
+			Expandable: true,
+			Children:   []*TreeNode{{ID: "leaf", Label: "Leaf"}},
+		}},
+	}
+	tree := NewTreeWidget(TreeConfig{Items: []*TreeNode{root}})
+	tree.SelectByID("root")
+	tree.ExpandAll()
+	if !root.Expanded || !root.Children[0].Expanded {
+		t.Fatalf("ExpandAll did not open materialized branches: root=%v child=%v", root.Expanded, root.Children[0].Expanded)
+	}
+	if tree.Selected() == nil || tree.Selected().ID != "root" {
+		t.Fatalf("selection after expand = %v, want root", tree.Selected())
+	}
+
+	tree.SelectByID("leaf")
+	tree.CollapseAll()
+	if root.Expanded || root.Children[0].Expanded {
+		t.Fatalf("CollapseAll left a branch open: root=%v child=%v", root.Expanded, root.Children[0].Expanded)
+	}
+	if tree.Selected() == nil || tree.Selected().ID != "root" {
+		t.Fatalf("hidden selection should fall back to first visible row, got %v", tree.Selected())
+	}
+}
+
+func TestTreeExpandAllLoadsOnlyOneNewLazyLevel(t *testing.T) {
+	root := &TreeNode{ID: "root", Label: "Root", Expandable: true}
+	loaded := []string{}
+	tree := NewTreeWidget(TreeConfig{
+		Items: []*TreeNode{root},
+		OnExpand: func(node *TreeNode) {
+			loaded = append(loaded, node.ID)
+			node.Children = []*TreeNode{{ID: node.ID + "/child", Label: "Child", Expandable: true}}
+		},
+	})
+	tree.ExpandAll()
+	if !root.Expanded || len(root.Children) != 1 {
+		t.Fatalf("lazy root was not expanded and loaded: %+v", root)
+	}
+	if root.Children[0].Expanded {
+		t.Fatal("newly loaded child should wait for a later expand action")
+	}
+	if len(loaded) != 1 || loaded[0] != "root" {
+		t.Fatalf("loaded nodes = %v, want only root", loaded)
+	}
+}
+
 // --- Shortcut key tests ---
 
 func TestTreeShortcutKey(t *testing.T) {

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -187,6 +187,44 @@ func TestTreeRenderExpandableNoChildren(t *testing.T) {
 	}
 }
 
+func TestTreeActivateExpandableSeparatesChevronFromActivation(t *testing.T) {
+	var expanded, activated int
+	node := &TreeNode{ID: "commit", Label: "Commit subject", Expandable: true}
+	tree := NewTreeWidget(TreeConfig{
+		Items:              []*TreeNode{node},
+		ActivateExpandable: true,
+		OnExpand: func(*TreeNode) {
+			expanded++
+		},
+		OnCommand: func(command string, got *TreeNode) {
+			if command == "activate" && got == node {
+				activated++
+			}
+		},
+	})
+	tree.SetRect(Rect{X: 4, Y: 3, W: 30, H: 4})
+	tree.Render(newTestSurface(30, 4))
+
+	// The disclosure control owns expansion and uses the screen position stored
+	// during Render, including the tree's non-zero origin.
+	tree.HandleEvent(mouseClick(4, 3))
+	if !node.Expanded || expanded != 1 || activated != 0 {
+		t.Fatalf("chevron click: expanded=%v onExpand=%d activated=%d", node.Expanded, expanded, activated)
+	}
+	tree.HandleEvent(mouseClick(4, 3))
+	if node.Expanded || expanded != 1 || activated != 0 {
+		t.Fatalf("second chevron click: expanded=%v onExpand=%d activated=%d", node.Expanded, expanded, activated)
+	}
+
+	// The label and Enter activate the same expandable row without changing its
+	// disclosure state.
+	tree.HandleEvent(mouseClick(8, 3))
+	tree.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if node.Expanded || expanded != 1 || activated != 2 {
+		t.Fatalf("activation: expanded=%v onExpand=%d activated=%d", node.Expanded, expanded, activated)
+	}
+}
+
 func TestTreeRenderEllipsisTruncation(t *testing.T) {
 	tree := NewTreeWidget(TreeConfig{
 		Items: []*TreeNode{

--- a/tests/e2e/changes_layout_test.go
+++ b/tests/e2e/changes_layout_test.go
@@ -1,0 +1,66 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestChangesHistoryResizeKeepsMinimumsAndTreeScrolling(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+	h.exec("sidebar.changes")
+
+	cp := h.app.Changes
+	items := make([]*widgets.TreeNode, 20)
+	for i := range items {
+		items[i] = &widgets.TreeNode{ID: fmt.Sprintf("history:%d", i), Label: fmt.Sprintf("commit %02d", i)}
+	}
+	cp.CommitLog.SetItems(items)
+	h.redraw()
+
+	drag := func(fromY, toY int) {
+		t.Helper()
+		x := cp.Split.GetRect().X + 2
+		h.app.Root.HandleEvent(tcell.NewEventMouse(x, fromY, tcell.Button1, tcell.ModNone))
+		h.app.Root.HandleEvent(tcell.NewEventMouse(x, toY, tcell.Button1, tcell.ModNone))
+		h.app.Root.HandleEvent(tcell.NewEventMouse(x, toY, tcell.ButtonNone, tcell.ModNone))
+		h.redraw()
+	}
+
+	// Dragging below the panel clamps the history to its title plus three log
+	// rows instead of collapsing it. The working tree receives the remainder.
+	drag(cp.Split.DividerScreenY(), cp.Split.GetRect().Y+cp.Split.GetRect().H)
+	if cp.Split.BottomH != 4 {
+		t.Fatalf("history height = %d, want minimum 4", cp.Split.BottomH)
+	}
+	if got := cp.CommitLog.GetRect().H; got != 3 {
+		t.Fatalf("commit log height = %d, want 3 usable rows", got)
+	}
+
+	// Dragging above the panel leaves the input, divider, and three working-tree
+	// rows rather than allowing history to consume the whole sidebar.
+	drag(cp.Split.DividerScreenY(), cp.Split.GetRect().Y-2)
+	if h.app.Sidebar.ActivePanel != "changes" {
+		t.Fatalf("drag across sidebar tabs switched to %q", h.app.Sidebar.ActivePanel)
+	}
+	if got := cp.Tree.GetRect().H; got != 3 {
+		t.Fatalf("working-tree height = %d, want minimum 3 rows", got)
+	}
+
+	// Shrink again, then prove the nested TreeWidget still owns wheel scrolling
+	// after repeated split captures. This guards against leaving capture or
+	// routing on the divider.
+	drag(cp.Split.DividerScreenY(), cp.Split.GetRect().Y+cp.Split.GetRect().H)
+	r := cp.CommitLog.GetRect()
+	for range 10 {
+		h.app.Root.HandleEvent(tcell.NewEventMouse(r.X+1, r.Y+1, tcell.WheelDown, tcell.ModNone))
+	}
+	h.redraw()
+	if cp.CommitLog.ScrollTop() == 0 {
+		t.Fatal("commit log did not scroll after resizing")
+	}
+	h.assertContains("commit 19")
+}

--- a/tests/e2e/changes_reactivity_test.go
+++ b/tests/e2e/changes_reactivity_test.go
@@ -1,13 +1,39 @@
 package e2e
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/app"
 	"github.com/gdamore/tcell/v3"
 )
+
+func (h *testHarness) awaitCurrentChanges() *app.CurrentChangesResult {
+	h.t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case event := <-h.screen.EventQ():
+			interrupt, ok := event.(*tcell.EventInterrupt)
+			if !ok {
+				continue
+			}
+			result, ok := interrupt.Data().(*app.CurrentChangesResult)
+			if !ok {
+				continue
+			}
+			h.app.ApplyCurrentChanges(result)
+			h.redraw()
+			return result
+		case <-deadline:
+			h.t.Fatal("timed out waiting for current changes")
+			return nil
+		}
+	}
+}
 
 func initializeHarnessRepo(t *testing.T, dir string) {
 	t.Helper()
@@ -45,4 +71,28 @@ func TestSavedFileAppearsInVisibleChangesWithoutManualRefresh(t *testing.T) {
 
 	h.assertContains("Changes (1)")
 	h.assertContains("alpha.txt")
+}
+
+func TestViewAllCurrentChangesOpensCombinedScrollableDocument(t *testing.T) {
+	h := newTestHarness(t, 110, 32)
+	initializeHarnessRepo(t, h.dir)
+	path := filepath.Join(h.dir, "alpha.txt")
+	if err := os.WriteFile(path, []byte("staged version\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "add", "alpha.txt")
+	cmd.Dir = h.dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("stage alpha: %v\n%s", err, output)
+	}
+	if err := os.WriteFile(path, []byte("final working version\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h.app.Repository.RefreshNow(app.RepositoryStatus)
+	h.exec("changes.viewAll")
+	h.awaitCurrentChanges()
+	h.assertContains("Current changes")
+	h.assertContains("M  alpha.txt · mixed")
+	h.assertContains("final working version")
 }

--- a/tests/e2e/changes_reactivity_test.go
+++ b/tests/e2e/changes_reactivity_test.go
@@ -1,0 +1,48 @@
+package e2e
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/app"
+	"github.com/gdamore/tcell/v3"
+)
+
+func initializeHarnessRepo(t *testing.T, dir string) {
+	t.Helper()
+	commands := [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test User"},
+		{"config", "commit.gpgsign", "false"},
+		{"add", "-A"},
+		{"commit", "-qm", "initial commit"},
+	}
+	for _, args := range commands {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+}
+
+func TestSavedFileAppearsInVisibleChangesWithoutManualRefresh(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	initializeHarnessRepo(t, h.dir)
+	h.app.Repository.RefreshNow(app.RepositoryStatus | app.RepositoryHistory)
+
+	path := filepath.Join(h.dir, "alpha.txt")
+	h.app.EditorGroup.OpenFile(path)
+	h.exec("sidebar.changes")
+	h.assertContains("No changes")
+
+	h.exec("editor.focus")
+	h.pressKey(tcell.KeyEnd, tcell.ModNone)
+	h.pressRune('X')
+	h.exec("file.save")
+
+	h.assertContains("Changes (1)")
+	h.assertContains("alpha.txt")
+}

--- a/tests/e2e/commit_detail_test.go
+++ b/tests/e2e/commit_detail_test.go
@@ -1,0 +1,121 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/app"
+	"github.com/gdamore/tcell/v3"
+)
+
+func gitDetailRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func (h *testHarness) awaitCommitDetail() *app.CommitDetailResult {
+	h.t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case event := <-h.screen.EventQ():
+			interrupt, ok := event.(*tcell.EventInterrupt)
+			if !ok {
+				continue
+			}
+			result, ok := interrupt.Data().(*app.CommitDetailResult)
+			if !ok {
+				continue
+			}
+			h.app.ApplyCommitDetail(result)
+			h.redraw()
+			return result
+		case <-deadline:
+			h.t.Fatal("timed out waiting for commit detail")
+			return nil
+		}
+	}
+}
+
+func TestCommitHistoryChevronExpandsWhileLabelOpensFullDetail(t *testing.T) {
+	h := newTestHarness(t, 100, 28)
+	defer h.stop()
+	gitDetailRun(t, h.dir, "init", "-q", "-b", "main")
+	gitDetailRun(t, h.dir, "config", "user.email", "test@test.com")
+	gitDetailRun(t, h.dir, "config", "user.name", "Test User")
+	gitDetailRun(t, h.dir, "config", "commit.gpgsign", "false")
+	gitDetailRun(t, h.dir, "add", "-A")
+	gitDetailRun(t, h.dir, "commit", "-qm", "base")
+	if err := os.WriteFile(filepath.Join(h.dir, "alpha.txt"), []byte("alpha changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(h.dir, "beta.txt"), []byte("beta changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitDetailRun(t, h.dir, "add", "-A")
+	gitDetailRun(t, h.dir, "commit", "-qm", "Detail subject", "-m", "Detail body paragraph.")
+
+	// The harness has no event-loop goroutine, so populate the panel inline.
+	// The detail open itself still uses the real screen and is applied from the
+	// posted interrupt below, matching production's async boundary.
+	h.app.Changes.Screen = nil
+	h.app.Changes.Refresh()
+	h.exec("sidebar.changes")
+
+	var commitIndex int
+	var commitID string
+	for index, node := range h.app.Changes.CommitLog.FlatList() {
+		if strings.HasPrefix(node.ID, "commit:") {
+			commitIndex = index
+			commitID = node.ID
+			break
+		}
+	}
+	if commitID == "" {
+		t.Fatal("commit history has no commit row")
+	}
+	logRect := h.app.Changes.CommitLog.GetRect()
+	rowY := logRect.Y + commitIndex - h.app.Changes.CommitLog.ScrollTop()
+
+	// The first column is the rendered chevron. It changes disclosure state and
+	// leaves the editor on its existing tab.
+	h.click(logRect.X, rowY)
+	commitNode := h.app.Changes.CommitLog.FlatList()[commitIndex]
+	if !commitNode.Expanded {
+		t.Fatal("chevron click did not expand the commit")
+	}
+	if strings.HasPrefix(h.app.EditorGroup.ActiveFilePath(), "commit:") {
+		t.Fatal("chevron click opened commit detail")
+	}
+	h.click(logRect.X, rowY)
+	if commitNode.Expanded {
+		t.Fatal("second chevron click did not collapse the commit")
+	}
+
+	// The label is deliberately separate from the chevron. It opens a loading
+	// editor tab immediately and does not alter expansion.
+	h.click(logRect.X+4, rowY)
+	if got := h.app.EditorGroup.ActiveFilePath(); got != commitID {
+		t.Fatalf("active tab = %q, want full-hash key %q", got, commitID)
+	}
+	if commitNode.Expanded {
+		t.Fatal("label activation changed commit expansion")
+	}
+	h.assertContains("Loading commit")
+
+	result := h.awaitCommitDetail()
+	if result.Ref != strings.TrimPrefix(commitID, "commit:") {
+		t.Fatalf("detail result ref = %q, want %q", result.Ref, strings.TrimPrefix(commitID, "commit:"))
+	}
+	for _, text := range []string{"Detail subject", "Detail body paragraph.", "alpha.txt", "alpha changed", "beta.txt", "beta changed"} {
+		h.assertContains(text)
+	}
+}

--- a/tests/e2e/editor_tab_reorder_test.go
+++ b/tests/e2e/editor_tab_reorder_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestEditorTabDragReordersThroughRootAndKeepsActiveFile(t *testing.T) {
+	h := newTestHarness(t, 120, 30)
+	defer h.stop()
+	for _, name := range []string{"alpha.txt", "beta.txt", "gamma.txt"} {
+		h.app.EditorGroup.OpenFile(filepath.Join(h.dir, name))
+		h.app.EditorGroup.CommitActiveTab()
+	}
+	h.redraw()
+
+	tabsY := h.app.EditorGroup.TabBar.GetRect().Y + 1
+	row := h.screenRow(tabsY)
+	gammaX := strings.Index(row, "gamma.txt")
+	if !strings.Contains(row, "alpha.txt") || gammaX < 0 {
+		t.Fatalf("tab labels not visible in %q", row)
+	}
+
+	if got := h.app.Root.HandleEvent(tcell.NewEventMouse(gammaX+2, tabsY, tcell.Button1, 0)); got != ui.EventConsumed {
+		t.Fatalf("mouse down result = %v, want consumed capture", got)
+	}
+	dropX := h.app.EditorGroup.TabBar.GetRect().X
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.Button1, 0))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.ButtonNone, 0))
+	h.redraw()
+
+	path0, _ := h.app.EditorGroup.TabInfo(0)
+	if !strings.HasSuffix(path0, "gamma.txt") {
+		t.Fatalf("first tab = %q, want gamma.txt", path0)
+	}
+	if got := h.app.EditorGroup.ActiveFilePath(); !strings.HasSuffix(got, "gamma.txt") {
+		t.Fatalf("active file = %q, want gamma.txt", got)
+	}
+
+	h.exec("tab.moveRight")
+	path1, _ := h.app.EditorGroup.TabInfo(1)
+	if !strings.HasSuffix(path1, "gamma.txt") {
+		t.Fatalf("command fallback moved tab to %q, want gamma.txt at index 1", path1)
+	}
+}

--- a/tests/e2e/editor_test.go
+++ b/tests/e2e/editor_test.go
@@ -72,6 +72,40 @@ func TestCommandPaletteDoesNotStack(t *testing.T) {
 	}
 }
 
+func TestCommandPaletteHelpOrientsThenNavigates(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.pressCtrl(tcell.KeyCtrlP)
+	h.pressRune('?')
+
+	// Empty help is an orientation surface, not a command shortlist. The first
+	// topic explains the workspace model in the dedicated detail row.
+	h.assertContains("Workspace map")
+	h.assertContains("folders, tabs, and editor groups")
+	h.assertNotContains("Open Folder")
+
+	// Search spans the registered command list, and its displayed shortcut is
+	// the one already derived from the configured keybindings by BindKeys.
+	for _, r := range "Open Folder" {
+		h.pressRune(r)
+	}
+	h.assertContains("Open Folder")
+	cmd, ok := h.reg.Get("workspace.openFolder")
+	if !ok {
+		t.Fatal("workspace.openFolder command is not registered")
+	}
+	if cmd.Shortcut == "" {
+		t.Fatal("workspace.openFolder should have a derived shortcut")
+	}
+	h.assertContains(cmd.Shortcut)
+
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+	if len(h.app.Root.Overlays) == 0 {
+		t.Fatal("executing Open Folder from help should open its dialog")
+	}
+}
+
 func TestGoToLineDialog(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()

--- a/tests/e2e/editor_test.go
+++ b/tests/e2e/editor_test.go
@@ -193,6 +193,9 @@ func TestThemeSwitchDialog(t *testing.T) {
 
 	h.exec("theme.switch")
 	if len(h.app.Root.Overlays) == 1 {
+		if !strings.Contains(h.screenText(), "Built-in Default") {
+			t.Fatalf("theme switcher omitted the built-in default:\n%s", h.screenText())
+		}
 		h.pressKey(tcell.KeyEscape, tcell.ModNone)
 		if len(h.app.Root.Overlays) != 0 {
 			t.Fatalf("expected 0 overlays after Escape, got %d", len(h.app.Root.Overlays))

--- a/tests/e2e/open_diff_test.go
+++ b/tests/e2e/open_diff_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/core/diff"
-	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/gdamore/tcell/v3"
 )
@@ -130,7 +129,7 @@ func TestDiffToggleUnifiedCommand(t *testing.T) {
 	}
 }
 
-func TestDiffExplicitModesAndViewMenuState(t *testing.T) {
+func TestDiffExplicitModesAreNotDuplicatedInViewMenu(t *testing.T) {
 	h := newTestHarness(t, 100, 14)
 	defer h.stop()
 
@@ -144,18 +143,10 @@ func TestDiffExplicitModesAndViewMenuState(t *testing.T) {
 		t.Fatalf("default presentation = mode %v wrap %v, want split/off", dv.Mode(), dv.WrapMode())
 	}
 
-	checked := func(command string) int {
-		t.Helper()
-		for _, item := range h.app.BuildViewMenu() {
-			if item.Command == command {
-				return item.Checked
-			}
+	for _, item := range h.app.BuildViewMenu() {
+		if strings.HasPrefix(item.Command, "diff.") {
+			t.Fatalf("View menu duplicated diff presentation command: %+v", item)
 		}
-		t.Fatalf("View menu missing %s", command)
-		return 0
-	}
-	if checked("diff.splitView") != ui.MenuChecked || checked("diff.unifiedView") != ui.MenuUnchecked || checked("diff.toggleWrap") != ui.MenuUnchecked {
-		t.Fatalf("default View menu did not expose split/off state: %+v", h.app.BuildViewMenu())
 	}
 
 	h.exec("diff.unifiedView")
@@ -163,12 +154,9 @@ func TestDiffExplicitModesAndViewMenuState(t *testing.T) {
 	if dv.Mode() != ui.DiffModeUnified || dv.WrapMode() != ui.DiffWrapOn {
 		t.Fatalf("explicit commands left mode %v wrap %v, want unified/on", dv.Mode(), dv.WrapMode())
 	}
-	if checked("diff.splitView") != ui.MenuUnchecked || checked("diff.unifiedView") != ui.MenuChecked || checked("diff.toggleWrap") != ui.MenuChecked {
-		t.Fatalf("updated View menu did not expose unified/on state: %+v", h.app.BuildViewMenu())
-	}
 }
 
-func TestViewDiffOverridesDoNotPersistAndNextDiffUsesDefaults(t *testing.T) {
+func TestExplicitDiffOverridesDoNotPersistAndNextDiffUsesDefaults(t *testing.T) {
 	h := newTestHarness(t, 100, 14)
 	defer h.stop()
 
@@ -183,15 +171,15 @@ func TestViewDiffOverridesDoNotPersistAndNextDiffUsesDefaults(t *testing.T) {
 	h.exec("diff.splitView")
 	h.exec("diff.toggleWrap")
 	if first.Mode() != ui.DiffModeSplit || first.WrapMode() != ui.DiffWrapOff {
-		t.Fatalf("View override = mode %v wrap %v, want split/off", first.Mode(), first.WrapMode())
+		t.Fatalf("explicit override = mode %v wrap %v, want split/off", first.Mode(), first.WrapMode())
 	}
 	if h.app.Settings.Editor.DiffMode != config.DiffModeUnified || !h.app.Settings.Editor.DiffWordWrap {
-		t.Fatalf("View override rewrote in-memory defaults: mode %q wrap %v",
+		t.Fatalf("explicit override rewrote in-memory defaults: mode %q wrap %v",
 			h.app.Settings.Editor.DiffMode, h.app.Settings.Editor.DiffWordWrap)
 	}
 	saved := config.LoadSettings()
 	if saved.Editor.DiffMode != config.DiffModeUnified || !saved.Editor.DiffWordWrap {
-		t.Fatalf("View override rewrote saved defaults: mode %q wrap %v",
+		t.Fatalf("explicit override rewrote saved defaults: mode %q wrap %v",
 			saved.Editor.DiffMode, saved.Editor.DiffWordWrap)
 	}
 
@@ -202,31 +190,14 @@ func TestViewDiffOverridesDoNotPersistAndNextDiffUsesDefaults(t *testing.T) {
 	}
 }
 
-func TestDiffTabModeControlSwitchesProjection(t *testing.T) {
+func TestDiffTabBarDoesNotDuplicateModeControls(t *testing.T) {
 	h := newTestHarness(t, 100, 14)
 	defer h.stop()
 	h.app.EditorGroup.OpenDiff("control.go", diff.FileDiff{}, []string{"old one", "old two"}, []string{"new one", "new two"}, true)
 	h.redraw()
 
-	lines := strings.Split(h.screenText(), "\n")
-	controlX, controlY := -1, -1
-	for y, line := range lines {
-		if byteIndex := strings.Index(line, "Unified"); byteIndex >= 0 && strings.Contains(line, "● Split") {
-			controlX = textwidth.String(line[:byteIndex]) + 1
-			controlY = y
-			break
-		}
-	}
-	if controlX < 0 {
-		t.Fatalf("visible diff mode control not found:\n%s", h.screenText())
-	}
-	h.click(controlX, controlY)
-	dv := h.app.EditorGroup.ActiveDiffWidget()
-	if dv == nil || dv.Mode() != ui.DiffModeUnified {
-		t.Fatalf("clicking Unified left active mode at %v", dv)
-	}
-	if !strings.Contains(h.screenText(), "● Unified") || !strings.Contains(h.screenText(), "○ Split") {
-		t.Fatalf("mode control did not update its visible current value:\n%s", h.screenText())
+	if strings.Contains(h.screenText(), "● Split") || strings.Contains(h.screenText(), "○ Unified") {
+		t.Fatalf("diff tab bar duplicated the Options mode control:\n%s", h.screenText())
 	}
 }
 

--- a/tests/e2e/open_diff_test.go
+++ b/tests/e2e/open_diff_test.go
@@ -3,9 +3,14 @@ package e2e
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/clipboard"
 	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -20,6 +25,343 @@ func TestOpenDiff(t *testing.T) {
 	h.redraw()
 
 	h.assertContains("test.go (diff)")
+}
+
+func TestDiffToggleWrapCommand(t *testing.T) {
+	h := newTestHarness(t, 80, 12)
+	defer h.stop()
+
+	oldLines := []string{"left-prefix-LEFT-SUFFIX"}
+	newLines := []string{"right-prefix-RIGHT-SUFFIX"}
+	h.app.EditorGroup.OpenDiff("wrapped.go", diff.FileDiff{}, oldLines, newLines, true)
+	h.redraw()
+
+	dv := h.app.EditorGroup.ActiveDiffWidget()
+	if dv == nil {
+		t.Fatal("expected active diff widget")
+	}
+	if dv.IsWrapped() {
+		t.Fatal("diff wrapping should be disabled by default")
+	}
+	if strings.Contains(h.screenText(), "FFIX") {
+		t.Fatalf("long suffix should be truncated before wrapping:\n%s", h.screenText())
+	}
+
+	h.exec("diff.toggleWrap")
+	if !dv.IsWrapped() {
+		t.Fatal("diff wrapping should be enabled after command")
+	}
+	if !strings.Contains(h.screenText(), "FFIX") {
+		t.Fatalf("wrapped diff should render both suffixes:\n%s", h.screenText())
+	}
+
+	h.exec("diff.toggleWrap")
+	if dv.IsWrapped() {
+		t.Fatal("second toggle should disable diff wrapping")
+	}
+}
+
+func TestDiffToggleWrapCommandTargetsCommitDetail(t *testing.T) {
+	h := newTestHarness(t, 100, 16)
+	defer h.stop()
+
+	oldLine := "left-prefix-" + strings.Repeat("L", 48) + "-LEFT-SUFFIX"
+	newLine := "right-prefix-" + strings.Repeat("R", 48) + "-RIGHT-SUFFIX"
+	fileDiff := diff.Parse("--- a/wrapped.go\n+++ b/wrapped.go\n@@ -1 +1 @@\n-" + oldLine + "\n+" + newLine + "\n")
+	detail := ui.NewCommitDetailWidget(h.dir, "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []ui.CommitDetailFile{{Path: "wrapped.go", Diff: fileDiff}}, "")
+	h.app.EditorGroup.OpenPluginTab("commit:full-hash", "Commit abc1234", detail)
+	h.redraw()
+
+	if detail.IsWrapped() {
+		t.Fatal("commit detail wrapping should be disabled by default")
+	}
+	if strings.Contains(h.screenText(), "LEFT-SUFFIX") || strings.Contains(h.screenText(), "RIGHT-SUFFIX") {
+		t.Fatalf("long suffixes should be clipped before wrapping:\n%s", h.screenText())
+	}
+
+	h.exec("diff.toggleWrap")
+	if !detail.IsWrapped() {
+		t.Fatal("diff wrap command did not enable commit detail wrapping")
+	}
+	for _, suffix := range []string{"LEFT-SUFFIX", "RIGHT-SUFFIX"} {
+		if !strings.Contains(h.screenText(), suffix) {
+			t.Fatalf("wrapped commit detail missing %q:\n%s", suffix, h.screenText())
+		}
+	}
+
+	h.exec("diff.toggleWrap")
+	if detail.IsWrapped() {
+		t.Fatal("second diff wrap command did not restore clipped detail rows")
+	}
+}
+
+func TestDiffToggleUnifiedCommand(t *testing.T) {
+	h := newTestHarness(t, 100, 14)
+	defer h.stop()
+
+	oldLines := []string{"old one", "old two"}
+	newLines := []string{"new one", "new two"}
+	h.app.EditorGroup.OpenDiff("unified.go", diff.FileDiff{}, oldLines, newLines, true)
+	h.redraw()
+
+	dv := h.app.EditorGroup.ActiveDiffWidget()
+	if dv == nil {
+		t.Fatal("expected active diff widget")
+	}
+	if dv.IsUnified() {
+		t.Fatal("unified mode should be disabled by default")
+	}
+
+	h.exec("diff.toggleUnified")
+	if !dv.IsUnified() {
+		t.Fatal("unified mode should be enabled after command")
+	}
+	screen := h.screenText()
+	oldOne, oldTwo := strings.Index(screen, "old one"), strings.Index(screen, "old two")
+	newOne, newTwo := strings.Index(screen, "new one"), strings.Index(screen, "new two")
+	if oldOne < 0 || oldTwo < oldOne || newOne < oldTwo || newTwo < newOne {
+		t.Fatalf("unified diff should stack all removals before additions:\n%s", screen)
+	}
+
+	h.exec("diff.toggleUnified")
+	if dv.IsUnified() {
+		t.Fatal("second toggle should restore split mode")
+	}
+}
+
+func TestDiffExplicitModesAndViewMenuState(t *testing.T) {
+	h := newTestHarness(t, 100, 14)
+	defer h.stop()
+
+	h.app.EditorGroup.OpenDiff("modes.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	h.redraw()
+	dv := h.app.EditorGroup.ActiveDiffWidget()
+	if dv == nil {
+		t.Fatal("expected active diff widget")
+	}
+	if dv.Mode() != ui.DiffModeSplit || dv.WrapMode() != ui.DiffWrapOff {
+		t.Fatalf("default presentation = mode %v wrap %v, want split/off", dv.Mode(), dv.WrapMode())
+	}
+
+	checked := func(command string) int {
+		t.Helper()
+		for _, item := range h.app.BuildViewMenu() {
+			if item.Command == command {
+				return item.Checked
+			}
+		}
+		t.Fatalf("View menu missing %s", command)
+		return 0
+	}
+	if checked("diff.splitView") != ui.MenuChecked || checked("diff.unifiedView") != ui.MenuUnchecked || checked("diff.toggleWrap") != ui.MenuUnchecked {
+		t.Fatalf("default View menu did not expose split/off state: %+v", h.app.BuildViewMenu())
+	}
+
+	h.exec("diff.unifiedView")
+	h.exec("diff.toggleWrap")
+	if dv.Mode() != ui.DiffModeUnified || dv.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("explicit commands left mode %v wrap %v, want unified/on", dv.Mode(), dv.WrapMode())
+	}
+	if checked("diff.splitView") != ui.MenuUnchecked || checked("diff.unifiedView") != ui.MenuChecked || checked("diff.toggleWrap") != ui.MenuChecked {
+		t.Fatalf("updated View menu did not expose unified/on state: %+v", h.app.BuildViewMenu())
+	}
+}
+
+func TestViewDiffOverridesDoNotPersistAndNextDiffUsesDefaults(t *testing.T) {
+	h := newTestHarness(t, 100, 14)
+	defer h.stop()
+
+	h.exec("options.useUnifiedDiff")
+	h.exec("options.toggleDiffWordWrap")
+	h.app.EditorGroup.OpenDiff("first.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	first := h.app.EditorGroup.ActiveDiffWidget()
+	if first == nil || first.Mode() != ui.DiffModeUnified || first.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("first diff did not adopt defaults: %+v", first)
+	}
+
+	h.exec("diff.splitView")
+	h.exec("diff.toggleWrap")
+	if first.Mode() != ui.DiffModeSplit || first.WrapMode() != ui.DiffWrapOff {
+		t.Fatalf("View override = mode %v wrap %v, want split/off", first.Mode(), first.WrapMode())
+	}
+	if h.app.Settings.Editor.DiffMode != config.DiffModeUnified || !h.app.Settings.Editor.DiffWordWrap {
+		t.Fatalf("View override rewrote in-memory defaults: mode %q wrap %v",
+			h.app.Settings.Editor.DiffMode, h.app.Settings.Editor.DiffWordWrap)
+	}
+	saved := config.LoadSettings()
+	if saved.Editor.DiffMode != config.DiffModeUnified || !saved.Editor.DiffWordWrap {
+		t.Fatalf("View override rewrote saved defaults: mode %q wrap %v",
+			saved.Editor.DiffMode, saved.Editor.DiffWordWrap)
+	}
+
+	h.app.EditorGroup.OpenDiff("second.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	second := h.app.EditorGroup.ActiveDiffWidget()
+	if second == nil || second.Mode() != ui.DiffModeUnified || second.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("next diff did not adopt saved defaults: %+v", second)
+	}
+}
+
+func TestDiffTabModeControlSwitchesProjection(t *testing.T) {
+	h := newTestHarness(t, 100, 14)
+	defer h.stop()
+	h.app.EditorGroup.OpenDiff("control.go", diff.FileDiff{}, []string{"old one", "old two"}, []string{"new one", "new two"}, true)
+	h.redraw()
+
+	lines := strings.Split(h.screenText(), "\n")
+	controlX, controlY := -1, -1
+	for y, line := range lines {
+		if byteIndex := strings.Index(line, "Unified"); byteIndex >= 0 && strings.Contains(line, "● Split") {
+			controlX = textwidth.String(line[:byteIndex]) + 1
+			controlY = y
+			break
+		}
+	}
+	if controlX < 0 {
+		t.Fatalf("visible diff mode control not found:\n%s", h.screenText())
+	}
+	h.click(controlX, controlY)
+	dv := h.app.EditorGroup.ActiveDiffWidget()
+	if dv == nil || dv.Mode() != ui.DiffModeUnified {
+		t.Fatalf("clicking Unified left active mode at %v", dv)
+	}
+	if !strings.Contains(h.screenText(), "● Unified") || !strings.Contains(h.screenText(), "○ Split") {
+		t.Fatalf("mode control did not update its visible current value:\n%s", h.screenText())
+	}
+}
+
+func TestDiffUnifiedCommandTargetsCommitDetail(t *testing.T) {
+	h := newTestHarness(t, 100, 16)
+	defer h.stop()
+	fileDiff := diff.Parse("--- a/detail.go\n+++ b/detail.go\n@@ -1,2 +1,2 @@\n-old one\n-old two\n+new one\n+new two\n")
+	detail := ui.NewCommitDetailWidget(h.dir, "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []ui.CommitDetailFile{{Path: "detail.go", Diff: fileDiff}}, "")
+	h.app.EditorGroup.OpenPluginTab("commit:full-hash", "Commit abc1234", detail)
+	h.redraw()
+
+	h.exec("diff.unifiedView")
+	if detail.Mode() != ui.DiffModeUnified {
+		t.Fatal("explicit unified command did not target commit detail")
+	}
+	screen := h.screenText()
+	oldOne, oldTwo := strings.Index(screen, "old one"), strings.Index(screen, "old two")
+	newOne, newTwo := strings.Index(screen, "new one"), strings.Index(screen, "new two")
+	if oldOne < 0 || oldTwo < oldOne || newOne < oldTwo || newTwo < newOne {
+		t.Fatalf("commit detail unified projection is not stacked:\n%s", screen)
+	}
+
+	h.exec("diff.splitView")
+	if detail.Mode() != ui.DiffModeSplit {
+		t.Fatal("explicit split command did not restore commit detail")
+	}
+}
+
+func TestCommitDetailSelectionCopiesAndCollapseCommandsRebuildDocument(t *testing.T) {
+	h := newTestHarness(t, 80, 14)
+	defer h.stop()
+	clipboard.DisableSystem()
+	clipboard.Set("")
+
+	fileDiff := diff.Parse("--- a/detail.go\n+++ b/detail.go\n@@ -1 +1 @@\n-abcdefghij\n+ABCDEFGHIJ\n")
+	detail := ui.NewCommitDetailWidget(h.dir, "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []ui.CommitDetailFile{{Path: "first.go", Diff: fileDiff}, {Path: "second.go", Diff: fileDiff}}, "")
+	h.app.EditorGroup.OpenPluginTab("commit:full-hash", "Commit abc1234", detail)
+	h.redraw()
+
+	// The first diff row follows the message header, subject, spacer, and file
+	// heading. The split view's content begins after the four-column gutter.
+	rect := detail.GetRect()
+	selectY := rect.Y + 4
+	h.app.Root.HandleEvent(tcell.NewEventMouse(rect.X+6, selectY, tcell.Button1, tcell.ModNone))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(rect.X+12, selectY, tcell.Button1, tcell.ModNone))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(rect.X+12, selectY, tcell.ButtonNone, tcell.ModNone))
+	h.exec("editor.copy")
+	if got := clipboard.Get(); got != "cdefgh" {
+		t.Fatalf("commit detail copied %q, want original selected text", got)
+	}
+
+	h.exec("commitDetail.collapseAll")
+	if strings.Contains(h.screenText(), "abcdefghij") || strings.Contains(h.screenText(), "ABCDEFGHIJ") {
+		t.Fatalf("collapse-all left diff content visible:\n%s", h.screenText())
+	}
+	for _, heading := range []string{"first.go", "second.go", "Expand all"} {
+		if !strings.Contains(h.screenText(), heading) {
+			t.Fatalf("collapsed document missing %q:\n%s", heading, h.screenText())
+		}
+	}
+
+	h.exec("commitDetail.expandAll")
+	if !strings.Contains(h.screenText(), "abcdefghij") || !strings.Contains(h.screenText(), "Collapse all") {
+		t.Fatalf("expand-all did not restore document:\n%s", h.screenText())
+	}
+}
+
+func TestCommitDetailStickyControlCollapsesCurrentLongFile(t *testing.T) {
+	h := newTestHarness(t, 72, 12)
+	defer h.stop()
+	var patch strings.Builder
+	patch.WriteString("--- a/deep.go\n+++ b/deep.go\n@@ -1,12 +1,12 @@\n")
+	for i := 0; i < 12; i++ {
+		patch.WriteString("-old sticky line\n")
+	}
+	for i := 0; i < 12; i++ {
+		patch.WriteString("+new sticky line\n")
+	}
+	detail := ui.NewCommitDetailWidget(h.dir, "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []ui.CommitDetailFile{{Path: "very/long/path/current-file.go", Diff: diff.Parse(patch.String())}}, "")
+	h.app.EditorGroup.OpenPluginTab("commit:full-hash", "Commit abc1234", detail)
+	detail.TopLine = 7
+	h.redraw()
+	rect := detail.GetRect()
+	if !strings.Contains(strings.Split(h.screenText(), "\n")[rect.Y], "current-file.go") {
+		t.Fatalf("sticky file heading missing before collapse:\n%s", h.screenText())
+	}
+
+	// The sticky disclosure remains at the content origin even though the real
+	// heading is above the viewport.
+	h.click(rect.X+1, rect.Y)
+	if strings.Contains(h.screenText(), "old sticky") || strings.Contains(h.screenText(), "new sticky") {
+		t.Fatalf("sticky disclosure did not collapse its file:\n%s", h.screenText())
+	}
+}
+
+func TestCompactDiffShowsCollapsedLineDistance(t *testing.T) {
+	h := newTestHarness(t, 100, 14)
+	defer h.stop()
+
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -22,3 +22,3 @@\n line 22\n line 23\n line 24\n@@ -356,2 +356,2 @@\n line 356\n line 357\n")
+	h.app.EditorGroup.OpenDiff("distance.go", fd, nil, nil, false)
+	h.redraw()
+
+	if !strings.Contains(h.screenText(), "⋯ 331 lines ⋯") {
+		t.Fatalf("compact diff should show the collapsed distance:\n%s", h.screenText())
+	}
+}
+
+func TestCompactDiffOmitsSeparatorForAdjacentLines(t *testing.T) {
+	h := newTestHarness(t, 100, 14)
+	defer h.stop()
+
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -24,1 +24,1 @@\n line 24\n@@ -25,1 +25,1 @@\n line 25\n")
+	h.app.EditorGroup.OpenDiff("distance.go", fd, nil, nil, false)
+	h.redraw()
+
+	rows := strings.Split(h.screenText(), "\n")
+	line24Row, line25Row := -1, -1
+	for i, row := range rows {
+		if strings.Contains(row, "line 24") {
+			line24Row = i
+		}
+		if strings.Contains(row, "line 25") {
+			line25Row = i
+		}
+	}
+	if line24Row < 0 || line25Row != line24Row+1 {
+		t.Fatalf("adjacent diff rows should render consecutively, got rows %d and %d:\n%s", line24Row, line25Row, h.screenText())
+	}
+	if strings.Contains(h.screenText(), "⋯") {
+		t.Fatalf("adjacent diff rows should not render a collapsed separator:\n%s", h.screenText())
+	}
 }
 
 func TestOpenBufferReadOnly(t *testing.T) {

--- a/tests/e2e/options_menu_test.go
+++ b/tests/e2e/options_menu_test.go
@@ -1,7 +1,14 @@
 package e2e
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/ui"
 )
 
 func TestOptionsMenuToggleLineNumbers(t *testing.T) {
@@ -55,6 +62,130 @@ func TestOptionsMenuToggleWordWrap(t *testing.T) {
 
 	if h.app.Settings.Editor.WordWrap {
 		t.Error("word wrap should be disabled after second toggle")
+	}
+}
+
+func TestOptionsMenuDiffDefaultsPersistAndUpdateInheritedSurface(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.app.EditorGroup.OpenDiff("existing.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	dv := h.app.EditorGroup.ActiveDiffWidget()
+	if dv == nil {
+		t.Fatal("expected active diff")
+	}
+
+	checked := func(command string) int {
+		t.Helper()
+		for _, item := range h.app.BuildOptionsMenu() {
+			if item.Command == command {
+				return item.Checked
+			}
+		}
+		t.Fatalf("Options menu missing %s", command)
+		return 0
+	}
+	if checked("options.useSplitDiff") != ui.MenuChecked ||
+		checked("options.useUnifiedDiff") != ui.MenuUnchecked ||
+		checked("options.toggleDiffWordWrap") != ui.MenuUnchecked {
+		t.Fatalf("default diff options state is wrong: %+v", h.app.BuildOptionsMenu())
+	}
+
+	h.exec("options.useUnifiedDiff")
+	h.exec("options.toggleDiffWordWrap")
+
+	if h.app.Settings.Editor.DiffMode != config.DiffModeUnified || !h.app.Settings.Editor.DiffWordWrap {
+		t.Fatalf("settings defaults = mode %q wrap %v, want unified/true",
+			h.app.Settings.Editor.DiffMode, h.app.Settings.Editor.DiffWordWrap)
+	}
+	if h.app.EditorGroup.DiffMode != ui.DiffModeUnified || !h.app.EditorGroup.DiffWordWrap {
+		t.Fatalf("live defaults = mode %v wrap %v, want unified/true",
+			h.app.EditorGroup.DiffMode, h.app.EditorGroup.DiffWordWrap)
+	}
+	if dv.Mode() != ui.DiffModeUnified || dv.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("open inherited surface = mode %v wrap %v, want unified/on", dv.Mode(), dv.WrapMode())
+	}
+	if checked("options.useSplitDiff") != ui.MenuUnchecked ||
+		checked("options.useUnifiedDiff") != ui.MenuChecked ||
+		checked("options.toggleDiffWordWrap") != ui.MenuChecked {
+		t.Fatalf("updated diff options state is wrong: %+v", h.app.BuildOptionsMenu())
+	}
+
+	data, err := os.ReadFile(filepath.Join(h.dir, "config", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved config.Settings
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.Editor.DiffMode != config.DiffModeUnified || !saved.Editor.DiffWordWrap {
+		t.Fatalf("saved defaults = mode %q wrap %v, want unified/true",
+			saved.Editor.DiffMode, saved.Editor.DiffWordWrap)
+	}
+}
+
+func TestOptionsDiffDefaultsPreservePerPropertyViewOverridesAcrossOpenDiffs(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.app.EditorGroup.OpenDiff("first.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	first := h.app.EditorGroup.ActiveDiffWidget()
+	if first == nil {
+		t.Fatal("expected first diff")
+	}
+	first.SetMode(ui.DiffModeUnified)
+
+	h.app.EditorGroup.OpenDiff("second.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	second := h.app.EditorGroup.ActiveDiffWidget()
+	if second == nil {
+		t.Fatal("expected second diff")
+	}
+	second.SetWrapMode(ui.DiffWrapOn)
+
+	h.exec("options.useUnifiedDiff")
+	h.exec("options.toggleDiffWordWrap")
+	if first.Mode() != ui.DiffModeUnified || first.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("first surface did not preserve mode and inherit wrap: mode %v wrap %v", first.Mode(), first.WrapMode())
+	}
+	if second.Mode() != ui.DiffModeUnified || second.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("second surface did not inherit mode and preserve wrap: mode %v wrap %v", second.Mode(), second.WrapMode())
+	}
+
+	h.exec("options.useSplitDiff")
+	h.exec("options.toggleDiffWordWrap")
+	if first.Mode() != ui.DiffModeUnified || first.WrapMode() != ui.DiffWrapOff {
+		t.Fatalf("first surface after second default = mode %v wrap %v, want unified/off", first.Mode(), first.WrapMode())
+	}
+	if second.Mode() != ui.DiffModeSplit || second.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("second surface after second default = mode %v wrap %v, want split/on", second.Mode(), second.WrapMode())
+	}
+}
+
+func TestOptionsDiffDefaultsUpdateInheritedCommitDetailAndPreserveViewOverrides(t *testing.T) {
+	h := newTestHarness(t, 100, 18)
+	defer h.stop()
+
+	fileDiff := diff.Parse("--- a/detail.go\n+++ b/detail.go\n@@ -1 +1 @@\n-old\n+new\n")
+	detail := ui.NewCommitDetailWidget(h.dir, "full-hash", "abc1234", false)
+	detail.SetDetail("Subject", []ui.CommitDetailFile{{Path: "detail.go", Diff: fileDiff}}, "")
+	h.app.EditorGroup.ApplyDiffDefaults(detail)
+	h.app.EditorGroup.OpenPluginTab("commit:full-hash", "Commit abc1234", detail)
+
+	h.exec("options.useUnifiedDiff")
+	h.exec("options.toggleDiffWordWrap")
+	if detail.Mode() != ui.DiffModeUnified || detail.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("inherited commit detail = mode %v wrap %v, want unified/on", detail.Mode(), detail.WrapMode())
+	}
+
+	h.exec("diff.splitView")
+	h.exec("diff.toggleWrap")
+	h.exec("options.useSplitDiff")
+	h.exec("options.toggleDiffWordWrap")
+	h.exec("options.useUnifiedDiff")
+	h.exec("options.toggleDiffWordWrap")
+	if detail.Mode() != ui.DiffModeSplit || detail.WrapMode() != ui.DiffWrapOff {
+		t.Fatalf("defaults replaced commit detail View overrides: mode %v wrap %v", detail.Mode(), detail.WrapMode())
 	}
 }
 

--- a/tests/e2e/options_menu_test.go
+++ b/tests/e2e/options_menu_test.go
@@ -87,17 +87,23 @@ func TestOptionsMenuDiffDefaultsPersistAndUpdateInheritedSurface(t *testing.T) {
 		t.Fatal("expected active diff")
 	}
 
-	checked := func(command string) int {
+	checked := func(items []ui.ContextMenuItem, command string) int {
 		t.Helper()
-		if item, ok := findMenuCommand(h.app.BuildOptionsMenu(), command); ok {
+		if item, ok := findMenuCommand(items, command); ok {
 			return item.Checked
 		}
-		t.Fatalf("Options menu missing %s", command)
+		t.Fatalf("menu missing %s", command)
 		return 0
 	}
-	if checked("options.useSplitDiff") != ui.MenuChecked ||
-		checked("options.useUnifiedDiff") != ui.MenuUnchecked ||
-		checked("options.toggleDiffWordWrap") != ui.MenuUnchecked {
+	if _, ok := findMenuCommand(h.app.BuildOptionsMenu(), "options.diffViewMode"); !ok {
+		t.Fatal("Options menu missing Diff View Mode picker")
+	}
+	if _, ok := findMenuCommand(h.app.BuildOptionsMenu(), "options.diffContext"); !ok {
+		t.Fatal("Options menu missing Diff Context picker")
+	}
+	if checked(h.app.BuildChangesPanelMenu(), "options.useSplitDiff") != ui.MenuChecked ||
+		checked(h.app.BuildChangesPanelMenu(), "options.useUnifiedDiff") != ui.MenuUnchecked ||
+		checked(h.app.BuildOptionsMenu(), "options.toggleDiffWordWrap") != ui.MenuUnchecked {
 		t.Fatalf("default diff options state is wrong: %+v", h.app.BuildOptionsMenu())
 	}
 
@@ -115,9 +121,9 @@ func TestOptionsMenuDiffDefaultsPersistAndUpdateInheritedSurface(t *testing.T) {
 	if dv.Mode() != ui.DiffModeUnified || dv.WrapMode() != ui.DiffWrapOn {
 		t.Fatalf("open inherited surface = mode %v wrap %v, want unified/on", dv.Mode(), dv.WrapMode())
 	}
-	if checked("options.useSplitDiff") != ui.MenuUnchecked ||
-		checked("options.useUnifiedDiff") != ui.MenuChecked ||
-		checked("options.toggleDiffWordWrap") != ui.MenuChecked {
+	if checked(h.app.BuildChangesPanelMenu(), "options.useSplitDiff") != ui.MenuUnchecked ||
+		checked(h.app.BuildChangesPanelMenu(), "options.useUnifiedDiff") != ui.MenuChecked ||
+		checked(h.app.BuildOptionsMenu(), "options.toggleDiffWordWrap") != ui.MenuChecked {
 		t.Fatalf("updated diff options state is wrong: %+v", h.app.BuildOptionsMenu())
 	}
 
@@ -135,22 +141,24 @@ func TestOptionsMenuDiffDefaultsPersistAndUpdateInheritedSurface(t *testing.T) {
 	}
 }
 
-func TestOptionsAndChangesMenusSharePresentationGroups(t *testing.T) {
+func TestOptionsAndChangesMenusExposePresentationControlsWithoutDuplicateModeSubmenu(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()
 
-	for _, menu := range [][]ui.ContextMenuItem{h.app.BuildOptionsMenu(), h.app.BuildChangesPanelMenu()} {
-		for _, command := range []string{
-			"options.useGitFileTree",
-			"options.useGitFileList",
-			"options.useSplitDiff",
-			"options.useUnifiedDiff",
-			"options.toggleDiffWordWrap",
-			"options.toggleDiffHighContrast",
-		} {
-			if _, ok := findMenuCommand(menu, command); !ok {
-				t.Errorf("menu missing shared presentation command %s", command)
-			}
+	options := h.app.BuildOptionsMenu()
+	for _, command := range []string{"options.diffViewMode", "options.diffContext", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast"} {
+		if _, ok := findMenuCommand(options, command); !ok {
+			t.Errorf("Options menu missing presentation command %s", command)
+		}
+	}
+	if _, ok := findMenuCommand(options, "options.useSplitDiff"); ok {
+		t.Fatal("Options menu should open a compact mode picker instead of duplicating mode actions")
+	}
+
+	changes := h.app.BuildChangesPanelMenu()
+	for _, command := range []string{"options.useGitFileTree", "options.useGitFileList", "options.useSplitDiff", "options.useUnifiedDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast"} {
+		if _, ok := findMenuCommand(changes, command); !ok {
+			t.Errorf("Changes menu missing contextual presentation command %s", command)
 		}
 	}
 }

--- a/tests/e2e/options_menu_test.go
+++ b/tests/e2e/options_menu_test.go
@@ -11,6 +11,18 @@ import (
 	"github.com/eugenioenko/ttt/internal/ui"
 )
 
+func findMenuCommand(items []ui.ContextMenuItem, command string) (ui.ContextMenuItem, bool) {
+	for _, item := range items {
+		if item.Command == command {
+			return item, true
+		}
+		if found, ok := findMenuCommand(item.Submenu, command); ok {
+			return found, true
+		}
+	}
+	return ui.ContextMenuItem{}, false
+}
+
 func TestOptionsMenuToggleLineNumbers(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()
@@ -77,10 +89,8 @@ func TestOptionsMenuDiffDefaultsPersistAndUpdateInheritedSurface(t *testing.T) {
 
 	checked := func(command string) int {
 		t.Helper()
-		for _, item := range h.app.BuildOptionsMenu() {
-			if item.Command == command {
-				return item.Checked
-			}
+		if item, ok := findMenuCommand(h.app.BuildOptionsMenu(), command); ok {
+			return item.Checked
 		}
 		t.Fatalf("Options menu missing %s", command)
 		return 0
@@ -122,6 +132,59 @@ func TestOptionsMenuDiffDefaultsPersistAndUpdateInheritedSurface(t *testing.T) {
 	if saved.Editor.DiffMode != config.DiffModeUnified || !saved.Editor.DiffWordWrap {
 		t.Fatalf("saved defaults = mode %q wrap %v, want unified/true",
 			saved.Editor.DiffMode, saved.Editor.DiffWordWrap)
+	}
+}
+
+func TestOptionsAndChangesMenusSharePresentationGroups(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	for _, menu := range [][]ui.ContextMenuItem{h.app.BuildOptionsMenu(), h.app.BuildChangesPanelMenu()} {
+		for _, command := range []string{
+			"options.useGitFileTree",
+			"options.useGitFileList",
+			"options.useSplitDiff",
+			"options.useUnifiedDiff",
+			"options.toggleDiffWordWrap",
+			"options.toggleDiffHighContrast",
+		} {
+			if _, ok := findMenuCommand(menu, command); !ok {
+				t.Errorf("menu missing shared presentation command %s", command)
+			}
+		}
+	}
+}
+
+func TestOptionsToggleDiffHighContrastPersistsAndApplies(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.app.EditorGroup.OpenDiff("contrast.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	dv := h.app.EditorGroup.ActiveDiffWidget()
+	if dv == nil {
+		t.Fatal("expected active diff")
+	}
+
+	h.exec("options.toggleDiffHighContrast")
+	if !h.app.Settings.Editor.DiffHighContrast || !h.app.EditorGroup.DiffHighContrast || !dv.DiffHighContrast() {
+		t.Fatalf("high contrast was not live-applied: settings=%v group=%v surface=%v",
+			h.app.Settings.Editor.DiffHighContrast, h.app.EditorGroup.DiffHighContrast, dv.DiffHighContrast())
+	}
+	item, ok := findMenuCommand(h.app.BuildChangesPanelMenu(), "options.toggleDiffHighContrast")
+	if !ok || item.Checked != ui.MenuChecked {
+		t.Fatalf("Changes menu high contrast state = %+v, found=%v", item, ok)
+	}
+
+	data, err := os.ReadFile(filepath.Join(h.dir, "config", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved config.Settings
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if !saved.Editor.DiffHighContrast {
+		t.Fatal("diffHighContrast was not persisted")
 	}
 }
 
@@ -262,12 +325,10 @@ func TestOptionsMenuDynamicChecked(t *testing.T) {
 	// Build the options menu and verify line numbers is checked
 	items := h.app.BuildOptionsMenu()
 	found := false
-	for _, item := range items {
-		if item.Command == "options.toggleLineNumbers" {
-			found = true
-			if item.Checked != 2 { // MenuChecked
-				t.Errorf("expected line numbers checked (2), got %d", item.Checked)
-			}
+	if item, ok := findMenuCommand(items, "options.toggleLineNumbers"); ok {
+		found = true
+		if item.Checked != 2 { // MenuChecked
+			t.Errorf("expected line numbers checked (2), got %d", item.Checked)
 		}
 	}
 	if !found {
@@ -279,11 +340,9 @@ func TestOptionsMenuDynamicChecked(t *testing.T) {
 
 	// Rebuild and verify unchecked
 	items = h.app.BuildOptionsMenu()
-	for _, item := range items {
-		if item.Command == "options.toggleLineNumbers" {
-			if item.Checked != 1 { // MenuUnchecked
-				t.Errorf("expected line numbers unchecked (1), got %d", item.Checked)
-			}
+	if item, ok := findMenuCommand(items, "options.toggleLineNumbers"); ok {
+		if item.Checked != 1 { // MenuUnchecked
+			t.Errorf("expected line numbers unchecked (1), got %d", item.Checked)
 		}
 	}
 }

--- a/tests/e2e/settings_view_test.go
+++ b/tests/e2e/settings_view_test.go
@@ -181,17 +181,17 @@ func TestSettingsGitFileViewLiveApply(t *testing.T) {
 	h := openSettings(t)
 	clickRowControl(t, h, "Advanced", "Advanced")
 
-	if !rowHas(h, "Git: file view", "Tree") {
-		t.Fatalf("git file view should default to Tree:\n%s", h.screenText())
+	if !rowHas(h, "Git: file view", "List") {
+		t.Fatalf("git file view should default to List:\n%s", h.screenText())
 	}
-	clickRowControl(t, h, "Git: file view", "Tree")
-	clickRowControl(t, h, "List", "List")
-	if h.app.Settings.Git.FileView != "tree" || h.app.Changes.FileView() != "tree" {
+	clickRowControl(t, h, "Git: file view", "List")
+	clickRowControl(t, h, "Tree", "Tree")
+	if h.app.Settings.Git.FileView != "list" || h.app.Changes.FileView() != "list" {
 		t.Fatal("git file view applied before Apply")
 	}
 
 	h.exec("settings.apply")
-	if h.app.Settings.Git.FileView != "list" || h.app.Changes.FileView() != "list" {
+	if h.app.Settings.Git.FileView != "tree" || h.app.Changes.FileView() != "tree" {
 		t.Fatalf("git file view was not live-applied: settings=%q panel=%q", h.app.Settings.Git.FileView, h.app.Changes.FileView())
 	}
 }

--- a/tests/e2e/settings_view_test.go
+++ b/tests/e2e/settings_view_test.go
@@ -128,7 +128,7 @@ func TestSettingsEnumSelectOpensPopup(t *testing.T) {
 	h := openSettings(t)
 	clickRowControl(t, h, "Appearance", "Appearance")
 
-	// The theme select shows "Default" until it is opened.
+	// The fallback theme has an explicit label until the select is opened.
 	if strings.Contains(h.screenText(), "default-dark") {
 		t.Fatal("theme list visible before the select was opened")
 	}
@@ -156,6 +156,24 @@ func TestSettingsEnumSelectOpensPopup(t *testing.T) {
 	h.exec("settings.apply")
 	if h.app.Settings.Theme != "default-dark" {
 		t.Errorf("theme = %q, want default-dark", h.app.Settings.Theme)
+	}
+}
+
+func TestSettingsHighContrastDiffsLiveApply(t *testing.T) {
+	h := openSettings(t)
+	clickRowControl(t, h, "Appearance", "Appearance")
+
+	if !rowHas(h, "High contrast diffs", uncheckedBox) {
+		t.Fatalf("high contrast diff setting should start unchecked:\n%s", h.screenText())
+	}
+	clickRowControl(t, h, "High contrast diffs", uncheckedBox)
+	if h.app.Settings.Editor.DiffHighContrast || h.app.EditorGroup.DiffHighContrast {
+		t.Fatal("high contrast diff setting applied before Apply")
+	}
+
+	h.exec("settings.apply")
+	if !h.app.Settings.Editor.DiffHighContrast || !h.app.EditorGroup.DiffHighContrast {
+		t.Fatalf("high contrast diff setting was not live-applied: settings=%v group=%v", h.app.Settings.Editor.DiffHighContrast, h.app.EditorGroup.DiffHighContrast)
 	}
 }
 

--- a/tests/e2e/settings_view_test.go
+++ b/tests/e2e/settings_view_test.go
@@ -177,6 +177,25 @@ func TestSettingsHighContrastDiffsLiveApply(t *testing.T) {
 	}
 }
 
+func TestSettingsGitFileViewLiveApply(t *testing.T) {
+	h := openSettings(t)
+	clickRowControl(t, h, "Advanced", "Advanced")
+
+	if !rowHas(h, "Git: file view", "Tree") {
+		t.Fatalf("git file view should default to Tree:\n%s", h.screenText())
+	}
+	clickRowControl(t, h, "Git: file view", "Tree")
+	clickRowControl(t, h, "List", "List")
+	if h.app.Settings.Git.FileView != "tree" || h.app.Changes.FileView() != "tree" {
+		t.Fatal("git file view applied before Apply")
+	}
+
+	h.exec("settings.apply")
+	if h.app.Settings.Git.FileView != "list" || h.app.Changes.FileView() != "list" {
+		t.Fatalf("git file view was not live-applied: settings=%q panel=%q", h.app.Settings.Git.FileView, h.app.Changes.FileView())
+	}
+}
+
 // runeIndex returns the screen column of sub within line. strings.Index would
 // give a byte offset, which is wrong on rows containing box-drawing characters.
 func runeIndex(line, sub string) int {

--- a/tests/e2e/sidebar_reorder_test.go
+++ b/tests/e2e/sidebar_reorder_test.go
@@ -1,0 +1,56 @@
+package e2e
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestSidebarHeaderDragReordersAndPersists(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	h.exec("sidebar.changes")
+
+	tabsY := h.app.Sidebar.Tabs.GetRect().Y
+	row := h.screenRow(tabsY)
+	changesX := strings.Index(row, "Changes")
+	explorerX := strings.Index(row, "Explore")
+	if changesX < 0 || explorerX < 0 {
+		t.Fatalf("tab labels not visible in %q", row)
+	}
+	var dragFrom, dragTo = -1, -1
+	originalReorder := h.app.Sidebar.Tabs.Config.OnReorder
+	h.app.Sidebar.Tabs.Config.OnReorder = func(from, to int) {
+		dragFrom, dragTo = from, to
+		originalReorder(from, to)
+	}
+
+	if got := h.app.Root.HandleEvent(tcell.NewEventMouse(changesX+2, tabsY, tcell.Button1, 0)); got != ui.EventConsumed {
+		t.Fatalf("mouse down result = %v, want EventConsumed", got)
+	}
+	dropX := h.app.Sidebar.Tabs.GetRect().X
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.Button1, 0))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.ButtonNone, 0))
+	h.redraw()
+
+	want := []string{"changes", "explorer", "search", "outline"}
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, want) {
+		t.Fatalf("drag = %d -> %d, panel order = %v, want %v", dragFrom, dragTo, got, want)
+	}
+	if h.app.Sidebar.ActivePanel != "changes" {
+		t.Fatalf("active panel = %q, want changes", h.app.Sidebar.ActivePanel)
+	}
+	if got := config.LoadSettings().Sidebar.PanelOrder; !slices.Equal(got, want) {
+		t.Fatalf("saved panel order = %v, want %v", got, want)
+	}
+
+	h.exec("sidebar.movePanelRight")
+	want = []string{"explorer", "changes", "search", "outline"}
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, want) {
+		t.Fatalf("command panel order = %v, want %v", got, want)
+	}
+}

--- a/tests/e2e/tree_actions_menu_test.go
+++ b/tests/e2e/tree_actions_menu_test.go
@@ -1,0 +1,25 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestChangesAndExplorerPanelMenusExposeTreeActions(t *testing.T) {
+	h := newTestHarness(t, 100, 28)
+	defer h.stop()
+
+	h.exec("sidebar.changes")
+	h.app.ShowSidebarMoreMenu(4, 3)
+	h.redraw()
+	h.assertContains("Expand All")
+	h.assertContains("Collapse All")
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	h.exec("sidebar.explorer")
+	h.app.ShowSidebarMoreMenu(4, 3)
+	h.redraw()
+	h.assertContains("Expand All")
+	h.assertContains("Collapse All")
+}

--- a/tests/functional/audit-theme-bugs.test.js
+++ b/tests/functional/audit-theme-bugs.test.js
@@ -1,6 +1,4 @@
-// Repro test for confirmed bug from audit/2026-07-12-ux-bug-audit.md (branch audit/bug-hunt).
-// Asserts the CORRECT behavior with `it.fails` — passes while the bug
-// exists, goes red when fixed. Remove `.fails` + audit entry when fixing.
+// Regression for BUG-041 from audit/2026-07-12-ux-bug-audit.md.
 import { describe, it, expect, afterEach } from "vitest";
 import * as tui from "./tui.js";
 import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
@@ -13,7 +11,7 @@ afterEach(() => {
 });
 
 describe("BUG-041: theme picker cancel leaves border charset stuck on the preview", () => {
-  it.fails("Escape reverts border glyphs to the pre-picker theme", () => {
+  it("Escape reverts border glyphs to the pre-picker theme", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "th.txt", "sample content\nline two\n");
 
@@ -27,9 +25,8 @@ describe("BUG-041: theme picker cancel leaves border charset stuck on the previe
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
-    // The default theme uses rounded borders (╭). Buggy: OnDismiss reverts
-    // the style map and palette but never resets *a.Borders, so the
-    // double-line preview glyph (╔) stays until another theme is applied.
+    // The default theme uses rounded borders (╭); the cancelled Turbo Vision
+    // preview must not leave its double-line glyph (╔) behind.
     expect(snapshots[s]).toContain("╭");
     expect(snapshots[s]).not.toContain("╔");
   });

--- a/tests/functional/changes-async.test.js
+++ b/tests/functional/changes-async.test.js
@@ -82,7 +82,7 @@ describe("changes panel does not wait for git", () => {
     tui.waitStable(300);
     tui.pressChord("ctrl+k", "c");
     tui.waitStable(600);
-    tui.click(1, 32);
+    tui.click(1, 23);
     tui.waitStable(400);
     const loading = tui.snapshot();
     tui.waitStable(6000);
@@ -105,7 +105,7 @@ describe("changes panel does not wait for git", () => {
     tui.waitStable(600);
     // The label activates commit detail; unlike the chevron at x=1, it must
     // not wait for the message, file list, and file diffs before returning.
-    tui.click(5, 32);
+    tui.click(5, 23);
     tui.waitStable(400);
     const loading = tui.snapshot();
     tui.waitStable(9000);

--- a/tests/functional/changes-async.test.js
+++ b/tests/functional/changes-async.test.js
@@ -1,0 +1,203 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { chmodSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createGitRepo, createTempFile, git, cleanupDir } from "./helpers.js";
+
+let dir;
+let binDir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+  if (binDir) cleanupDir(binDir);
+});
+
+// slowGitOn returns a directory holding a `git` that sleeps before delegating to
+// the real one, for the listed subcommands. Putting it first on PATH is the only
+// way to observe whether the editor waits for git or carries on without it.
+// The delay has to comfortably outlast the "during" snapshot and comfortably
+// undershoot the wait after it, on a machine running the rest of the suite in
+// parallel. Hence generous margins on both sides rather than tight ones.
+function slowGitOn(subcommands, seconds = 3) {
+  const d = createTempDir();
+  mkdirSync(d, { recursive: true });
+  const script = [
+    "#!/bin/sh",
+    'for a in "$@"; do',
+    `  case "$a" in ${subcommands.join("|")}) sleep ${seconds} ;; esac`,
+    "done",
+    'exec /usr/bin/git "$@"',
+    "",
+  ].join("\n");
+  const path = join(d, "git");
+  writeFileSync(path, script, "utf8");
+  chmodSync(path, 0o755);
+  return d;
+}
+
+// The committed file and the working-tree files have different names on
+// purpose: the changes tree and the expanded commit render into the same panel,
+// so a shared name would make every "not yet visible" assertion meaningless.
+function repoWithChanges() {
+  const d = createGitRepo(createTempDir());
+  createTempFile(d, "committed.txt", "in the last commit\n");
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "second commit");
+  createTempFile(d, "tracked.txt", "original\nchanged\n");
+  createTempFile(d, "untracked.txt", "new\n");
+  return d;
+}
+
+describe("changes panel does not wait for git", () => {
+  it("should draw the panel before the working-tree scan finishes", () => {
+    dir = repoWithChanges();
+    binDir = slowGitOn(["status"]);
+
+    tui.start(dir);
+    tui.setEnv({ PATH: `${binDir}:${process.env.PATH}` });
+    tui.waitStable(300);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    // git status is still sleeping here. Reading it on the event path would
+    // mean nothing has been drawn yet.
+    const during = tui.snapshot();
+    tui.waitStable(6000);
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run(45000);
+    // Drawn, and drawn empty: the scan has not come back yet.
+    expect(snapshots[during]).toContain("No changes");
+    expect(snapshots[during]).not.toContain("untracked.txt");
+    expect(snapshots[after]).toContain("tracked.txt");
+    expect(snapshots[after]).toContain("untracked.txt");
+  });
+
+  it("should show a placeholder while a commit's files are read", () => {
+    dir = repoWithChanges();
+    binDir = slowGitOn(["show"]);
+
+    tui.start(dir);
+    tui.setEnv({ PATH: `${binDir}:${process.env.PATH}` });
+    tui.waitStable(300);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(600);
+    tui.click(1, 32);
+    tui.waitStable(400);
+    const loading = tui.snapshot();
+    tui.waitStable(6000);
+    const loaded = tui.snapshot();
+
+    const { snapshots } = tui.run(45000);
+    expect(snapshots[loading]).toContain("Loading");
+    expect(snapshots[loading]).not.toContain("committed.txt");
+    expect(snapshots[loaded]).toContain("committed.txt");
+  });
+
+  it("should show a usable loading tab while the full commit is read", () => {
+    dir = repoWithChanges();
+    binDir = slowGitOn(["show"], 2);
+
+    tui.start(dir);
+    tui.setEnv({ PATH: `${binDir}:${process.env.PATH}` });
+    tui.waitStable(300);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(600);
+    // The label activates commit detail; unlike the chevron at x=1, it must
+    // not wait for the message, file list, and file diffs before returning.
+    tui.click(5, 32);
+    tui.waitStable(400);
+    const loading = tui.snapshot();
+    tui.waitStable(9000);
+    const loaded = tui.snapshot();
+
+    const { snapshots } = tui.run(45000);
+    expect(snapshots[loading]).toContain("Loading commit");
+    expect(snapshots[loading]).toContain("Commit History");
+    expect(snapshots[loading]).not.toContain("committed.txt");
+    expect(snapshots[loaded]).toContain("second commit");
+    expect(snapshots[loaded]).toContain("committed.txt");
+    expect(snapshots[loaded]).toContain("in the last commit");
+  });
+
+  it("should keep the editor drawn while a working-tree diff is read", () => {
+    dir = repoWithChanges();
+    // Only `git diff` is delayed, so opening the panel is quick and the wait
+    // that matters is the one the click starts.
+    binDir = slowGitOn(["diff"]);
+
+    tui.start(dir);
+    tui.setEnv({ PATH: `${binDir}:${process.env.PATH}` });
+    tui.waitStable(300);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(600);
+    // Row 7 is the modified file under "Changes"; row 8 is the untracked one,
+    // which opens immediately and never reads a diff.
+    tui.click(5, 7);
+    tui.waitStable(400);
+    const during = tui.snapshot();
+    tui.waitStable(6000);
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run(45000);
+    // Still drawn, and saying so, while git diff runs.
+    expect(snapshots[during]).toContain("Opening diff");
+    expect(snapshots[during]).not.toContain("(diff)");
+    expect(snapshots[after]).toContain("(diff)");
+    expect(snapshots[after]).not.toContain("Opening diff");
+  });
+
+  it("should not replace a tab chosen while a diff is read", () => {
+    dir = repoWithChanges();
+    binDir = slowGitOn(["diff"]);
+
+    // Start on untracked.txt with tracked.txt available as a second existing
+    // tab. The click below starts tracked.txt's slow diff; the tab click then
+    // chooses the plain tracked.txt buffer while that read is still running.
+    tui.start(join(dir, "tracked.txt"), join(dir, "untracked.txt"), dir);
+    tui.setEnv({ PATH: `${binDir}:${process.env.PATH}` });
+    tui.waitStable(300);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(600);
+    tui.click(5, 7);
+    tui.waitStable(400);
+    const pending = tui.snapshot();
+    tui.click(48, 2);
+    tui.waitStable(300);
+    const switched = tui.snapshot();
+    tui.waitStable(6000);
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run(45000);
+    expect(snapshots[pending]).toContain("Opening diff");
+    expect(snapshots[switched]).toContain("changed");
+    expect(snapshots[switched]).not.toContain("tracked.txt (diff)");
+    expect(snapshots[after]).toContain("changed");
+    expect(snapshots[after]).not.toContain("tracked.txt (diff)");
+  });
+
+  it("should draw the status bar before the branch name is known", () => {
+    dir = repoWithChanges();
+    // Only `git rev-parse --abbrev-ref` — the branch lookup — is delayed.
+    // Delaying every rev-parse would also stall the explorer, which is still
+    // synchronous and would mask what this test is about.
+    binDir = slowGitOn(["--abbrev-ref"]);
+    git(dir, "checkout", "-q", "-b", "slow-branch-check");
+
+    // Both: the segment needs an active file to attribute to a repository, and
+    // the workspace needs the folder for that repository to be known. With only
+    // the folder and no open file the branch is correctly blank.
+    tui.start(join(dir, "tracked.txt"), dir);
+    tui.setEnv({ PATH: `${binDir}:${process.env.PATH}` });
+    tui.waitStable(300);
+    const during = tui.snapshot();
+    tui.waitStable(6000);
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run(45000);
+    // The status bar is up — it just has no branch in it yet.
+    expect(snapshots[during]).toContain("Ln 1, Col 1");
+    expect(snapshots[during]).not.toContain("slow-branch-check");
+    expect(snapshots[after]).toContain("slow-branch-check");
+  });
+});

--- a/tests/functional/command-palette.test.js
+++ b/tests/functional/command-palette.test.js
@@ -57,4 +57,68 @@ describe("command palette", () => {
     const { snapshots } = tui.run();
     expect(snapshots[s0]).toContain("Dismiss test");
   });
+
+  it("should orient a new user before listing commands in help mode", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "help.txt", "Help mode test");
+
+    tui.start(file);
+    tui.setSize(80, 24);
+    tui.waitFor("help.txt");
+    tui.press("ctrl+p");
+    tui.type("?");
+    tui.waitStable();
+
+    const topics = tui.snapshot();
+    tui.press("arrow_down");
+    const nextTopic = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[topics]).toContain("Workspace map");
+    expect(snapshots[topics]).toContain("folders, tabs, and editor groups");
+    expect(snapshots[topics]).not.toContain("Open Folder");
+    expect(snapshots[nextTopic]).toContain("Explorer, Search, Changes, and Output");
+  });
+
+  it("should search commands outside the curated help topics", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "help-search.txt", "Help search test");
+
+    tui.start(file);
+    tui.waitFor("help-search.txt");
+    tui.press("ctrl+p");
+    tui.type("?saved tabs");
+    tui.waitStable();
+
+    const result = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[result]).toContain("Close All Saved Tabs");
+  });
+
+  it("should prefer precise help matches and explain an empty result", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "help-precision.txt", "Help precision test");
+
+    tui.start(file);
+    tui.setSize(80, 24);
+    tui.waitFor("help-precision.txt");
+    tui.press("ctrl+p");
+    tui.type("?undo");
+    tui.waitStable();
+    const precise = tui.snapshot();
+
+    for (let i = 0; i < 4; i++) tui.press("backspace");
+    tui.type("qxzvjk");
+    tui.waitStable();
+    const empty = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[precise]).toContain("Undo");
+    expect(snapshots[precise]).toContain("Undo Last Cursor");
+    expect(snapshots[precise]).not.toContain("Git: Discard Changes");
+    expect(snapshots[precise]).not.toContain("Add Next Occurrence");
+    expect(snapshots[empty]).toContain('No help entries match "qxzvjk"');
+    expect(snapshots[empty]).toContain("Try > for all commands");
+  });
 });

--- a/tests/functional/commit-history.test.js
+++ b/tests/functional/commit-history.test.js
@@ -333,7 +333,7 @@ describe("commit history", () => {
     expect(snapshots[compact]).toContain("changed near top");
     expect(snapshots[compact]).not.toContain("unchanged line 15");
     expect(snapshots[full]).toContain("unchanged line 15");
-    expect(snapshots[viewMenu]).toContain("✓ Diff: Full File");
+    expect(snapshots[viewMenu]).not.toContain("Diff: Full File");
   });
 
   it("should wrap and unwrap the active commit detail through the shared diff command", () => {
@@ -378,8 +378,6 @@ describe("commit history", () => {
     const unified = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(snapshots[unified]).toContain("○ Split");
-    expect(snapshots[unified]).toContain("● Unified");
     const rows = snapshots[unified].split("\n");
     const removed = rows.findIndex((row) => row.includes("left-prefix"));
     const added = rows.findIndex((row) => row.includes("right-prefix"));

--- a/tests/functional/commit-history.test.js
+++ b/tests/functional/commit-history.test.js
@@ -9,11 +9,11 @@ afterEach(() => {
   if (dir) cleanupDir(dir);
 });
 
-// The resizable commit log starts at the former 7-row height, pinned to the
-// bottom of the changes panel. At 120x40 the branch header is row 31 and the
-// newest commit row 32 until the reader drags the divider.
-const BRANCH_ROW = 31;
-const FIRST_COMMIT_ROW = 32;
+// The resizable commit log starts at half the changes-panel height. At 120x40
+// the branch header is row 22 and the newest commit is row 23 until the reader
+// drags the divider.
+const BRANCH_ROW = 22;
+const FIRST_COMMIT_ROW = 23;
 
 function repoWithTwoCommits() {
   const d = createGitRepo(createTempDir());
@@ -98,33 +98,27 @@ describe("commit history", () => {
     tui.waitStable(400);
 
     const initial = tui.snapshot();
-    // Grow history from its default divider row. The whole log now fits.
-    tui.drag(5, 29, 5, 20);
-    tui.waitStable(300);
-    const grown = tui.snapshot();
-
-    // Shrink past the minimum. The divider clamps at row 33, leaving the title
+    // Shrink past the minimum. The divider clamps near the bottom, leaving the title
     // and three log rows. Keyboard navigation must still scroll TreeWidget to
     // the oldest row.
     tui.drag(5, 20, 5, 38);
     tui.waitStable(300);
     const clampedHistory = tui.snapshot();
-    tui.click(5, 35); // branch header inside the clamped history tree
+    tui.click(5, 36); // branch header inside the clamped history tree
     for (let i = 0; i < 10; i++) tui.press("down");
     tui.waitStable(300);
     const scrolled = tui.snapshot();
 
     // Grow history past the opposite limit. The input, divider, and three rows
     // of working-tree changes remain above it.
-    tui.drag(5, 33, 5, 2);
+    tui.drag(5, 34, 5, 2);
     tui.waitStable(300);
     const clampedTree = tui.snapshot();
 
     const { snapshots } = tui.run();
-    // The history query is capped at ten entries; history 03 is the oldest
-    // loaded row and starts below the default viewport.
-    expect(snapshots[initial]).not.toContain("history 03");
-    expect(snapshots[grown]).toContain("history 03");
+    // The history query is capped at ten entries; a half-height default fits
+    // the complete query at this geometry.
+    expect(snapshots[initial]).toContain("history 03");
     expect(snapshots[clampedHistory]).toContain("Commit History");
     expect(snapshots[scrolled]).toContain("history 03");
     expect(snapshots[clampedTree]).toContain("❯ Commit to");

--- a/tests/functional/commit-history.test.js
+++ b/tests/functional/commit-history.test.js
@@ -1,0 +1,391 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createGitRepo, createTempFile, git, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+// The resizable commit log starts at the former 7-row height, pinned to the
+// bottom of the changes panel. At 120x40 the branch header is row 31 and the
+// newest commit row 32 until the reader drags the divider.
+const BRANCH_ROW = 31;
+const FIRST_COMMIT_ROW = 32;
+
+function repoWithTwoCommits() {
+  const d = createGitRepo(createTempDir());
+  createTempFile(d, "tracked.txt", "original\nsecond line\n");
+  createTempFile(d, "added.txt", "brand new\n");
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "second commit");
+  return d;
+}
+
+function repoWithLongHistory() {
+  const d = createGitRepo(createTempDir());
+  for (let i = 1; i <= 12; i++) {
+    createTempFile(d, "history.txt", `revision ${i}\n`);
+    git(d, "add", "-A");
+    git(d, "commit", "-qm", `history ${String(i).padStart(2, "0")}`);
+  }
+  createTempFile(d, "history.txt", "working tree change\n");
+  return d;
+}
+
+function repoWithDetailedCommit() {
+  const d = createGitRepo(createTempDir());
+  const lines = (prefix) => Array.from({ length: 24 }, (_, i) => `${prefix} line ${i + 1}`).join("\n") + "\n";
+  createTempFile(d, "first-detail.txt", lines("first"));
+  createTempFile(d, "second-detail.txt", lines("second"));
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "detail subject", "-m", "Full commit body paragraph.");
+  return d;
+}
+
+function repoWithStickyDetail() {
+  const d = createGitRepo(createTempDir());
+  const lines = (prefix, count) => Array.from({ length: count }, (_, i) => `${prefix} line ${i + 1}`).join("\n") + "\n";
+  createTempFile(d, "first-detail.txt", lines("first", 12));
+  createTempFile(d, "second-detail.txt", lines("second", 60));
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "detail subject", "-m", "Full commit body paragraph.");
+  return d;
+}
+
+function repoWithLongDetailLines() {
+  const d = createGitRepo(createTempDir());
+  createTempFile(d, "tracked.txt", `left-prefix-${"L".repeat(70)}-LEFT-SUFFIX\n`);
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "long detail");
+  createTempFile(d, "tracked.txt", `right-prefix-${"R".repeat(70)}-RIGHT-SUFFIX\n`);
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "wrapped detail");
+  return d;
+}
+
+describe("commit history", () => {
+  it("should not focus commit history when small geometry does not render it", () => {
+    dir = repoWithTwoCommits();
+
+    tui.start(dir);
+    tui.setSize(80, 10);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    const hidden = tui.snapshot();
+
+    tui.press("tab");
+    tui.press("tab");
+    tui.press("down");
+    tui.press("enter");
+    tui.waitStable(400);
+    const afterKeyboard = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[hidden].match(/Commit History/g) ?? []).toHaveLength(0);
+    expect(snapshots[afterKeyboard]).not.toMatch(/Commit [0-9a-f]{7}/);
+  });
+
+  it("should resize the history while preserving both trees and overflow navigation", () => {
+    dir = repoWithLongHistory();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+
+    const initial = tui.snapshot();
+    // Grow history from its default divider row. The whole log now fits.
+    tui.drag(5, 29, 5, 20);
+    tui.waitStable(300);
+    const grown = tui.snapshot();
+
+    // Shrink past the minimum. The divider clamps at row 33, leaving the title
+    // and three log rows. Keyboard navigation must still scroll TreeWidget to
+    // the oldest row.
+    tui.drag(5, 20, 5, 38);
+    tui.waitStable(300);
+    const clampedHistory = tui.snapshot();
+    tui.click(5, 35); // branch header inside the clamped history tree
+    for (let i = 0; i < 10; i++) tui.press("down");
+    tui.waitStable(300);
+    const scrolled = tui.snapshot();
+
+    // Grow history past the opposite limit. The input, divider, and three rows
+    // of working-tree changes remain above it.
+    tui.drag(5, 33, 5, 2);
+    tui.waitStable(300);
+    const clampedTree = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    // The history query is capped at ten entries; history 03 is the oldest
+    // loaded row and starts below the default viewport.
+    expect(snapshots[initial]).not.toContain("history 03");
+    expect(snapshots[grown]).toContain("history 03");
+    expect(snapshots[clampedHistory]).toContain("Commit History");
+    expect(snapshots[scrolled]).toContain("history 03");
+    expect(snapshots[clampedTree]).toContain("❯ Commit to");
+    expect(snapshots[clampedTree]).toContain("Changes (1)");
+    expect(snapshots[clampedTree]).toContain("history.txt");
+    expect(snapshots[clampedTree]).toContain("Commit History");
+  });
+
+  it("should list a commit's files when the commit is expanded", () => {
+    dir = repoWithTwoCommits();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.press("ctrl+k");
+    tui.press("c");
+    tui.waitStable(400);
+
+    const collapsed = tui.snapshot();
+    // Only the disclosure chevron expands; the label opens commit detail.
+    tui.click(1, FIRST_COMMIT_ROW);
+    tui.waitStable(400);
+    const expanded = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[collapsed]).toContain("second commit");
+    expect(snapshots[collapsed]).not.toContain("added.txt");
+    expect(snapshots[expanded]).toContain("added.txt");
+    expect(snapshots[expanded]).toContain("tracked.txt");
+  });
+
+  it("should open a diff for a file inside a commit", () => {
+    dir = repoWithTwoCommits();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.press("ctrl+k");
+    tui.press("c");
+    tui.waitStable(400);
+
+    tui.click(1, FIRST_COMMIT_ROW);
+    tui.waitStable(400);
+    // First child of the expanded commit.
+    tui.click(5, FIRST_COMMIT_ROW + 1);
+    tui.waitStable(400);
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    // The tab is labelled "<file> @ <hash>" so two commits touching the same
+    // file do not collapse into one tab.
+    expect(snapshots[s0]).toMatch(/added\.txt @ [0-9a-f]{7}/);
+    expect(snapshots[s0]).toContain("brand new");
+  });
+
+  it("should route registered diff commands to the focused commit file", () => {
+    dir = repoWithTwoCommits();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.press("ctrl+k");
+    tui.press("c");
+    tui.waitStable(400);
+
+    // Clicking the commit expands it and focuses the history tree. Move onto
+    // its first child without activating it, then use the same registered
+    // command surface exposed by ttt.exec_command and the debug harness.
+    tui.click(1, FIRST_COMMIT_ROW);
+    tui.waitStable(400);
+    tui.press("down");
+    tui.exec("Git: Open Compact Diff");
+    tui.waitStable(400);
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toMatch(/added\.txt @ [0-9a-f]{7}/);
+    expect(snapshots[s0]).toContain("brand new");
+  });
+
+  it("should keep the commit-file context through the command palette", () => {
+    dir = repoWithTwoCommits();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+
+    tui.click(1, FIRST_COMMIT_ROW);
+    tui.waitStable(400);
+    tui.press("down");
+    tui.press("ctrl+p");
+    tui.type("Git: Open Compact Diff");
+    tui.press("enter");
+    tui.waitStable(400);
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).toMatch(/added\.txt @ [0-9a-f]{7}/);
+    expect(snapshots[s0]).toContain("brand new");
+  });
+
+  it("should keep the branch header inert", () => {
+    dir = repoWithTwoCommits();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.press("ctrl+k");
+    tui.press("c");
+    tui.waitStable(400);
+
+    tui.click(5, BRANCH_ROW);
+    tui.waitStable(300);
+
+    const s0 = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[s0]).not.toContain("added.txt");
+    expect(snapshots[s0]).not.toContain("(diff)");
+  });
+
+  it("should open the full commit message and every file diff from the commit label", () => {
+    dir = repoWithDetailedCommit();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+
+    // The label begins after the chevron and commit icon. Activating it opens
+    // detail without changing disclosure state.
+    tui.click(5, FIRST_COMMIT_ROW);
+    tui.waitStable(800);
+    const top = tui.snapshot();
+    // Jump near the end through the detail view's global scrollbar. Editor
+    // keybindings own End before content widgets see it.
+    tui.click(118, 36);
+    tui.waitStable(300);
+    const bottom = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[top]).toMatch(/Commit [0-9a-f]{7}/);
+    expect(snapshots[top]).toContain("detail subject");
+    expect(snapshots[top]).toContain("Full commit body paragraph.");
+    expect(snapshots[top]).toContain("first-detail.txt");
+    expect(snapshots[top]).toContain("first line 1");
+    expect(snapshots[top]).not.toContain("second line 24");
+    expect(snapshots[bottom]).toContain("second-detail.txt");
+    expect(snapshots[bottom]).toContain("second line 24");
+  });
+
+  it("should wrap and unwrap the active commit detail through the shared diff command", () => {
+    dir = repoWithLongDetailLines();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    tui.click(5, FIRST_COMMIT_ROW);
+    tui.waitStable(800);
+
+    const clipped = tui.snapshot();
+    tui.exec("Git: Toggle Diff Wrap");
+    tui.waitStable(300);
+    const wrapped = tui.snapshot();
+    tui.exec("Git: Toggle Diff Wrap");
+    tui.waitStable(300);
+    const restored = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[clipped]).not.toContain("LEFT-SUFFIX");
+    expect(snapshots[clipped]).not.toContain("RIGHT-SUFFIX");
+    expect(snapshots[wrapped]).toContain("LEFT-SUFFIX");
+    expect(snapshots[wrapped]).toContain("RIGHT-SUFFIX");
+    expect(snapshots[restored]).not.toContain("LEFT-SUFFIX");
+    expect(snapshots[restored]).not.toContain("RIGHT-SUFFIX");
+  });
+
+  it("should keep an explicit unified choice made while commit detail is loading", () => {
+    dir = repoWithLongDetailLines();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    tui.click(5, FIRST_COMMIT_ROW);
+    // The tab is active before its background Git read completes. Set the mode
+    // immediately so the eventual detail must honor existing reader state.
+    tui.exec("Git: Unified Diff");
+    tui.waitStable(800);
+    const unified = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[unified]).toContain("○ Split");
+    expect(snapshots[unified]).toContain("● Unified");
+    const rows = snapshots[unified].split("\n");
+    const removed = rows.findIndex((row) => row.includes("left-prefix"));
+    const added = rows.findIndex((row) => row.includes("right-prefix"));
+    expect(removed).toBeGreaterThanOrEqual(0);
+    expect(added).toBeGreaterThan(removed);
+  });
+
+  it("should collapse and expand commit files, including from the sticky heading", () => {
+    dir = repoWithStickyDetail();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    tui.click(5, FIRST_COMMIT_ROW);
+    tui.waitStable(800);
+
+    tui.exec("Git: Collapse All Commit Files");
+    tui.waitStable(300);
+    const collapsed = tui.snapshot();
+    tui.exec("Git: Expand All Commit Files");
+    tui.waitStable(300);
+    const expanded = tui.snapshot();
+
+    // At the bottom of the document, the second file's path remains visible
+    // in the sticky heading while its real heading is above the viewport.
+    tui.click(118, 36);
+    tui.waitStable(300);
+    const sticky = tui.snapshot();
+    tui.exec("View: Focus Editor");
+    tui.click(33, 4);
+    tui.waitStable(300);
+    const oneCollapsed = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[collapsed]).toContain("first-detail.txt");
+    expect(snapshots[collapsed]).toContain("second-detail.txt");
+    expect(snapshots[collapsed]).toContain("Expand all");
+    expect(snapshots[collapsed]).not.toContain("first line 1");
+    expect(snapshots[collapsed]).not.toContain("second line 1");
+    expect(snapshots[expanded]).toContain("Collapse all");
+    expect(snapshots[expanded]).toContain("first line 1");
+    expect(snapshots[sticky].split("\n")[4]).toContain("second-detail.txt");
+    expect(snapshots[oneCollapsed]).not.toContain("second line");
+  });
+
+  it("should copy original text across wrapped commit-detail rows", () => {
+    dir = repoWithLongDetailLines();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    tui.click(5, FIRST_COMMIT_ROW);
+    tui.waitStable(800);
+    tui.exec("Git: Toggle Diff Wrap");
+    tui.waitStable(300);
+
+    // Select left-side text from the first visual segment through the last.
+    // Copy must join those visual segments back into the original source line.
+    tui.drag(38, 8, 58, 10);
+    tui.copy();
+    tui.exec("New File");
+    tui.press("ctrl+v");
+    const atEnd = tui.snapshot();
+    tui.press("home");
+    const atStart = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[atEnd]).toContain("LEFT-SUFFIX");
+    expect(snapshots[atStart]).toContain("ft-prefix-");
+  });
+});

--- a/tests/functional/commit-history.test.js
+++ b/tests/functional/commit-history.test.js
@@ -340,7 +340,8 @@ describe("commit history", () => {
     tui.waitStable(300);
     const sticky = tui.snapshot();
     tui.exec("View: Focus Editor");
-    tui.click(33, 4);
+    // The full sticky title row is a disclosure target, not only its chevron.
+    tui.click(50, 4);
     tui.waitStable(300);
     const oneCollapsed = tui.snapshot();
 

--- a/tests/functional/commit-history.test.js
+++ b/tests/functional/commit-history.test.js
@@ -35,6 +35,15 @@ function repoWithLongHistory() {
   return d;
 }
 
+function repoWithPagedHistory() {
+  const d = createGitRepo(createTempDir());
+  for (let i = 1; i <= 51; i++) {
+    git(d, "commit", "--allow-empty", "-qm", `paged ${String(i).padStart(2, "0")}`);
+  }
+  createTempFile(d, "history.txt", "working tree change\n");
+  return d;
+}
+
 function repoWithDetailedCommit() {
   const d = createGitRepo(createTempDir());
   const lines = (prefix) => Array.from({ length: 24 }, (_, i) => `${prefix} line ${i + 1}`).join("\n") + "\n";
@@ -63,6 +72,20 @@ function repoWithLongDetailLines() {
   createTempFile(d, "tracked.txt", `right-prefix-${"R".repeat(70)}-RIGHT-SUFFIX\n`);
   git(d, "add", "-A");
   git(d, "commit", "-qm", "wrapped detail");
+  return d;
+}
+
+function repoWithContextGaps() {
+  const d = createGitRepo(createTempDir());
+  const lines = Array.from({ length: 30 }, (_, i) => `unchanged line ${i + 1}`);
+  createTempFile(d, "context.txt", `${lines.join("\n")}\n`);
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "context base");
+  lines[1] = "changed near top";
+  lines[28] = "changed near bottom";
+  createTempFile(d, "context.txt", `${lines.join("\n")}\n`);
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "two distant edits");
   return d;
 }
 
@@ -116,8 +139,8 @@ describe("commit history", () => {
     const clampedTree = tui.snapshot();
 
     const { snapshots } = tui.run();
-    // The history query is capped at ten entries; a half-height default fits
-    // the complete query at this geometry.
+    // The initial history page includes this full fixture; a half-height
+    // viewport scrolls through it without changing the panel split.
     expect(snapshots[initial]).toContain("history 03");
     expect(snapshots[clampedHistory]).toContain("Commit History");
     expect(snapshots[scrolled]).toContain("history 03");
@@ -125,6 +148,27 @@ describe("commit history", () => {
     expect(snapshots[clampedTree]).toContain("Changes (1)");
     expect(snapshots[clampedTree]).toContain("history.txt");
     expect(snapshots[clampedTree]).toContain("Commit History");
+  });
+
+  it("should append older history from an explicit final row", () => {
+    dir = repoWithPagedHistory();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(500);
+    tui.click(5, BRANCH_ROW);
+    for (let i = 0; i < 51; i++) tui.press("down");
+    tui.waitStable(300);
+    const loadRow = tui.snapshot();
+    tui.press("enter");
+    tui.waitStable(800);
+    const appended = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[loadRow]).toContain("Load older commits…");
+    expect(snapshots[appended]).toContain("paged 01");
+    expect(snapshots[appended]).not.toContain("Load older commits…");
   });
 
   it("should list a commit's files when the commit is expanded", () => {
@@ -258,12 +302,38 @@ describe("commit history", () => {
     const { snapshots } = tui.run();
     expect(snapshots[top]).toMatch(/Commit [0-9a-f]{7}/);
     expect(snapshots[top]).toContain("detail subject");
+    expect(snapshots[top]).toMatch(/Authored [A-Z][a-z]{2} \d{1,2}, \d{4} at \d{1,2}:\d{2} [AP]M [+-]\d{4}/);
     expect(snapshots[top]).toContain("Full commit body paragraph.");
     expect(snapshots[top]).toContain("first-detail.txt");
     expect(snapshots[top]).toContain("first line 1");
     expect(snapshots[top]).not.toContain("second line 24");
     expect(snapshots[bottom]).toContain("second-detail.txt");
     expect(snapshots[bottom]).toContain("second line 24");
+  });
+
+  it("should switch an aggregate commit diff between changes only and the full file", () => {
+    dir = repoWithContextGaps();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    tui.click(5, FIRST_COMMIT_ROW);
+    tui.waitStable(800);
+    const compact = tui.snapshot();
+
+    tui.exec("Git: Show Full File");
+    tui.waitStable(800);
+    const full = tui.snapshot();
+    tui.exec("Menu: View");
+    tui.waitStable(200);
+    const viewMenu = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[compact]).toContain("changed near top");
+    expect(snapshots[compact]).not.toContain("unchanged line 15");
+    expect(snapshots[full]).toContain("unchanged line 15");
+    expect(snapshots[viewMenu]).toContain("✓ Diff: Full File");
   });
 
   it("should wrap and unwrap the active commit detail through the shared diff command", () => {
@@ -371,7 +441,9 @@ describe("commit history", () => {
 
     // Select left-side text from the first visual segment through the last.
     // Copy must join those visual segments back into the original source line.
-    tui.drag(38, 8, 58, 10);
+    // Commit metadata adds one row between the header and message, so the
+    // wrapped diff segments begin one row lower than the message-only layout.
+    tui.drag(38, 9, 58, 11);
     tui.copy();
     tui.exec("New File");
     tui.press("ctrl+v");

--- a/tests/functional/current-changes-view.test.js
+++ b/tests/functional/current-changes-view.test.js
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createGitRepo, createTempDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("current changes document", () => {
+  it("shows the final working tree in one combined scrollable view", () => {
+    dir = createGitRepo(createTempDir());
+    const tracked = join(dir, "tracked.txt");
+    writeFileSync(tracked, "staged version\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", "tracked.txt"]);
+    writeFileSync(tracked, "final working version\n", "utf8");
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+    tui.exec("Git: View All Current Changes");
+    tui.waitStable(600);
+    const screen = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[screen]).toContain("Current changes");
+    expect(snapshots[screen]).toContain("M  tracked.txt · mixed");
+    expect(snapshots[screen]).toContain("final working version");
+  });
+});

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -75,13 +75,21 @@ describe("diff reading preferences", () => {
     tui.exec("Menu: Options");
     tui.waitStable();
     const options = tui.snapshot();
+    tui.press("down");
+    tui.press("down");
+    tui.press("right");
+    tui.waitStable();
+    const diffOptions = tui.snapshot();
     tui.press("escape");
     enableUnifiedWrappedDefaults();
 
     const { snapshots } = tui.run();
-    expect(snapshots[options]).toContain("Split Diff");
-    expect(snapshots[options]).toContain("Unified Diff");
-    expect(snapshots[options]).toContain("Diff Word Wrap");
+    expect(snapshots[options]).toContain("Diff View");
+    expect(snapshots[options]).toContain("Git Files");
+    expect(snapshots[diffOptions]).toContain("Split");
+    expect(snapshots[diffOptions]).toContain("Unified");
+    expect(snapshots[diffOptions]).toContain("Wrap Lines");
+    expect(snapshots[diffOptions]).toContain("High Contrast");
 
     const saved = savedSettings(fixture.configDir);
     expect(saved.editor.diffMode).toBe("unified");

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -56,6 +56,10 @@ function savedSettings(configDir) {
   return JSON.parse(readFileSync(join(configDir, "settings.json"), "utf8"));
 }
 
+function diffRow(screen, text) {
+  return screen.split("\n").findIndex((row) => row.includes(text));
+}
+
 describe("diff reading preferences", () => {
   it("marks removed and added line numbers in the shared diff gutter", () => {
     const fixture = diffFixture();
@@ -77,21 +81,20 @@ describe("diff reading preferences", () => {
     const options = tui.snapshot();
     tui.press("down");
     tui.press("down");
-    tui.press("right");
+    tui.press("enter");
     tui.waitStable();
     const diffOptions = tui.snapshot();
     tui.press("escape");
     enableUnifiedWrappedDefaults();
 
     const { snapshots } = tui.run();
-    expect(snapshots[options]).toContain("Diff View");
+    expect(snapshots[options]).toContain("Diff View Mode");
+    expect(snapshots[options]).toContain("Diff Context");
+    expect(snapshots[options]).toContain("Wrap Diff Lines");
+    expect(snapshots[options]).toContain("High Contrast Diffs");
     expect(snapshots[options]).toContain("Git Files");
     expect(snapshots[diffOptions]).toContain("Split");
     expect(snapshots[diffOptions]).toContain("Unified");
-    expect(snapshots[diffOptions]).toContain("Changes Only");
-    expect(snapshots[diffOptions]).toContain("Full File");
-    expect(snapshots[diffOptions]).toContain("Wrap Lines");
-    expect(snapshots[diffOptions]).toContain("High Contrast");
 
     const saved = savedSettings(fixture.configDir);
     expect(saved.editor.diffMode).toBe("unified");
@@ -123,13 +126,18 @@ describe("diff reading preferences", () => {
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(snapshots[before]).toContain("● Split");
+    expect(diffRow(snapshots[before], "left-prefix")).toBeGreaterThanOrEqual(0);
+    expect(diffRow(snapshots[before], "left-prefix")).toBe(
+      diffRow(snapshots[before], "right-prefix"),
+    );
     expect(snapshots[before]).not.toContain("SUFFIX");
-    expect(snapshots[after]).toContain("● Unified");
+    expect(diffRow(snapshots[after], "left-prefix")).toBeLessThan(
+      diffRow(snapshots[after], "right-prefix"),
+    );
     expect(snapshots[after]).toContain("SUFFIX");
   });
 
-  it("keeps View overrides when Options defaults later change", () => {
+  it("keeps explicit surface overrides when Options defaults later change", () => {
     const fixture = diffFixture();
     startWithConfig(fixture);
     tui.exec("Test Preference Diff");
@@ -144,8 +152,9 @@ describe("diff reading preferences", () => {
     const overridden = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(snapshots[overridden]).toContain("○ Split");
-    expect(snapshots[overridden]).toContain("● Unified");
+    expect(diffRow(snapshots[overridden], "left-prefix")).toBeLessThan(
+      diffRow(snapshots[overridden], "right-prefix"),
+    );
     expect(snapshots[overridden]).toContain("SUFFIX");
 
     const saved = savedSettings(fixture.configDir);
@@ -169,11 +178,17 @@ describe("diff reading preferences", () => {
     const untouchedAfter = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(snapshots[overriddenBefore]).toContain("● Unified");
+    expect(diffRow(snapshots[overriddenBefore], "left-prefix")).toBeLessThan(
+      diffRow(snapshots[overriddenBefore], "right-prefix"),
+    );
     expect(snapshots[overriddenBefore]).toContain("SUFFIX");
-    expect(snapshots[overriddenAfter]).toContain("● Unified");
+    expect(diffRow(snapshots[overriddenAfter], "left-prefix")).toBeLessThan(
+      diffRow(snapshots[overriddenAfter], "right-prefix"),
+    );
     expect(snapshots[overriddenAfter]).toContain("SUFFIX");
-    expect(snapshots[untouchedAfter]).toContain("● Unified");
+    expect(diffRow(snapshots[untouchedAfter], "left-prefix")).toBeLessThan(
+      diffRow(snapshots[untouchedAfter], "right-prefix"),
+    );
     expect(snapshots[untouchedAfter]).toContain("SUFFIX");
   });
 
@@ -189,8 +204,9 @@ describe("diff reading preferences", () => {
     const reopened = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(snapshots[reopened]).toContain("○ Split");
-    expect(snapshots[reopened]).toContain("● Unified");
+    expect(diffRow(snapshots[reopened], "left-prefix")).toBeLessThan(
+      diffRow(snapshots[reopened], "right-prefix"),
+    );
     expect(snapshots[reopened]).toContain("SUFFIX");
   });
 });

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -88,12 +88,28 @@ describe("diff reading preferences", () => {
     expect(snapshots[options]).toContain("Git Files");
     expect(snapshots[diffOptions]).toContain("Split");
     expect(snapshots[diffOptions]).toContain("Unified");
+    expect(snapshots[diffOptions]).toContain("Changes Only");
+    expect(snapshots[diffOptions]).toContain("Full File");
     expect(snapshots[diffOptions]).toContain("Wrap Lines");
     expect(snapshots[diffOptions]).toContain("High Contrast");
 
     const saved = savedSettings(fixture.configDir);
     expect(saved.editor.diffMode).toBe("unified");
     expect(saved.editor.diffWordWrap).toBe(true);
+  });
+
+  it("persists the default diff context independently of layout and wrapping", () => {
+    const fixture = diffFixture();
+    startWithConfig(fixture);
+    tui.exec("Show Full File Diff by Default");
+    tui.waitStable();
+
+    const { snapshots } = tui.run();
+    expect(snapshots).toBeDefined();
+    const saved = savedSettings(fixture.configDir);
+    expect(saved.editor.diffContext).toBe("full");
+    expect(saved.editor.diffMode).toBe("split");
+    expect(saved.editor.diffWordWrap).toBe(false);
   });
 
   it("updates an already-open diff when its Options defaults change", () => {

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -57,6 +57,17 @@ function savedSettings(configDir) {
 }
 
 describe("diff reading preferences", () => {
+  it("marks removed and added line numbers in the shared diff gutter", () => {
+    const fixture = diffFixture();
+    startWithConfig(fixture);
+    tui.exec("Test Preference Diff");
+    tui.waitStable();
+    const diff = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[diff]).toMatch(/1 -.*1 \+/);
+  });
+
   it("shows persistent diff defaults in Options even without an open diff", () => {
     const fixture = diffFixture();
     startWithConfig(fixture);

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function diffFixture() {
+  dir = createTempDir();
+  const file = createTempFile(dir, "test.txt", "hello\n");
+  const configDir = join(dir, "config");
+  mkdirSync(configDir, { recursive: true });
+  const plugin = join(dir, "diff.lua");
+  writeFileSync(plugin, `
+    local ttt = require("ttt")
+    ttt.register({
+      commands = {
+        { id = "test.diff", title = "Test Preference Diff", handler = function()
+            ttt.open_diff("prefs.go", {"left-prefix-LEFT-SUFFIX"}, {"right-prefix-RIGHT-SUFFIX"}, "prefs.go")
+          end
+        },
+        { id = "test.diffFirst", title = "Test First Preference Diff", handler = function()
+            ttt.open_diff("first.go", {"left-prefix-LEFT-SUFFIX"}, {"right-prefix-RIGHT-SUFFIX"}, "first.go")
+          end
+        },
+        { id = "test.diffSecond", title = "Test Second Preference Diff", handler = function()
+            ttt.open_diff("second.go", {"left-prefix-LEFT-SUFFIX"}, {"right-prefix-RIGHT-SUFFIX"}, "second.go")
+          end
+        }
+      },
+    })
+  `, "utf8");
+  return { file, configDir, plugin };
+}
+
+function startWithConfig({ file, configDir, plugin }) {
+  tui.start("--plugin", plugin, file);
+  tui.setEnv({ TTT_CONFIG_DIR: configDir });
+  tui.setSize(42, 14);
+  tui.waitStable(300);
+}
+
+function enableUnifiedWrappedDefaults() {
+  tui.exec("Use Unified Diff by Default");
+  tui.exec("Toggle Diff Word Wrap Default");
+  tui.waitStable();
+}
+
+function savedSettings(configDir) {
+  return JSON.parse(readFileSync(join(configDir, "settings.json"), "utf8"));
+}
+
+describe("diff reading preferences", () => {
+  it("shows persistent diff defaults in Options even without an open diff", () => {
+    const fixture = diffFixture();
+    startWithConfig(fixture);
+
+    tui.exec("Menu: Options");
+    tui.waitStable();
+    const options = tui.snapshot();
+    tui.press("escape");
+    enableUnifiedWrappedDefaults();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[options]).toContain("Split Diff");
+    expect(snapshots[options]).toContain("Unified Diff");
+    expect(snapshots[options]).toContain("Diff Word Wrap");
+
+    const saved = savedSettings(fixture.configDir);
+    expect(saved.editor.diffMode).toBe("unified");
+    expect(saved.editor.diffWordWrap).toBe(true);
+  });
+
+  it("updates an already-open diff when its Options defaults change", () => {
+    const fixture = diffFixture();
+    startWithConfig(fixture);
+    tui.exec("Test Preference Diff");
+    tui.waitStable();
+    const before = tui.snapshot();
+
+    enableUnifiedWrappedDefaults();
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[before]).toContain("● Split");
+    expect(snapshots[before]).not.toContain("SUFFIX");
+    expect(snapshots[after]).toContain("● Unified");
+    expect(snapshots[after]).toContain("SUFFIX");
+  });
+
+  it("keeps View overrides when Options defaults later change", () => {
+    const fixture = diffFixture();
+    startWithConfig(fixture);
+    tui.exec("Test Preference Diff");
+    tui.waitStable();
+
+    tui.exec("Git: Unified Diff");
+    tui.exec("Git: Toggle Diff Wrap");
+    enableUnifiedWrappedDefaults();
+    tui.exec("Use Split Diff by Default");
+    tui.exec("Toggle Diff Word Wrap Default");
+    tui.waitStable();
+    const overridden = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[overridden]).toContain("○ Split");
+    expect(snapshots[overridden]).toContain("● Unified");
+    expect(snapshots[overridden]).toContain("SUFFIX");
+
+    const saved = savedSettings(fixture.configDir);
+    expect(saved.editor.diffMode).toBe("split");
+    expect(saved.editor.diffWordWrap).toBe(false);
+  });
+
+  it("updates only the untouched diff when one of two open diffs is overridden", () => {
+    const fixture = diffFixture();
+    startWithConfig(fixture);
+    tui.exec("Test First Preference Diff");
+    tui.exec("Test Second Preference Diff");
+    tui.exec("Git: Unified Diff");
+    tui.exec("Git: Toggle Diff Wrap");
+    tui.waitStable();
+    const overriddenBefore = tui.snapshot();
+
+    enableUnifiedWrappedDefaults();
+    const overriddenAfter = tui.snapshot();
+    tui.exec("View: Previous Tab");
+    const untouchedAfter = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[overriddenBefore]).toContain("● Unified");
+    expect(snapshots[overriddenBefore]).toContain("SUFFIX");
+    expect(snapshots[overriddenAfter]).toContain("● Unified");
+    expect(snapshots[overriddenAfter]).toContain("SUFFIX");
+    expect(snapshots[untouchedAfter]).toContain("● Unified");
+    expect(snapshots[untouchedAfter]).toContain("SUFFIX");
+  });
+
+  it("opens a new diff with defaults loaded from the prior run", () => {
+    const fixture = diffFixture();
+    startWithConfig(fixture);
+    enableUnifiedWrappedDefaults();
+    tui.run();
+
+    startWithConfig(fixture);
+    tui.exec("Test Preference Diff");
+    tui.waitStable();
+    const reopened = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[reopened]).toContain("○ Split");
+    expect(snapshots[reopened]).toContain("● Unified");
+    expect(snapshots[reopened]).toContain("SUFFIX");
+  });
+});

--- a/tests/functional/editor-tab-reorder.test.js
+++ b/tests/functional/editor-tab-reorder.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("editor tab order", () => {
+  it("drags visible file tabs and supports the command fallback", () => {
+    dir = createTempDir();
+    const alpha = createTempFile(dir, "alpha.txt", "alpha\n");
+    const beta = createTempFile(dir, "beta.txt", "beta\n");
+    const gamma = createTempFile(dir, "gamma.txt", "gamma\n");
+
+    tui.start(alpha, beta, gamma);
+    const before = tui.snapshot();
+    tui.drag(38, 2, 2, 2);
+    tui.waitStable();
+    const dragged = tui.snapshot();
+    tui.exec("View: Move Tab Right");
+    tui.waitStable();
+    const moved = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    const beforeHeader = snapshots[before].split("\n")[2];
+    const draggedHeader = snapshots[dragged].split("\n")[2];
+    const movedHeader = snapshots[moved].split("\n")[2];
+    expect(beforeHeader.indexOf("gamma.txt")).toBeGreaterThan(beforeHeader.indexOf("untitled"));
+    expect(draggedHeader.indexOf("gamma.txt")).toBeLessThan(draggedHeader.indexOf("untitled"));
+    expect(movedHeader.indexOf("gamma.txt")).toBeGreaterThan(movedHeader.indexOf("untitled"));
+  });
+});

--- a/tests/functional/exec-harness.test.js
+++ b/tests/functional/exec-harness.test.js
@@ -1,0 +1,80 @@
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+const BINARY = resolve(import.meta.dirname, "../../bin/ttt");
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("exec harness reliability", () => {
+  it("waitFor blocks until delayed text is actually visible", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "wait.txt", "waiting\n");
+    const pluginFile = join(dir, "delayed.lua");
+    writeFileSync(
+      pluginFile,
+      `local ttt = require("ttt")
+ttt.set_timeout(350, function()
+  ttt.set_status_item("left", "ready", "ASYNC READY", { priority = 10 })
+end)
+`
+    );
+
+    tui.start("--plugin", pluginFile, file);
+    tui.waitFor("ASYNC READY");
+    const screen = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[screen]).toContain("ASYNC READY");
+  });
+
+  it("returns a nonzero exit and stderr for an invalid action", () => {
+    dir = createTempDir();
+    const result = spawnSync(BINARY, ["--size", "80x24", "--exec", "not-an-action"], {
+      encoding: "utf8",
+      env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--exec failed");
+    expect(result.stderr).toContain('unknown action "not-an-action"');
+  });
+
+  it("returns a nonzero exit when wait-for reaches its bound", () => {
+    dir = createTempDir();
+    const result = spawnSync(
+      BINARY,
+      ["--size", "80x24", "--exec", `wait-for "NEVER VISIBLE" timeout=40`],
+      {
+        encoding: "utf8",
+        env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
+      }
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('screen text "NEVER VISIBLE" not visible');
+  });
+
+  it("rejects an overflowing wait-for timeout as invalid input", () => {
+    dir = createTempDir();
+    const result = spawnSync(
+      BINARY,
+      ["--size", "40x12", "--exec", "wait-for x timeout=9223372036854775807"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
+      }
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('invalid wait-for timeout "9223372036854775807"');
+    expect(result.stderr).not.toContain("not visible after -");
+  });
+});

--- a/tests/functional/git-changes-reactive.test.js
+++ b/tests/functional/git-changes-reactive.test.js
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createGitRepo, createTempDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("reactive git changes", () => {
+  it("shows a saved editor change without a manual refresh", () => {
+    dir = createGitRepo(createTempDir());
+    const tracked = join(dir, "tracked.txt");
+
+    tui.start(dir, tracked);
+    tui.waitFor("Explore");
+    tui.exec("Show Changes");
+    tui.waitStable(300);
+    const clean = tui.snapshot();
+
+    tui.exec("View: Focus Editor");
+    tui.press("end");
+    tui.type("changed");
+    tui.exec("Save File");
+    tui.waitStable(600);
+    const updated = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[clean]).toContain("No changes");
+    expect(snapshots[updated]).toContain("Changes (1)");
+    expect(snapshots[updated]).toContain("tracked.txt");
+  });
+});

--- a/tests/functional/git-changes.test.js
+++ b/tests/functional/git-changes.test.js
@@ -17,6 +17,9 @@ afterEach(() => {
 function openChanges() {
   tui.exec("Show Changes");
   tui.waitStable();
+  // The commit input is the first action in both visual and focus order. Most
+  // tests below exercise working-tree commands, so move to the tree once.
+  tui.press("tab");
 }
 
 describe("git changes panel", () => {
@@ -79,7 +82,9 @@ describe("git changes panel", () => {
 
     tui.press("a");
     tui.waitStable();
-    // Tab moves focus from the file tree to the commit message input.
+    // The history tree follows the working tree in focus order, then the cycle
+    // returns to the commit message at the top.
+    tui.press("tab");
     tui.press("tab");
     tui.type("a commit from the editor");
     tui.press("enter");
@@ -104,6 +109,7 @@ describe("git changes panel", () => {
 
     tui.press("a");
     tui.waitStable();
+    tui.press("tab");
     tui.press("tab");
     tui.type("logged commit");
     tui.press("enter");
@@ -259,6 +265,7 @@ describe("git changes panel", () => {
 
     tui.press("a");
     tui.waitStable();
+    tui.press("tab");
     tui.press("tab");
     tui.type("first message");
     tui.press("enter");

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -42,7 +42,9 @@ describe("git file tree", () => {
     tui.click(29, 2);
     tui.waitStable();
     const panelMenu = tui.snapshot();
-    // Skip the new Expand All and Collapse All actions to reach Git Files.
+    // Move past View All Changes, Refresh, Expand All, and Collapse All to
+    // reach Git Files.
+    tui.press("down");
     tui.press("down");
     tui.press("down");
     tui.press("down");

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -24,7 +24,7 @@ function repoWithNestedGitFiles() {
 }
 
 describe("git file tree", () => {
-  it("groups working and commit files and can switch back to full-path lists", () => {
+  it("defaults to full-path lists and can explicitly switch to tree view", () => {
     dir = repoWithNestedGitFiles();
 
     tui.start(dir);
@@ -35,10 +35,10 @@ describe("git file tree", () => {
     // the branch header at 22 and the newest commit at 23 at this geometry.
     tui.click(1, 23);
     tui.waitStable(400);
-    const tree = tui.snapshot();
+    const list = tui.snapshot();
 
     // Open the Changes panel's contextual three-dot menu, then use its nested
-    // Git Files group to switch to List view.
+    // Git Files group to switch to Tree view.
     tui.click(29, 2);
     tui.waitStable();
     const panelMenu = tui.snapshot();
@@ -51,25 +51,24 @@ describe("git file tree", () => {
     tui.press("right");
     tui.waitStable();
     const gitFilesMenu = tui.snapshot();
-    tui.press("down");
     tui.press("enter");
     tui.waitStable(300);
-    const list = tui.snapshot();
+    const tree = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(snapshots[tree]).toContain("src/work");
-    expect(snapshots[tree]).toContain("changed.go");
-    expect(snapshots[tree]).toContain("pkg/history");
-    expect(snapshots[tree]).toContain("committed.go");
-    expect(snapshots[tree]).not.toContain("src/work/changed.go");
-    expect(snapshots[tree]).not.toContain("pkg/history/committed.go");
+    expect(snapshots[list]).toContain("src/work/changed.go");
+    expect(snapshots[list]).toContain("pkg/history/committed.go");
 
     expect(snapshots[panelMenu]).toContain("Git Files");
     expect(snapshots[panelMenu]).toContain("Diff View");
     expect(snapshots[gitFilesMenu]).toContain("Tree");
     expect(snapshots[gitFilesMenu]).toContain("List");
 
-    expect(snapshots[list]).toContain("src/work/changed.go");
-    expect(snapshots[list]).toContain("pkg/history/committed.go");
+    expect(snapshots[tree]).toContain("src/work");
+    expect(snapshots[tree]).toContain("changed.go");
+    expect(snapshots[tree]).toContain("pkg/history");
+    expect(snapshots[tree]).toContain("committed.go");
+    expect(snapshots[tree]).not.toContain("src/work/changed.go");
+    expect(snapshots[tree]).not.toContain("pkg/history/committed.go");
   });
 });

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -37,7 +37,17 @@ describe("git file tree", () => {
     tui.waitStable(400);
     const tree = tui.snapshot();
 
-    tui.exec("View Git Files as List");
+    // Open the Changes panel's contextual three-dot menu, then use its nested
+    // Git Files group to switch to List view.
+    tui.click(29, 2);
+    tui.waitStable();
+    const panelMenu = tui.snapshot();
+    tui.press("down");
+    tui.press("right");
+    tui.waitStable();
+    const gitFilesMenu = tui.snapshot();
+    tui.press("down");
+    tui.press("enter");
     tui.waitStable(300);
     const list = tui.snapshot();
 
@@ -48,6 +58,11 @@ describe("git file tree", () => {
     expect(snapshots[tree]).toContain("committed.go");
     expect(snapshots[tree]).not.toContain("src/work/changed.go");
     expect(snapshots[tree]).not.toContain("pkg/history/committed.go");
+
+    expect(snapshots[panelMenu]).toContain("Git Files");
+    expect(snapshots[panelMenu]).toContain("Diff View");
+    expect(snapshots[gitFilesMenu]).toContain("Tree");
+    expect(snapshots[gitFilesMenu]).toContain("List");
 
     expect(snapshots[list]).toContain("src/work/changed.go");
     expect(snapshots[list]).toContain("pkg/history/committed.go");

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createGitRepo, createTempFile, git, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function repoWithNestedGitFiles() {
+  const d = createGitRepo(createTempDir());
+  mkdirSync(join(d, "pkg/history"), { recursive: true });
+  createTempFile(d, "pkg/history/committed.go", "package history\n");
+  git(d, "add", "-A");
+  git(d, "commit", "-qm", "nested commit");
+
+  mkdirSync(join(d, "src/work"), { recursive: true });
+  createTempFile(d, "src/work/changed.go", "package work\n");
+  return d;
+}
+
+describe("git file tree", () => {
+  it("groups working and commit files and can switch back to full-path lists", () => {
+    dir = repoWithNestedGitFiles();
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(400);
+    // Expand the newest commit. The resizable history begins at row 22, with
+    // the branch header at 22 and the newest commit at 23 at this geometry.
+    tui.click(1, 23);
+    tui.waitStable(400);
+    const tree = tui.snapshot();
+
+    tui.exec("View Git Files as List");
+    tui.waitStable(300);
+    const list = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[tree]).toContain("src/work");
+    expect(snapshots[tree]).toContain("changed.go");
+    expect(snapshots[tree]).toContain("pkg/history");
+    expect(snapshots[tree]).toContain("committed.go");
+    expect(snapshots[tree]).not.toContain("src/work/changed.go");
+    expect(snapshots[tree]).not.toContain("pkg/history/committed.go");
+
+    expect(snapshots[list]).toContain("src/work/changed.go");
+    expect(snapshots[list]).toContain("pkg/history/committed.go");
+  });
+});

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -42,6 +42,9 @@ describe("git file tree", () => {
     tui.click(29, 2);
     tui.waitStable();
     const panelMenu = tui.snapshot();
+    // Skip the new Expand All and Collapse All actions to reach Git Files.
+    tui.press("down");
+    tui.press("down");
     tui.press("down");
     tui.press("right");
     tui.waitStable();

--- a/tests/functional/plugin-menu-checked.test.js
+++ b/tests/functional/plugin-menu-checked.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("plugin menu checked entries", () => {
+  it("renders checked entries without shifting menus that omit checked", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = join(dir, "menu-indicators.lua");
+    writeFileSync(
+      plugin,
+      `local ttt = require("ttt")
+
+ttt.register({
+  bottom = {
+    title = "Menu Indicators",
+    render = function(panel)
+      panel:dropdown({
+        label = "Checked menu",
+        entries = {
+          { label = "Checked mode", command = "checked", checked = true },
+        },
+      })
+      panel:dropdown({
+        label = "Legacy menu",
+        entries = {
+          { label = "Legacy mode", command = "legacy" },
+        },
+      })
+    end,
+  },
+})
+`,
+      "utf8",
+    );
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(80, 20);
+    tui.waitStable(300);
+    tui.panel("plugin.menu-indicators");
+    tui.waitStable();
+
+    // The two dropdowns occupy the first two content rows of the bottom panel.
+    tui.click(35, 12);
+    const checked = tui.snapshot();
+    tui.press("esc");
+    tui.click(35, 13);
+    const omitted = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[checked]).toContain("│✓ Checked mode");
+    expect(snapshots[omitted]).not.toContain("✓");
+    expect(snapshots[omitted]).toContain("│ Legacy mode   │");
+  });
+});

--- a/tests/functional/plugin-open-diff.test.js
+++ b/tests/functional/plugin-open-diff.test.js
@@ -42,6 +42,265 @@ describe("ttt.open_diff plugin API", () => {
 
     expect(snapshots[s]).toContain("myfile.go (diff)");
   });
+
+  it("wraps long diff lines through the palette command", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("wrapped.go", {"left-prefix-LEFT-SUFFIX"}, {"right-prefix-RIGHT-SUFFIX"}, "wrapped.go")
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(42, 12);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    const before = tui.snapshot();
+    tui.exec("Git: Toggle Diff Wrap");
+    const after = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[before]).not.toContain("FFIX");
+    expect(snapshots[after]).toContain("FFIX");
+  });
+
+  it("turns diff wrapping off with a second toggle", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("wrapped.go", {"left-prefix-LEFT-SUFFIX"}, {"right-prefix-RIGHT-SUFFIX"}, "wrapped.go")
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(42, 12);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    tui.exec("Git: Toggle Diff Wrap");
+    const wrapped = tui.snapshot();
+    tui.exec("Git: Toggle Diff Wrap");
+    const afterSecondToggle = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[wrapped]).toContain("FFIX");
+    expect(snapshots[afterSecondToggle]).not.toContain("FFIX");
+  });
+
+  it("stacks removed lines before added lines in unified mode", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("unified.go", {"old one", "old two"}, {"new one", "new two"}, "unified.go")
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(80, 14);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    tui.exec("Git: Toggle Unified Diff");
+    const unified = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const screen = snapshots[unified];
+    expect(screen.indexOf("old one")).toBeLessThan(screen.indexOf("old two"));
+    expect(screen.indexOf("old two")).toBeLessThan(screen.indexOf("new one"));
+    expect(screen.indexOf("new one")).toBeLessThan(screen.indexOf("new two"));
+  });
+
+  it("restores the side-by-side diff after a second unified toggle", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("unified.go", {"old one"}, {"new one"}, "unified.go")
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(80, 14);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    tui.exec("Git: Toggle Unified Diff");
+    const unified = tui.snapshot();
+    tui.exec("Git: Toggle Unified Diff");
+    const split = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const unifiedLines = snapshots[unified].split("\n");
+    const oldRow = unifiedLines.findIndex((line) => line.includes("old one"));
+    const newRow = unifiedLines.findIndex((line) => line.includes("new one"));
+    expect(oldRow).toBeGreaterThanOrEqual(0);
+    expect(newRow).toBeGreaterThan(oldRow);
+    expect(unifiedLines[oldRow]).not.toContain("new one");
+    expect(snapshots[split]).toMatch(/old one.*│.*new one/);
+  });
+
+  it("switches modes from the visible tab control and shows the current value", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("control.go", {"old one", "old two"}, {"new one", "new two"}, "control.go")
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(80, 14);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    const split = tui.snapshot();
+    // The segmented control is right-aligned in the editor tab bar. At this
+    // deterministic width, Unified occupies columns 65..75 beside More.
+    tui.click(70, 2);
+    const unified = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[split]).toContain("● Split");
+    expect(snapshots[split]).toContain("○ Unified");
+    expect(snapshots[unified]).toContain("○ Split");
+    expect(snapshots[unified]).toContain("● Unified");
+    const rows = snapshots[unified].split("\n");
+    expect(rows.findIndex((row) => row.includes("old two"))).toBeLessThan(
+      rows.findIndex((row) => row.includes("new one")),
+    );
+  });
+
+  it("shows the distance across a large collapsed region", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("distance.go", {}, {}, "distance.go", false, [[--- a/distance.go
++++ b/distance.go
+@@ -22,3 +22,3 @@
+ line 22
+ line 23
+ line 24
+@@ -356,2 +356,2 @@
+ line 356
+ line 357
+]])
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(100, 14);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    const compact = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[compact]).toContain("⋯ 331 lines ⋯");
+    expect(snapshots[compact]).not.toContain("@@ -356,2 +356,2 @@");
+  });
+
+  it("uses singular wording for exactly one hidden line", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("distance.go", {}, {}, "distance.go", false, [[--- a/distance.go
++++ b/distance.go
+@@ -24,1 +24,1 @@
+ line 24
+@@ -26,1 +26,1 @@
+ line 26
+]])
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(100, 14);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    const compact = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[compact]).toContain("⋯ 1 line ⋯");
+    expect(snapshots[compact]).not.toContain("⋯ 1 lines ⋯");
+  });
+
+  it("omits the separator when adjacent lines hide nothing", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = writePlugin(dir, "test.lua", `
+      local ttt = require("ttt")
+      ttt.register({
+        commands = {
+          { id = "test.diff", title = "Test Diff", handler = function()
+              ttt.open_diff("distance.go", {}, {}, "distance.go", false, [[--- a/distance.go
++++ b/distance.go
+@@ -24,1 +24,1 @@
+ line 24
+@@ -25,1 +25,1 @@
+ line 25
+]])
+            end
+          }
+        },
+      })
+    `);
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(100, 14);
+    tui.waitStable(300);
+    tui.exec("Test Diff");
+    const compact = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    const rows = snapshots[compact].split("\n");
+    const line24Row = rows.findIndex((row) => row.includes("line 24"));
+    const line25Row = rows.findIndex((row) => row.includes("line 25"));
+    expect(line24Row).toBeGreaterThanOrEqual(0);
+    expect(line25Row).toBe(line24Row + 1);
+    expect(snapshots[compact]).not.toContain("⋯");
+  });
 });
 
 describe("ttt.open_readonly plugin API", () => {

--- a/tests/functional/plugin-open-diff.test.js
+++ b/tests/functional/plugin-open-diff.test.js
@@ -163,7 +163,7 @@ describe("ttt.open_diff plugin API", () => {
     expect(snapshots[split]).toMatch(/old one.*│.*new one/);
   });
 
-  it("switches modes from the visible tab control and shows the current value", () => {
+  it("switches modes through the compact Options dialog", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "test.txt", "hello\n");
     const plugin = writePlugin(dir, "test.lua", `
@@ -183,16 +183,14 @@ describe("ttt.open_diff plugin API", () => {
     tui.waitStable(300);
     tui.exec("Test Diff");
     const split = tui.snapshot();
-    // The segmented control is right-aligned in the editor tab bar. At this
-    // deterministic width, Unified occupies columns 65..75 beside More.
-    tui.click(70, 2);
+    tui.exec("Change Diff View Mode");
+    tui.type("Unified");
+    tui.press("enter");
+    tui.waitStable();
     const unified = tui.snapshot();
     const { snapshots } = tui.run();
 
-    expect(snapshots[split]).toContain("● Split");
-    expect(snapshots[split]).toContain("○ Unified");
-    expect(snapshots[unified]).toContain("○ Split");
-    expect(snapshots[unified]).toContain("● Unified");
+    expect(snapshots[split]).toMatch(/old one.*│.*new one/);
     const rows = snapshots[unified].split("\n");
     expect(rows.findIndex((row) => row.includes("old two"))).toBeLessThan(
       rows.findIndex((row) => row.includes("new one")),
@@ -231,6 +229,7 @@ describe("ttt.open_diff plugin API", () => {
     const { snapshots } = tui.run();
 
     expect(snapshots[compact]).toContain("⋯ 331 lines ⋯");
+    expect(snapshots[compact]).toMatch(/▶⋯ 331 lines ⋯/);
     expect(snapshots[compact]).not.toContain("@@ -356,2 +356,2 @@");
   });
 

--- a/tests/functional/settings-ui.test.js
+++ b/tests/functional/settings-ui.test.js
@@ -35,6 +35,8 @@ describe("settings editor", () => {
       "Advanced",
       "Tab size",
       "Word wrap",
+      "Diff mode",
+      "Diff word wrap",
       "Apply",
     ]) {
       expect(snapshots[s0]).toContain(want);

--- a/tests/functional/sidebar-tab-reorder.test.js
+++ b/tests/functional/sidebar-tab-reorder.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("sidebar tab order", () => {
+  it("drags Changes before Explore and persists the order", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "file.txt", "hello\n");
+    const configDir = join(dir, "config");
+    mkdirSync(configDir, { recursive: true });
+
+    tui.start(file);
+    tui.setEnv({ TTT_CONFIG_DIR: configDir });
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable();
+    const before = tui.snapshot();
+    tui.drag(16, 2, 1, 2);
+    tui.waitStable();
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    const beforeHeader = snapshots[before].split("\n")[2];
+    const afterHeader = snapshots[after].split("\n")[2];
+    expect(beforeHeader.indexOf("Changes")).toBeGreaterThan(beforeHeader.indexOf("Explore"));
+    expect(afterHeader.indexOf("Changes")).toBeLessThan(afterHeader.indexOf("Explore"));
+
+    const saved = JSON.parse(readFileSync(join(configDir, "settings.json"), "utf8"));
+    expect(saved.sidebar.panelOrder.slice(0, 2)).toEqual(["changes", "explorer"]);
+  });
+});

--- a/tests/functional/sidebar-toggle.test.js
+++ b/tests/functional/sidebar-toggle.test.js
@@ -40,7 +40,7 @@ describe("sidebar toggle", () => {
 
     // Narrow sidebar to near-zero width using the command palette
     for (let i = 0; i < 25; i++) {
-      tui.exec("Decrease Sidebar Width");
+      tui.exec("View: Decrease Sidebar Width");
       tui.waitStable(50);
     }
 

--- a/tests/functional/tree-actions.test.js
+++ b/tests/functional/tree-actions.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createGitRepo, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("tree actions", () => {
+  it("expands and collapses Git file trees and exposes panel actions on right click", () => {
+    dir = createGitRepo(createTempDir());
+    mkdirSync(join(dir, "src", "nested"), { recursive: true });
+    createTempFile(dir, "src/nested/change.txt", "new file\n");
+
+    tui.start(dir);
+    tui.waitFor("Changes");
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(500);
+    const expanded = tui.snapshot();
+    tui.exec("Git: Collapse All File Trees");
+    tui.waitStable();
+    const collapsed = tui.snapshot();
+    tui.exec("Git: Expand All File Trees");
+    tui.waitStable();
+    const restored = tui.snapshot();
+    tui.rclick(5, 5);
+    tui.waitStable();
+    const menu = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[expanded]).toContain("change.txt");
+    expect(snapshots[collapsed]).not.toContain("change.txt");
+    expect(snapshots[restored]).toContain("change.txt");
+    expect(snapshots[menu]).toContain("Expand All");
+    expect(snapshots[menu]).toContain("Collapse All");
+    expect(snapshots[menu]).toContain("Git Files");
+    expect(snapshots[menu]).toContain("Diff View");
+  });
+
+  it("expands represented Explorer folders progressively and collapses them together", () => {
+    dir = createGitRepo(createTempDir());
+    mkdirSync(join(dir, "src", "nested"), { recursive: true });
+    createTempFile(dir, "src/nested/file.txt", "hello\n");
+
+    tui.start(dir);
+    tui.pressChord("ctrl+k", "e");
+    tui.waitStable();
+    tui.exec("Explorer: Collapse All");
+    tui.waitStable();
+    const collapsed = tui.snapshot();
+    tui.exec("Explorer: Expand All");
+    tui.waitStable();
+    const rootExpanded = tui.snapshot();
+    tui.exec("Explorer: Expand All");
+    tui.waitStable();
+    const nestedExpanded = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[collapsed]).not.toContain("src");
+    expect(snapshots[rootExpanded]).toContain("src");
+    expect(snapshots[nestedExpanded]).toContain("nested");
+  });
+});

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -22,6 +22,7 @@ let args = [];
 let snapCount = 0;
 let tmpDir = "";
 let size = "120x40";
+let extraEnv = {};
 
 export function start(...startArgs) {
   commands = [];
@@ -29,9 +30,17 @@ export function start(...startArgs) {
   size = "120x40";
   tmpDir = mkdtempSync(join(tmpdir(), "ttt-bb-"));
   args = [];
+  extraEnv = {};
   for (const a of startArgs) {
     args.push(a);
   }
+}
+
+// Add environment variables for this run. Reset by start(). Used to put a
+// wrapper ahead of a real binary on PATH, so a test can watch what the editor
+// does while a slow subprocess is still running.
+export function setEnv(vars) {
+  extraEnv = { ...extraEnv, ...vars };
 }
 
 // Override the terminal size for this run (default 120x40). Reset by start().
@@ -42,6 +51,11 @@ export function setSize(w, h) {
 // Simulate a mouse click at screen coordinates (col x, row y).
 export function click(x, y) {
   commands.push(`click ${x} ${y}`);
+}
+
+// Drag from one screen coordinate to another while holding the primary button.
+export function drag(x1, y1, x2, y2) {
+  commands.push(`drag ${x1} ${y1} ${x2} ${y2}`);
 }
 
 // Simulate a right-click (opens context menus) at screen coordinates.
@@ -128,7 +142,7 @@ export function run(timeout = 15000) {
       timeout,
       stdio: "pipe",
       // Isolate from the real ~/.config/ttt — settings toggles persist and race across test files.
-      env: { ...process.env, TTT_CONFIG_DIR: join(tmpDir, "config") },
+      env: { ...process.env, TTT_CONFIG_DIR: join(tmpDir, "config"), ...extraEnv },
     });
   } catch (err) {
     if (err.status !== null && err.status !== 0 && err.status !== undefined) {

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -112,8 +112,8 @@ export function wait(ms = 200) {
   commands.push(`wait ${ms}`);
 }
 
-export function waitFor(_text) {
-  commands.push("wait 200");
+export function waitFor(text) {
+  commands.push(`wait-for ${JSON.stringify(String(text))}`);
 }
 
 export function waitStable(ms = 200) {
@@ -136,6 +136,8 @@ export function run(timeout = 15000) {
   commands.push("quit");
   const script = commands.join(SEP);
 
+  let runError;
+
   try {
     execFileSync(BINARY, ["--size", size, "--exec-split-on", SEP, "--exec", script, ...args], {
       encoding: "utf8",
@@ -145,9 +147,7 @@ export function run(timeout = 15000) {
       env: { ...process.env, TTT_CONFIG_DIR: join(tmpDir, "config"), ...extraEnv },
     });
   } catch (err) {
-    if (err.status !== null && err.status !== 0 && err.status !== undefined) {
-      // non-zero exit is ok for quit-confirm tests etc.
-    }
+    runError = err;
   }
 
   const snapshots = [];
@@ -160,6 +160,7 @@ export function run(timeout = 15000) {
   }
 
   cleanup();
+  if (runError) throw runError;
   return { snapshots };
 }
 

--- a/tests/integration/git-changes-reactive.test.js
+++ b/tests/integration/git-changes-reactive.test.js
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createTempDir } from "./helpers.js";
+
+let dir;
+
+function git(...args) {
+  return execFileSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+}
+
+function createRepository() {
+  dir = createTempDir();
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "test@test.com");
+  git("config", "user.name", "Test User");
+  git("config", "commit.gpgsign", "false");
+  writeFileSync(join(dir, "tracked.txt"), "original\n", "utf8");
+  git("add", "tracked.txt");
+  git("commit", "-qm", "initial commit");
+}
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("reactive git polling", () => {
+  it("detects an external change to an unopened file", () => {
+    createRepository();
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+    tui.exec("Show Changes");
+    tui.waitFor("No changes");
+
+    // The editor never opens this file, so its existing file watcher cannot be
+    // the source of the update. The visible Changes observer must poll Git.
+    writeFileSync(join(dir, "tracked.txt"), "external\n", "utf8");
+    tui.waitFor("tracked.txt");
+
+    const screen = tui.snapshot();
+    expect(screen).toContain("Changes (1)");
+    expect(screen).toContain("tracked.txt");
+  });
+});

--- a/tests/integration/git-changes-reactive.test.js
+++ b/tests/integration/git-changes-reactive.test.js
@@ -45,4 +45,21 @@ describe("reactive git polling", () => {
     expect(screen).toContain("Changes (1)");
     expect(screen).toContain("tracked.txt");
   });
+
+  it("keeps an active current-changes document live", () => {
+    createRepository();
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+    tui.exec("Git: View All Current Changes");
+    tui.waitFor("Working tree clean");
+
+    writeFileSync(join(dir, "tracked.txt"), "live external version\n", "utf8");
+    tui.waitFor("live external version");
+
+    const screen = tui.snapshot();
+    expect(screen).toContain("Current changes");
+    expect(screen).toContain("M  tracked.txt · unstaged");
+    expect(screen).toContain("live external version");
+  });
 });

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -8,6 +8,7 @@
     "test:stress": "for i in $(seq 1 10); do echo \"--- Run $i/10 ---\" && vitest run || exit 1; done"
   },
   "devDependencies": {
+    "tui-use": "0.1.20",
     "vitest": "^4.1.7"
   }
 }

--- a/tests/integration/pnpm-lock.yaml
+++ b/tests/integration/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      tui-use:
+        specifier: 0.1.20
+        version: 0.1.20
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(vite@7.3.3)
@@ -355,12 +358,19 @@ packages:
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
+  '@xterm/headless@6.0.0':
+    resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
@@ -402,6 +412,12 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -452,6 +468,11 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tui-use@0.1.20:
+    resolution: {integrity: sha512-dOv3ZpJ741kzA/VJ5AOeG28YPpOlt3ofuukECmRoZ0TfJx+LtB158kHGpX+3Evqlz8TJykrLgCOLe7q0NHaRQA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
@@ -750,9 +771,13 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xterm/headless@6.0.0': {}
+
   assertion-error@2.0.1: {}
 
   chai@6.2.2: {}
+
+  commander@12.1.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -805,6 +830,12 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   nanoid@3.3.12: {}
+
+  node-addon-api@7.1.1: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   obug@2.1.1: {}
 
@@ -869,6 +900,12 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tui-use@0.1.20:
+    dependencies:
+      '@xterm/headless': 6.0.0
+      commander: 12.1.0
+      node-pty: 1.1.0
 
   vite@7.3.3:
     dependencies:

--- a/tests/integration/pnpm-workspace.yaml
+++ b/tests/integration/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 allowBuilds:
   esbuild: true
+  node-pty: true
+  tui-use: false


### PR DESCRIPTION
## Summary

This turns the Changes surface into a fuller Git review workspace while tightening the surrounding editor ergonomics.

- Organize staged and unstaged files as collapsible trees, with matching expand/collapse controls in Changes and Explorer.
- Browse commit history in a resizable half-panel, open complete commit details with authored date/time, and review all current changes in one scrollable document.
- Keep repository state live while the editor is open, including external file changes and Git index updates.
- Switch between split/unified and changes-only/full-file diffs, with clearer +/- gutters and an optional high-contrast treatment.
- Consolidate presentation controls into submenus and make sidebar/editor tabs draggable to reorder.
- Reconcile the bundled theme catalog/default-theme behavior and make the integration harness reproducible by pinning `tui-use` locally.

## Verification

- `make build`
- `go test ./...`
- `cd tests/functional && pnpm test` — 96 files passed; 334 passed, 26 expected failures
- `cd tests/integration && pnpm exec vitest run --no-file-parallelism` — 8 files passed; 49 tests passed
- Default parallel integration runs each reached 48/49 with a moving shared signature-help/log timeout; both affected tests pass independently, and one also passes independently on `origin/main`, isolating the failure to shared-log/PTY contention rather than feature behavior

## Implementation notes

- Core/editor state remains owned by `App`; filesystem and Git watchers publish typed events back onto the main event loop before widgets are reconciled.
- Diff syntax colors continue to layer over semantic diff backgrounds through the existing theme/style system.
- Commit pagination appends into the existing tree instead of rebuilding it, preserving selection and expansion state.

## Demo

Media captured from deterministic throwaway repositories with `termctrl` at 120x40 using the bundled Aurora theme and high-contrast diffs. Each video covers a distinct workflow; there is no stitched replay.

<!-- PR_MEDIA_START -->
<table>
  <tr>
    <td width="50%"><strong>Changed-file trees</strong><br><img alt="Staged and unstaged files organized as collapsible trees" src="https://github.com/user-attachments/assets/54245cab-2b96-4d7c-ad67-e643112bb063" /></td>
    <td width="50%"><strong>Current changes document</strong><br><img alt="All current changes in one scrollable diff document" src="https://github.com/user-attachments/assets/5f458a21-9861-498c-a172-26992769a985" /></td>
  </tr>
  <tr>
    <td width="50%"><strong>Commit details and timestamps</strong><br><img alt="Commit detail view with authored date and time" src="https://github.com/user-attachments/assets/78fbb844-293c-4f01-8c8d-854886dbbd23" /></td>
    <td width="50%"><strong>Grouped diff controls</strong><br><img alt="Grouped split unified and diff-context presentation controls" src="https://github.com/user-attachments/assets/e01999a2-eeb6-4343-8aea-65afe0d75581" /></td>
  </tr>
  <tr>
    <td colspan="2"><strong>Full-file diff context</strong><br><img alt="Full-file diff context with compact and expanded presentation controls" src="https://github.com/user-attachments/assets/4fafd148-edb4-49f6-8abb-79aab1841914" /></td>
  </tr>
</table>

### Focused workflows

**Changed-file views and live repository updates** — switch between full-path lists and file trees, bulk collapse/expand, and receive external changes without refreshing.

https://github.com/user-attachments/assets/1b0aa1a2-b463-46d1-94fc-cef5f51c3165

**Current-change review and diff presentation** — open all current changes, collapse/expand the review, switch split/unified views, and use grouped high-contrast controls.

https://github.com/user-attachments/assets/7bbdbd64-84f6-456b-8a42-d33eb7912a3d

**Tab and panel reordering** — drag editor tabs and sidebar panel headers using the same interaction.

https://github.com/user-attachments/assets/850cbd44-eef9-4de1-8e80-bf1fe273f8f0

**Commit review and scalable history** — disclose a commit's file tree, open historical diffs, show full-file context, review timestamped commit details, collapse/expand files, and load older history.

https://github.com/user-attachments/assets/0807a96a-6e9b-4e66-b8ab-7f602372c257

<details>
<summary><strong>Additional discoverability and control coverage</strong></summary>

<table>
  <tr>
    <td width="50%"><strong>Complete theme picker</strong><br><img alt="Theme picker including Built-in Default and bundled themes" src="https://github.com/user-attachments/assets/9d5e1966-af7d-4170-be4d-5045b0bb0a50" /></td>
    <td width="50%"><strong>Palette help mode</strong><br><img alt="Question-mark command palette help topics" src="https://github.com/user-attachments/assets/0c5017e1-7fb5-4588-9b2d-168b10435f80" /></td>
  </tr>
  <tr>
    <td width="50%"><strong>Explorer tree controls</strong><br><img alt="Explorer panel menu with expand all and collapse all" src="https://github.com/user-attachments/assets/2a639b77-8ff0-42e8-aeb3-b6908d31fbd6" /></td>
    <td width="50%"><strong>Changes panel menu</strong><br><img alt="Changes panel menu with grouped Git Files and Diff View submenus" src="https://github.com/user-attachments/assets/d95edd13-f88a-4428-bfcb-9fbdb8b50596" /></td>
  </tr>
  <tr>
    <td width="50%"><strong>Changes context menu</strong><br><img alt="Changed-file right-click menu with file, bulk tree, and presentation actions" src="https://github.com/user-attachments/assets/f56c644f-3e66-43e4-bd73-4798eaf9a153" /></td>
    <td width="50%"><strong>Plugin checked menus</strong><br><img alt="Plugin dropdown with checked and unchecked menu indicators" src="https://github.com/user-attachments/assets/29e65241-7148-42f9-92ed-211162e3ef5d" /></td>
  </tr>
</table>

</details>

### Functional commit coverage

| Commit | User-facing behavior | Evidence above |
|---|---|---|
| `0427858` | Commit browsing, historical diffs, complete commit review, palette help, checked plugin menus | Commit review video; palette-help and plugin-menu screenshots |
| `9fff8d7` | Built-in Default/theme catalog, clearer +/- gutters, high-contrast diffs | Theme-picker screenshot; current-change review video |
| `0b5d021` | Changed files as Tree or full-path List | Changed-file views video |
| `892ca12` | Grouped presentation submenus in Options and panel menus | Current-change review video; Changes menu screenshots |
| `fc08761` | Draggable sidebar panel headers | Reordering video |
| `e69b2b1` | Draggable editor tabs | Reordering video |
| `931828e` | Bulk expand/collapse in Changes, commit detail, and Explorer; Changes context menu | All four videos; Explorer and Changes menu screenshots |
| `8afbb24` | Repository changes reconcile without manual refresh | Changed-file views/live-update video |
| `591eefa` | All current changes in one scrollable document | Current-change review video and primary screenshot |
| `413d30c` | Full-file context, timestamps, half-height history, and incremental history loading | Commit-review/history video; full-file and timestamp screenshots |

The non-functional `de772eb` integration-harness pin is intentionally omitted from media coverage.

<!-- PR_MEDIA_END -->
