### PR TITLE
feat(debug): make exec automation deterministic and failure-safe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ Functional tests are the highest-value tests. Use `tui.exec("Command Name")` for
 **`--exec "commands"`** — Execute semicolon-separated commands after startup. Run the real binary, interact with it, capture state, and exit — all in one command:
 
 ```bash
-bin/ttt --size 120x40 --exec "wait 200; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
+bin/ttt --size 120x40 --exec "wait-for Explore; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
 cat /tmp/screen.txt   # see what's rendered
 cat /tmp/state.json   # see full widget tree, focus, selection, panels
 ```
@@ -215,14 +215,17 @@ Supported commands:
 - `screenshot PATH` — save screen text to file
 - `debug PATH` — save debug state JSON (screen, cursor, buffer, focus, panels, tabs, selection, output log, integrated-terminal raw PTY byte tails, full widget tree with rect/focus/props per node)
 - `wait MS` — wait milliseconds
+- `wait-for TEXT [timeout=MS]` — wait until text appears on the actual visible screen; defaults to a bounded 5000ms timeout. Quote text to preserve surrounding whitespace or escapes.
 - `panel ID` — show and focus a bottom panel by ID
 - `quit` / `shutdown` — exit the editor
+
+Scripted input and main-thread commands are acknowledged after the event loop handles and redraws them, so following actions observe completed visible state. Invalid actions, missing commands/panels, capture failures, and wait timeouts stop the script: CLI `--exec` reports the error on stderr and exits nonzero; `POST /exec` returns a non-2xx response with the same detail.
 
 **`--listen`** — Start an HTTP command server on `127.0.0.1:4242` (loopback-only — never exposed off the local machine). `POST /exec` runs the same script format as `--exec`, synchronously, against an **already-running** editor — for capturing a repro at the exact moment it happens instead of scripting it in advance:
 
 ```bash
 bin/ttt --listen &
-curl -X POST --data "type hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 
@@ -235,6 +238,8 @@ Pass `?sep=` to use a different command separator, mirroring `--exec-split-on`.
 **`--debug`** — Enable debug mode regardless of config setting.
 
 **`TTT_CONFIG_DIR` env var** — overrides the config directory entirely (settings, keybindings, themes, plugins, plugin registry). Always set this when running scripted `--exec` sessions that touch settings or plugins, so the developer's real `~/.config/ttt` is not read or mutated. The functional test harness (`tests/functional/tui.js`) sets it automatically.
+
+Headless `--exec` sessions use a process-local clipboard, so concurrent automation cannot overwrite the desktop clipboard or each other's copied text. Interactive sessions, including `--listen`, continue to use the system clipboard.
 
 **Lua API equivalents** — Plugins can also call `ttt.screenshot(path)`, `ttt.debug(path)`, `ttt.click(x, y)`, and `ttt.quit()` directly.
 

--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ TTT includes a built-in scripted interaction system designed for AI agent intera
 | `--size WxH` | Force screen dimensions (e.g. `120x40`) for deterministic layout |
 | `--debug` | Enable debug mode regardless of config |
 
-The `TTT_CONFIG_DIR` environment variable overrides the config directory (`~/.config/ttt`) entirely — settings, keybindings, themes, and plugins are read from and written to that directory instead. Use it to run scripted sessions isolated from your real configuration.
+The `TTT_CONFIG_DIR` environment variable overrides the config directory (`~/.config/ttt`) entirely — settings, keybindings, themes, and plugins are read from and written to that directory instead. Use it to run scripted sessions isolated from your real configuration. Headless `--exec` sessions also use a process-local clipboard so concurrent automation cannot overwrite the desktop clipboard; interactive sessions, including `--listen`, keep the system clipboard.
 
 ### `--exec` Commands
 
@@ -761,19 +761,22 @@ The `--exec` flag accepts a semicolon-separated string of commands that run sequ
 | `screenshot PATH` | Save the current screen text to a file |
 | `debug PATH` | Save the editor's debug state as JSON to a file |
 | `wait MS` | Wait for the given number of milliseconds |
+| `wait-for TEXT [timeout=MS]` | Wait until text appears on the visible screen (default timeout: 5000ms) |
 | `quit` / `shutdown` | Exit the editor |
+
+Quote `wait-for` text when it contains leading/trailing whitespace or escapes, for example `wait-for "Indexing complete" timeout=10000`. Scripted input and commands are acknowledged only after the main event loop handles and redraws them, so a following `wait-for`, `screenshot`, or `debug` observes their completed visible state. Invalid actions, missing commands/panels, capture failures, and wait timeouts stop the script: CLI `--exec` writes the error to stderr and exits nonzero; `POST /exec` returns a non-2xx response with the same detail.
 
 Example — capture a screenshot and debug state, then quit:
 
 ```sh
-ttt --size 120x40 --exec "wait 200; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
+ttt --size 120x40 --exec "wait-for Explore; screenshot /tmp/screen.txt; debug /tmp/state.json; quit"
 ```
 
 Example — drive an already-running editor over `--listen` instead of scripting in advance:
 
 ```sh
 ttt --listen &
-curl -X POST --data "type hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -374,14 +374,14 @@ Docs: https://tttedit.dev
 		go func() {
 			result, err := app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
 			execOutcome <- cliExecOutcome{result: result, err: err}
-			if err != nil {
+			if err != nil || result.ShutdownRequested {
 				_ = app.StopExecLoop(editor)
 			}
 		}()
 	}
 
 	if flags.listen {
-		editor.LogOutput("info", "ttt", "Listening on "+app.ListenAddr+" (POST /exec)")
+		editor.LogOutput("info", "ttt", "Listening on "+app.ListenAddress()+" (POST /exec)")
 		go app.StartListenServer(editor)
 	}
 

--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -73,6 +73,11 @@ type cliFlags struct {
 	listen       bool
 }
 
