### PR TITLE
feat(palette): add orientation help mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 - **Ctrl+K P** — opens quick file open (searches all files across workspace folders)
 - Type `>` in quick-open mode to switch to command mode
 - Delete the `>` in command mode to switch to file mode
+- Type `?` to browse searchable help for panels, navigation, and key chords
 - Menu shortcuts resolve dynamically from your keybindings
 
 ### Bottom Panel

--- a/docs-web/src/content/docs/getting-started/quick-start.md
+++ b/docs-web/src/content/docs/getting-started/quick-start.md
@@ -45,7 +45,7 @@ ttt https://github.com/owner/repo/pull/123  # review a PR
 
 ## Command Palette
 
-Press **Ctrl+P** to open the command palette. By default it searches files. Type a `>` prefix to switch to command mode, which lists all available editor commands.
+Press **Ctrl+P** to open the command palette. By default it searches files. Type a `>` prefix to switch to command mode, which lists all available editor commands. Type `?` to browse orientation topics for the workspace, panels, navigation, changes, terminal, and keybinding chords; continue typing to search the help entries, or use `>` when you want the complete command list.
 
 ## Configuration
 

--- a/docs-web/src/content/docs/getting-started/quick-start.md
+++ b/docs-web/src/content/docs/getting-started/quick-start.md
@@ -45,7 +45,7 @@ ttt https://github.com/owner/repo/pull/123  # review a PR
 
 ## Command Palette
 
-Press **Ctrl+P** to open the command palette. By default it searches files. Type a `>` prefix to switch to command mode, which lists all available editor commands. Type `?` to browse orientation topics for the workspace, panels, navigation, changes, terminal, and keybinding chords; continue typing to search the help entries, or use `>` when you want the complete command list.
+Press **Ctrl+P** to open command mode with a `>` prefix and the complete command registry. Press **Ctrl+K P** to search workspace files. At either palette's initial prompt, type `?` to browse orientation topics for the workspace, panels, navigation, changes, terminal, and keybinding chords; continue typing to search the help entries, or use `>` when you want the complete command list.
 
 ## Configuration
 

