### PR TITLE
test(integration): pin tui-use locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: tests/integration/pnpm-lock.yaml
 
-      - name: Install tui-use
-        run: npm install -g tui-use
-
       - name: Install test dependencies
         working-directory: tests/integration
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run integration tests
         working-directory: tests/integration
@@ -137,9 +134,6 @@ jobs:
           cache: pnpm
           cache-dependency-path: tests/integration/pnpm-lock.yaml
 
-      - name: Install tui-use
-        run: npm install -g tui-use
-
       - name: Install LSP servers
         run: |
           go install golang.org/x/tools/gopls@latest
@@ -160,7 +154,7 @@ jobs:
 
       - name: Install test dependencies
         working-directory: tests/integration
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run LSP tests
         working-directory: tests/integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ const { snapshots } = tui.run();
 expect(snapshots[s0]).toContain("hello");
 ```
 
-**Integration tests** (`tests/integration/`) — JavaScript tests using vitest + `tui-use` CLI that drive the binary via a real PTY. Used for tests that need live PTY interaction: LSP, external file changes, settings roundtrip, bracketed paste. Run with `cd tests/integration && pnpm test`. Requires `npm install -g tui-use`.
+**Integration tests** (`tests/integration/`) — JavaScript tests using vitest + the locally pinned `tui-use` CLI to drive the binary via a real PTY. Used for tests that need live PTY interaction: LSP, external file changes, settings roundtrip, bracketed paste. Run with `cd tests/integration && pnpm install && pnpm test`.
 
 ### Test expectations for new features
 

--- a/README.md
+++ b/README.md
@@ -710,7 +710,6 @@ Tests that require live PTY interaction — scenarios where something external h
 ```sh
 cd tests/integration
 pnpm install
-npm install -g tui-use
 pnpm test
 ```
 

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -8,6 +8,7 @@
     "test:stress": "for i in $(seq 1 10); do echo \"--- Run $i/10 ---\" && vitest run || exit 1; done"
   },
   "devDependencies": {
+    "tui-use": "0.1.20",
     "vitest": "^4.1.7"
   }
 }

--- a/tests/integration/pnpm-lock.yaml
+++ b/tests/integration/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      tui-use:
+        specifier: 0.1.20
+        version: 0.1.20
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(vite@7.3.3)
@@ -355,12 +358,19 @@ packages:
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
+  '@xterm/headless@6.0.0':
+    resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
@@ -402,6 +412,12 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -452,6 +468,11 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tui-use@0.1.20:
+    resolution: {integrity: sha512-dOv3ZpJ741kzA/VJ5AOeG28YPpOlt3ofuukECmRoZ0TfJx+LtB158kHGpX+3Evqlz8TJykrLgCOLe7q0NHaRQA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
@@ -750,9 +771,13 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xterm/headless@6.0.0': {}
+
   assertion-error@2.0.1: {}
 
   chai@6.2.2: {}
+
+  commander@12.1.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -805,6 +830,12 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   nanoid@3.3.12: {}
+
+  node-addon-api@7.1.1: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   obug@2.1.1: {}
 
@@ -869,6 +900,12 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tui-use@0.1.20:
+    dependencies:
+      '@xterm/headless': 6.0.0
+      commander: 12.1.0
+      node-pty: 1.1.0
 
   vite@7.3.3:
     dependencies:

--- a/tests/integration/pnpm-workspace.yaml
+++ b/tests/integration/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 allowBuilds:
   esbuild: true
+  node-pty: true
+  tui-use: false


### PR DESCRIPTION
Extracted from #474 as the first independently reviewable unit.

## Summary

- pin `tui-use@0.1.20` in the integration test package and lockfile
- allow the required `node-pty` native build through pnpm
- remove the global `tui-use` installation from CI
- use frozen integration installs in both integration jobs
- update local testing documentation to use repository-declared dependencies

This keeps the live PTY harness reproducible without requiring developers or CI to mutate global package state. There are no production-code changes.

## Verification

- `make build`
- `pnpm install --frozen-lockfile`
- `pnpm exec which tui-use`
  - resolved `tests/integration/node_modules/.bin/tui-use`
- `pnpm exec vitest run --reporter=verbose --exclude='**/lsp*.test.js'`
  - 4 test files passed
  - 11 tests passed
- `git diff --check`

The dependency graph resolves the pinned `tui-use@0.1.20` with `node-pty@1.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated setup consistency by using the project’s locked package configuration.
  * Removed obsolete global command-line tool installation steps from development and continuous integration workflows.
  * Updated integration tooling to use a locally pinned version for more predictable test execution.

* **Documentation**
  * Revised setup instructions to reflect the streamlined installation and testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->