### PR TITLE
feat(plugin): support checked menu entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Lua plugins render UI in sidebar panels, bottom-panel tabs, drawers, and editor 
 | Method | Lua fields | Description |
 |---|---|---|
 | `p:label(text)` or `p:label({...})` | `text`, `style`, `badge`, `width`, borders | Static text line. `style` is a named style (see below). `border`/`border_top`/`border_bottom`/`border_left`/`border_right` draw borders. Supports box model. |
-| `p:title(text)` or `p:title({...})` | `text`, `badge`, `menu`, `on_menu(command)`, `icon`, `padded` | Bold section heading with optional right-aligned badge and dropdown menu. `menu` is `{label, command, separator}` tables; `icon` overrides the dropdown button (default `⋮`). Supports box model. |
+| `p:title(text)` or `p:title({...})` | `text`, `badge`, `menu`, `on_menu(command)`, `icon`, `padded` | Bold section heading with optional right-aligned badge and dropdown menu. `menu` is `{label, command, separator, checked}` tables; optional boolean `checked` reserves and controls a check indicator. `icon` overrides the dropdown button (default `⋮`). Supports box model. |
 | `p:tree({...})` | `items`, `indent` (default 2), `on_select`, `on_expand`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Expandable tree view. Items are `{id, label, icon, badge, muted, expandable, expanded, children}` tables. `key_commands` maps single chars to commands via `on_command`. `truncate_left` truncates overflowing labels from the left (`…tail`) so the end stays visible. |
 | `p:list({...})` | `items`, `on_select`, `on_command`, `node_menu`, `key_commands`, `truncate_left` | Flat list (backed by TreeWidget, no indentation). `truncate_left` keeps label tails visible on overflow. |
 | `p:button({...})` | `label`, `on_click` | Clickable button. Label is immutable after creation (accelerator parsing). |
@@ -126,10 +126,12 @@ Lua plugins render UI in sidebar panels, bottom-panel tabs, drawers, and editor 
 | `p:scrollview({...})` | `render(child_panel)` | Scrollable container. Wraps children with mouse wheel scrolling and scrollbar when content overflows. |
 | `p:box({...})` | `render(child_panel)`, `border` (+ per-side), `height` | Container with optional border and fixed height. Children via `render` callback. |
 | `p:divider()` | (none) | Horizontal divider line. Single-line separator, no configuration. |
-| `p:dropdown({...})` | `label`, `entries`, `on_menu(command)` | Dropdown menu button. `entries` are `{label, command, separator}` tables. |
+| `p:dropdown({...})` | `label`, `entries`, `on_menu(command)` | Dropdown menu button. `entries` are `{label, command, separator, checked}` tables; optional boolean `checked` reserves and controls a check indicator. |
 | `p:progress({...})` | `value` (0–1), `style`, `char` (default `▄`) | Horizontal progress bar. |
 | `p:table({...})` | `columns` (`{label, width, align}`), `rows` (arrays of strings), `on_select(row_idx)`, `on_command(cmd, row_idx)`, `node_menu`, `key_commands` | Data table with headers and row selection. Row indices are 1-based. |
 | `p:markdown(text)` or `p:markdown({...})` | `text` | Rendered markdown with selection/copy, auto-wrapped in a scrollview. Wraps at `markdown.wrapWidth` (default 80). |
+
+All menu-entry tables (`actions`, `menu`, `entries`, and `node_menu`) accept `label`, `command`, `separator`, and optional boolean `checked`. Omitting `checked` keeps the menu indicator-free; `false` shows an unchecked slot and `true` shows a check.
 
 **Raw cell API** (low-level drawing; can be mixed with widgets — raw cells draw directly on the surface, widgets stack from the top over it):
 

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -1202,18 +1202,20 @@ Used in `items` arrays for both `tree` and `list` widgets.
 
 ### Menu Entry Format
 
-Used in `actions` (sidebar header menu), `node_menu` (tree/list context menu), and `entries` (dropdown).
+Used in `actions` (sidebar header menu), `menu` (title menu), `node_menu` (tree/list/table context menu), and `entries` (dropdown).
 
 | Field       | Type    | Required | Description                             |
 |-------------|---------|----------|-----------------------------------------|
 | `label`     | string  | yes*     | Display text of the menu item.          |
 | `command`   | string  | yes*     | Command identifier passed to the callback. |
 | `separator` | boolean | no       | If `true`, renders as a separator line instead of an item. When `true`, `label` and `command` are ignored. |