--- a/internal/ui/palette_help.go
+++ b/internal/ui/palette_help.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/command"
+)
+
+type paletteItemKind uint8
+
+// Help favors trustworthy results over fuzzy recall. Weak character-order
+// coincidences remain below the absolute floor, while the relative floor keeps
+// secondary metadata associations from trailing a much stronger title match.
+const (
+	paletteHelpScoreFloor          = 200
+	paletteHelpRelativeNumerator   = 3
+	paletteHelpRelativeDenominator = 4
+)
+
+const (
+	paletteCommandItem paletteItemKind = iota
+	paletteHelpTopicItem
+)
+
+type paletteHelpTopic struct {
+	ID              string
+	Title           string
+	Description     string
+	CommandPrefixes []string
+	CommandIDs      []string
+	ChordsOnly      bool
+}
+
+// paletteHelpTopics is a deliberately curated new-user onramp. Command titles
+// and shortcuts remain derived from the command registry and keybinding config;
+// only this small orientation layer is authored by hand and maintained here.
+var paletteHelpTopics = []paletteHelpTopic{
+	{
+		ID:              "workspace",
+		Title:           "Workspace map",
+		Description:     "Understand folders, tabs, and editor groups",
+		CommandPrefixes: []string{"workspace.", "file.", "tab.", "focus."},
+		CommandIDs:      []string{"command.palette"},
+	},
+	{
+		ID:              "panels",
+		Title:           "Sidebar and panels",
+		Description:     "Use Explorer, Search, Changes, and Output",
+		CommandPrefixes: []string{"sidebar.", "panel.", "output."},
+		CommandIDs:      []string{"explorer.help", "search.help", "changes.help"},
+	},
+	{
+		ID:              "navigation",
+		Title:           "Navigate files",
+		Description:     "Open files, switch tabs, and move focus",
+		CommandPrefixes: []string{"file.", "tab.", "focus."},
+		CommandIDs:      []string{"editor.goToLine", "command.palette"},
+	},
+	{
+		ID:              "changes",
+		Title:           "Review changes",
+		Description:     "Review, stage, and commit workspace changes",
+		CommandPrefixes: []string{"changes.", "git.", "pr."},
+		CommandIDs:      []string{"sidebar.changes", "changes.help"},
+	},
+	{
+		ID:              "terminal",
+		Title:           "Integrated terminal",
+		Description:     "Open shells without leaving the editor",
+		CommandPrefixes: []string{"terminal."},
+		CommandIDs:      []string{"focus.terminal"},
+	},
+	{
+		ID:          "chords",
+		Title:       "Keybinding chords",
+		Description: "Use multi-step chords and edit shortcuts",
+		CommandIDs:  []string{"view.keybindings", "keybindings.open"},
+		ChordsOnly:  true,
+	},
+}
+
+func buildPaletteHelpItems(commands []command.Command) ([]PaletteItem, []PaletteItem) {
+	topics := make([]PaletteItem, 0, len(paletteHelpTopics))
+	for _, topic := range paletteHelpTopics {
+		topics = append(topics, PaletteItem{
+			Label:       topic.Title,
+			ID:          "help:" + topic.ID,
+			Description: topic.Description,
+			kind:        paletteHelpTopicItem,
+			topicID:     topic.ID,
+			searchText:  []string{topic.Title, topic.Description, topic.ID},
+		})
+	}
+
+	items := make([]PaletteItem, 0, len(commands))
+	for _, cmd := range commands {
+		description := paletteCommandDescription(cmd.ID)
+		searchText := []string{cmd.Title, cmd.ID, cmd.Shortcut, description}
+		searchText = append(searchText, cmd.Keywords...)
+		items = append(items, PaletteItem{
+			Label:       cmd.Title,
+			Detail:      cmd.Shortcut,
+			ID:          cmd.ID,
+			Description: description,
+			kind:        paletteCommandItem,
+			searchText:  searchText,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Label < items[j].Label
+	})
+	return topics, items
+}
+
+func paletteCommandDescription(id string) string {
+	switch {
+	case strings.HasPrefix(id, "workspace."):
+		return "Manage folders and saved workspaces"
+	case strings.HasPrefix(id, "file."):
+		return "Create, open, save, or find a file"
+	case strings.HasPrefix(id, "tab."), strings.HasPrefix(id, "focus."):
+		return "Move between open files and editor groups"
+	case strings.HasPrefix(id, "sidebar."), strings.HasPrefix(id, "panel."), strings.HasPrefix(id, "output."):
+		return "Show, hide, or focus an editor panel"
+	case strings.HasPrefix(id, "changes."), strings.HasPrefix(id, "git."), strings.HasPrefix(id, "pr."):
+		return "Inspect or act on version-control changes"
+	case strings.HasPrefix(id, "terminal."):
+		return "Use the integrated terminal"
+	case strings.HasPrefix(id, "settings."), strings.HasPrefix(id, "theme."), strings.HasPrefix(id, "options."), strings.HasPrefix(id, "keybindings."):
+		return "Customize behavior and shortcuts"
+	default:
+		return "Run this editor command"
+	}
+}
+
+func paletteHelpTopicByID(id string) (paletteHelpTopic, bool) {
+	for _, topic := range paletteHelpTopics {
+		if topic.ID == id {
+			return topic, true
+		}
+	}
+	return paletteHelpTopic{}, false
+}
+
+func paletteTopicMatchesCommand(topic paletteHelpTopic, item PaletteItem) bool {
+	for _, id := range topic.CommandIDs {
+		if item.ID == id {
+			return true
+		}
+	}
+	for _, prefix := range topic.CommandPrefixes {
+		if strings.HasPrefix(item.ID, prefix) {
+			return true
+		}
+	}
+	return topic.ChordsOnly && strings.Contains(item.Detail, " ")
+}
+
+func scorePaletteHelpItem(query string, item PaletteItem) (bool, int) {
+	bestOK, bestScore := fuzzyMatch(query, item.Label)
+	for _, text := range item.searchText {
+		if ok, score := fuzzyMatch(query, text); ok {
+			if text != item.Label {
+				score /= 2
+			}
+			if !bestOK || score > bestScore {
+				bestOK = true
+				bestScore = score
+			}
+		}
+	}
+	return bestOK, bestScore
+}

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -24,6 +24,16 @@ const (
 	paletteHelpMode
 )
 
+const ordinaryPaletteMaxWidth = 60
+
+type selectDialogLayout struct {
+	boxX         int
+	boxY         int
+	boxW         int
+	boxH         int
+	visibleItems int
+}
+
 type PaletteItem struct {
 	Label       string
 	Detail      string
@@ -123,10 +133,11 @@ func (p *SelectDialogWidget) CursorPosition() (int, int, bool) {
 	return p.Input.CursorX(p.inputX), p.inputY, true
 }
 
-func (p *SelectDialogWidget) Render(surface Surface) {
-	sw, sh := surface.Size()
-
+func (p *SelectDialogWidget) calculateLayout(sw, sh int) selectDialogLayout {
 	boxW := sw * 6 / 10 // 60% of terminal width
+	if p.mode != paletteHelpMode && boxW > ordinaryPaletteMaxWidth {
+		boxW = ordinaryPaletteMaxWidth
+	}
 	if boxW < 40 {
 		boxW = 40
 	}
@@ -156,8 +167,30 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 		boxH = sh - 2
 	}
 
-	boxX := (sw - boxW) / 2
-	boxY := 2
+	visibleItems := 0
+	if p.mode != paletteGoToLineMode {
+		visibleItems = boxH - 4
+		if p.mode == paletteHelpMode {
+			visibleItems -= 2
+		}
+	}
+
+	return selectDialogLayout{
+		boxX:         (sw - boxW) / 2,
+		boxY:         2,
+		boxW:         boxW,
+		boxH:         boxH,
+		visibleItems: visibleItems,
+	}
+}
+
+func (p *SelectDialogWidget) Render(surface Surface) {
+	sw, sh := surface.Size()
+	layout := p.calculateLayout(sw, sh)
+	boxX := layout.boxX
+	boxY := layout.boxY
+	boxW := layout.boxW
+	boxH := layout.boxH
 
 	p.boxX = boxX
 	p.boxY = boxY
@@ -177,7 +210,7 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 	p.Input.Render(surface, p.inputX, p.inputY, boxW-2)
 
 	if p.mode == paletteGoToLineMode {
-		p.visibleItems = 0
+		p.visibleItems = layout.visibleItems
 		p.showScroll = false
 		return
 	}
@@ -186,10 +219,7 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 		surface.SetCell(x, boxY+2, term.Cell{Ch: b.Horizontal, Style: term.StyleBorder})
 	}
 
-	visibleItems := boxH - 4
-	if p.mode == paletteHelpMode {
-		visibleItems -= 2
-	}
+	visibleItems := layout.visibleItems
 	p.visibleItems = visibleItems
 	p.ensureVisible(visibleItems)
 	showScroll := len(p.Items) > visibleItems

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -19,12 +21,17 @@ const (
 	paletteCommandMode paletteMode = iota
 	paletteFileMode
 	paletteGoToLineMode
+	paletteHelpMode
 )
 
 type PaletteItem struct {
-	Label  string
-	Detail string
-	ID     string
+	Label       string
+	Detail      string
+	ID          string
+	Description string
+	kind        paletteItemKind
+	topicID     string
+	searchText  []string
 }
 
 type paletteFile struct {
@@ -43,6 +50,10 @@ type SelectDialogWidget struct {
 	inputY            int
 	mode              paletteMode
 	files             []paletteFile
+	helpTopics        []PaletteItem
+	helpCommands      []PaletteItem
+	activeHelpTopic   string
+	helpQuery         string
 	OnExecute         func(id string)
 	OnOpenFile        func(path string)
 	OnGoToLine        func(line int)
@@ -63,6 +74,7 @@ func NewSelectDialogWidget(commands []command.Command) *SelectDialogWidget {
 	p := &SelectDialogWidget{
 		Commands: commands,
 	}
+	p.helpTopics, p.helpCommands = buildPaletteHelpItems(commands)
 	p.Input = NewInputWidget()
 	p.Input.Prefix = " "
 	p.Input.SetText(">")
@@ -115,9 +127,6 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 	sw, sh := surface.Size()
 
 	boxW := sw * 6 / 10 // 60% of terminal width
-	if boxW > 60 {
-		boxW = 60
-	}
 	if boxW < 40 {
 		boxW = 40
 	}
@@ -129,9 +138,18 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 		boxH = 3
 	} else {
 		maxItems := 10
-		boxH = 4 + len(p.Items)
-		if boxH > maxItems+4 {
-			boxH = maxItems + 4
+		chromeRows := 4
+		if p.mode == paletteHelpMode {
+			// Help reserves one divider and one detail row beneath the list.
+			chromeRows += 2
+		}
+		itemRows := len(p.Items)
+		if p.mode == paletteHelpMode && p.helpQuery != "" && itemRows == 0 {
+			itemRows = 1
+		}
+		boxH = chromeRows + itemRows
+		if boxH > maxItems+chromeRows {
+			boxH = maxItems + chromeRows
 		}
 	}
 	if boxH > sh-2 {
@@ -169,6 +187,9 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 	}
 
 	visibleItems := boxH - 4
+	if p.mode == paletteHelpMode {
+		visibleItems -= 2
+	}
 	p.visibleItems = visibleItems
 	p.ensureVisible(visibleItems)
 	showScroll := len(p.Items) > visibleItems
@@ -197,32 +218,84 @@ func (p *SelectDialogWidget) Render(surface Surface) {
 		}
 
 		surface.ClearRect(boxX+1, y, contentRight-boxX-1, 1, style)
-		surface.DrawText(boxX+2, y, item.Label, contentRight-1, style)
-
-		if item.Detail != "" {
-			detailStyle := term.StyleMuted
-			if idx == p.Selected {
-				detailStyle = style
-			}
-			labelEnd := boxX + 2 + len([]rune(item.Label))
-			minGap := 3
-			availStart := labelEnd + minGap
-			availW := contentRight - 1 - availStart
-			if availW > 0 {
-				detail := item.Detail
-				detailRunes := []rune(detail)
-				if len(detailRunes) > availW {
-					detail = "…" + string(detailRunes[len(detailRunes)-availW+1:])
-				}
-				sx := contentRight - 1 - len([]rune(detail))
-				surface.DrawText(sx, y, detail, contentRight-1, detailStyle)
-			}
-		}
+		p.renderItemRow(surface, y, contentRight, item, style, idx == p.Selected)
+	}
+	if p.mode == paletteHelpMode && p.helpQuery != "" && len(p.Items) == 0 && visibleItems > 0 {
+		y := boxY + 3
+		message := fmt.Sprintf("No help entries match %q", p.helpQuery)
+		surface.DrawText(boxX+2, y, message, contentRight-1, term.StyleMuted)
 	}
 
 	if showScroll {
 		p.scrollbar.Render(surface, p.scrollbar.X, p.scrollbar.Y)
 	}
+
+	if p.mode == paletteHelpMode {
+		dividerY := boxY + boxH - 3
+		for x := boxX + 1; x < boxX+boxW-1; x++ {
+			surface.SetCell(x, dividerY, term.Cell{Ch: b.Horizontal, Style: term.StyleBorder})
+		}
+		detailY := boxY + boxH - 2
+		surface.ClearRect(boxX+1, detailY, boxW-2, 1, term.StyleDefault)
+		if p.Selected >= 0 && p.Selected < len(p.Items) {
+			description := p.Items[p.Selected].Description
+			surface.DrawText(boxX+2, detailY, description, boxX+boxW-2, term.StyleMuted)
+		} else if p.helpQuery != "" {
+			surface.DrawText(boxX+2, detailY, "Try > for all commands", boxX+boxW-2, term.StyleMuted)
+		}
+	}
+}
+
+func (p *SelectDialogWidget) renderItemRow(surface Surface, y, contentRight int, item PaletteItem, style term.Style, selected bool) {
+	detail := item.Detail
+	detailStyle := term.StyleMuted
+	if selected {
+		detailStyle = style
+	}
+
+	// Help commands reserve room for their derived shortcut. Other modes keep
+	// their existing preference for the complete label and add detail only if it
+	// fits after the columns DrawText actually consumed.
+	if p.mode == paletteHelpMode && item.kind == paletteCommandItem && detail != "" {
+		detailW := textwidth.String(detail)
+		detailX := contentRight - 1 - detailW
+		if detailX > p.boxX+4 {
+			surface.DrawText(p.boxX+2, y, item.Label, detailX-2, style)
+			surface.DrawText(detailX, y, detail, contentRight-1, detailStyle)
+			return
+		}
+	}
+
+	labelEnd := surface.DrawText(p.boxX+2, y, item.Label, contentRight-1, style)
+	if detail == "" {
+		return
+	}
+	availStart := labelEnd + 3
+	availW := contentRight - 1 - availStart
+	if availW <= 0 {
+		return
+	}
+	detail = truncatePaletteDetail(detail, availW)
+	detailX := contentRight - 1 - textwidth.String(detail)
+	surface.DrawText(detailX, y, detail, contentRight-1, detailStyle)
+}
+
+func truncatePaletteDetail(detail string, availW int) string {
+	if textwidth.String(detail) <= availW {
+		return detail
+	}
+	runes := []rune(detail)
+	tailW := 0
+	i := len(runes)
+	for i > 0 {
+		width := textwidth.Rune(runes[i-1])
+		if tailW+width > availW-1 {
+			break
+		}
+		tailW += width
+		i--
+	}
+	return "…" + string(runes[i:])
 }
 
 func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -287,16 +360,7 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 				clickedIdx := p.scrollOffset + (my - itemsStartY)
 				if clickedIdx >= 0 && clickedIdx < len(p.Items) {
 					p.Selected = clickedIdx
-					item := p.Items[p.Selected]
-					if p.mode == paletteCommandMode {
-						if p.OnExecute != nil {
-							p.OnExecute(item.ID)
-						}
-					} else {
-						if p.OnOpenFile != nil {
-							p.OnOpenFile(item.ID)
-						}
-					}
+					p.activateItem(p.Items[p.Selected])
 				}
 			}
 		}
@@ -311,6 +375,11 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 
 	switch kev.Key() {
 	case tcell.KeyEscape:
+		if p.mode == paletteHelpMode && p.activeHelpTopic != "" {
+			p.activeHelpTopic = ""
+			p.Input.SetText("?")
+			return EventConsumed
+		}
 		if p.OnDismiss != nil {
 			p.OnDismiss()
 		}
@@ -326,16 +395,7 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 				}
 			}
 		} else if p.Selected >= 0 && p.Selected < len(p.Items) {
-			item := p.Items[p.Selected]
-			if p.mode == paletteCommandMode {
-				if p.OnExecute != nil {
-					p.OnExecute(item.ID)
-				}
-			} else {
-				if p.OnOpenFile != nil {
-					p.OnOpenFile(item.ID)
-				}
-			}
+			p.activateItem(p.Items[p.Selected])
 		}
 	case tcell.KeyUp:
 		if p.Selected > 0 {
@@ -352,10 +412,37 @@ func (p *SelectDialogWidget) HandleEvent(ev tcell.Event) EventResult {
 		}
 		p.notifySelectionChange()
 	default:
+		if kev.Key() == tcell.KeyRune && kev.Str() == "?" && p.mode == paletteCommandMode && p.Input.Text == ">" {
+			p.Input.SetText("?")
+			return EventConsumed
+		}
 		p.Input.HandleEvent(ev)
 	}
 
 	return EventConsumed