+type cliExecOutcome struct {
+	result app.ExecResult
+	err    error
+}
+
 func parseFlags() cliFlags {
 	var f cliFlags
 	args := os.Args[1:]
@@ -131,6 +136,13 @@ func initSimulationScreen(w, h int) *term.TcellScreen {
 }
 
 func main() {
+	exitCode := 0
+	defer func() {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	}()
+
 	for _, arg := range os.Args[1:] {
 		switch arg {
 		case "--help", "-h":
@@ -151,6 +163,8 @@ Options:
   --workspace <file>  Open a saved workspace (.ttt file)
   --config <file>     Use a custom config file
   --exec "commands"   Execute semicolon-separated commands after startup
+                      (wait-for TEXT [timeout=MS] waits for visible text;
+                      invalid or failed actions exit nonzero)
   --exec-split-on <s> Split --exec on <s> instead of ";" (for scripts that
                       need to send a literal semicolon)
   --plugin <file>     Load a Lua plugin file on startup with full permissions
@@ -198,6 +212,7 @@ Docs: https://tttedit.dev
 
 	var screen *term.TcellScreen
 	if flags.exec != "" {
+		clipboard.DisableSystem()
 		screen = initSimulationScreen(flags.sizeW, flags.sizeH)
 	} else {
 		screen = initTerminalScreen()
@@ -353,8 +368,16 @@ Docs: https://tttedit.dev
 		editor.LogOutput("info", "ttt", "Debug mode enabled")
 	}
 
+	var execOutcome chan cliExecOutcome
 	if flags.exec != "" {
-		go app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
+		execOutcome = make(chan cliExecOutcome, 1)
+		go func() {
+			result, err := app.RunExecScriptSep(editor, flags.exec, flags.execSplitOn)
+			execOutcome <- cliExecOutcome{result: result, err: err}
+			if err != nil {
+				_ = app.StopExecLoop(editor)
+			}
+		}()
 	}
 
 	if flags.listen {
@@ -363,4 +386,14 @@ Docs: https://tttedit.dev
 	}
 
 	app.RunEventLoop(screen, renderer, editor, &running, editor.CloseTerminal)
+	if execOutcome != nil {
+		select {
+		case outcome := <-execOutcome:
+			if outcome.err != nil {
+				fmt.Fprintf(os.Stderr, "ttt: --exec failed after %d action(s): %v\n", outcome.result.Completed, outcome.err)
+				exitCode = 1
+			}
+		default:
+		}
+	}
 }

--- a/docs-web/src/content/docs/guides/plugin-testing.md
+++ b/docs-web/src/content/docs/guides/plugin-testing.md
@@ -23,6 +23,7 @@ The plugin's name (used for its panel id, `plugin.<name>`) is the Lua file's bas
 | Command | Description |
 |---------|-------------|
 | `wait MS` | Pause (let timers, async callbacks, and renders settle) |
+| `wait-for TEXT [timeout=MS]` | Wait until text is visible on screen (default timeout: 5000ms) |
 | `panel ID` | Open a bottom-panel tab by id (e.g. `panel output`, `panel plugin.init`) |
 | `key COMBO` | Press a key or chord (`key enter`, `key ctrl+k p`, `key tab`) |
 | `type TEXT` | Type a string |
@@ -34,13 +35,15 @@ The plugin's name (used for its panel id, `plugin.<name>`) is the Lua file's bas
 | `debug PATH` | Write the editor's full state as JSON to a file |
 | `quit` / `shutdown` | Exit |
 
+Prefer `wait-for` when a visible state has a reliable text marker. Quote text that contains whitespace or escapes: `wait-for "Indexing complete" timeout=10000`. Scripted input and commands are acknowledged after the main event loop handles and redraws them, so the condition checks the rendered screen rather than whether an event was merely posted. Invalid actions and timeouts stop the script; CLI `--exec` exits nonzero with stderr and `POST /exec` returns a non-2xx response with the error.
+
 ## Driving a running editor with `--listen`
 
 `--exec` only runs its script once, at startup, then exits. `--listen` keeps the editor running and lets you POST the same commands to it at any point:
 
 ```sh
 bin/ttt --listen &
-curl -X POST --data "type hi; wait 100; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
+curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 
@@ -75,6 +78,8 @@ TTT_CONFIG_DIR=/tmp/ttt-test bin/ttt --plugin ./init.lua --exec "..."
 ```
 
 Always do this in any automated test — a scripted run of a settings-toggling command will otherwise persist into your real config.
+
+Headless `--exec` sessions use a process-local clipboard, so parallel scripts cannot overwrite the desktop clipboard or each other's copied text. Interactive sessions, including `--listen`, continue to use the system clipboard.
 
 ## Testing a scoped plugin (with a manifest)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -98,7 +98,24 @@ type App struct {
 	settingsView         *settingsView
 	// appliedSettings is the last value ApplySettings acted on. Callers routinely
 	// mutate a.Settings before calling it, so a.Settings cannot serve as "before".
-	appliedSettings config.Settings
+	appliedSettings    config.Settings
+	eventLoopDoneOnce  sync.Once
+	eventLoopCloseOnce sync.Once
+	eventLoopDone      chan struct{}
+}
+
+func (a *App) eventLoopDoneSignal() chan struct{} {
+	a.eventLoopDoneOnce.Do(func() {
+		a.eventLoopDone = make(chan struct{})
+	})
+	return a.eventLoopDone
+}
+
+func (a *App) closeEventLoopDone() {
+	done := a.eventLoopDoneSignal()
+	a.eventLoopCloseOnce.Do(func() {
+		close(done)
+	})
 }
 
 func (a *App) KeyFor(cmd string) string {

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -26,6 +26,8 @@ func RunEventLoop(
 	running *bool,
 	closeTerminal func(panelID string),
 ) {
+	app.eventLoopDoneSignal()
+	defer app.closeEventLoopDone()
 	if app.Watcher != nil {
 		defer app.Watcher.Close()
 	}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -265,7 +265,7 @@ func RunEventLoop(
 			redraw()
 
 		case *tcell.EventInterrupt:
-			var execDone chan error
+			var execRequest *execRequestLifecycle
 			var execErr error
 			switch v := tev.Data().(type) {
 			case string:
@@ -284,19 +284,23 @@ func RunEventLoop(
 			case *GitGutterTrigger:
 				app.RequestGitGutterForActiveFile()
 			case *execInputRequest:
-				switch event := v.Event.(type) {
-				case *tcell.EventKey:
-					handleKey(event)
-				case *tcell.EventMouse:
-					handleMouse(event)
-				default:
-					execErr = failedExec("unsupported input event %T", v.Event)
+				if v.Lifecycle.claim() {
+					switch event := v.Event.(type) {
+					case *tcell.EventKey:
+						handleKey(event)
+					case *tcell.EventMouse:
+						handleMouse(event)
+					default:
+						execErr = failedExec("unsupported input event %T", v.Event)
+					}
+					execRequest = v.Lifecycle
 				}
-				execDone = v.Done
 			case *execMainRequest:
-				execErr = v.Run()
-				syncStatus()
-				execDone = v.Done
+				if v.Lifecycle.claim() {
+					execErr = v.Run()
+					syncStatus()
+					execRequest = v.Lifecycle
+				}
 			case *AutocompleteTrigger:
 				triggerChar := app.charBeforeCursor()
 				isTrigger := triggerChar != "" && (len(app.CompletionTriggers) == 0 || app.isCompletionTrigger(triggerChar))
@@ -421,8 +425,8 @@ func RunEventLoop(
 				}
 			}
 			redraw()
-			if execDone != nil {
-				execDone <- execErr
+			if execRequest != nil {
+				execRequest.complete(execErr)
 			}
 		}
 	}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -189,6 +189,39 @@ func RunEventLoop(
 
 	app.ShowPendingPluginApprovals()
 
+	handleKey := func(tev *tcell.EventKey) {
+		app.cancelHoverTimer()
+		if app.EditorGroup.SignatureHelp != nil {
+			switch tev.Key() {
+			case tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,
+				tcell.KeyHome, tcell.KeyEnd, tcell.KeyPgUp, tcell.KeyPgDn:
+				app.DismissSignatureHelp()
+			}
+		}
+		slog.Debug("key", "key", tev.Key(), "rune", string(term.KeyRune(tev)), "mod", tev.Modifiers())
+		app.Root.HandleEvent(tev)
+		app.FlushEditorOnChange()
+		app.RefreshAutocomplete()
+		syncStatus()
+	}
+
+	handleMouse := func(tev *tcell.EventMouse) {
+		mx, my := tev.Position()
+		btn := tev.Buttons()
+		slog.Debug("mouse", "x", mx, "y", my, "btn", btn)
+		app.DismissSignatureHelp()
+		if app.EditorGroup.Hover == nil {
+			if btn == 0 {
+				app.checkMouseHover(mx, my)
+			}
+		} else if !app.isMouseOverHover(mx, my) && !app.EditorGroup.Hover.IsDragging() {
+			app.DismissHover()
+		}
+		app.Root.HandleEvent(tev)
+		app.FlushEditorOnChange()
+		syncStatus()
+	}
+
 	for *running {
 		ev := screen.PollEvent()
 		switch tev := ev.(type) {
@@ -217,36 +250,11 @@ func RunEventLoop(
 			}
 
 		case *tcell.EventKey:
-			app.cancelHoverTimer()
-			if app.EditorGroup.SignatureHelp != nil {
-				switch tev.Key() {
-				case tcell.KeyUp, tcell.KeyDown, tcell.KeyLeft, tcell.KeyRight,
-					tcell.KeyHome, tcell.KeyEnd, tcell.KeyPgUp, tcell.KeyPgDn:
-					app.DismissSignatureHelp()
-				}
-			}
-			slog.Debug("key", "key", tev.Key(), "rune", string(term.KeyRune(tev)), "mod", tev.Modifiers())
-			app.Root.HandleEvent(tev)
-			app.FlushEditorOnChange()
-			app.RefreshAutocomplete()
-			syncStatus()
+			handleKey(tev)
 			redraw()
 
 		case *tcell.EventMouse:
-			mx, my := tev.Position()
-			btn := tev.Buttons()
-			slog.Debug("mouse", "x", mx, "y", my, "btn", btn)
-			app.DismissSignatureHelp()
-			if app.EditorGroup.Hover == nil {
-				if btn == 0 {
-					app.checkMouseHover(mx, my)
-				}
-			} else if !app.isMouseOverHover(mx, my) && !app.EditorGroup.Hover.IsDragging() {
-				app.DismissHover()
-			}
-			app.Root.HandleEvent(tev)
-			app.FlushEditorOnChange()
-			syncStatus()
+			handleMouse(tev)
 			redraw()
 
 		case *tcell.EventResize:
@@ -257,6 +265,8 @@ func RunEventLoop(
 			redraw()
 
 		case *tcell.EventInterrupt:
+			var execDone chan error
+			var execErr error
 			switch v := tev.Data().(type) {
 			case string:
 				if v != "" {
@@ -273,10 +283,20 @@ func RunEventLoop(
 				}
 			case *GitGutterTrigger:
 				app.RequestGitGutterForActiveFile()
-			case *ExecCommandRequest:
-				app.Reg.Execute(v.ID)
-				app.FlushEditorOnChange()
+			case *execInputRequest:
+				switch event := v.Event.(type) {
+				case *tcell.EventKey:
+					handleKey(event)
+				case *tcell.EventMouse:
+					handleMouse(event)
+				default:
+					execErr = failedExec("unsupported input event %T", v.Event)
+				}
+				execDone = v.Done
+			case *execMainRequest:
+				execErr = v.Run()
 				syncStatus()
+				execDone = v.Done
 			case *AutocompleteTrigger:
 				triggerChar := app.charBeforeCursor()
 				isTrigger := triggerChar != "" && (len(app.CompletionTriggers) == 0 || app.isCompletionTrigger(triggerChar))
@@ -401,6 +421,9 @@ func RunEventLoop(
 				}
 			}
 			redraw()
+			if execDone != nil {
+				execDone <- execErr
+			}
 		}
 	}
 }

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,75 +14,166 @@ import (
 	"github.com/gdamore/tcell/v3"
 )
 
-// DefaultExecSeparator splits exec scripts when no override is given.
-const DefaultExecSeparator = ";"
+const (
+	DefaultExecSeparator  = ";"
+	defaultWaitForTimeout = 5 * time.Second
+	execRequestTimeout    = 5 * time.Second
+	waitForPollInterval   = 25 * time.Millisecond
+	maxExecMilliseconds   = int64((1<<63 - 1) / int64(time.Millisecond))
+)
 
-// RunExecScript parses a separator-delimited script string and executes each
-// command sequentially. Intended to be run in a goroutine after the event loop
-// starts.
-func RunExecScript(a *App, script string) {
-	RunExecScriptSep(a, script, DefaultExecSeparator)
+type ExecErrorKind string
+
+const (
+	ExecErrorInvalid ExecErrorKind = "invalid"
+	ExecErrorFailed  ExecErrorKind = "failed"
+	ExecErrorTimeout ExecErrorKind = "timeout"
+)
+
+type ExecResult struct {
+	Completed int
 }
 
-// RunExecScriptSep is RunExecScript with a caller-chosen separator. Semicolons
-// are unusable when the script must type or send one -- `;` is a Vim motion,
-// for instance -- so callers can pick a delimiter that cannot collide with
-// their payload.
-func RunExecScriptSep(a *App, script, sep string) {
+type ExecError struct {
+	Kind    ExecErrorKind
+	Index   int
+	Command string
+	Action  string
+	Err     error
+}
+
+func (e *ExecError) Error() string {
+	return fmt.Sprintf("command %d %q: %v", e.Index, e.Command, e.Err)
+}
+
+func (e *ExecError) Unwrap() error {
+	return e.Err
+}
+
+type execActionError struct {
+	kind ExecErrorKind
+	err  error
+}
+
+func (e *execActionError) Error() string {
+	return e.err.Error()
+}
+
+func (e *execActionError) Unwrap() error {
+	return e.err
+}
+
+func invalidExec(format string, args ...any) error {
+	return &execActionError{kind: ExecErrorInvalid, err: fmt.Errorf(format, args...)}
+}
+
+func failedExec(format string, args ...any) error {
+	return &execActionError{kind: ExecErrorFailed, err: fmt.Errorf(format, args...)}
+}
+
+func timeoutExec(format string, args ...any) error {
+	return &execActionError{kind: ExecErrorTimeout, err: fmt.Errorf(format, args...)}
+}
+
+type execInputRequest struct {
+	Event tcell.Event
+	Done  chan error
+}
+
+type execMainRequest struct {
+	Run  func() error
+	Done chan error
+}
+
+func RunExecScript(a *App, script string) (ExecResult, error) {
+	return RunExecScriptSep(a, script, DefaultExecSeparator)
+}
+
+func RunExecScriptSep(a *App, script, sep string) (ExecResult, error) {
 	if sep == "" {
 		sep = DefaultExecSeparator
 	}
-	commands := strings.Split(script, sep)
-	for _, raw := range commands {
+	var result ExecResult
+	commandIndex := 0
+	for _, raw := range strings.Split(script, sep) {
 		cmd := strings.TrimSpace(raw)
 		if cmd == "" {
 			continue
 		}
+		commandIndex++
 		action, args := parseExecCommand(cmd)
 		slog.Debug("exec_script", "action", action, "args", args)
 
-		switch action {
-		case "click":
-			execClick(a, args)
-		case "rclick":
-			execRClick(a, args)
-		case "hover":
-			execHover(a, args)
-		case "drag":
-			execDrag(a, args)
-		case "key":
-			execKey(a, args)
-		case "type":
-			execType(a, args)
-		case "exec":
-			execCommand(a, args)
-		case "screenshot":
-			execScreenshot(a, args)
-		case "debug":
-			execDebug(a, args)
-		case "wait":
-			execWait(args)
-		case "paste":
-			execPaste(a, args)
-		case "copy":
-			a.Copy()
-		case "panel":
-			execPanel(a, args)
-		case "quit", "shutdown":
-			execQuit(a)
-		default:
-			slog.Error("exec_script: unknown command", "action", action)
+		if err := runExecAction(a, action, args); err != nil {
+			kind := ExecErrorFailed
+			var actionErr *execActionError
+			if errors.As(err, &actionErr) {
+				kind = actionErr.kind
+			}
+			return result, &ExecError{
+				Kind:    kind,
+				Index:   commandIndex,
+				Command: cmd,
+				Action:  action,
+				Err:     err,
+			}
 		}
-
-		// Small implicit delay between commands to let the event loop process
+		result.Completed++
+		if action == "quit" || action == "shutdown" {
+			return result, nil
+		}
 		time.Sleep(50 * time.Millisecond)
+	}
+	return result, nil
+}
+
+func runExecAction(a *App, action, args string) error {
+	switch action {
+	case "click":
+		return execClick(a, args)
+	case "rclick":
+		return execRClick(a, args)
+	case "hover":
+		return execHover(a, args)
+	case "drag":
+		return execDrag(a, args)
+	case "key":
+		return execKey(a, args)
+	case "type":
+		return execType(a, args)
+	case "exec":
+		return execCommand(a, args)
+	case "screenshot":
+		return execScreenshot(a, args)
+	case "debug":
+		return execDebug(a, args)
+	case "wait":
+		return execWait(args)
+	case "wait-for":
+		return execWaitFor(a, args)
+	case "paste":
+		return execPaste(a, args)
+	case "copy":
+		if strings.TrimSpace(args) != "" {
+			return invalidExec("copy does not accept arguments")
+		}
+		return runExecMain(a, func() error {
+			a.Copy()
+			return nil
+		})
+	case "panel":
+		return execPanel(a, args)
+	case "quit", "shutdown":
+		if strings.TrimSpace(args) != "" {
+			return invalidExec("%s does not accept arguments", action)
+		}
+		return StopExecLoop(a)
+	default:
+		return invalidExec("unknown action %q", action)
 	}
 }
 
-// parseExecCommand splits a command string into action and arguments.
-// Handles quoted strings for the exec command (e.g., exec "Command Name").
 func parseExecCommand(cmd string) (string, string) {
-	// Find the first space to split action from args
 	idx := strings.IndexByte(cmd, ' ')
 	if idx < 0 {
 		return cmd, ""
@@ -89,246 +181,349 @@ func parseExecCommand(cmd string) (string, string) {
 	return cmd[:idx], strings.TrimSpace(cmd[idx+1:])
 }
 
-func execClick(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 2 {
-		slog.Error("exec_script: click requires X Y", "args", args)
-		return
-	}
-	x, err := strconv.Atoi(parts[0])
+func execClick(a *App, args string) error {
+	x, y, err := parseCoordinates("click", args, 2)
 	if err != nil {
-		slog.Error("exec_script: invalid click X", "value", parts[0], "error", err)
-		return
+		return err
 	}
-	y, err := strconv.Atoi(parts[1])
-	if err != nil {
-		slog.Error("exec_script: invalid click Y", "value", parts[1], "error", err)
-		return
+	if err := postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.Button1, tcell.ModNone)); err != nil {
+		return err
 	}
-
-	// Press
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button1, tcell.ModNone))
 	time.Sleep(50 * time.Millisecond)
-	// Release
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.ButtonNone, tcell.ModNone))
 }
 
-// execRClick simulates a secondary (right) mouse click, which opens context
-// menus. Right-click is tcell.Button2 (see menus.go).
-func execRClick(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 2 {
-		slog.Error("exec_script: rclick requires X Y", "args", args)
-		return
-	}
-	x, err := strconv.Atoi(parts[0])
+func execRClick(a *App, args string) error {
+	x, y, err := parseCoordinates("rclick", args, 2)
 	if err != nil {
-		slog.Error("exec_script: invalid rclick X", "value", parts[0], "error", err)
-		return
+		return err
 	}
-	y, err := strconv.Atoi(parts[1])
-	if err != nil {
-		slog.Error("exec_script: invalid rclick Y", "value", parts[1], "error", err)
-		return
+	if err := postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.Button2, tcell.ModNone)); err != nil {
+		return err
 	}
-
-	// Press
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.Button2, tcell.ModNone))
 	time.Sleep(50 * time.Millisecond)
-	// Release
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.ButtonNone, tcell.ModNone))
 }
 
-func execHover(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 2 {
-		slog.Error("exec_script: hover requires X Y", "args", args)
-		return
-	}
-	x, err := strconv.Atoi(parts[0])
+func execHover(a *App, args string) error {
+	x, y, err := parseCoordinates("hover", args, 2)
 	if err != nil {
-		slog.Error("exec_script: invalid hover X", "value", parts[0], "error", err)
-		return
+		return err
 	}
-	y, err := strconv.Atoi(parts[1])
-	if err != nil {
-		slog.Error("exec_script: invalid hover Y", "value", parts[1], "error", err)
-		return
-	}
-	a.Screen.PostEvent(tcell.NewEventMouse(x, y, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.ButtonNone, tcell.ModNone))
 }
 
-func execDrag(a *App, args string) {
-	parts := strings.Fields(args)
-	if len(parts) < 4 {
-		slog.Error("exec_script: drag requires X1 Y1 X2 Y2", "args", args)
-		return
+func execDrag(a *App, args string) error {
+	x, y, err := parseCoordinates("drag", args, 4)
+	if err != nil {
+		return err
 	}
-	x1, err1 := strconv.Atoi(parts[0])
-	y1, err2 := strconv.Atoi(parts[1])
-	x2, err3 := strconv.Atoi(parts[2])
-	y2, err4 := strconv.Atoi(parts[3])
-	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
-		slog.Error("exec_script: invalid drag coordinates", "args", args)
-		return
+	if err := postExecInput(a, tcell.NewEventMouse(x[0], y[0], tcell.Button1, tcell.ModNone)); err != nil {
+		return err
 	}
-
-	a.Screen.PostEvent(tcell.NewEventMouse(x1, y1, tcell.Button1, tcell.ModNone))
 	time.Sleep(30 * time.Millisecond)
 
-	steps := 10
+	const steps = 10
 	for i := 1; i <= steps; i++ {
-		mx := x1 + (x2-x1)*i/steps
-		my := y1 + (y2-y1)*i/steps
-		a.Screen.PostEvent(tcell.NewEventMouse(mx, my, tcell.Button1, tcell.ModNone))
+		mx := x[0] + (x[1]-x[0])*i/steps
+		my := y[0] + (y[1]-y[0])*i/steps
+		if err := postExecInput(a, tcell.NewEventMouse(mx, my, tcell.Button1, tcell.ModNone)); err != nil {
+			return err
+		}
 		time.Sleep(15 * time.Millisecond)
 	}
 
-	a.Screen.PostEvent(tcell.NewEventMouse(x2, y2, tcell.ButtonNone, tcell.ModNone))
+	return postExecInput(a, tcell.NewEventMouse(x[1], y[1], tcell.ButtonNone, tcell.ModNone))
 }
 
-func execKey(a *App, args string) {
+func parseCoordinates(action, args string, count int) ([2]int, [2]int, error) {
+	var xs, ys [2]int
+	parts := strings.Fields(args)
+	if len(parts) != count {
+		return xs, ys, invalidExec("%s requires %d coordinates", action, count)
+	}
+	values := make([]int, count)
+	for i, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return xs, ys, invalidExec("invalid %s coordinate %q: %v", action, part, err)
+		}
+		values[i] = value
+	}
+	xs[0], ys[0] = values[0], values[1]
+	if count == 4 {
+		xs[1], ys[1] = values[2], values[3]
+	}
+	return xs, ys, nil
+}
+
+func execKey(a *App, args string) error {
 	combo := strings.TrimSpace(args)
 	if combo == "" {
-		slog.Error("exec_script: key requires a key combo")
-		return
+		return invalidExec("key requires a key combo")
 	}
 
 	steps, err := config.ParseKeyString(combo)
 	if err != nil {
-		slog.Error("exec_script: invalid key combo", "combo", combo, "error", err)
-		return
+		return invalidExec("invalid key combo %q: %v", combo, err)
 	}
 
 	for _, step := range steps {
 		key, mod, ch := comboToTcell(step)
-		a.Screen.PostEvent(tcell.NewEventKey(key, keyEventStr(ch), mod))
+		if err := postExecInput(a, tcell.NewEventKey(key, keyEventStr(ch), mod)); err != nil {
+			return err
+		}
 		time.Sleep(30 * time.Millisecond)
 	}
+	return nil
 }
 
-func execType(a *App, args string) {
+func execType(a *App, args string) error {
 	text := stripQuotes(args)
 	for _, r := range text {
-		a.Screen.PostEvent(tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone))
+		if err := postExecInput(a, tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone)); err != nil {
+			return err
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	return nil
 }
 
-func execPaste(a *App, args string) {
+func execPaste(a *App, args string) error {
 	text := stripQuotes(args)
 	if text == "" {
-		slog.Error("exec_script: paste requires text")
-		return
+		return invalidExec("paste requires text")
 	}
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	time.Sleep(50 * time.Millisecond)
-	a.PasteText(text)
-	a.FlushEditorOnChange()
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+	return runExecMain(a, func() error {
+		a.PasteText(text)
+		a.FlushEditorOnChange()
+		return nil
+	})
 }
 
-func execCommand(a *App, args string) {
+func execCommand(a *App, args string) error {
 	title := stripQuotes(strings.TrimSpace(args))
 	if title == "" {
-		slog.Error("exec_script: exec requires a command title")
-		return
+		return invalidExec("exec requires a command title")
 	}
 
-	cmd, ok := a.Reg.FindByTitle(title)
-	if !ok {
-		slog.Error("exec_script: command not found", "title", title)
-		return
-	}
-	// Hand the command to the event loop instead of running it here. `key` and
-	// `click` already post real events, so they get the status bar sync that
-	// follows real input; running a command straight from the script goroutine
-	// skipped that sync and mutated widget state off the main thread.
-	a.Screen.PostEvent(tcell.NewEventInterrupt(&ExecCommandRequest{ID: cmd.ID}))
+	return runExecMain(a, func() error {
+		cmd, ok := a.Reg.FindByTitle(title)
+		if !ok {
+			return invalidExec("command %q not found", title)
+		}
+		if !a.Reg.Execute(cmd.ID) {
+			return failedExec("command %q disappeared before execution", title)
+		}
+		a.FlushEditorOnChange()
+		return nil
+	})
 }
 
-// ExecCommandRequest is posted as an EventInterrupt so a command named by an
-// --exec script runs on the main thread, on the same path as key and mouse
-// input.
-type ExecCommandRequest struct {
-	ID string
-}
-
-func execScreenshot(a *App, args string) {
+func execScreenshot(a *App, args string) error {
 	path := stripQuotes(strings.TrimSpace(args))
 	if path == "" {
-		slog.Error("exec_script: screenshot requires a file path")
-		return
+		return invalidExec("screenshot requires a file path")
 	}
-	// Trigger a redraw so the screen is up-to-date
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	time.Sleep(50 * time.Millisecond)
-
-	if err := a.DumpScreenshot(path); err != nil {
-		slog.Error("exec_script: screenshot failed", "path", path, "error", err)
-	}
+	return runExecMain(a, func() error {
+		if err := a.DumpScreenshot(path); err != nil {
+			return failedExec("screenshot %q failed: %v", path, err)
+		}
+		return nil
+	})
 }
 
-func execDebug(a *App, args string) {
+func execDebug(a *App, args string) error {
 	path := stripQuotes(strings.TrimSpace(args))
 	if path == "" {
-		slog.Error("exec_script: debug requires a file path")
-		return
+		return invalidExec("debug requires a file path")
 	}
-	// Trigger a redraw so state is current
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	time.Sleep(50 * time.Millisecond)
-
-	if err := a.DumpDebugState(path); err != nil {
-		slog.Error("exec_script: debug dump failed", "path", path, "error", err)
-	}
+	return runExecMain(a, func() error {
+		if err := a.DumpDebugState(path); err != nil {
+			return failedExec("debug dump %q failed: %v", path, err)
+		}
+		return nil
+	})
 }
 
-func execWait(args string) {
+func execWait(args string) error {
 	ms := strings.TrimSpace(args)
 	if ms == "" {
-		slog.Error("exec_script: wait requires milliseconds")
-		return
+		return invalidExec("wait requires milliseconds")
 	}
-	n, err := strconv.Atoi(ms)
+	duration, err := parseExecMilliseconds(ms, true)
 	if err != nil {
-		slog.Error("exec_script: invalid wait duration", "value", ms, "error", err)
-		return
+		return invalidExec("invalid wait duration %q", ms)
 	}
-	time.Sleep(time.Duration(n) * time.Millisecond)
+	time.Sleep(duration)
+	return nil
 }
 
-func execPanel(a *App, args string) {
+func execWaitFor(a *App, args string) error {
+	text, timeout, err := parseWaitForArgs(args)
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		var visible bool
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return timeoutExec("screen text %q not visible after %s", text, timeout)
+		}
+		requestTimeout := min(remaining, execRequestTimeout)
+		if err := runExecMainTimeout(a, func() error {
+			visible = strings.Contains(a.Screenshot(), text)
+			return nil
+		}, requestTimeout); err != nil {
+			return err
+		}
+		if visible {
+			return nil
+		}
+		remaining = time.Until(deadline)
+		if remaining <= 0 {
+			return timeoutExec("screen text %q not visible after %s", text, timeout)
+		}
+		time.Sleep(min(waitForPollInterval, remaining))
+	}
+}
+
+func parseWaitForArgs(args string) (string, time.Duration, error) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return "", 0, invalidExec("wait-for requires screen text")
+	}
+
+	text := args
+	option := ""
+	if strings.HasPrefix(args, "\"") {
+		end := quotedStringEnd(args)
+		if end < 0 {
+			return "", 0, invalidExec("wait-for has an unterminated quoted string")
+		}
+		quoted := args[:end]
+		unquoted, err := strconv.Unquote(quoted)
+		if err != nil {
+			return "", 0, invalidExec("invalid wait-for text: %v", err)
+		}
+		text = unquoted
+		option = strings.TrimSpace(args[end:])
+	} else {
+		fields := strings.Fields(args)
+		last := fields[len(fields)-1]
+		if strings.HasPrefix(last, "timeout=") {
+			option = last
+			text = strings.TrimSpace(strings.TrimSuffix(args, last))
+		}
+	}
+
+	if text == "" {
+		return "", 0, invalidExec("wait-for requires non-empty screen text")
+	}
+	timeout := defaultWaitForTimeout
+	if option != "" {
+		if strings.ContainsAny(option, " \t\r\n") || !strings.HasPrefix(option, "timeout=") {
+			return "", 0, invalidExec("wait-for expects optional timeout=MS after the text")
+		}
+		ms := strings.TrimPrefix(option, "timeout=")
+		parsed, err := parseExecMilliseconds(ms, false)
+		if err != nil {
+			return "", 0, invalidExec("invalid wait-for timeout %q", ms)
+		}
+		timeout = parsed
+	}
+	return text, timeout, nil
+}
+
+func parseExecMilliseconds(value string, allowZero bool) (time.Duration, error) {
+	milliseconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || milliseconds < 0 || (!allowZero && milliseconds == 0) || milliseconds > maxExecMilliseconds {
+		return 0, fmt.Errorf("milliseconds out of range")
+	}
+	return time.Duration(milliseconds) * time.Millisecond, nil
+}
+
+func quotedStringEnd(s string) int {
+	escaped := false
+	for i := 1; i < len(s); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch s[i] {
+		case '\\':
+			escaped = true
+		case '"':
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func execPanel(a *App, args string) error {
 	id := stripQuotes(strings.TrimSpace(args))
 	if id == "" {
-		slog.Error("exec_script: panel requires a panel ID")
-		return
+		return invalidExec("panel requires a panel ID")
 	}
-	if !a.BottomPanel.HasPanel(id) {
-		slog.Error("exec_script: panel not found", "id", id)
-		return
-	}
-	a.BottomPanel.SetActivePanel(id)
-	if !a.ContentSplit.ShowBottom {
-		r := a.ContentSplit.GetRect()
-		maxH := r.H - 4
-		if a.ContentSplit.BottomH <= 1 || a.ContentSplit.BottomH > maxH {
-			a.ContentSplit.BottomH = min(r.H/2, maxH)
+	return runExecMain(a, func() error {
+		if !a.BottomPanel.HasPanel(id) {
+			return invalidExec("panel %q not found", id)
 		}
-		a.ContentSplit.ShowBottom = true
-	}
-	if w := a.BottomPanel.ActiveWidget(); w != nil {
-		a.Root.SetFocus(w)
-	}
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+		a.BottomPanel.SetActivePanel(id)
+		if !a.ContentSplit.ShowBottom {
+			r := a.ContentSplit.GetRect()
+			maxH := r.H - 4
+			if a.ContentSplit.BottomH <= 1 || a.ContentSplit.BottomH > maxH {
+				a.ContentSplit.BottomH = min(r.H/2, maxH)
+			}
+			a.ContentSplit.ShowBottom = true
+		}
+		if w := a.BottomPanel.ActiveWidget(); w != nil {
+			a.Root.SetFocus(w)
+		}
+		return nil
+	})
 }
 
-func execQuit(a *App) {
-	*a.Running = false
-	a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
+func postExecInput(a *App, event tcell.Event) error {
+	done := make(chan error, 1)
+	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execInputRequest{Event: event, Done: done})); err != nil {
+		return failedExec("failed to post input event: %v", err)
+	}
+	return awaitExecRequest(done, execRequestTimeout)
 }
 
-// stripQuotes removes surrounding double quotes from a string if present.
+func runExecMain(a *App, run func() error) error {
+	return runExecMainTimeout(a, run, execRequestTimeout)
+}
+
+func runExecMainTimeout(a *App, run func() error, timeout time.Duration) error {
+	done := make(chan error, 1)
+	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execMainRequest{Run: run, Done: done})); err != nil {
+		return failedExec("failed to post main-thread action: %v", err)
+	}
+	return awaitExecRequest(done, timeout)
+}
+
+func awaitExecRequest(done <-chan error, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		return timeoutExec("event loop did not acknowledge action within %s", timeout)
+	}
+}
+
+func StopExecLoop(a *App) error {
+	return runExecMain(a, func() error {
+		*a.Running = false
+		return nil
+	})
+}
+
 func stripQuotes(s string) string {
 	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
 		return s[1 : len(s)-1]
@@ -336,7 +531,6 @@ func stripQuotes(s string) string {
 	return s
 }
 
-// ExecScriptUsage returns the usage text for the --exec flag.
 func ExecScriptUsage() string {
 	return fmt.Sprintf(`--exec "commands"  Execute semicolon-separated commands after startup
 
@@ -353,15 +547,20 @@ Supported commands:
   screenshot PATH    Save screen text to file
   debug PATH         Save debug state JSON to file
   wait MS            Wait milliseconds
+  wait-for TEXT [timeout=MS]
+                     Wait until visible screen text appears (default 5000ms)
   panel ID           Show and focus a bottom panel by ID
   quit               Exit the editor
   shutdown           Alias for quit, for use over --listen
 
+Invalid actions fail --exec with a nonzero exit and POST /exec with a non-2xx
+response. Quote wait-for text to preserve surrounding whitespace or escapes.
+
 --listen starts an HTTP command server on 127.0.0.1:4242 that accepts the
 same script format over POST /exec, so a running editor can be driven
 interactively instead of scripted in advance:
-  curl -X POST --data "type hi; screenshot /tmp/s1.txt" http://127.0.0.1:4242/exec
+  curl -X POST --data "type hi; wait-for hi; screenshot /tmp/s1.txt" http://127.0.0.1:4242/exec
 
 Example:
-  %s --exec "wait 200; screenshot /tmp/s1.txt; quit"`, os.Args[0])
+  %s --exec "wait-for Explore; screenshot /tmp/s1.txt; quit"`, os.Args[0])
 }

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -560,10 +560,15 @@ func awaitExecRequest(lifecycle *execRequestLifecycle, timeout time.Duration) er
 }
 
 func StopExecLoop(a *App) error {
-	return runExecMain(a, func() error {
+	lifecycle := newExecRequestLifecycle()
+	request := &execMainRequest{Run: func() error {
 		*a.Running = false
 		return nil
-	})
+	}, Lifecycle: lifecycle}
+	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(request)); err != nil {
+		return failedExec("failed to post shutdown request: %v", err)
+	}
+	return <-lifecycle.done
 }
 
 func stripQuotes(s string) string {

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/config"
@@ -31,7 +32,8 @@ const (
 )
 
 type ExecResult struct {
-	Completed int
+	Completed         int
+	ShutdownRequested bool
 }
 
 type ExecError struct {
@@ -76,13 +78,45 @@ func timeoutExec(format string, args ...any) error {
 }
 
 type execInputRequest struct {
-	Event tcell.Event
-	Done  chan error
+	Event     tcell.Event
+	Lifecycle *execRequestLifecycle
 }
 
 type execMainRequest struct {
-	Run  func() error
-	Done chan error
+	Run       func() error
+	Lifecycle *execRequestLifecycle
+}
+
+type execRequestState uint32
+
+const (
+	execRequestPending execRequestState = iota
+	execRequestClaimed
+	execRequestCanceled
+)
+
+type execRequestLifecycle struct {
+	state atomic.Uint32
+	done  chan error
+}
+
+func newExecRequestLifecycle() *execRequestLifecycle {
+	return &execRequestLifecycle{done: make(chan error, 1)}
+}
+
+func (r *execRequestLifecycle) claim() bool {
+	return r.state.CompareAndSwap(uint32(execRequestPending), uint32(execRequestClaimed))
+}
+
+func (r *execRequestLifecycle) cancel() bool {
+	return r.state.CompareAndSwap(uint32(execRequestPending), uint32(execRequestCanceled))
+}
+
+func (r *execRequestLifecycle) complete(err error) {
+	select {
+	case r.done <- err:
+	default:
+	}
 }
 
 func RunExecScript(a *App, script string) (ExecResult, error) {
@@ -120,6 +154,7 @@ func RunExecScriptSep(a *App, script, sep string) (ExecResult, error) {
 		}
 		result.Completed++
 		if action == "quit" || action == "shutdown" {
+			result.ShutdownRequested = true
 			return result, nil
 		}
 		time.Sleep(50 * time.Millisecond)
@@ -167,7 +202,7 @@ func runExecAction(a *App, action, args string) error {
 		if strings.TrimSpace(args) != "" {
 			return invalidExec("%s does not accept arguments", action)
 		}
-		return StopExecLoop(a)
+		return nil
 	default:
 		return invalidExec("unknown action %q", action)
 	}
@@ -487,11 +522,15 @@ func execPanel(a *App, args string) error {
 }
 
 func postExecInput(a *App, event tcell.Event) error {
-	done := make(chan error, 1)
-	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execInputRequest{Event: event, Done: done})); err != nil {
+	return postExecInputTimeout(a, event, execRequestTimeout)
+}
+
+func postExecInputTimeout(a *App, event tcell.Event, timeout time.Duration) error {
+	lifecycle := newExecRequestLifecycle()
+	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execInputRequest{Event: event, Lifecycle: lifecycle})); err != nil {
 		return failedExec("failed to post input event: %v", err)
 	}
-	return awaitExecRequest(done, execRequestTimeout)
+	return awaitExecRequest(lifecycle, timeout)
 }
 
 func runExecMain(a *App, run func() error) error {
@@ -499,21 +538,24 @@ func runExecMain(a *App, run func() error) error {
 }
 
 func runExecMainTimeout(a *App, run func() error, timeout time.Duration) error {
-	done := make(chan error, 1)
-	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execMainRequest{Run: run, Done: done})); err != nil {
+	lifecycle := newExecRequestLifecycle()
+	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(&execMainRequest{Run: run, Lifecycle: lifecycle})); err != nil {
 		return failedExec("failed to post main-thread action: %v", err)
 	}
-	return awaitExecRequest(done, timeout)
+	return awaitExecRequest(lifecycle, timeout)
 }
 
-func awaitExecRequest(done <-chan error, timeout time.Duration) error {
+func awaitExecRequest(lifecycle *execRequestLifecycle, timeout time.Duration) error {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
-	case err := <-done:
+	case err := <-lifecycle.done:
 		return err
 	case <-timer.C:
-		return timeoutExec("event loop did not acknowledge action within %s", timeout)
+		if lifecycle.cancel() {
+			return timeoutExec("event loop did not acknowledge action within %s", timeout)
+		}
+		return <-lifecycle.done
 	}
 }
 

--- a/internal/app/exec_script.go
+++ b/internal/app/exec_script.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -438,7 +439,7 @@ func parseWaitForArgs(args string) (string, time.Duration, error) {
 			return "", 0, invalidExec("wait-for has an unterminated quoted string")
 		}
 		quoted := args[:end]
-		unquoted, err := strconv.Unquote(quoted)
+		unquoted, err := unquoteExecString(quoted)
 		if err != nil {
 			return "", 0, invalidExec("invalid wait-for text: %v", err)
 		}
@@ -469,6 +470,14 @@ func parseWaitForArgs(args string) (string, time.Duration, error) {
 		timeout = parsed
 	}
 	return text, timeout, nil
+}
+
+func unquoteExecString(quoted string) (string, error) {
+	var value string
+	if err := json.Unmarshal([]byte(quoted), &value); err == nil {
+		return value, nil
+	}
+	return strconv.Unquote(quoted)
 }
 
 func parseExecMilliseconds(value string, allowZero bool) (time.Duration, error) {
@@ -560,15 +569,37 @@ func awaitExecRequest(lifecycle *execRequestLifecycle, timeout time.Duration) er
 }
 
 func StopExecLoop(a *App) error {
+	eventLoopDone := a.eventLoopDoneSignal()
+	select {
+	case <-eventLoopDone:
+		return nil
+	default:
+	}
+
 	lifecycle := newExecRequestLifecycle()
 	request := &execMainRequest{Run: func() error {
 		*a.Running = false
 		return nil
 	}, Lifecycle: lifecycle}
 	if err := a.Screen.PostEvent(tcell.NewEventInterrupt(request)); err != nil {
+		select {
+		case <-eventLoopDone:
+			return nil
+		default:
+		}
 		return failedExec("failed to post shutdown request: %v", err)
 	}
-	return <-lifecycle.done
+	select {
+	case err := <-lifecycle.done:
+		return err
+	case <-eventLoopDone:
+		select {
+		case err := <-lifecycle.done:
+			return err
+		default:
+			return nil
+		}
+	}
 }
 
 func stripQuotes(s string) string {

--- a/internal/app/exec_script_test.go
+++ b/internal/app/exec_script_test.go
@@ -3,11 +3,42 @@ package app
 import (
 	"errors"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/view"
+
+	"github.com/gdamore/tcell/v3"
 )
+
+func holdExecEventLoop(t *testing.T, a *App) (chan struct{}, <-chan error) {
+	t.Helper()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+	done := make(chan error, 1)
+	go func() {
+		done <- runExecMain(a, func() error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("event loop did not claim blocking action")
+	}
+	return release, done
+}
 
 func TestParseWaitForArgs(t *testing.T) {
 	tests := []struct {
@@ -117,6 +148,107 @@ func TestRunExecScriptReturnsTypedPartialResult(t *testing.T) {
 	}
 	if execErr.Kind != ExecErrorInvalid || execErr.Index != 2 || execErr.Action != "click" {
 		t.Fatalf("exec error = %+v, want invalid click at command 2", execErr)
+	}
+}
+
+func TestRunExecScriptReturnsShutdownIntentWithoutStoppingLoop(t *testing.T) {
+	for _, action := range []string{"quit", "shutdown"} {
+		t.Run(action, func(t *testing.T) {
+			a := newListenTestApp(t)
+
+			result, err := RunExecScript(a, "wait 0; "+action+"; type skipped")
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Completed != 2 || !result.ShutdownRequested {
+				t.Fatalf("result = %+v, want two completed actions and shutdown request", result)
+			}
+			if !*a.Running {
+				t.Fatal("script applied shutdown instead of returning caller-owned intent")
+			}
+		})
+	}
+}
+
+func TestExecRequestTimeoutCancelsQueuedMainAction(t *testing.T) {
+	a := newListenTestApp(t)
+	release, blockerDone := holdExecEventLoop(t, a)
+	var ran atomic.Bool
+
+	err := runExecMainTimeout(a, func() error {
+		ran.Store(true)
+		return nil
+	}, 25*time.Millisecond)
+
+	var actionErr *execActionError
+	if !errors.As(err, &actionErr) || actionErr.kind != ExecErrorTimeout {
+		t.Fatalf("error = %T %v, want timeout", err, err)
+	}
+	close(release)
+	if err := <-blockerDone; err != nil {
+		t.Fatalf("blocking action failed: %v", err)
+	}
+	if err := runExecMain(a, func() error { return nil }); err != nil {
+		t.Fatalf("draining event loop: %v", err)
+	}
+	if ran.Load() {
+		t.Fatal("canceled queued main action ran after timeout")
+	}
+}
+
+func TestExecRequestTimeoutCancelsQueuedInput(t *testing.T) {
+	a := newListenTestApp(t)
+	a.Root.SetFocus(a.EditorGroup)
+	before := strings.Join(a.EditorGroup.ActiveBuffer().Lines, "\n")
+	release, blockerDone := holdExecEventLoop(t, a)
+
+	err := postExecInputTimeout(a, tcell.NewEventKey(tcell.KeyRune, "X", tcell.ModNone), 25*time.Millisecond)
+
+	var actionErr *execActionError
+	if !errors.As(err, &actionErr) || actionErr.kind != ExecErrorTimeout {
+		t.Fatalf("error = %T %v, want timeout", err, err)
+	}
+	close(release)
+	if err := <-blockerDone; err != nil {
+		t.Fatalf("blocking action failed: %v", err)
+	}
+	if err := runExecMain(a, func() error { return nil }); err != nil {
+		t.Fatalf("draining event loop: %v", err)
+	}
+	if after := strings.Join(a.EditorGroup.ActiveBuffer().Lines, "\n"); after != before {
+		t.Fatalf("canceled queued input mutated buffer: before %q after %q", before, after)
+	}
+}
+
+func TestExecRequestWaitsForClaimedActionPastTimeout(t *testing.T) {
+	a := newListenTestApp(t)
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	var runs atomic.Int32
+	begin := time.Now()
+	go func() {
+		done <- runExecMain(a, func() error {
+			runs.Add(1)
+			close(started)
+			time.Sleep(execRequestTimeout + 100*time.Millisecond)
+			return nil
+		})
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("event loop did not claim slow action")
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("claimed action returned false timeout: %v", err)
+	}
+	if elapsed := time.Since(begin); elapsed < execRequestTimeout {
+		t.Fatalf("claimed action returned after %s, want at least %s", elapsed, execRequestTimeout)
+	}
+	if got := runs.Load(); got != 1 {
+		t.Fatalf("slow action ran %d times, want once", got)
 	}
 }
 

--- a/internal/app/exec_script_test.go
+++ b/internal/app/exec_script_test.go
@@ -1,0 +1,164 @@
+package app
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/view"
+)
+
+func TestParseWaitForArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        string
+		wantText    string
+		wantTimeout time.Duration
+	}{
+		{name: "plain text", args: "Explore", wantText: "Explore", wantTimeout: defaultWaitForTimeout},
+		{name: "plain whitespace", args: "working tree clean", wantText: "working tree clean", wantTimeout: defaultWaitForTimeout},
+		{name: "numeric suffix is text", args: "build 123", wantText: "build 123", wantTimeout: defaultWaitForTimeout},
+		{name: "explicit timeout", args: "ready now timeout=125", wantText: "ready now", wantTimeout: 125 * time.Millisecond},
+		{name: "quoted escapes", args: `"  ready \"now\"  " timeout=250`, wantText: `  ready "now"  `, wantTimeout: 250 * time.Millisecond},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text, timeout, err := parseWaitForArgs(tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if text != tc.wantText {
+				t.Errorf("text = %q, want %q", text, tc.wantText)
+			}
+			if timeout != tc.wantTimeout {
+				t.Errorf("timeout = %s, want %s", timeout, tc.wantTimeout)
+			}
+		})
+	}
+}
+
+func TestParseWaitForArgsRejectsInvalidSyntax(t *testing.T) {
+	for _, args := range []string{
+		"",
+		`"unterminated`,
+		`"ready" eventually`,
+		"ready timeout=0",
+		"timeout=100",
+	} {
+		t.Run(args, func(t *testing.T) {
+			if _, _, err := parseWaitForArgs(args); err == nil {
+				t.Fatalf("parseWaitForArgs(%q) succeeded, want error", args)
+			}
+		})
+	}
+}
+
+func TestParseExecMillisecondsBoundaries(t *testing.T) {
+	maximum := strconv.FormatInt(maxExecMilliseconds, 10)
+	overflow := strconv.FormatInt(maxExecMilliseconds+1, 10)
+
+	duration, err := parseExecMilliseconds(maximum, false)
+	if err != nil {
+		t.Fatalf("maximum representable milliseconds rejected: %v", err)
+	}
+	if want := time.Duration(maxExecMilliseconds) * time.Millisecond; duration != want {
+		t.Fatalf("duration = %s, want %s", duration, want)
+	}
+	if _, err := parseExecMilliseconds(overflow, false); err == nil {
+		t.Fatalf("first overflowing millisecond value %s accepted", overflow)
+	}
+	if duration, err := parseExecMilliseconds("0", true); err != nil || duration != 0 {
+		t.Fatalf("wait zero = %s, %v; want accepted zero", duration, err)
+	}
+	if _, err := parseExecMilliseconds("0", false); err == nil {
+		t.Fatal("wait-for accepted zero timeout")
+	}
+}
+
+func TestExecDurationOverflowIsTypedInvalidInput(t *testing.T) {
+	a := newListenTestApp(t)
+	overflow := strconv.FormatInt(maxExecMilliseconds+1, 10)
+	tests := []string{
+		"wait " + overflow,
+		`wait-for x timeout=` + overflow,
+	}
+
+	for _, script := range tests {
+		t.Run(script, func(t *testing.T) {
+			start := time.Now()
+			result, err := RunExecScript(a, script)
+			if result.Completed != 0 {
+				t.Fatalf("completed = %d, want 0", result.Completed)
+			}
+			var execErr *ExecError
+			if !errors.As(err, &execErr) || execErr.Kind != ExecErrorInvalid {
+				t.Fatalf("error = %T %v, want invalid ExecError", err, err)
+			}
+			if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+				t.Fatalf("overflow rejection took %s", elapsed)
+			}
+		})
+	}
+}
+
+func TestRunExecScriptReturnsTypedPartialResult(t *testing.T) {
+	a := newListenTestApp(t)
+
+	result, err := RunExecScript(a, "wait 0; click nope 2; type skipped")
+
+	if result.Completed != 1 {
+		t.Fatalf("completed = %d, want 1", result.Completed)
+	}
+	var execErr *ExecError
+	if !errors.As(err, &execErr) {
+		t.Fatalf("error = %T %v, want *ExecError", err, err)
+	}
+	if execErr.Kind != ExecErrorInvalid || execErr.Index != 2 || execErr.Action != "click" {
+		t.Fatalf("exec error = %+v, want invalid click at command 2", execErr)
+	}
+}
+
+func TestRunExecScriptWaitForObservesDelayedVisibleScreen(t *testing.T) {
+	a := newListenTestApp(t)
+	posted := make(chan error, 1)
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		posted <- runExecMain(a, func() error {
+			a.Status.SetNotification("ASYNC READY", view.NotifyInfo, time.Second)
+			return nil
+		})
+	}()
+
+	result, err := RunExecScript(a, `wait-for "ASYNC READY" timeout=1000`)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Completed != 1 {
+		t.Fatalf("completed = %d, want 1", result.Completed)
+	}
+	if err := <-posted; err != nil {
+		t.Fatalf("posting visible text: %v", err)
+	}
+}
+
+func TestRunExecScriptWaitForTimeoutIsBounded(t *testing.T) {
+	a := newListenTestApp(t)
+	start := time.Now()
+
+	result, err := RunExecScript(a, `wait-for "never visible" timeout=40`)
+	elapsed := time.Since(start)
+
+	if result.Completed != 0 {
+		t.Fatalf("completed = %d, want 0", result.Completed)
+	}
+	var execErr *ExecError
+	if !errors.As(err, &execErr) || execErr.Kind != ExecErrorTimeout {
+		t.Fatalf("error = %T %v, want timeout ExecError", err, err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("wait-for took %s, want bounded near 40ms", elapsed)
+	}
+}

--- a/internal/app/exec_script_test.go
+++ b/internal/app/exec_script_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,6 +53,8 @@ func TestParseWaitForArgs(t *testing.T) {
 		{name: "numeric suffix is text", args: "build 123", wantText: "build 123", wantTimeout: defaultWaitForTimeout},
 		{name: "explicit timeout", args: "ready now timeout=125", wantText: "ready now", wantTimeout: 125 * time.Millisecond},
 		{name: "quoted escapes", args: `"  ready \"now\"  " timeout=250`, wantText: `  ready "now"  `, wantTimeout: 250 * time.Millisecond},
+		{name: "JSON lone surrogate", args: `"\ud800"`, wantText: "\ufffd", wantTimeout: defaultWaitForTimeout},
+		{name: "Go hex escape compatibility", args: `"ready\x20now"`, wantText: "ready now", wantTimeout: defaultWaitForTimeout},
 	}
 
 	for _, tc := range tests {
@@ -249,6 +252,83 @@ func TestExecRequestWaitsForClaimedActionPastTimeout(t *testing.T) {
 	}
 	if got := runs.Load(); got != 1 {
 		t.Fatalf("slow action ran %d times, want once", got)
+	}
+}
+
+func TestStopExecLoopWaitsForEventLoopStarting(t *testing.T) {
+	a := prepareListenTestApp(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- StopExecLoop(a)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("StopExecLoop returned before event loop started: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	startListenTestEventLoop(t, a)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StopExecLoop did not drain after event loop started")
+	}
+}
+
+func TestStopExecLoopReturnsAfterEventLoopStopped(t *testing.T) {
+	a := newListenTestApp(t)
+	if err := StopExecLoop(a); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- StopExecLoop(a)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("repeated StopExecLoop blocked after event loop stopped")
+	}
+}
+
+func TestConcurrentStopExecLoopReturnsForEveryCaller(t *testing.T) {
+	a := newListenTestApp(t)
+	release, blockerDone := holdExecEventLoop(t, a)
+
+	const callers = 8
+	results := make(chan error, callers)
+	var started sync.WaitGroup
+	started.Add(callers)
+	for range callers {
+		go func() {
+			started.Done()
+			results <- StopExecLoop(a)
+		}()
+	}
+	started.Wait()
+	time.Sleep(25 * time.Millisecond)
+	close(release)
+	if err := <-blockerDone; err != nil {
+		t.Fatalf("blocking action failed: %v", err)
+	}
+
+	for range callers {
+		select {
+		case err := <-results:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("concurrent StopExecLoop caller did not return")
+		}
 	}
 }
 

--- a/internal/app/listen.go
+++ b/internal/app/listen.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -15,6 +17,15 @@ import (
 const ListenAddr = "127.0.0.1:4242"
 
 const maxExecBodySize = 1 << 20 // 1MB
+
+func ListenAddress() string {
+	port := os.Getenv("TTT_LISTEN_PORT")
+	value, err := strconv.ParseUint(port, 10, 16)
+	if port == "" || err != nil || value == 0 {
+		return ListenAddr
+	}
+	return net.JoinHostPort("127.0.0.1", port)
+}
 
 // NewExecHandler is split out from StartListenServer so tests can drive it
 // through httptest.Server. Concurrent /exec requests are not synchronized:
@@ -46,7 +57,8 @@ func NewExecHandler(a *App) http.Handler {
 		if sep == "" {
 			sep = DefaultExecSeparator
 		}
-		if _, err := RunExecScriptSep(a, script, sep); err != nil {
+		result, err := RunExecScriptSep(a, script, sep)
+		if err != nil {
 			status := http.StatusUnprocessableEntity
 			var execErr *ExecError
 			if errors.As(err, &execErr) {
@@ -60,8 +72,21 @@ func NewExecHandler(a *App) http.Handler {
 			http.Error(w, err.Error(), status)
 			return
 		}
+		w.Header().Set("Content-Length", "2")
 		w.WriteHeader(http.StatusOK)
-		io.WriteString(w, "ok")
+		written, err := io.WriteString(w, "ok")
+		if err != nil || written != 2 {
+			slog.Error("listen: failed to write exec response", "written", written, "error", err)
+			return
+		}
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		if result.ShutdownRequested {
+			if err := StopExecLoop(a); err != nil {
+				slog.Error("listen: failed to apply exec shutdown", "error", err)
+			}
+		}
 	})
 	return mux
 }
@@ -69,12 +94,13 @@ func NewExecHandler(a *App) http.Handler {
 // StartListenServer starts the --listen HTTP command server. Blocks until
 // the listener fails, so callers run it in a goroutine.
 func StartListenServer(a *App) {
-	ln, err := net.Listen("tcp", ListenAddr)
+	addr := ListenAddress()
+	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		slog.Error("listen: failed to bind", "addr", ListenAddr, "error", err)
+		slog.Error("listen: failed to bind", "addr", addr, "error", err)
 		return
 	}
-	slog.Info("listen: HTTP command server started", "addr", ListenAddr)
+	slog.Info("listen: HTTP command server started", "addr", addr)
 	if err := http.Serve(ln, NewExecHandler(a)); err != nil {
 		slog.Error("listen: server stopped", "error", err)
 	}

--- a/internal/app/listen.go
+++ b/internal/app/listen.go
@@ -46,7 +46,20 @@ func NewExecHandler(a *App) http.Handler {
 		if sep == "" {
 			sep = DefaultExecSeparator
 		}
-		RunExecScriptSep(a, script, sep)
+		if _, err := RunExecScriptSep(a, script, sep); err != nil {
+			status := http.StatusUnprocessableEntity
+			var execErr *ExecError
+			if errors.As(err, &execErr) {
+				switch execErr.Kind {
+				case ExecErrorInvalid:
+					status = http.StatusBadRequest
+				case ExecErrorTimeout:
+					status = http.StatusRequestTimeout
+				}
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, "ok")
 	})

--- a/internal/app/listen_test.go
+++ b/internal/app/listen_test.go
@@ -69,30 +69,56 @@ func execHandlerRequest(t *testing.T, a *App, method, path, body string) *http.R
 	return resp
 }
 
-func TestExecHandlerRunsScriptSynchronously(t *testing.T) {
+func execHandlerDirect(t *testing.T, a *App, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	response := httptest.NewRecorder()
+	NewExecHandler(a).ServeHTTP(response, req)
+	return response
+}
+
+func TestExecHandlerAppliesQuitAfterWritingResponse(t *testing.T) {
 	a := newListenTestApp(t)
 
-	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "quit")
+	response := execHandlerDirect(t, a, "/exec", "quit")
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	if response.Code != http.StatusOK || response.Body.String() != "ok" || !response.Flushed {
+		t.Fatalf("response = status %d body %q flushed %v", response.Code, response.Body.String(), response.Flushed)
 	}
-	// The handler returns only after the event loop has acknowledged quit.
 	if *a.Running {
-		t.Error("expected quit script to have set Running to false")
+		t.Error("handler returned before applying quit")
 	}
 }
 
 func TestExecHandlerShutdownAliasesQuit(t *testing.T) {
 	a := newListenTestApp(t)
 
-	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "shutdown")
+	response := execHandlerDirect(t, a, "/exec", "shutdown")
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.Code)
+	}
+	if response.Body.String() != "ok" || response.Header().Get("Content-Length") != "2" || !response.Flushed {
+		t.Fatalf("response = %q length %q flushed %v, want flushed two-byte success", response.Body.String(), response.Header().Get("Content-Length"), response.Flushed)
 	}
 	if *a.Running {
-		t.Error("expected shutdown script to have set Running to false")
+		t.Error("handler returned before applying shutdown")
+	}
+}
+
+func TestListenAddressUsesLoopbackPortOverride(t *testing.T) {
+	t.Setenv("TTT_LISTEN_PORT", "54321")
+	if got := ListenAddress(); got != "127.0.0.1:54321" {
+		t.Fatalf("ListenAddress() = %q, want loopback override", got)
+	}
+
+	for _, invalid := range []string{"", "0", "65536", "not-a-port"} {
+		t.Run(invalid, func(t *testing.T) {
+			t.Setenv("TTT_LISTEN_PORT", invalid)
+			if got := ListenAddress(); got != ListenAddr {
+				t.Fatalf("ListenAddress() = %q, want default %q", got, ListenAddr)
+			}
+		})
 	}
 }
 
@@ -129,10 +155,10 @@ func TestExecHandlerRejectsNonPost(t *testing.T) {
 func TestExecHandlerRespectsSepQueryParam(t *testing.T) {
 	a := newListenTestApp(t)
 
-	resp := execHandlerRequest(t, a, http.MethodPost, "/exec?sep=,", "wait 10,quit")
+	response := execHandlerDirect(t, a, "/exec?sep=,", "wait 10,quit")
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	if response.Code != http.StatusOK || response.Body.String() != "ok" {
+		t.Fatalf("response = status %d body %q, want 200 ok", response.Code, response.Body.String())
 	}
 	if *a.Running {
 		t.Error("expected script split on custom separator to run both commands, including quit")

--- a/internal/app/listen_test.go
+++ b/internal/app/listen_test.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
@@ -28,6 +30,24 @@ func newListenTestApp(t *testing.T) *App {
 	a.Running = &running
 	RegisterCommands(a)
 	a.Root.SetSize(80, 24)
+	loopDone := make(chan struct{})
+	go func() {
+		RunEventLoop(a.Screen, a.Renderer, a, a.Running, a.CloseTerminal)
+		close(loopDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-loopDone:
+			return
+		default:
+		}
+		_ = StopExecLoop(a)
+		select {
+		case <-loopDone:
+		case <-time.After(time.Second):
+			t.Error("event loop did not stop")
+		}
+	})
 
 	return a
 }
@@ -57,9 +77,7 @@ func TestExecHandlerRunsScriptSynchronously(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	// execQuit sets *a.Running = false before posting its interrupt event, so
-	// by the time RunExecScriptSep (and therefore the handler) returns, the
-	// script's effect is already observable -- proof it ran synchronously.
+	// The handler returns only after the event loop has acknowledged quit.
 	if *a.Running {
 		t.Error("expected quit script to have set Running to false")
 	}
@@ -118,5 +136,61 @@ func TestExecHandlerRespectsSepQueryParam(t *testing.T) {
 	}
 	if *a.Running {
 		t.Error("expected script split on custom separator to run both commands, including quit")
+	}
+}
+
+func TestExecHandlerWaitsForAcknowledgedVisibleInput(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", `type hello; wait-for hello timeout=500`)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(a.Screenshot(), "hello") {
+		t.Fatal("handler returned before typed text was visible")
+	}
+}
+
+func TestExecHandlerRejectsInvalidAction(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "not-an-action")
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `unknown action "not-an-action"`) {
+		t.Fatalf("body = %q, want useful invalid-action error", body)
+	}
+}
+
+func TestExecHandlerReportsExecutionFailure(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", "screenshot /missing/parent/screen.txt")
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "screenshot") {
+		t.Fatalf("body = %q, want screenshot failure", body)
+	}
+}
+
+func TestExecHandlerReportsWaitForTimeout(t *testing.T) {
+	a := newListenTestApp(t)
+
+	resp := execHandlerRequest(t, a, http.MethodPost, "/exec", `wait-for "never visible" timeout=40`)
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `screen text "never visible" not visible`) {
+		t.Fatalf("body = %q, want timeout detail", body)
 	}
 }

--- a/internal/app/listen_test.go
+++ b/internal/app/listen_test.go
@@ -16,6 +16,13 @@ import (
 
 func newListenTestApp(t *testing.T) *App {
 	t.Helper()
+	a := prepareListenTestApp(t)
+	startListenTestEventLoop(t, a)
+	return a
+}
+
+func prepareListenTestApp(t *testing.T) *App {
+	t.Helper()
 	a := buildTestApp(t, config.DefaultSettings())
 
 	sim := term.NewSimScreen()
@@ -30,6 +37,11 @@ func newListenTestApp(t *testing.T) *App {
 	a.Running = &running
 	RegisterCommands(a)
 	a.Root.SetSize(80, 24)
+	return a
+}
+
+func startListenTestEventLoop(t *testing.T, a *App) {
+	t.Helper()
 	loopDone := make(chan struct{})
 	go func() {
 		RunEventLoop(a.Screen, a.Renderer, a, a.Running, a.CloseTerminal)
@@ -48,8 +60,6 @@ func newListenTestApp(t *testing.T) *App {
 			t.Error("event loop did not stop")
 		}
 	})
-
-	return a
 }
 
 func execHandlerRequest(t *testing.T, a *App, method, path, body string) *http.Response {
@@ -103,6 +113,31 @@ func TestExecHandlerShutdownAliasesQuit(t *testing.T) {
 	}
 	if *a.Running {
 		t.Error("handler returned before applying shutdown")
+	}
+}
+
+func TestExecHandlerRepeatedShutdownReturnsAfterLoopStopped(t *testing.T) {
+	a := newListenTestApp(t)
+	first := execHandlerDirect(t, a, "/exec", "shutdown")
+	if first.Code != http.StatusOK || first.Body.String() != "ok" {
+		t.Fatalf("first response = status %d body %q, want 200 ok", first.Code, first.Body.String())
+	}
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	handler := NewExecHandler(a)
+	go func() {
+		request := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader("shutdown"))
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		done <- response
+	}()
+	select {
+	case second := <-done:
+		if second.Code != http.StatusOK || second.Body.String() != "ok" {
+			t.Fatalf("second response = status %d body %q, want 200 ok", second.Code, second.Body.String())
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("repeated HTTP shutdown blocked after event loop stopped")
 	}
 }
 
@@ -174,7 +209,14 @@ func TestExecHandlerWaitsForAcknowledgedVisibleInput(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
 	}
-	if !strings.Contains(a.Screenshot(), "hello") {
+	var screen string
+	if err := runExecMain(a, func() error {
+		screen = a.Screenshot()
+		return nil
+	}); err != nil {
+		t.Fatalf("capturing screen: %v", err)
+	}
+	if !strings.Contains(screen, "hello") {
 		t.Fatal("handler returned before typed text was visible")
 	}
 }

--- a/tests/functional/exec-harness.test.js
+++ b/tests/functional/exec-harness.test.js
@@ -1,0 +1,80 @@
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+const BINARY = resolve(import.meta.dirname, "../../bin/ttt");
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("exec harness reliability", () => {
+  it("waitFor blocks until delayed text is actually visible", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "wait.txt", "waiting\n");
+    const pluginFile = join(dir, "delayed.lua");
+    writeFileSync(
+      pluginFile,
+      `local ttt = require("ttt")
+ttt.set_timeout(350, function()
+  ttt.set_status_item("left", "ready", "ASYNC READY", { priority = 10 })
+end)
+`
+    );
+
+    tui.start("--plugin", pluginFile, file);
+    tui.waitFor("ASYNC READY");
+    const screen = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[screen]).toContain("ASYNC READY");
+  });
+
+  it("returns a nonzero exit and stderr for an invalid action", () => {
+    dir = createTempDir();
+    const result = spawnSync(BINARY, ["--size", "80x24", "--exec", "not-an-action"], {
+      encoding: "utf8",
+      env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--exec failed");
+    expect(result.stderr).toContain('unknown action "not-an-action"');
+  });
+
+  it("returns a nonzero exit when wait-for reaches its bound", () => {
+    dir = createTempDir();
+    const result = spawnSync(
+      BINARY,
+      ["--size", "80x24", "--exec", `wait-for "NEVER VISIBLE" timeout=40`],
+      {
+        encoding: "utf8",
+        env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
+      }
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('screen text "NEVER VISIBLE" not visible');
+  });
+
+  it("rejects an overflowing wait-for timeout as invalid input", () => {
+    dir = createTempDir();
+    const result = spawnSync(
+      BINARY,
+      ["--size", "40x12", "--exec", "wait-for x timeout=9223372036854775807"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
+      }
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('invalid wait-for timeout "9223372036854775807"');
+    expect(result.stderr).not.toContain("not visible after -");
+  });
+});

--- a/tests/functional/exec-harness.test.js
+++ b/tests/functional/exec-harness.test.js
@@ -11,6 +11,7 @@ let dir;
 afterEach(() => {
   tui.kill();
   if (dir) cleanupDir(dir);
+  dir = undefined;
 });
 
 describe("exec harness reliability", () => {
@@ -39,6 +40,7 @@ end)
     dir = createTempDir();
     const result = spawnSync(BINARY, ["--size", "80x24", "--exec", "not-an-action"], {
       encoding: "utf8",
+      timeout: 15000,
       env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
     });
 
@@ -54,6 +56,7 @@ end)
       ["--size", "80x24", "--exec", `wait-for "NEVER VISIBLE" timeout=40`],
       {
         encoding: "utf8",
+        timeout: 15000,
         env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
       }
     );
@@ -69,6 +72,7 @@ end)
       ["--size", "40x12", "--exec", "wait-for x timeout=9223372036854775807"],
       {
         encoding: "utf8",
+        timeout: 15000,
         env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
       }
     );

--- a/tests/functional/listen-shutdown.test.js
+++ b/tests/functional/listen-shutdown.test.js
@@ -286,13 +286,21 @@ ttt.register({
     });
   }, 15000);
 
-  it("honors HTTP shutdown queued behind a claimed timer callback", async () => {
+  it("honors concurrent HTTP and CLI shutdown queued behind a claimed timer callback", async () => {
     dir = createTempDir();
     const port = await allocatePort();
     const { plugin, startedPath } = writeBlockingTimerPlugin(dir);
     child = spawn(
       BINARY,
-      ["--size", "40x12", "--plugin", plugin, "--listen", "--exec", "wait 0"],
+      [
+        "--size",
+        "40x12",
+        "--plugin",
+        plugin,
+        "--listen",
+        "--exec",
+        "wait 200;quit",
+      ],
       {
         cwd: dir,
         env: {

--- a/tests/functional/listen-shutdown.test.js
+++ b/tests/functional/listen-shutdown.test.js
@@ -1,0 +1,170 @@
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { request as httpRequest } from "node:http";
+import { createServer } from "node:net";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupDir, createTempDir } from "./helpers.js";
+
+const BINARY = resolve(import.meta.dirname, "../../bin/ttt");
+let child;
+let dir;
+
+function allocatePort() {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close((err) => (err ? reject(err) : resolvePort(port)));
+    });
+  });
+}
+
+function postExec(port, body, timeout = 1000) {
+  return new Promise((resolveResponse, reject) => {
+    const req = httpRequest(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: "/exec",
+        method: "POST",
+        headers: { "Content-Length": Buffer.byteLength(body) },
+      },
+      (res) => {
+        let responseBody = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          responseBody += chunk;
+        });
+        res.once("aborted", () => reject(new Error("response aborted before completion")));
+        res.once("end", () => resolveResponse({ status: res.statusCode, body: responseBody }));
+      }
+    );
+    req.setTimeout(timeout, () => req.destroy(new Error("request timed out")));
+    req.once("error", reject);
+    req.end(body);
+  });
+}
+
+function waitForExit(process, timeout = 3000) {
+  if (process.exitCode !== null || process.signalCode !== null) {
+    return Promise.resolve({ code: process.exitCode, signal: process.signalCode });
+  }
+  return new Promise((resolveExit, reject) => {
+    const timer = setTimeout(() => {
+      process.removeListener("exit", onExit);
+      reject(new Error("process did not exit before timeout"));
+    }, timeout);
+    const onExit = (code, signal) => {
+      clearTimeout(timer);
+      resolveExit({ code, signal });
+    };
+    process.once("exit", onExit);
+  });
+}
+
+async function waitForListener(port, process) {
+  const deadline = Date.now() + 5000;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (process.exitCode !== null) {
+      throw new Error(`listener exited early with code ${process.exitCode}`);
+    }
+    try {
+      const response = await postExec(port, "wait 0", 250);
+      if (response.status === 200 && response.body === "ok") return;
+      lastError = new Error(`unexpected readiness response ${response.status} ${response.body}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+  throw lastError ?? new Error("listener did not become ready");
+}
+
+afterEach(async () => {
+  if (child && child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGTERM");
+    try {
+      await waitForExit(child, 1000);
+    } catch {
+      child.kill("SIGKILL");
+      await waitForExit(child, 1000).catch(() => {});
+    }
+  }
+  child = undefined;
+  if (dir) cleanupDir(dir);
+  dir = undefined;
+});
+
+describe("live listen shutdown", () => {
+  it("flushes the success response before the process exits", async () => {
+    dir = createTempDir();
+    const port = await allocatePort();
+    child = spawn(BINARY, ["--size", "80x24", "--listen", "--exec", "wait 0"], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        TTT_CONFIG_DIR: join(dir, "config"),
+        TTT_LISTEN_PORT: String(port),
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    await waitForListener(port, child);
+    const response = await postExec(port, "shutdown");
+    expect(response).toEqual({ status: 200, body: "ok" });
+    await expect(waitForExit(child)).resolves.toEqual({ code: 0, signal: null });
+  });
+
+  it("waits for a claimed slow command instead of returning a false timeout", async () => {
+    dir = createTempDir();
+    const port = await allocatePort();
+    const plugin = join(dir, "blocking.lua");
+    const debugPath = join(dir, "state.json");
+    writeFileSync(
+      plugin,
+      `local ttt = require("ttt")
+ttt.register({
+  commands = {
+    {
+      id = "review.block",
+      title = "Review: Block",
+      handler = function()
+        local started = os.clock()
+        while os.clock() - started < 6 do end
+        ttt.log("info", "BLOCK DONE")
+      end,
+    },
+  },
+})
+`
+    );
+    child = spawn(
+      BINARY,
+      ["--size", "80x24", "--plugin", plugin, "--listen", "--exec", "wait 0"],
+      {
+        cwd: dir,
+        env: {
+          ...process.env,
+          TTT_CONFIG_DIR: join(dir, "config"),
+          TTT_LISTEN_PORT: String(port),
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      }
+    );
+
+    await waitForListener(port, child);
+    const started = Date.now();
+    const response = await postExec(port, `exec "Review: Block"`, 10000);
+    expect(response).toEqual({ status: 200, body: "ok" });
+    expect(Date.now() - started).toBeGreaterThanOrEqual(5900);
+
+    await expect(postExec(port, `debug ${debugPath}`)).resolves.toEqual({ status: 200, body: "ok" });
+    expect(readFileSync(debugPath, "utf8")).toContain("BLOCK DONE");
+
+    await expect(postExec(port, "shutdown")).resolves.toEqual({ status: 200, body: "ok" });
+    await expect(waitForExit(child)).resolves.toEqual({ code: 0, signal: null });
+  }, 15000);
+});

--- a/tests/functional/listen-shutdown.test.js
+++ b/tests/functional/listen-shutdown.test.js
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { request as httpRequest } from "node:http";
-import { createServer } from "node:net";
+import { createConnection, createServer } from "node:net";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupDir, createTempDir } from "./helpers.js";
@@ -37,9 +37,13 @@ function postExec(port, body, timeout = 1000) {
         res.on("data", (chunk) => {
           responseBody += chunk;
         });
-        res.once("aborted", () => reject(new Error("response aborted before completion")));
-        res.once("end", () => resolveResponse({ status: res.statusCode, body: responseBody }));
-      }
+        res.once("aborted", () =>
+          reject(new Error("response aborted before completion")),
+        );
+        res.once("end", () =>
+          resolveResponse({ status: res.statusCode, body: responseBody }),
+        );
+      },
     );
     req.setTimeout(timeout, () => req.destroy(new Error("request timed out")));
     req.once("error", reject);
@@ -49,7 +53,10 @@ function postExec(port, body, timeout = 1000) {
 
 function waitForExit(process, timeout = 3000) {
   if (process.exitCode !== null || process.signalCode !== null) {
-    return Promise.resolve({ code: process.exitCode, signal: process.signalCode });
+    return Promise.resolve({
+      code: process.exitCode,
+      signal: process.signalCode,
+    });
   }
   return new Promise((resolveExit, reject) => {
     const timer = setTimeout(() => {
@@ -64,6 +71,73 @@ function waitForExit(process, timeout = 3000) {
   });
 }
 
+function probeListener(port) {
+  return new Promise((resolveProbe, reject) => {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("listener probe timed out"));
+    }, 250);
+    socket.once("connect", () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolveProbe();
+    });
+    socket.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+async function waitForTCPListener(port, process) {
+  const deadline = Date.now() + 5000;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (process.exitCode !== null) {
+      throw new Error(`listener exited early with code ${process.exitCode}`);
+    }
+    try {
+      await probeListener(port);
+      return;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+  throw lastError ?? new Error("listener did not become ready");
+}
+
+async function waitForFile(path, process) {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    if (process.exitCode !== null) {
+      throw new Error(`process exited before creating ${path}`);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+  }
+  throw new Error(`process did not create ${path}`);
+}
+
+function writeBlockingTimerPlugin(directory) {
+  const plugin = join(directory, "blocking-timer.lua");
+  const startedPath = join(directory, "timer-started");
+  writeFileSync(
+    plugin,
+    `local ttt = require("ttt")
+local fs = require("ttt.fs")
+ttt.set_timeout(100, function()
+  fs.write(${JSON.stringify(startedPath)}, "started")
+  local started = os.clock()
+  while os.clock() - started < 6 do end
+  ttt.log("info", "BLOCK DONE")
+end)
+`,
+  );
+  return { plugin, startedPath };
+}
+
 async function waitForListener(port, process) {
   const deadline = Date.now() + 5000;
   let lastError;
@@ -74,7 +148,9 @@ async function waitForListener(port, process) {
     try {
       const response = await postExec(port, "wait 0", 250);
       if (response.status === 200 && response.body === "ok") return;
-      lastError = new Error(`unexpected readiness response ${response.status} ${response.body}`);
+      lastError = new Error(
+        `unexpected readiness response ${response.status} ${response.body}`,
+      );
     } catch (err) {
       lastError = err;
     }
@@ -99,6 +175,36 @@ afterEach(async () => {
 });
 
 describe("live listen shutdown", () => {
+  it("drains a claimed timer callback before CLI shutdown exits", async () => {
+    dir = createTempDir();
+    const { plugin, startedPath } = writeBlockingTimerPlugin(dir);
+    const started = Date.now();
+    child = spawn(
+      BINARY,
+      [
+        "--size",
+        "40x12",
+        "--plugin",
+        plugin,
+        "--exec",
+        "wait 200;quit",
+        "README.md",
+      ],
+      {
+        cwd: resolve(import.meta.dirname, "../.."),
+        env: { ...process.env, TTT_CONFIG_DIR: join(dir, "config") },
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
+
+    await waitForFile(startedPath, child);
+    await expect(waitForExit(child, 10000)).resolves.toEqual({
+      code: 0,
+      signal: null,
+    });
+    expect(Date.now() - started).toBeGreaterThanOrEqual(5900);
+  }, 12000);
+
   it("flushes the success response before the process exits", async () => {
     dir = createTempDir();
     const port = await allocatePort();
@@ -115,7 +221,10 @@ describe("live listen shutdown", () => {
     await waitForListener(port, child);
     const response = await postExec(port, "shutdown");
     expect(response).toEqual({ status: 200, body: "ok" });
-    await expect(waitForExit(child)).resolves.toEqual({ code: 0, signal: null });
+    await expect(waitForExit(child)).resolves.toEqual({
+      code: 0,
+      signal: null,
+    });
   });
 
   it("waits for a claimed slow command instead of returning a false timeout", async () => {
@@ -139,7 +248,7 @@ ttt.register({
     },
   },
 })
-`
+`,
     );
     child = spawn(
       BINARY,
@@ -152,7 +261,7 @@ ttt.register({
           TTT_LISTEN_PORT: String(port),
         },
         stdio: ["ignore", "ignore", "pipe"],
-      }
+      },
     );
 
     await waitForListener(port, child);
@@ -161,10 +270,51 @@ ttt.register({
     expect(response).toEqual({ status: 200, body: "ok" });
     expect(Date.now() - started).toBeGreaterThanOrEqual(5900);
 
-    await expect(postExec(port, `debug ${debugPath}`)).resolves.toEqual({ status: 200, body: "ok" });
+    await expect(postExec(port, `debug ${debugPath}`)).resolves.toEqual({
+      status: 200,
+      body: "ok",
+    });
     expect(readFileSync(debugPath, "utf8")).toContain("BLOCK DONE");
 
-    await expect(postExec(port, "shutdown")).resolves.toEqual({ status: 200, body: "ok" });
-    await expect(waitForExit(child)).resolves.toEqual({ code: 0, signal: null });
+    await expect(postExec(port, "shutdown")).resolves.toEqual({
+      status: 200,
+      body: "ok",
+    });
+    await expect(waitForExit(child)).resolves.toEqual({
+      code: 0,
+      signal: null,
+    });
   }, 15000);
+
+  it("honors HTTP shutdown queued behind a claimed timer callback", async () => {
+    dir = createTempDir();
+    const port = await allocatePort();
+    const { plugin, startedPath } = writeBlockingTimerPlugin(dir);
+    child = spawn(
+      BINARY,
+      ["--size", "40x12", "--plugin", plugin, "--listen", "--exec", "wait 0"],
+      {
+        cwd: dir,
+        env: {
+          ...process.env,
+          TTT_CONFIG_DIR: join(dir, "config"),
+          TTT_LISTEN_PORT: String(port),
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
+
+    await waitForTCPListener(port, child);
+    await waitForFile(startedPath, child);
+    const started = Date.now();
+    await expect(postExec(port, "shutdown", 2000)).resolves.toEqual({
+      status: 200,
+      body: "ok",
+    });
+    await expect(waitForExit(child, 10000)).resolves.toEqual({
+      code: 0,
+      signal: null,
+    });
+    expect(Date.now() - started).toBeGreaterThanOrEqual(5500);
+  }, 12000);
 });

--- a/tests/functional/sidebar-toggle.test.js
+++ b/tests/functional/sidebar-toggle.test.js
@@ -40,7 +40,7 @@ describe("sidebar toggle", () => {
 
     // Narrow sidebar to near-zero width using the command palette
     for (let i = 0; i < 25; i++) {
-      tui.exec("Decrease Sidebar Width");
+      tui.exec("View: Decrease Sidebar Width");
       tui.waitStable(50);
     }
 

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -98,8 +98,8 @@ export function wait(ms = 200) {
   commands.push(`wait ${ms}`);
 }
 
-export function waitFor(_text) {
-  commands.push("wait 200");
+export function waitFor(text) {
+  commands.push(`wait-for ${JSON.stringify(String(text))}`);
 }
 
 export function waitStable(ms = 200) {
@@ -121,6 +121,7 @@ const SEP = "\x1f";
 export function run(timeout = 15000) {
   commands.push("quit");
   const script = commands.join(SEP);
+  let runError;
 
   try {
     execFileSync(BINARY, ["--size", size, "--exec-split-on", SEP, "--exec", script, ...args], {
@@ -131,9 +132,7 @@ export function run(timeout = 15000) {
       env: { ...process.env, TTT_CONFIG_DIR: join(tmpDir, "config") },
     });
   } catch (err) {
-    if (err.status !== null && err.status !== 0 && err.status !== undefined) {
-      // non-zero exit is ok for quit-confirm tests etc.
-    }
+    runError = err;
   }
 
   const snapshots = [];
@@ -146,6 +145,7 @@ export function run(timeout = 15000) {
   }
 
   cleanup();
+  if (runError) throw runError;
   return { snapshots };
 }
 


### PR DESCRIPTION
Extracted from #474 as the second independently reviewable unit.

## Summary

- make `--exec` and live `/exec` requests return structured completion or actionable errors
- acknowledge main-thread actions only after the event loop applies them and redraws
- atomically cancel timed-out requests only while they are still unclaimed
- wait for already-claimed commands to finish, preventing false failures followed by delayed side effects
- preserve outcome-before-shutdown ordering for CLI and response-before-shutdown ordering for HTTP
- make queued shutdown non-cancelable so a busy event loop cannot report success and then remain alive
- improve `wait-for`, parser, separator, and functional-harness reliability
- add a loopback-only `TTT_LISTEN_PORT` override for collision-free subprocess coverage

The key invariant is that an unclaimed request may time out without later mutating state, while a claimed request reports its actual outcome. Shutdown follows the same event-loop ordering boundary but cannot be canceled merely because another claimed callback temporarily occupies the loop.

## Verification

- `make build`
- `go test -count=1 ./internal/app ./tests/e2e`
- `go test -race -count=1 ./internal/app -run 'Test(ExecRequest|RunExecScriptReturnsShutdown|ExecHandler|ListenAddress)'`
- full functional suite: 88 files; 295 passing; 27 expected failures
- focused functional suite: 2 files; 8 passing
  - delayed `wait-for`
  - CLI error propagation
  - claimed slow-command completion
  - CLI shutdown queued behind a six-second callback
  - HTTP response flush and queued shutdown behind a six-second callback
- exact fail-before/pass-after live subprocess probes for both previously reported shutdown races
- `go vet ./cmd/ttt ./internal/app`
- `git diff --check`

The branch was adversarially reviewed twice. It was rebased onto current `main` after #478 merged, producing the same clean three-way merge tree, and the focused build/race/E2E/live verification was repeated afterward.

Part of #474. No Git-review, tree, theme, tab-reordering, or repository-state functionality is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wait-for` scripting to wait for visible text with configurable timeouts.
  * Added configurable loopback listening ports via `TTT_LISTEN_PORT`.
  * Scripted headless sessions now use a process-local clipboard.

* **Bug Fixes**
  * Script failures now produce nonzero exit statuses and clearer CLI or HTTP responses.
  * Shutdown requests and responses are handled more reliably.
  * Updated examples and tests to wait for visible UI content instead of fixed delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->