+| `checked`   | boolean | no       | If provided, reserves a check indicator: `true` shows a checkmark and `false` shows an empty slot. Omit it to keep the menu indicator-free with its existing spacing. |
 
 ```lua
 {
-  { label = "Start", command = "start" },
-  { label = "Stop", command = "stop" },
+  { label = "Active", command = "active", checked = true },
+  { label = "Available", command = "available", checked = false },
+  { label = "Legacy action", command = "legacy" },
   { separator = true },
   { label = "Remove", command = "remove" },
 }

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -69,13 +69,7 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 		if a.PluginManager != nil {
 			for _, p := range a.PluginManager.Plugins() {
 				if a.Sidebar.ActivePanel == "plugin."+p.Name && len(p.SidebarMenuEntries) > 0 {
-					for _, e := range p.SidebarMenuEntries {
-						items = append(items, ui.ContextMenuItem{
-							Label:   e.Label,
-							Command: e.Command,
-							IsSep:   e.Separator,
-						})
-					}
+					items = contextMenuItemsFromWidgetEntries(p.SidebarMenuEntries)
 					break
 				}
 			}

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -503,11 +503,7 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	p.ShowContextMenu = func(entries []widgets.MenuEntry, x, y int, onCommand func(string)) {
 		items := make([]ui.ContextMenuItem, len(entries))
 		for i, e := range entries {
-			items[i] = ui.ContextMenuItem{
-				Label:   e.Label,
-				Command: e.Command,
-				IsSep:   e.Separator,
-			}
+			items[i] = contextMenuItemFromWidgetEntry(e)
 		}
 		a.captureMenuFocus()
 		menu := ui.NewContextMenuWidget(items, x, y)
@@ -771,11 +767,7 @@ func (a *App) handleRemoteRegistryResult(result *RemoteRegistryResult) {
 func (a *App) ShowPluginDropdownMenu(entries []widgets.MenuEntry, x, y int) {
 	items := make([]ui.ContextMenuItem, len(entries))
 	for i, e := range entries {
-		items[i] = ui.ContextMenuItem{
-			Label:   e.Label,
-			Command: e.Command,
-			IsSep:   e.Separator,
-		}
+		items[i] = contextMenuItemFromWidgetEntry(e)
 	}
 	a.captureMenuFocus()
 	menu := ui.NewContextMenuWidget(items, x, y)
@@ -791,6 +783,21 @@ func (a *App) ShowPluginDropdownMenu(entries []widgets.MenuEntry, x, y int) {
 	}
 	a.Root.PushOverlay(ui.Overlay{Widget: menu, Modal: true})
 	a.Root.SetFocus(menu)
+}
+
+func contextMenuItemFromWidgetEntry(entry widgets.MenuEntry) ui.ContextMenuItem {
+	item := ui.ContextMenuItem{
+		Label:   entry.Label,
+		Command: entry.Command,
+		IsSep:   entry.Separator,
+	}
+	if entry.Checked != nil {
+		item.Checked = ui.MenuUnchecked
+		if *entry.Checked {
+			item.Checked = ui.MenuChecked
+		}
+	}
+	return item
 }
 
 func (a *App) handlePluginDropdownCommand(cmd string) {

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -501,10 +501,7 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 		})
 	}
 	p.ShowContextMenu = func(entries []widgets.MenuEntry, x, y int, onCommand func(string)) {
-		items := make([]ui.ContextMenuItem, len(entries))
-		for i, e := range entries {
-			items[i] = contextMenuItemFromWidgetEntry(e)
-		}
+		items := contextMenuItemsFromWidgetEntries(entries)
 		a.captureMenuFocus()
 		menu := ui.NewContextMenuWidget(items, x, y)
 		menu.Borders = a.Borders
@@ -765,10 +762,7 @@ func (a *App) handleRemoteRegistryResult(result *RemoteRegistryResult) {
 }
 
 func (a *App) ShowPluginDropdownMenu(entries []widgets.MenuEntry, x, y int) {
-	items := make([]ui.ContextMenuItem, len(entries))
-	for i, e := range entries {
-		items[i] = contextMenuItemFromWidgetEntry(e)
-	}
+	items := contextMenuItemsFromWidgetEntries(entries)
 	a.captureMenuFocus()
 	menu := ui.NewContextMenuWidget(items, x, y)
 	menu.Borders = a.Borders
@@ -791,13 +785,21 @@ func contextMenuItemFromWidgetEntry(entry widgets.MenuEntry) ui.ContextMenuItem 
 		Command: entry.Command,
 		IsSep:   entry.Separator,
 	}
-	if entry.Checked != nil {
+	if !entry.Separator && entry.Checked != nil {
 		item.Checked = ui.MenuUnchecked
 		if *entry.Checked {
 			item.Checked = ui.MenuChecked
 		}
 	}
 	return item
+}
+
+func contextMenuItemsFromWidgetEntries(entries []widgets.MenuEntry) []ui.ContextMenuItem {
+	items := make([]ui.ContextMenuItem, len(entries))
+	for i, entry := range entries {
+		items[i] = contextMenuItemFromWidgetEntry(entry)
+	}
+	return items
 }
 
 func (a *App) handlePluginDropdownCommand(cmd string) {

--- a/internal/app/plugin_api_test.go
+++ b/internal/app/plugin_api_test.go
@@ -5,7 +5,44 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
 )
+
+func TestContextMenuItemFromWidgetEntryPreservesMenuContract(t *testing.T) {
+	checked, unchecked := true, false
+	tests := []struct {
+		name      string
+		checked   *bool
+		separator bool
+		want      int
+	}{
+		{name: "omitted", want: 0},
+		{name: "unchecked", checked: &unchecked, want: ui.MenuUnchecked},
+		{name: "checked", checked: &checked, want: ui.MenuChecked},
+		{name: "separator", separator: true, want: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry := widgets.MenuEntry{
+				Label:     "Mode",
+				Command:   "mode",
+				Separator: test.separator,
+				Checked:   test.checked,
+			}
+			item := contextMenuItemFromWidgetEntry(entry)
+
+			if item.Label != entry.Label || item.Command != entry.Command || item.IsSep != entry.Separator {
+				t.Fatalf("menu fields changed during conversion: got %+v, entry %+v", item, entry)
+			}
+			if item.Checked != test.want {
+				t.Fatalf("checked indicator = %d, want %d", item.Checked, test.want)
+			}
+		})
+	}
+}
 
 func TestSetPathNilDeletesKey(t *testing.T) {
 	m := map[string]any{

--- a/internal/app/plugin_api_test.go
+++ b/internal/app/plugin_api_test.go
@@ -44,6 +44,30 @@ func TestContextMenuItemFromWidgetEntryPreservesMenuContract(t *testing.T) {
 	}
 }
 
+func TestContextMenuItemsFromWidgetEntriesPreservesMixedRows(t *testing.T) {
+	checked, unchecked := true, false
+	entries := []widgets.MenuEntry{
+		{Label: "Omitted", Command: "omitted"},
+		{Label: "Unchecked", Command: "unchecked", Checked: &unchecked},
+		{Separator: true, Checked: &checked},
+		{Label: "Checked", Command: "checked", Checked: &checked},
+	}
+
+	items := contextMenuItemsFromWidgetEntries(entries)
+	if len(items) != len(entries) {
+		t.Fatalf("items = %d, want %d", len(items), len(entries))
+	}
+	wantChecked := []int{0, ui.MenuUnchecked, 0, ui.MenuChecked}
+	for i := range items {
+		if items[i].Label != entries[i].Label || items[i].Command != entries[i].Command || items[i].IsSep != entries[i].Separator {
+			t.Errorf("row %d changed during conversion: got %+v, entry %+v", i, items[i], entries[i])
+		}
+		if items[i].Checked != wantChecked[i] {
+			t.Errorf("row %d checked = %d, want %d", i, items[i].Checked, wantChecked[i])
+		}
+	}
+}
+
 func TestSetPathNilDeletesKey(t *testing.T) {
 	m := map[string]any{
 		"lsp": map[string]any{

--- a/internal/plugin/lua_panel.go
+++ b/internal/plugin/lua_panel.go
@@ -551,6 +551,10 @@ func parseLuaMenuEntries(L *lua.LState, tbl *lua.LTable) []widgets.MenuEntry {
 		if sep := L.GetField(entry, "separator"); sep != lua.LNil {
 			me.Separator = lua.LVAsBool(sep)
 		}
+		if checked := L.GetField(entry, "checked"); checked != lua.LNil {
+			value := lua.LVAsBool(checked)
+			me.Checked = &value
+		}
 		entries = append(entries, me)
 	})
 	return entries

--- a/internal/plugin/panel_widget_test.go
+++ b/internal/plugin/panel_widget_test.go
@@ -220,3 +220,80 @@ func TestTitleWidgetLuaFields(t *testing.T) {
 		t.Error("expected on_menu callback to be wired")
 	}
 }
+
+func TestPluginWidgetMenusParseOptionalCheckedState(t *testing.T) {
+	p := &Plugin{
+		Name:    "checked-menu-test",
+		Granted: PermissionSet{PanelSidebar: true},
+	}
+	p.State = NewSandbox()
+	defer p.State.Close()
+	setupTTTModule(p.State, p)
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		local function menu_entries()
+			return {
+				{ label = "Omitted", command = "omitted" },
+				{ label = "Unchecked", command = "unchecked", checked = false },
+				{ separator = true },
+				{ label = "Checked", command = "checked", checked = true },
+			}
+		end
+		ttt.register({
+			sidebar = {
+				title = "Checked menus",
+				render = function(panel)
+					panel:title({ text = "Title", menu = menu_entries() })
+					panel:dropdown({ label = "Dropdown", entries = menu_entries() })
+					panel:tree({ items = {{ id = "tree", label = "Tree" }}, node_menu = menu_entries() })
+					panel:list({ items = {{ id = "list", label = "List" }}, node_menu = menu_entries() })
+					panel:table({
+						columns = {{ label = "Column" }},
+						rows = {{ "Row" }},
+						node_menu = menu_entries(),
+					})
+				end,
+			},
+		})
+	`)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	proxy := NewPanelProxy(newMockSurface(80, 20), p)
+	if err := p.CallRenderWith(p.RenderFunc, proxy); err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	descs := proxy.Descriptors()
+	if len(descs) != 5 {
+		t.Fatalf("descriptors = %d, want title, dropdown, tree, list, and table", len(descs))
+	}
+	for _, desc := range descs {
+		entries := desc.Entries
+		if desc.Kind == WidgetTree || desc.Kind == WidgetList || desc.Kind == WidgetTable {
+			entries = desc.NodeMenu
+		}
+		assertOptionalCheckedEntries(t, desc.Kind.String(), entries)
+	}
+}
+
+func assertOptionalCheckedEntries(t *testing.T, surface string, entries []widgets.MenuEntry) {
+	t.Helper()
+	if len(entries) != 4 {
+		t.Fatalf("%s entries = %d, want 4", surface, len(entries))
+	}
+	if entries[0].Checked != nil {
+		t.Errorf("%s omitted checked = %v, want nil", surface, *entries[0].Checked)
+	}
+	if entries[1].Checked == nil || *entries[1].Checked {
+		t.Errorf("%s unchecked entry = %+v, want non-nil false", surface, entries[1])
+	}
+	if !entries[2].Separator {
+		t.Errorf("%s separator entry lost separator state", surface)
+	}
+	if entries[3].Checked == nil || !*entries[3].Checked {
+		t.Errorf("%s checked entry = %+v, want non-nil true", surface, entries[3])
+	}
+}

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -102,12 +102,15 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 		}
 	case WidgetTitle:
 		if tw, ok := w.(*widgets.TitleWidget); ok {
-			tw.Config.Title = desc.Text
-			tw.Config.Badge = desc.Badge
-			tw.Config.Menu = desc.Entries
-			tw.Config.Icon = desc.Icon
-			tw.Config.Padded = desc.Padded
-			wireTitleMenu(&tw.Config, desc, p)
+			config := widgets.TitleConfig{
+				Title:  desc.Text,
+				Badge:  desc.Badge,
+				Menu:   desc.Entries,
+				Icon:   desc.Icon,
+				Padded: desc.Padded,
+			}
+			wireTitleMenu(&config, desc, p)
+			tw.UpdateConfig(config)
 			applyBoxModel(&tw.Box, desc)
 		}
 	case WidgetKeyValue:
@@ -160,6 +163,16 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 		}
 	case WidgetDivider:
 		// nothing to update
+	case WidgetDropdown:
+		if dd, ok := w.(*widgets.DropdownWidget); ok {
+			dd.UpdateConfig(widgets.DropdownConfig{
+				Label:   desc.Label,
+				Entries: desc.Entries,
+				Box:     &widgets.BoxModel{PaddingLeft: 1, PaddingRight: 1},
+			})
+			wireDropdownCallback(dd, desc, p)
+			applyBoxModel(&dd.Box, desc)
+		}
 	case WidgetScrollView:
 		if sv, ok := w.(*widgets.ScrollViewWidget); ok {
 			if vs, ok := sv.Child.(*widgets.VStackWidget); ok {
@@ -461,7 +474,8 @@ func createDropdownWidget(desc WidgetDesc, p *Plugin) *widgets.DropdownWidget {
 }
 
 func wireDropdownCallback(dd *widgets.DropdownWidget, desc WidgetDesc, p *Plugin) {
-	if p.ShowContextMenu != nil && len(desc.Entries) > 0 {
+	dd.Config.OnMenu = nil
+	if p != nil && p.ShowContextMenu != nil && len(desc.Entries) > 0 {
 		dd.Config.OnMenu = func(entries []widgets.MenuEntry, screenX, screenY int) {
 			p.ShowContextMenu(entries, screenX, screenY, func(cmd string) {
 				if desc.OnMenu != nil {
@@ -473,18 +487,13 @@ func wireDropdownCallback(dd *widgets.DropdownWidget, desc WidgetDesc, p *Plugin
 }
 
 func wireTreeCallbacks(tw *widgets.TreeWidget, desc WidgetDesc, p *Plugin) {
-	if desc.OnSelect != nil {
-		tw.Config.OnSelect = desc.OnSelect
-	}
-	if desc.OnExpand != nil {
-		tw.Config.OnExpand = desc.OnExpand
-	}
-	if desc.OnCommand != nil {
-		tw.Config.OnCommand = desc.OnCommand
-	}
+	tw.Config.OnSelect = desc.OnSelect
+	tw.Config.OnExpand = desc.OnExpand
+	tw.Config.OnCommand = desc.OnCommand
+	tw.Config.NodeMenu = desc.NodeMenu
+	tw.Config.OnMenu = nil
 	if len(desc.NodeMenu) > 0 {
-		tw.Config.NodeMenu = desc.NodeMenu
-		if p.ShowContextMenu != nil {
+		if p != nil && p.ShowContextMenu != nil {
 			tw.Config.OnMenu = func(entries []widgets.MenuEntry, node *widgets.TreeNode, sx, sy int) {
 				p.ShowContextMenu(entries, sx, sy, func(cmd string) {
 					if tw.Config.OnCommand != nil {
@@ -494,6 +503,7 @@ func wireTreeCallbacks(tw *widgets.TreeWidget, desc WidgetDesc, p *Plugin) {
 			}
 		}
 	}
+	tw.Config.OnKey = nil
 	if len(desc.KeyCommands) > 0 {
 		kc := desc.KeyCommands
 		tw.Config.OnKey = func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
@@ -610,6 +620,7 @@ func createTableWidget(desc WidgetDesc, p *Plugin) *widgets.TableWidget {
 }
 
 func wireTableMenu(tw *widgets.TableWidget, p *Plugin) {
+	tw.Config.OnMenu = nil
 	if p == nil || p.ShowContextMenu == nil {
 		return
 	}

--- a/internal/plugin/widget_builder_test.go
+++ b/internal/plugin/widget_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -207,5 +208,123 @@ func TestReconcileUpdatesLabelWidth(t *testing.T) {
 	lw2 := ws.items[0].(*widgets.LabelWidget)
 	if lw2.FixedWidth != 20 {
 		t.Errorf("expected width updated to 20 on reconcile, got %d", lw2.FixedWidth)
+	}
+}
+
+func TestReconcileUpdatesReusableDropdownStateAndCallback(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	var shown []widgets.MenuEntry
+	var commands []string
+	p.ShowContextMenu = func(entries []widgets.MenuEntry, _, _ int, onCommand func(string)) {
+		shown = entries
+		onCommand(entries[0].Command)
+	}
+
+	checked, unchecked := true, false
+	states := []struct {
+		name    string
+		label   string
+		checked *bool
+	}{
+		{name: "checked", label: "Checked", checked: &checked},
+		{name: "unchecked", label: "Unchecked", checked: &unchecked},
+		{name: "omitted", label: "Omitted"},
+		{name: "checked-again", label: "Checked again", checked: &checked},
+	}
+
+	var original *widgets.DropdownWidget
+	for i, state := range states {
+		desc := WidgetDesc{
+			Kind:  WidgetDropdown,
+			Key:   "dropdown:0",
+			Label: state.label,
+			Entries: []widgets.MenuEntry{{
+				Label:   "界 Mode",
+				Command: state.name,
+				Checked: state.checked,
+			}},
+			OnMenu: func(command string) { commands = append(commands, command) },
+		}
+		ws.Reconcile([]WidgetDesc{desc}, p)
+
+		dd := ws.items[0].(*widgets.DropdownWidget)
+		if i == 0 {
+			original = dd
+		} else if dd != original {
+			t.Fatalf("%s reconcile replaced reusable dropdown", state.name)
+		}
+		if dd.Config.Label != state.label {
+			t.Errorf("%s label = %q, want %q", state.name, dd.Config.Label, state.label)
+		}
+		if dd.Config.OnMenu == nil {
+			t.Fatalf("%s callback was not wired", state.name)
+		}
+		dd.Config.OnMenu(dd.Config.Entries, 0, 0)
+		assertMenuEntryChecked(t, state.name, shown[0], state.checked)
+		if got := commands[len(commands)-1]; got != state.name {
+			t.Errorf("%s callback command = %q, want %q", state.name, got, state.name)
+		}
+	}
+}
+
+func TestReconcileUpdatesReusableTitleAndNodeMenus(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	var shown []widgets.MenuEntry
+	p.ShowContextMenu = func(entries []widgets.MenuEntry, _, _ int, _ func(string)) {
+		shown = entries
+	}
+
+	checked, unchecked := true, false
+	initial := []WidgetDesc{
+		{Kind: WidgetTitle, Key: "title:0", Text: "Modes", Entries: []widgets.MenuEntry{{Label: "Mode", Checked: &checked}}},
+		{Kind: WidgetTree, Key: "tree:0", Items: []*widgets.TreeNode{{ID: "node", Label: "Node"}}, NodeMenu: []widgets.MenuEntry{{Label: "Mode", Checked: &checked}}},
+		{Kind: WidgetList, Key: "list:0", Items: []*widgets.TreeNode{{ID: "node", Label: "Node"}}, NodeMenu: []widgets.MenuEntry{{Label: "Mode", Checked: &checked}}},
+		{Kind: WidgetTable, Key: "table:0", Rows: [][]string{{"Row"}}, NodeMenu: []widgets.MenuEntry{{Label: "Mode", Checked: &checked}}},
+	}
+	ws.Reconcile(initial, p)
+
+	updated := []WidgetDesc{
+		{Kind: WidgetTitle, Key: "title:0", Text: "Modes", Entries: []widgets.MenuEntry{{Label: "Mode", Checked: &unchecked}}},
+		{Kind: WidgetTree, Key: "tree:0", Items: []*widgets.TreeNode{{ID: "node", Label: "Node"}}},
+		{Kind: WidgetList, Key: "list:0", Items: []*widgets.TreeNode{{ID: "node", Label: "Node"}}, NodeMenu: []widgets.MenuEntry{{Label: "Mode"}}},
+		{Kind: WidgetTable, Key: "table:0", Rows: [][]string{{"Row"}}, NodeMenu: []widgets.MenuEntry{{Label: "Mode", Checked: &unchecked}}},
+	}
+	ws.Reconcile(updated, p)
+
+	title := ws.items[0].(*widgets.TitleWidget)
+	title.SetRect(widgets.Rect{X: 0, Y: 0, W: 30, H: 1})
+	title.Render(newMockSurface(30, 1))
+	title.HandleEvent(tcell.NewEventMouse(29, 0, tcell.Button1, tcell.ModNone))
+	if len(shown) != 1 {
+		t.Fatalf("title menu entries = %d, want 1", len(shown))
+	}
+	assertMenuEntryChecked(t, "title", shown[0], &unchecked)
+
+	tree := ws.items[1].(*widgets.TreeWidget)
+	if len(tree.Config.NodeMenu) != 0 || tree.Config.OnMenu != nil {
+		t.Errorf("tree retained removed node menu: entries=%v callback=%v", tree.Config.NodeMenu, tree.Config.OnMenu != nil)
+	}
+	list := ws.items[2].(*widgets.TreeWidget)
+	assertMenuEntryChecked(t, "list", list.Config.NodeMenu[0], nil)
+	table := ws.items[3].(*widgets.TableWidget)
+	assertMenuEntryChecked(t, "table", table.Config.NodeMenu[0], &unchecked)
+}
+
+func assertMenuEntryChecked(t *testing.T, surface string, entry widgets.MenuEntry, want *bool) {
+	t.Helper()
+	if want == nil {
+		if entry.Checked != nil {
+			t.Errorf("%s checked = %v, want omitted", surface, *entry.Checked)
+		}
+		return
+	}
+	if entry.Checked == nil || *entry.Checked != *want {
+		t.Errorf("%s checked = %v, want %v", surface, entry.Checked, *want)
 	}
 }

--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -72,11 +73,11 @@ func (c *ContextMenuWidget) menuWidth() int {
 		if it.IsSep {
 			continue
 		}
-		lr := len([]rune(it.Label))
+		lr := textwidth.String(it.Label)
 		if lr > maxLabel {
 			maxLabel = lr
 		}
-		sr := len([]rune(it.Shortcut))
+		sr := textwidth.String(it.Shortcut)
 		if sr > maxShort {
 			maxShort = sr
 		}
@@ -151,8 +152,7 @@ func (c *ContextMenuWidget) Render(surface Surface) {
 			if i == c.Selected {
 				shortStyle = style
 			}
-			shortRunes := []rune(it.Shortcut)
-			sx := x + menuW - 2 - len(shortRunes)
+			sx := x + menuW - 2 - textwidth.String(it.Shortcut)
 			surface.DrawText(sx, row, it.Shortcut, x+menuW-1, shortStyle)
 		}
 	}

--- a/internal/ui/contextmenu_widget.go
+++ b/internal/ui/contextmenu_widget.go
@@ -97,9 +97,19 @@ func (c *ContextMenuWidget) menuWidth() int {
 
 func (c *ContextMenuWidget) Render(surface Surface) {
 	sw, sh := surface.Size()
+	if sw <= 0 || sh <= 0 {
+		c.storeRect(0, 0, 0, 0)
+		return
+	}
 
 	menuW := c.menuWidth()
 	menuH := len(c.Items) + 2
+	if menuW > sw {
+		menuW = sw
+	}
+	if menuH > sh {
+		menuH = sh
+	}
 
 	x := c.AnchorX
 	y := c.AnchorY
@@ -115,6 +125,10 @@ func (c *ContextMenuWidget) Render(surface Surface) {
 	if y < 0 {
 		y = 0
 	}
+	c.storeRect(x, y, menuW, menuH)
+	if menuW < 2 || menuH < 2 {
+		return
+	}
 
 	b := term.SingleBorderSet()
 	if c.Borders != nil {
@@ -125,6 +139,9 @@ func (c *ContextMenuWidget) Render(surface Surface) {
 
 	for i, it := range c.Items {
 		row := y + 1 + i
+		if row >= y+menuH-1 {
+			break
+		}
 		if it.IsSep {
 			for bx := x + 1; bx < x+menuW-1; bx++ {
 				surface.SetCell(bx, row, term.Cell{Ch: b.Horizontal, Style: bs})
@@ -139,7 +156,7 @@ func (c *ContextMenuWidget) Render(surface Surface) {
 
 		surface.ClearRect(x+1, row, menuW-2, 1, style)
 		labelX := x + 2
-		if c.hasCheckedItems() {
+		if it.Checked != 0 {
 			if it.Checked == MenuChecked {
 				surface.SetCell(x+1, row, term.Cell{Ch: '✓', Style: style})
 			}
@@ -156,8 +173,6 @@ func (c *ContextMenuWidget) Render(surface Surface) {
 			surface.DrawText(sx, row, it.Shortcut, x+menuW-1, shortStyle)
 		}
 	}
-
-	c.storeRect(x, y, menuW, menuH)
 }
 
 func (c *ContextMenuWidget) storeRect(x, y, w, h int) {

--- a/internal/ui/contextmenu_widget_test.go
+++ b/internal/ui/contextmenu_widget_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v3"
+)
+
+func renderContextMenu(menu *ContextMenuWidget, w, h int) [][]term.Cell {
+	cells := makeGrid(w, h)
+	menu.Render(NewRenderSurface(cells, Rect{X: 0, Y: 0, W: w, H: h}))
+	return cells
+}
+
+func TestContextMenuCheckedStateControlsIndicatorLayout(t *testing.T) {
+	menus := map[string]*ContextMenuWidget{
+		"omitted":   NewContextMenuWidget([]ContextMenuItem{{Label: "Long menu choice"}}, 0, 0),
+		"unchecked": NewContextMenuWidget([]ContextMenuItem{{Label: "Long menu choice", Checked: MenuUnchecked}}, 0, 0),
+		"checked":   NewContextMenuWidget([]ContextMenuItem{{Label: "Long menu choice", Checked: MenuChecked}}, 0, 0),
+	}
+
+	if got, want := menus["omitted"].menuWidth(), 22; got != want {
+		t.Fatalf("omitted checked width = %d, want legacy width %d", got, want)
+	}
+	for _, state := range []string{"unchecked", "checked"} {
+		if got, want := menus[state].menuWidth(), 24; got != want {
+			t.Errorf("%s width = %d, want indicator width %d", state, got, want)
+		}
+	}
+
+	checkedCells := renderContextMenu(menus["checked"], 40, 5)
+	if got := checkedCells[1][1].Ch; got != '✓' {
+		t.Errorf("checked indicator = %q, want checkmark", got)
+	}
+	uncheckedCells := renderContextMenu(menus["unchecked"], 40, 5)
+	if got := uncheckedCells[1][1].Ch; got != ' ' {
+		t.Errorf("unchecked indicator slot = %q, want space", got)
+	}
+	omittedCells := renderContextMenu(menus["omitted"], 40, 5)
+	if got := strings.TrimRight(cellRow(omittedCells, 1), "."); !strings.HasPrefix(got, "│ Long menu choice") {
+		t.Errorf("omitted checked row = %q, want indicator-free legacy spacing", got)
+	}
+}
+
+func TestContextMenuWidthUsesTerminalColumns(t *testing.T) {
+	menu := NewContextMenuWidget([]ContextMenuItem{{
+		Label:    "界界界界界",
+		Shortcut: "界",
+	}}, 0, 0)
+
+	if got, want := menu.menuWidth(), 20; got != want {
+		t.Fatalf("menu width = %d, want %d terminal columns", got, want)
+	}
+}
+
+func TestContextMenuSelectionStillSkipsSeparatorsAndExecutes(t *testing.T) {
+	var commands []string
+	menu := NewContextMenuWidget([]ContextMenuItem{
+		MenuSep(),
+		{Label: "First", Command: "first", Checked: MenuChecked},
+		MenuSep(),
+		{Label: "Second", Command: "second", Checked: MenuUnchecked},
+	}, 4, 2)
+	menu.OnExec = func(command string) { commands = append(commands, command) }
+
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyDown, "", tcell.ModNone))
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if len(commands) != 1 || commands[0] != "second" {
+		t.Fatalf("keyboard command = %v, want [second]", commands)
+	}
+
+	renderContextMenu(menu, 40, 10)
+	menu.HandleEvent(tcell.NewEventMouse(6, 4, tcell.ButtonNone, tcell.ModNone))
+	menu.HandleEvent(tcell.NewEventMouse(6, 4, tcell.Button1, tcell.ModNone))
+	if len(commands) != 2 || commands[1] != "first" {
+		t.Fatalf("mouse commands = %v, want second then first", commands)
+	}
+}

--- a/internal/ui/contextmenu_widget_test.go
+++ b/internal/ui/contextmenu_widget_test.go
@@ -78,3 +78,53 @@ func TestContextMenuSelectionStillSkipsSeparatorsAndExecutes(t *testing.T) {
 		t.Fatalf("mouse commands = %v, want second then first", commands)
 	}
 }
+
+func TestContextMenuMixedFullwidthLabelsKeepExactMouseBounds(t *testing.T) {
+	var commands []string
+	menu := NewContextMenuWidget([]ContextMenuItem{
+		{Label: "Mode 界A", Command: "first", Checked: MenuUnchecked},
+		{Label: "界界 option", Command: "second", Checked: MenuChecked},
+	}, 14, 1)
+	menu.OnExec = func(command string) { commands = append(commands, command) }
+
+	renderContextMenu(menu, 15, 6)
+	r := menu.GetRect()
+	if r.X != 0 || r.W != 15 {
+		t.Fatalf("rendered bounds = %+v, want display-width-clamped 15-column menu", r)
+	}
+
+	menu.HandleEvent(tcell.NewEventMouse(r.X+r.W-1, r.Y+2, tcell.ButtonNone, tcell.ModNone))
+	menu.HandleEvent(tcell.NewEventMouse(r.X+r.W-1, r.Y+2, tcell.Button1, tcell.ModNone))
+	if len(commands) != 1 || commands[0] != "second" {
+		t.Fatalf("right-edge command = %v, want [second]", commands)
+	}
+
+	menu.HandleEvent(tcell.NewEventMouse(r.X+r.W, r.Y+1, tcell.Button1, tcell.ModNone))
+	if len(commands) != 1 {
+		t.Fatalf("outside click executed command: %v", commands)
+	}
+}
+
+func TestContextMenuRenderClampsToZeroAndNarrowBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		w    int
+		h    int
+	}{
+		{name: "zero", w: 0, h: 0},
+		{name: "one-column", w: 1, h: 4},
+		{name: "one-row", w: 8, h: 1},
+		{name: "narrow", w: 8, h: 3},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			menu := NewContextMenuWidget([]ContextMenuItem{{Label: "界界界界", Checked: MenuChecked}}, 20, 20)
+			renderContextMenu(menu, test.w, test.h)
+			r := menu.GetRect()
+			if r.X < 0 || r.Y < 0 || r.W < 0 || r.H < 0 || r.X+r.W > test.w || r.Y+r.H > test.h {
+				t.Fatalf("rendered bounds %+v escape %dx%d surface", r, test.w, test.h)
+			}
+		})
+	}
+}

--- a/internal/widgets/dropdown.go
+++ b/internal/widgets/dropdown.go
@@ -34,6 +34,19 @@ func NewDropdownWidget(config DropdownConfig) *DropdownWidget {
 	return &DropdownWidget{Config: config, button: btn}
 }
 
+func (d *DropdownWidget) UpdateConfig(config DropdownConfig) {
+	if config.Label == "" {
+		config.Label = "⋮"
+	}
+	d.Config = config
+	d.button.Config.Label = config.Label
+	d.button.Config.Style = config.Style
+	d.button.SetLabel(config.Label)
+	if config.Box != nil {
+		d.button.Box = *config.Box
+	}
+}
+
 func (d *DropdownWidget) Height() int { return d.button.Height() }
 func (d *DropdownWidget) Width() int  { return d.button.Width() }
 

--- a/internal/widgets/title.go
+++ b/internal/widgets/title.go
@@ -23,7 +23,13 @@ type TitleWidget struct {
 }
 
 func NewTitleWidget(config TitleConfig) *TitleWidget {
-	t := &TitleWidget{Config: config}
+	t := &TitleWidget{}
+	t.UpdateConfig(config)
+	return t
+}
+
+func (t *TitleWidget) UpdateConfig(config TitleConfig) {
+	t.Config = config
 	if len(config.Menu) > 0 {
 		label := config.Icon
 		if label == "" {
@@ -35,15 +41,21 @@ func NewTitleWidget(config TitleConfig) *TitleWidget {
 		} else {
 			box = &BoxModel{PaddingLeft: 0, PaddingRight: 0}
 		}
-		t.dropdown = NewDropdownWidget(DropdownConfig{
+		dropdownConfig := DropdownConfig{
 			Label:   label,
 			Entries: config.Menu,
 			Style:   config.Style,
 			Box:     box,
 			OnMenu:  config.OnMenu,
-		})
+		}
+		if t.dropdown == nil {
+			t.dropdown = NewDropdownWidget(dropdownConfig)
+		} else {
+			t.dropdown.UpdateConfig(dropdownConfig)
+		}
+	} else {
+		t.dropdown = nil
 	}
-	return t
 }
 
 func (t *TitleWidget) Height() int { return 1 + t.BoxOverheadH() }

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -32,6 +32,8 @@ type MenuEntry struct {
 	Label     string `json:"label"`
 	Command   string `json:"command"`
 	Separator bool   `json:"separator,omitempty"`
+	// Checked is nil for indicator-free entries; non-nil reserves a check slot.
+	Checked *bool `json:"checked,omitempty"`
 }
 
 type TreeConfig struct {

--- a/tests/functional/plugin-menu-checked.test.js
+++ b/tests/functional/plugin-menu-checked.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("plugin menu checked entries", () => {
+  it("renders optional checked states and keeps callbacks interactive", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = join(dir, "menu-indicators.lua");
+    writeFileSync(
+      plugin,
+      `local ttt = require("ttt")
+
+ttt.register({
+  bottom = {
+    title = "Menu Indicators",
+    render = function(panel)
+      panel:dropdown({
+        label = "Checked menu",
+        entries = {
+          { label = "Checked mode", command = "checked", checked = true },
+          { label = "Unchecked mode", command = "unchecked", checked = false },
+          { separator = true },
+        },
+        on_menu = function(command)
+          ttt.notify("selected:" .. command)
+        end,
+      })
+      panel:dropdown({
+        label = "Legacy menu",
+        entries = {
+          { label = "Legacy mode", command = "legacy" },
+        },
+      })
+    end,
+  },
+})
+`,
+      "utf8",
+    );
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(80, 20);
+    tui.waitStable(300);
+    tui.panel("plugin.menu-indicators");
+    tui.waitStable();
+
+    tui.click(35, 12);
+    const checkedStates = tui.snapshot();
+    tui.press("arrow_down");
+    tui.press("enter");
+    const callback = tui.snapshot();
+    tui.click(35, 13);
+    const omitted = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[checkedStates]).toContain("│✓ Checked mode");
+    expect(snapshots[checkedStates]).toContain("│  Unchecked mode");
+    expect(snapshots[callback]).toContain("selected:unchecked");
+    expect(snapshots[omitted]).not.toContain("✓");
+    expect(snapshots[omitted]).toContain("│ Legacy mode   │");
+  });
+});

--- a/tests/functional/plugin-menu-checked.test.js
+++ b/tests/functional/plugin-menu-checked.test.js
@@ -69,4 +69,147 @@ ttt.register({
     expect(snapshots[omitted]).not.toContain("✓");
     expect(snapshots[omitted]).toContain("│ Legacy mode   │");
   });
+
+  it("preserves mixed checked states in sidebar actions and action indexes", () => {
+    dir = createTempDir();
+    createTempFile(dir, "test.txt", "hello\n");
+    const plugin = join(dir, "sidebar-menu-indicators.lua");
+    writeFileSync(
+      plugin,
+      `local ttt = require("ttt")
+
+ttt.register({
+  sidebar = {
+    title = "State Probe",
+    actions = {
+      { label = "Omitted", command = "omitted" },
+      { label = "Unchecked", command = "unchecked", checked = false },
+      { separator = true },
+      { label = "Checked", command = "checked", checked = true },
+    },
+    on_action = function(command)
+      ttt.notify("action:" .. command)
+    end,
+    render = function(panel)
+      panel:label("probe")
+    end,
+  },
+})
+`,
+      "utf8",
+    );
+
+    tui.start("--plugin", plugin, dir);
+    tui.setSize(80, 20);
+    tui.waitStable(300);
+    tui.click(27, 2);
+    tui.waitStable();
+    tui.click(29, 5);
+    tui.waitStable();
+    tui.click(29, 2);
+    tui.click(29, 2);
+    tui.waitStable();
+    const mixed = tui.snapshot();
+    tui.press("arrow_down");
+    tui.press("enter");
+    const uncheckedCallback = tui.snapshot();
+    tui.click(29, 2);
+    tui.click(29, 2);
+    tui.press("arrow_down");
+    tui.press("arrow_down");
+    tui.press("enter");
+    const checkedCallback = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[mixed]).toContain("│ Omitted");
+    expect(snapshots[mixed]).not.toContain("│  Omitted");
+    expect(snapshots[mixed]).toContain("│  Unchecked");
+    expect(snapshots[mixed]).toContain("│✓ Checked");
+    expect(snapshots[mixed]).toContain("───────────────");
+    expect(snapshots[uncheckedCallback]).toContain("action:unchecked");
+    expect(snapshots[checkedCallback]).toContain("action:checked");
+  });
+
+  it("reconciles dropdown checked state across redraw and reopen", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "test.txt", "hello\n");
+    const plugin = join(dir, "dynamic-menu-indicators.lua");
+    writeFileSync(
+      plugin,
+      `local ttt = require("ttt")
+
+local state = "checked"
+
+ttt.register({
+  bottom = {
+    title = "Dynamic Indicators",
+    render = function(panel)
+      local entry = { label = "Dynamic mode", command = "cycle" }
+      if state ~= "omitted" then
+        entry.checked = state == "checked"
+      end
+      panel:dropdown({
+        label = "State " .. state,
+        entries = {
+          entry,
+          { separator = true },
+          { label = "Tail action", command = "tail" },
+        },
+        on_menu = function(command)
+          if command == "cycle" then
+            if state == "checked" then
+              state = "unchecked"
+            elseif state == "unchecked" then
+              state = "omitted"
+            else
+              state = "checked"
+            end
+            panel:redraw()
+          end
+          ttt.notify("selected:" .. command .. ":" .. state)
+        end,
+      })
+    end,
+  },
+})
+`,
+      "utf8",
+    );
+
+    tui.start("--plugin", plugin, file);
+    tui.setSize(80, 20);
+    tui.waitStable(300);
+    tui.panel("plugin.dynamic-menu-indicators");
+    tui.waitStable();
+
+    tui.click(35, 12);
+    const checked = tui.snapshot();
+    tui.press("enter");
+    tui.waitStable();
+    tui.click(35, 12);
+    const unchecked = tui.snapshot();
+    tui.press("enter");
+    tui.waitStable();
+    tui.click(35, 12);
+    const omitted = tui.snapshot();
+    tui.press("enter");
+    tui.waitStable();
+    tui.click(35, 12);
+    const checkedAgain = tui.snapshot();
+    tui.press("arrow_down");
+    tui.press("enter");
+    const tailCallback = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[checked]).toContain("State checked");
+    expect(snapshots[checked]).toContain("│✓ Dynamic mode");
+    expect(snapshots[unchecked]).toContain("State unchecked");
+    expect(snapshots[unchecked]).toContain("│  Dynamic mode");
+    expect(snapshots[omitted]).toContain("State omitted");
+    expect(snapshots[omitted]).toContain("│ Dynamic mode");
+    expect(snapshots[omitted]).not.toContain("│  Dynamic mode");
+    expect(snapshots[checkedAgain]).toContain("State checked");
+    expect(snapshots[checkedAgain]).toContain("│✓ Dynamic mode");
+    expect(snapshots[tailCallback]).toContain("selected:tail:checked");
+  });
 });


### PR DESCRIPTION
Extracted from #474 as an independent plugin/widget foundation.

## Summary

- add optional `checked` state to plugin menu entries used by titles, dropdowns, sidebar actions, and tree/list/table node menus
- preserve three distinct backward-compatible states:
  - omitted: legacy indicator-free layout
  - `false`: reserved unchecked slot
  - `true`: checked slot
- centralize conversion through the existing context-menu renderer
- reconcile reused dropdown/title/tree/list/table widgets so dynamic redraws update entries and callbacks instead of retaining stale state
- measure menu labels and shortcuts in terminal display columns and clamp narrow/zero-width surfaces safely
- document the Lua API contract

Existing plugins that omit `checked` retain their previous menu geometry and behavior.

## Verification

- focused app/plugin/UI/widget tests, including 20 repeated runs
- affected race tests
- full Go suite with only the four independently reproduced terminal-mouse baseline timeouts excluded
- `make build`
- checked-menu functional tests: 3/3 passing
- functional composite: 86 non-clipboard files passing; clipboard file 5/5 passing in isolation
  - the parallel shared-clipboard interference was reproduced independently on current `main` and is unrelated to this diff
- fresh exact-head runtime probes for mixed sidebar rows and dynamic dropdown `true → false → omitted → true` redraw/reopen transitions
- fullwidth label/shortcut sizing, narrow-surface hit bounds, separators, keyboard/mouse indexes, and current callback replacement
- `gofmt` and `git diff --check`

The corrected head passed independent adversarial re-review. The branch contains no Git-review, diff, tree, theme, palette, tab, repository-state, integration dependency, or permission changes.

Part of #474.