+}
+
+func (p *SelectDialogWidget) activateItem(item PaletteItem) {
+	if p.mode == paletteHelpMode {
+		if item.kind == paletteHelpTopicItem {
+			p.activeHelpTopic = item.topicID
+			p.Input.SetText("?")
+			return
+		}
+		if p.OnExecute != nil {
+			p.OnExecute(item.ID)
+		}
+		return
+	}
+	if p.mode == paletteCommandMode {
+		if p.OnExecute != nil {
+			p.OnExecute(item.ID)
+		}
+		return
+	}
+	if p.OnOpenFile != nil {
+		p.OnOpenFile(item.ID)
+	}
 }
 
 func (p *SelectDialogWidget) ensureVisible(visibleItems int) {
@@ -380,18 +467,91 @@ func (p *SelectDialogWidget) filter() {
 	text := p.Input.Text
 	if strings.HasPrefix(text, ">") {
 		p.mode = paletteCommandMode
+		p.activeHelpTopic = ""
 		query := strings.TrimLeft(text[1:], " ")
 		p.filterCommands(query)
 	} else if strings.HasPrefix(text, ":") {
 		p.mode = paletteGoToLineMode
+		p.activeHelpTopic = ""
 		p.Items = nil
 		p.Selected = 0
 		p.scrollOffset = 0
+	} else if strings.HasPrefix(text, "?") {
+		p.mode = paletteHelpMode
+		query := strings.TrimSpace(text[1:])
+		p.filterHelp(query)
 	} else {
 		p.mode = paletteFileMode
+		p.activeHelpTopic = ""
 		p.filterFiles(text)
 	}
 	p.notifySelectionChange()
+}
+
+func (p *SelectDialogWidget) filterHelp(query string) {
+	p.helpQuery = query
+	if p.activeHelpTopic != "" {
+		topic, ok := paletteHelpTopicByID(p.activeHelpTopic)
+		if !ok {
+			p.activeHelpTopic = ""
+		} else {
+			candidates := make([]PaletteItem, 0, len(p.helpCommands))
+			for _, item := range p.helpCommands {
+				if paletteTopicMatchesCommand(topic, item) {
+					candidates = append(candidates, item)
+				}
+			}
+			p.Items = filterPaletteHelpCandidates(query, candidates)
+			p.Selected = 0
+			p.scrollOffset = 0
+			return
+		}
+	}
+
+	if query == "" {
+		p.Items = append(p.Items[:0], p.helpTopics...)
+	} else {
+		candidates := make([]PaletteItem, 0, len(p.helpTopics)+len(p.helpCommands))
+		candidates = append(candidates, p.helpTopics...)
+		candidates = append(candidates, p.helpCommands...)
+		p.Items = filterPaletteHelpCandidates(query, candidates)
+	}
+	p.Selected = 0
+	p.scrollOffset = 0
+}
+
+func filterPaletteHelpCandidates(query string, candidates []PaletteItem) []PaletteItem {
+	if query == "" {
+		return append([]PaletteItem(nil), candidates...)
+	}
+	type scored struct {
+		item  PaletteItem
+		score int
+	}
+	matches := make([]scored, 0, len(candidates))
+	bestScore := 0
+	for _, item := range candidates {
+		if ok, score := scorePaletteHelpItem(query, item); ok {
+			matches = append(matches, scored{item: item, score: score})
+			if score > bestScore {
+				bestScore = score
+			}
+		}
+	}
+	relevanceFloor := bestScore * paletteHelpRelativeNumerator / paletteHelpRelativeDenominator
+	if relevanceFloor < paletteHelpScoreFloor {
+		relevanceFloor = paletteHelpScoreFloor
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return matches[i].score > matches[j].score
+	})
+	items := make([]PaletteItem, 0, len(matches))
+	for _, match := range matches {
+		if match.score >= relevanceFloor {
+			items = append(items, match.item)
+		}
+	}
+	return items
 }
 
 func (p *SelectDialogWidget) filterCommands(query string) {

--- a/internal/ui/selectdialog_widget_test.go
+++ b/internal/ui/selectdialog_widget_test.go
@@ -1,11 +1,41 @@
 package ui
 
 import (
-	"github.com/eugenioenko/ttt/internal/command"
+	"strings"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/command"
+	"github.com/eugenioenko/ttt/internal/config"
 
 	"github.com/gdamore/tcell/v3"
 )
+
+func defaultShortcut(commandID string) string {
+	for _, binding := range config.DefaultKeybindings() {
+		if binding.Command == commandID {
+			return binding.Key
+		}
+	}
+	return ""
+}
+
+func helpTestCommands() []command.Command {
+	return []command.Command{
+		{
+			ID:       "file.quickOpen",
+			Title:    "Open Anything From the Workspace",
+			Shortcut: defaultShortcut("file.quickOpen"),
+			Keywords: []string{"file", "navigate", "open"},
+		},
+		{
+			ID:       "sidebar.search",
+			Title:    "Search Everywhere",
+			Shortcut: defaultShortcut("sidebar.search"),
+			Keywords: []string{"sidebar", "search", "workspace"},
+		},
+		{ID: "tab.closeAllSaved", Title: "Close All Saved Tabs"},
+	}
+}
 
 func testCommands() []command.Command {
 	return []command.Command{
@@ -345,5 +375,144 @@ func TestPaletteTitleMatchRanksAboveKeywordOnly(t *testing.T) {
 	}
 	if p.Items[0].ID != "settings" {
 		t.Fatalf("expected title match 'Preferences: Open Settings' (id=settings) to rank first, got id=%s (%s)", p.Items[0].ID, p.Items[0].Label)
+	}
+}
+
+func TestPaletteHelpStartsWithOrientationTopics(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyRune, "?", tcell.ModNone))
+
+	if p.mode != paletteHelpMode || p.Input.Text != "?" {
+		t.Fatalf("expected question-mark help mode, got mode=%d input=%q", p.mode, p.Input.Text)
+	}
+	if len(p.Items) == 0 {
+		t.Fatal("expected orientation topics")
+	}
+	for _, item := range p.Items {
+		if item.kind != paletteHelpTopicItem {
+			t.Fatalf("empty help should show topics, not %q", item.ID)
+		}
+	}
+	if p.Items[0].Description == "" {
+		t.Fatal("expected the selected topic to have orientation detail")
+	}
+}
+
+func TestPaletteHelpSearchDerivesCommandsAndShortcuts(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.Input.SetText("?Open Anything")
+
+	if len(p.Items) == 0 {
+		t.Fatal("expected command search result")
+	}
+	got := p.Items[0]
+	if got.ID != "file.quickOpen" {
+		t.Fatalf("expected derived command ID, got %q", got.ID)
+	}
+	if got.Label != "Open Anything From the Workspace" {
+		t.Fatalf("expected registered title, got %q", got.Label)
+	}
+	if got.Detail != defaultShortcut("file.quickOpen") {
+		t.Fatalf("expected shortcut derived from DefaultKeybindings, got %q", got.Detail)
+	}
+}
+
+func TestPaletteHelpTopicKeyboardAndMouseNavigation(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.Input.SetText("?")
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+
+	if p.activeHelpTopic != "workspace" {
+		t.Fatalf("expected workspace topic after Enter, got %q", p.activeHelpTopic)
+	}
+	if len(p.Items) == 0 || p.Items[0].kind != paletteCommandItem {
+		t.Fatal("expected topic to drill into commands")
+	}
+
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyEscape, "", tcell.ModNone))
+	if p.activeHelpTopic != "" || len(p.Items) != len(paletteHelpTopics) {
+		t.Fatal("expected Escape to return to help topics")
+	}
+
+	p.Render(NewRenderSurface(makeGrid(80, 24), Rect{X: 0, Y: 0, W: 80, H: 24}))
+	p.HandleEvent(tcell.NewEventMouse(p.boxX+2, p.boxY+4, tcell.Button1, tcell.ModNone))
+	if p.activeHelpTopic != "panels" {
+		t.Fatalf("expected second topic click to open panels help, got %q", p.activeHelpTopic)
+	}
+
+	dismissed := false
+	p.OnDismiss = func() { dismissed = true }
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyEscape, "", tcell.ModNone))
+	if dismissed {
+		t.Fatal("first Escape from a topic should not dismiss the palette")
+	}
+	p.HandleEvent(tcell.NewEventKey(tcell.KeyEscape, "", tcell.ModNone))
+	if !dismissed {
+		t.Fatal("second Escape should dismiss help")
+	}
+}
+
+func TestPaletteHelpRelevanceFloorRejectsFuzzyNoise(t *testing.T) {
+	commands := []command.Command{
+		{ID: "editor.undo", Title: "Undo", Shortcut: defaultShortcut("editor.undo")},
+		{ID: "multicursor.undoCursor", Title: "Undo Last Cursor", Shortcut: defaultShortcut("multicursor.undoCursor")},
+		{ID: "changes.discard", Title: "Git: Discard Changes", Keywords: []string{"git", "changes", "revert", "restore", "undo"}},
+		{ID: "sourceAction.formatDocument", Title: "Source Action: Format Document"},
+		{ID: "about", Title: "About TTT Editor"},
+		{ID: "multicursor.selectNext", Title: "Add Next Occurrence"},
+		{ID: "editor.indentation", Title: "Change Indentation"},
+	}
+	p := NewSelectDialogWidget(commands)
+	p.Input.SetText("?undo")
+
+	if len(p.Items) != 2 {
+		labels := make([]string, len(p.Items))
+		for i, item := range p.Items {
+			labels[i] = item.Label
+		}
+		t.Fatalf("expected only two relevant undo matches, got %d: %v", len(p.Items), labels)
+	}
+	if p.Items[0].ID != "editor.undo" || p.Items[1].ID != "multicursor.undoCursor" {
+		t.Fatalf("unexpected undo result order: %q, %q", p.Items[0].ID, p.Items[1].ID)
+	}
+
+	p.Input.SetText("?revert")
+	if len(p.Items) != 1 || p.Items[0].ID != "changes.discard" {
+		t.Fatalf("expected exact keyword-only match, got %#v", p.Items)
+	}
+}
+
+func TestPaletteHelpNoMatchesRendersGuidance(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.Input.SetText("?qxzvjk")
+	if len(p.Items) != 0 {
+		t.Fatalf("expected no matches, got %d", len(p.Items))
+	}
+
+	cells := makeGrid(80, 24)
+	p.Render(NewRenderSurface(cells, Rect{X: 0, Y: 0, W: 80, H: 24}))
+	var rendered strings.Builder
+	for _, row := range cells {
+		for _, cell := range row {
+			if cell.Ch == 0 {
+				rendered.WriteByte(' ')
+			} else {
+				rendered.WriteRune(cell.Ch)
+			}
+		}
+		rendered.WriteByte('\n')
+	}
+	text := rendered.String()
+	if !strings.Contains(text, `No help entries match "qxzvjk"`) {
+		t.Fatalf("missing no-results message:\n%s", text)
+	}
+	if !strings.Contains(text, "Try > for all commands") {
+		t.Fatalf("missing command-mode hint:\n%s", text)
+	}
+}
+
+func TestTruncatePaletteDetailUsesDisplayWidth(t *testing.T) {
+	if got := truncatePaletteDetail("prefix界界", 4); got != "…界" {
+		t.Fatalf("expected width-safe tail, got %q", got)
 	}
 }

--- a/internal/ui/selectdialog_widget_test.go
+++ b/internal/ui/selectdialog_widget_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/command"
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/term"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -375,6 +376,76 @@ func TestPaletteTitleMatchRanksAboveKeywordOnly(t *testing.T) {
 	}
 	if p.Items[0].ID != "settings" {
 		t.Fatalf("expected title match 'Preferences: Open Settings' (id=settings) to rank first, got id=%s (%s)", p.Items[0].ID, p.Items[0].Label)
+	}
+}
+
+func renderPaletteAt(p *SelectDialogWidget, width, height int) [][]term.Cell {
+	cells := makeGrid(width, height)
+	p.Render(NewRenderSurface(cells, Rect{X: 0, Y: 0, W: width, H: height}))
+	return cells
+}
+
+func TestPaletteWideGeometryTransitionsAndReopen(t *testing.T) {
+	p := NewSelectDialogWidget(helpTestCommands())
+	p.files = []paletteFile{{Rel: "alpha.txt", Abs: "/workspace/alpha.txt"}}
+
+	commandCells := renderPaletteAt(p, 200, 50)
+	if p.boxX != 70 || p.boxW != 60 {
+		t.Fatalf("command geometry = x:%d width:%d, want x:70 width:60", p.boxX, p.boxW)
+	}
+	if commandCells[p.boxY][70].Ch != '╔' || commandCells[p.boxY][129].Ch != '╗' {
+		t.Fatal("command border does not match its 60-column layout")
+	}
+
+	p.Input.SetText("?")
+	p.Selected = 2
+	helpCells := renderPaletteAt(p, 200, 50)
+	if p.boxX != 40 || p.boxW != 120 {
+		t.Fatalf("help geometry = x:%d width:%d, want x:40 width:120", p.boxX, p.boxW)
+	}
+	if helpCells[p.boxY][40].Ch != '╔' || helpCells[p.boxY][159].Ch != '╗' {
+		t.Fatal("help border does not match its responsive layout")
+	}
+
+	p.Input.SetText(">")
+	commandCells = renderPaletteAt(p, 200, 50)
+	if p.Selected != 0 || p.scrollOffset != 0 {
+		t.Fatalf("command transition retained selection state: selected=%d scroll=%d", p.Selected, p.scrollOffset)
+	}
+	if p.boxX != 70 || p.boxW != 60 {
+		t.Fatalf("command transition geometry = x:%d width:%d, want x:70 width:60", p.boxX, p.boxW)
+	}
+	if commandCells[p.boxY][40].Ch != '.' {
+		t.Fatal("command render retained the old help border")
+	}
+
+	p.Input.Clear()
+	fileCells := renderPaletteAt(p, 200, 50)
+	if p.boxX != 70 || p.boxW != 60 {
+		t.Fatalf("file geometry = x:%d width:%d, want x:70 width:60", p.boxX, p.boxW)
+	}
+	if fileCells[p.boxY][70].Ch != '╔' || fileCells[p.boxY][129].Ch != '╗' {
+		t.Fatal("file border does not match its 60-column layout")
+	}
+
+	dismissed := false
+	p.OnDismiss = func() { dismissed = true }
+	p.HandleEvent(tcell.NewEventMouse(50, p.inputY, tcell.Button1, tcell.ModNone))
+	if !dismissed {
+		t.Fatal("file mode retained the wider help hit target")
+	}
+
+	opened := ""
+	p.OnOpenFile = func(path string) { opened = path }
+	p.HandleEvent(tcell.NewEventMouse(p.boxX+2, p.boxY+3, tcell.Button1, tcell.ModNone))
+	if opened != "/workspace/alpha.txt" {
+		t.Fatalf("file row hit target opened %q", opened)
+	}
+
+	reopened := NewSelectDialogWidget(helpTestCommands())
+	renderPaletteAt(reopened, 200, 50)
+	if reopened.Input.Text != ">" || reopened.boxX != 70 || reopened.boxW != 60 {
+		t.Fatalf("reopened command palette = input:%q x:%d width:%d", reopened.Input.Text, reopened.boxX, reopened.boxW)
 	}
 }
 

--- a/tests/e2e/editor_test.go
+++ b/tests/e2e/editor_test.go
@@ -72,6 +72,59 @@ func TestCommandPaletteDoesNotStack(t *testing.T) {
 	}
 }
 
+func TestCommandPaletteHelpOrientsThenNavigates(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.pressCtrl(tcell.KeyCtrlP)
+	h.pressRune('?')
+
+	h.assertContains("Workspace map")
+	h.assertContains("folders, tabs, and editor groups")
+	h.assertNotContains("Open Folder")
+
+	for _, r := range "Open Folder" {
+		h.pressRune(r)
+	}
+	h.assertContains("Open Folder")
+	cmd, ok := h.reg.Get("workspace.openFolder")
+	if !ok {
+		t.Fatal("workspace.openFolder command is not registered")
+	}
+	if cmd.Shortcut == "" {
+		t.Fatal("workspace.openFolder should have a derived shortcut")
+	}
+	h.assertContains(cmd.Shortcut)
+
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+	if len(h.app.Root.Overlays) == 0 {
+		t.Fatal("executing Open Folder from help should open its dialog")
+	}
+}
+
+func TestCommandPaletteHelpNoMatchAndEscape(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.pressCtrl(tcell.KeyCtrlP)
+	h.pressRune('?')
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+	h.assertContains("Open Folder")
+
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+	h.assertContains("Workspace map")
+	for _, r := range "qxzvjk" {
+		h.pressRune(r)
+	}
+	h.assertContains(`No help entries match "qxzvjk"`)
+	h.assertContains("Try > for all commands")
+
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+	if len(h.app.Root.Overlays) != 0 {
+		t.Fatalf("expected help palette to dismiss, got %d overlays", len(h.app.Root.Overlays))
+	}
+}
+
 func TestGoToLineDialog(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()

--- a/tests/e2e/editor_test.go
+++ b/tests/e2e/editor_test.go
@@ -72,6 +72,93 @@ func TestCommandPaletteDoesNotStack(t *testing.T) {
 	}
 }
 
+func paletteBorderWidth(row string) int {
+	runes := []rune(row)
+	for _, border := range [][2]rune{{'╭', '╮'}, {'╔', '╗'}, {'┌', '┐'}} {
+		start := -1
+		for i, r := range runes {
+			if r == border[0] {
+				start = i
+				break
+			}
+		}
+		if start < 0 {
+			continue
+		}
+		for i := start + 1; i < len(runes); i++ {
+			if runes[i] == border[1] {
+				return i - start + 1
+			}
+		}
+	}
+	return 0
+}
+
+func TestCommandPaletteWideGeometryBindingsAndTransitions(t *testing.T) {
+	h := newTestHarness(t, 200, 50)
+	defer h.stop()
+
+	h.pressCtrl(tcell.KeyCtrlP)
+	palette, ok := h.app.Root.TopOverlayWidget().(*ui.SelectDialogWidget)
+	if !ok {
+		t.Fatalf("Ctrl+P opened %T, want command palette", h.app.Root.TopOverlayWidget())
+	}
+	if palette.Input.Text != ">" || len(palette.Items) != len(h.reg.List()) {
+		t.Fatalf("Ctrl+P input=%q items=%d, want > and complete registry of %d", palette.Input.Text, len(palette.Items), len(h.reg.List()))
+	}
+	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
+		t.Fatalf("Ctrl+P command palette width=%d, want 60; row=%q", got, h.screenRow(2))
+	}
+
+	h.pressRune('?')
+	if got := paletteBorderWidth(h.screenRow(2)); got != 120 {
+		t.Fatalf("help palette width=%d, want responsive width 120", got)
+	}
+	palette.Selected = 3
+
+	h.pressKey(tcell.KeyBackspace2, tcell.ModNone)
+	h.pressRune('>')
+	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
+		t.Fatalf("help-to-command palette width=%d, want 60", got)
+	}
+	if palette.Selected != 0 {
+		t.Fatalf("help-to-command selected=%d, want 0", palette.Selected)
+	}
+
+	h.pressKey(tcell.KeyBackspace2, tcell.ModNone)
+	if palette.Input.Text != "" {
+		t.Fatalf("file-mode input=%q, want empty", palette.Input.Text)
+	}
+	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
+		t.Fatalf("file palette width=%d, want 60", got)
+	}
+	h.assertContains("alpha.txt")
+
+	h.click(50, 3)
+	if h.app.Root.HasOverlay() {
+		t.Fatal("file palette retained the wider help hit target")
+	}
+
+	h.pressCtrl(tcell.KeyCtrlP)
+	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
+		t.Fatalf("reopened command palette width=%d, want 60", got)
+	}
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	h.pressCtrl(tcell.KeyCtrlK)
+	h.pressRune('p')
+	palette, ok = h.app.Root.TopOverlayWidget().(*ui.SelectDialogWidget)
+	if !ok {
+		t.Fatalf("Ctrl+K P opened %T, want file search", h.app.Root.TopOverlayWidget())
+	}
+	if palette.Input.Text != "" {
+		t.Fatalf("Ctrl+K P input=%q, want empty file search", palette.Input.Text)
+	}
+	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
+		t.Fatalf("Ctrl+K P file palette width=%d, want 60", got)
+	}
+}
+
 func TestCommandPaletteHelpOrientsThenNavigates(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()

--- a/tests/functional/command-palette.test.js
+++ b/tests/functional/command-palette.test.js
@@ -4,6 +4,12 @@ import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
 
 let dir;
 
+function paletteWidth(snapshot) {
+  const borderRow = snapshot.split("\n")[2] || "";
+  const matches = borderRow.matchAll(/(?:╭─+╮|╔═+╗|┌─+┐)/g);
+  return Math.max(0, ...[...matches].map((match) => [...match[0]].length));
+}
+
 afterEach(() => {
   tui.kill();
   if (dir) cleanupDir(dir);
@@ -56,6 +62,48 @@ describe("command palette", () => {
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
     expect(snapshots[s0]).toContain("Dismiss test");
+  });
+
+  it("should keep ordinary modes narrow while help responds and transitions cleanly", () => {
+    dir = createTempDir();
+    createTempFile(dir, "wide.txt", "Wide palette test");
+
+    tui.start(dir);
+    tui.setSize(200, 50);
+    tui.waitFor("wide.txt");
+    tui.press("ctrl+p");
+    const command = tui.snapshot();
+
+    tui.type("?");
+    const help = tui.snapshot();
+
+    tui.press("backspace");
+    tui.type(">");
+    const commandAgain = tui.snapshot();
+
+    tui.press("backspace");
+    const files = tui.snapshot();
+
+    tui.click(50, 3);
+    const dismissed = tui.snapshot();
+
+    tui.press("ctrl+p");
+    const reopened = tui.snapshot();
+    tui.press("escape");
+    tui.pressChord("ctrl+k", "p");
+    const fileBinding = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(paletteWidth(snapshots[command])).toBe(60);
+    expect(paletteWidth(snapshots[help])).toBe(120);
+    expect(paletteWidth(snapshots[commandAgain])).toBe(60);
+    expect(paletteWidth(snapshots[files])).toBe(60);
+    expect(paletteWidth(snapshots[dismissed])).toBe(0);
+    expect(paletteWidth(snapshots[reopened])).toBe(60);
+    expect(paletteWidth(snapshots[fileBinding])).toBe(60);
+    expect(snapshots[command]).toContain(">");
+    expect(snapshots[files]).toContain("wide.txt");
+    expect(snapshots[fileBinding]).toContain("wide.txt");
   });
 
   it("should orient a new user before listing commands in help mode", () => {

--- a/tests/functional/command-palette.test.js
+++ b/tests/functional/command-palette.test.js
@@ -57,4 +57,68 @@ describe("command palette", () => {
     const { snapshots } = tui.run();
     expect(snapshots[s0]).toContain("Dismiss test");
   });
+
+  it("should orient a new user before listing commands in help mode", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "help.txt", "Help mode test");
+
+    tui.start(file);
+    tui.setSize(80, 24);
+    tui.waitFor("help.txt");
+    tui.press("ctrl+p");
+    tui.type("?");
+    tui.waitStable();
+
+    const topics = tui.snapshot();
+    tui.press("arrow_down");
+    const nextTopic = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[topics]).toContain("Workspace map");
+    expect(snapshots[topics]).toContain("folders, tabs, and editor groups");
+    expect(snapshots[topics]).not.toContain("Open Folder");
+    expect(snapshots[nextTopic]).toContain("Explorer, Search, Changes, and Output");
+  });
+
+  it("should search commands outside the curated help topics", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "help-search.txt", "Help search test");
+
+    tui.start(file);
+    tui.waitFor("help-search.txt");
+    tui.press("ctrl+p");
+    tui.type("?saved tabs");
+    tui.waitStable();
+
+    const result = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[result]).toContain("Close All Saved Tabs");
+  });
+
+  it("should prefer precise help matches and explain an empty result", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "help-precision.txt", "Help precision test");
+
+    tui.start(file);
+    tui.setSize(80, 24);
+    tui.waitFor("help-precision.txt");
+    tui.press("ctrl+p");
+    tui.type("?undo");
+    tui.waitStable();
+    const precise = tui.snapshot();
+
+    for (let i = 0; i < 4; i++) tui.press("backspace");
+    tui.type("qxzvjk");
+    tui.waitStable();
+    const empty = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[precise]).toContain("Undo");
+    expect(snapshots[precise]).toContain("Undo Last Cursor");
+    expect(snapshots[precise]).not.toContain("Git: Discard Changes");
+    expect(snapshots[precise]).not.toContain("Add Next Occurrence");
+    expect(snapshots[empty]).toContain('No help entries match "qxzvjk"');
+    expect(snapshots[empty]).toContain("Try > for all commands");
+  });
 });


### PR DESCRIPTION
Extracted from #474 as an independent command-palette discoverability feature.

## Summary

- add a `?` help mode with six curated orientation topics for workspace, panels, navigation, changes, terminal, and keybinding chords
- provide topic drill-in with precise command ranking, stable ordering, and a relevance floor that avoids unrelated result floods
- show explicit zero-result guidance and direct users to `>` for the complete command registry
- preserve current routing:
  - `Ctrl+P` opens `>` command mode
  - `Ctrl+K P` opens file search
- keep ordinary command/file palettes at the existing 60-column maximum while allowing help mode to use a responsive wider layout
- recalculate geometry, borders, selection, scrolling, and mouse hit targets when switching modes or resizing
- render long and fullwidth labels with the project text-width rules

## Verification

- focused UI and E2E tests, including race runs
- command-palette functional tests: 6/6 passing
- functional composite: clipboard file 5/5 in isolation; remaining 85 files passing with 286 passes and 27 expected failures
  - the known parallel shared-clipboard interference was independently reproduced on current `main`
- broad Go suite with only the four established terminal-mouse baseline timeouts excluded
- `make build`, formatting, and `git diff --check`
- direct 200×50 mode replay: `60 command → 120 help → 60 command → 60 file → dismissed → 60 reopen → 60 Ctrl+K P`
- width thresholds around each cap, same-widget resize, narrow/degenerate surfaces, fullwidth border safety, scrolled/truncated mouse execution, ranking stability, drill-in/Escape, and registry completeness

The corrected head passed independent adversarial re-review. This seven-file branch contains no plugin checked-menu, Git-review, diff, tree, theme, tab, or repository-state work.

Part of #474.