### PR TITLE
feat(ui): reorder tabs by dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ To edit the raw files, use **Settings: Open settings.json** and **Settings: Open
 | `search.debounce` | int | `350` | Milliseconds to debounce global search input |
 | `explorer.showHidden` | bool | `true` | Show hidden files (dot-prefixed) in the file explorer |
 | `explorer.showGitIgnored` | bool | `true` | Show gitignored files in the file explorer |
+| `sidebar.panelOrder` | string[] | built-in order | Preferred sidebar panel IDs; updated when headers are dragged or moved with commands |
 | `terminal.shell` | string | `""` | Shell command for the integrated terminal (empty = system default) |
 | `terminal.scrollback` | int | `1000` | Number of scrollback lines to retain in the terminal |
 | `lsp.saveOnRename` | bool | `false` | Auto-save all files affected by a rename operation |
@@ -563,6 +564,9 @@ Example `~/.config/ttt/settings.json` (also available at [`config/settings.json`
   "explorer": {
     "showHidden": true,
     "showGitIgnored": true
+  },
+  "sidebar": {
+    "panelOrder": ["explorer", "search", "changes", "outline"]
   },
   "terminal": {
     "shell": "",

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -57,6 +57,12 @@ All editor settings are nested under the `editor` key.
 | `explorer.showHidden` | bool | `true` | Show hidden files (dot-prefixed) in the file explorer |
 | `explorer.showGitIgnored` | bool | `true` | Show gitignored files in the file explorer |
 
+## Sidebar
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `sidebar.panelOrder` | string[] | built-in order | Preferred sidebar panel-header order. Dragging a header or using **Move Panel Left/Right** updates it automatically. Unknown plugin panel IDs are retained until that plugin loads. |
+
 ## Terminal
 
 | Key | Type | Default | Description |
@@ -160,6 +166,9 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
   "explorer": {
     "showHidden": true,
     "showGitIgnored": true
+  },
+  "sidebar": {
+    "panelOrder": ["explorer", "search", "changes", "outline"]
   },
   "terminal": {
     "shell": "/bin/zsh",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -151,6 +151,7 @@ func (a *App) ShowSidebar() {
 }
 
 func (a *App) HideSidebar() {
+	a.Sidebar.InvalidatePointerInteraction()
 	a.Sidebar.Visible = false
 	a.SplitPanel.ShowLeft = false
 	a.EditorGroup.ClearSearch()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -430,6 +430,9 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	a.Screen = screen
 	a.Renderer = renderer
 	a.LspManager = lspManager
+	a.EditorGroup.TabBar.PostDragAutoScrollTick = func(generation uint64) {
+		screen.PostEvent(tcell.NewEventInterrupt(&ui.TabDragAutoScrollTick{Generation: generation}))
+	}
 	a.StartWatcher()
 
 	a.EditorGroup.OnError = func(msg string) {

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -81,6 +81,13 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			}
 		}
 	}
+	moveItems := a.sidebarMoveMenuItems()
+	if len(moveItems) > 0 {
+		if len(items) > 0 && !items[len(items)-1].IsSep {
+			items = append(items, ui.MenuSep())
+		}
+		items = append(items, moveItems...)
+	}
 	if len(items) > 0 {
 		openContextMenu(a, items, sx, sy)
 	}
@@ -430,6 +437,7 @@ func registerWidgetCallbacks(app *App) {
 	app.Sidebar.Tabs.Config.Actions = []widgets.TabAction{
 		{Icon: "⋮", OnClick: app.ShowSidebarMoreMenu},
 	}
+	app.Sidebar.OnPanelReorder = app.persistSidebarPanelOrder
 
 	app.Sidebar.Tabs.Config.OnOverflow = func(sx, sy int) {
 		ids, titles := app.Sidebar.HiddenTabs()
@@ -504,15 +512,23 @@ func registerWidgetCallbacks(app *App) {
 		}
 		tabContextMenu := []ui.ContextMenuItem{
 			{Label: pinLabel, Shortcut: app.KeyFor("tab.pin"), Command: "tab.pin"},
-			ui.MenuSep(),
-			{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
-			{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
-			{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
-			{Label: "Close All Saved", Shortcut: "", Command: "tab.closeAllSaved"},
-			ui.MenuSep(),
-			{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
-			{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
 		}
+		if app.EditorGroup.CanMoveActiveTab(-1) {
+			tabContextMenu = append(tabContextMenu, ui.ContextMenuItem{Label: "Move Tab Left", Command: "tab.moveLeft"})
+		}
+		if app.EditorGroup.CanMoveActiveTab(1) {
+			tabContextMenu = append(tabContextMenu, ui.ContextMenuItem{Label: "Move Tab Right", Command: "tab.moveRight"})
+		}
+		tabContextMenu = append(tabContextMenu,
+			ui.MenuSep(),
+			ui.ContextMenuItem{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
+			ui.ContextMenuItem{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
+			ui.ContextMenuItem{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
+			ui.ContextMenuItem{Label: "Close All Saved", Shortcut: "", Command: "tab.closeAllSaved"},
+			ui.MenuSep(),
+			ui.ContextMenuItem{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
+			ui.ContextMenuItem{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
+		)
 		if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
 			cmd := "diff.extendedView"
 			label := "Extended Diff"

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -445,6 +445,18 @@ func registerEditorCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "tab.moveLeft", Title: "View: Move Tab Left",
+		Keywords: []string{"tab", "reorder", "move", "left"},
+		Handler:  func() { app.EditorGroup.MoveActiveTab(-1) },
+	})
+
+	reg.Register(command.Command{
+		ID: "tab.moveRight", Title: "View: Move Tab Right",
+		Keywords: []string{"tab", "reorder", "move", "right"},
+		Handler:  func() { app.EditorGroup.MoveActiveTab(1) },
+	})
+
+	reg.Register(command.Command{
 		ID: "diff.extendedView", Title: "Git: Extended Diff",
 		Keywords: []string{"git", "changes", "compare"},
 		Handler: func() {

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -36,6 +36,9 @@ func (a *App) ApplySettings(s config.Settings) {
 	a.EditorGroup.BracketPairColorization = s.Editor.BracketPairColorization
 	a.EditorGroup.UndoDeleteCursorStart = s.Editor.UndoDeleteCursorStart
 	a.EditorGroup.ApplyUndoDeleteCursorStart(s.Editor.UndoDeleteCursorStart)
+	if a.Sidebar != nil {
+		a.Sidebar.SetPanelOrder(s.Sidebar.PanelOrder)
+	}
 
 	if a.EditorGroup.Editor != nil {
 		a.EditorGroup.Editor.TabSize = s.Editor.TabSize

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -351,6 +351,18 @@ func registerViewCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "sidebar.movePanelLeft", Title: "View: Move Sidebar Panel Left",
+		Keywords: []string{"view", "sidebar", "panel", "tab", "reorder", "left"},
+		Handler:  func() { app.MoveActiveSidebarPanel(-1) },
+	})
+
+	reg.Register(command.Command{
+		ID: "sidebar.movePanelRight", Title: "View: Move Sidebar Panel Right",
+		Keywords: []string{"view", "sidebar", "panel", "tab", "reorder", "right"},
+		Handler:  func() { app.MoveActiveSidebarPanel(1) },
+	})
+
+	reg.Register(command.Command{
 		ID: "panel.toggle", Title: "View: Toggle Panel",
 		Keywords: []string{"view", "bottom", "show", "hide"},
 		Handler:  app.ToggleBottomPanel,

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -27,6 +27,7 @@ func (a *App) ToggleTerminalFullscreen() {
 	if a.ContentSplit.ShowBottom && a.ContentSplit.BottomH >= fullH {
 		a.HideBottomPanel()
 	} else {
+		a.EditorGroup.InvalidatePointerInteraction()
 		a.ContentSplit.BottomH = fullH
 		a.showTerminalPanel()
 		resizeTerminals(a)

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -28,6 +28,7 @@ func RunEventLoop(
 ) {
 	app.eventLoopDoneSignal()
 	defer app.closeEventLoopDone()
+	defer app.Root.CancelPointerCapture()
 	if app.Watcher != nil {
 		defer app.Watcher.Close()
 	}
@@ -279,6 +280,8 @@ func RunEventLoop(
 					app.Status.SetSegment(view.StatusSegment{ID: "blame", Side: "left", Priority: 200, Text: fmt.Sprintf("%s, %s",
 						v.Info.Author, git.FormatRelativeTime(v.Info.Time))})
 				}
+			case *ui.TabDragAutoScrollTick:
+				app.EditorGroup.TabBar.HandleDragAutoScrollTick(v.Generation)
 			case *GitGutterResult:
 				if v.Gen == app.GitGutterGen {
 					app.EditorGroup.SetLineChanges(v.Path, v.Changes)

--- a/internal/app/sidebar_order.go
+++ b/internal/app/sidebar_order.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"slices"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func (a *App) persistSidebarPanelOrder(ids []string) {
+	a.Settings.Sidebar.PanelOrder = slices.Clone(ids)
+	if err := config.SaveSettings(*a.Settings); err != nil {
+		a.StatusError("Failed to save sidebar order: " + err.Error())
+	}
+}
+
+func (a *App) MoveActiveSidebarPanel(dir int) {
+	a.Sidebar.MoveActivePanel(dir)
+}
+
+func (a *App) sidebarMoveMenuItems() []ui.ContextMenuItem {
+	var items []ui.ContextMenuItem
+	if a.Sidebar.CanMoveActivePanel(-1) {
+		items = append(items, ui.ContextMenuItem{Label: "Move Panel Left", Command: "sidebar.movePanelLeft"})
+	}
+	if a.Sidebar.CanMoveActivePanel(1) {
+		items = append(items, ui.ContextMenuItem{Label: "Move Panel Right", Command: "sidebar.movePanelRight"})
+	}
+	return items
+}

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -285,6 +285,13 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	splitPanel.ShowLeft = sidebar.Visible
 	splitPanel.RightBorderStartY = 2
 	contentSplit.RightBorderStartY = &splitPanel.RightBorderStartY
+	editorGroup.TabBar.PointerInteractionValid = func() bool {
+		return contentSplit.TopContentHeight() > 3
+	}
+	sidebar.Tabs.Config.PointerInteractionValid = func() bool {
+		r := sidebar.GetRect()
+		return sidebar.Visible && splitPanel.ShowLeft && r.W > 0 && r.H > 2
+	}
 
 	rootBox := widgets.NewVStackWidget(menuBar, splitPanel, statusBar)
 

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -271,6 +271,8 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	sidebar.AddPanel("search", "Find", search)
 	sidebar.AddPanel("changes", "Changes", changes.Adapter)
 	sidebar.AddPanel("outline", "Outline", symbols.Adapter)
+	sidebar.SetPanelOrder(cfg.Settings.Sidebar.PanelOrder)
+	sidebar.Tabs.Config.Reorderable = true
 	hasFolders := len(ws.Paths()) > 0
 	sidebar.Visible = hasFolders
 	sidebar.Borders = borders

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -146,6 +146,10 @@ type ExplorerSettings struct {
 	ShowGitIgnored bool `json:"showGitIgnored"`
 }
 
+type SidebarSettings struct {
+	PanelOrder []string `json:"panelOrder,omitempty"`
+}
+
 func DefaultExplorerSettings() ExplorerSettings {
 	return ExplorerSettings{
 		ShowHidden:     true,
@@ -181,6 +185,7 @@ type Settings struct {
 	Editor       EditorSettings       `json:"editor"`
 	Search       SearchSettings       `json:"search"`
 	Explorer     ExplorerSettings     `json:"explorer"`
+	Sidebar      SidebarSettings      `json:"sidebar,omitzero"`
 	Terminal     TerminalSettings     `json:"terminal"`
 	LSP          LSPSettings          `json:"lsp"`
 	Autocomplete AutocompleteSettings `json:"autocomplete"`
@@ -200,7 +205,7 @@ type Settings struct {
 // Any other top-level key is preserved via Settings.Extra.
 var knownSettingsKeys = map[string]bool{
 	"version": true, "theme": true, "debugMode": true, "editor": true,
-	"search": true, "explorer": true, "terminal": true, "lsp": true,
+	"search": true, "explorer": true, "sidebar": true, "terminal": true, "lsp": true,
 	"autocomplete": true, "markdown": true, "plugins": true, "formatters": true,
 }
 
@@ -275,6 +280,16 @@ func normalizeSettings(s *Settings) {
 	if !slices.Contains(BorderStyles, s.Editor.BorderStyle) {
 		s.Editor.BorderStyle = "default"
 	}
+	seenPanels := make(map[string]bool)
+	panelOrder := s.Sidebar.PanelOrder[:0]
+	for _, id := range s.Sidebar.PanelOrder {
+		if id == "" || seenPanels[id] {
+			continue
+		}
+		seenPanels[id] = true
+		panelOrder = append(panelOrder, id)
+	}
+	s.Sidebar.PanelOrder = panelOrder
 }
 
 func LoadSettings() Settings {

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -21,6 +22,7 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s := DefaultSettings()
 	s.Editor.TabSize = 7
 	s.Editor.WordWrap = true
+	s.Sidebar.PanelOrder = []string{"changes", "plugin.todo", "explorer"}
 	enabled := false
 	s.Editor.SyntaxHighlight = &enabled
 	s.Terminal.Shell = "/bin/zsh"
@@ -35,6 +37,9 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if !got.Editor.WordWrap {
 		t.Error("wordWrap did not round-trip")
+	}
+	if !slices.Equal(got.Sidebar.PanelOrder, []string{"changes", "plugin.todo", "explorer"}) {
+		t.Errorf("sidebar.panelOrder = %v", got.Sidebar.PanelOrder)
 	}
 	if got.Editor.IsSyntaxHighlightEnabled() {
 		t.Error("syntaxHighlight=false did not round-trip; tri-state pointer lost")

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 )
 
@@ -36,6 +37,16 @@ func TestSettingsEmptyJSON(t *testing.T) {
 
 	if s.Editor.TabSize != 4 {
 		t.Fatalf("expected TabSize 4, got %d", s.Editor.TabSize)
+	}
+}
+
+func TestNormalizeSidebarPanelOrder(t *testing.T) {
+	s := DefaultSettings()
+	s.Sidebar.PanelOrder = []string{"changes", "", "explorer", "changes", "plugin.todo"}
+	normalizeSettings(&s)
+	want := []string{"changes", "explorer", "plugin.todo"}
+	if !slices.Equal(s.Sidebar.PanelOrder, want) {
+		t.Fatalf("panelOrder = %v, want %v", s.Sidebar.PanelOrder, want)
 	}
 }
 

--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -9,18 +9,19 @@ import (
 
 type ContentSplitWidget struct {
 	BaseWidget
-	Top               Widget
-	Bottom            Widget
-	ShowBottom        bool
-	BottomH           int
-	Borders           *term.BorderSet
-	OnResize          func(height int)
-	OnBottomClick     func()
-	OnTopClick        func()
-	RightBorderStartY *int
-	dragging          bool
-	wasPressed        bool
-	capturedChild     Widget
+	Top                       Widget
+	Bottom                    Widget
+	ShowBottom                bool
+	BottomH                   int
+	Borders                   *term.BorderSet
+	OnResize                  func(height int)
+	OnBottomClick             func()
+	OnTopClick                func()
+	RightBorderStartY         *int
+	dragging                  bool
+	wasPressed                bool
+	capturedChild             Widget
+	pointerCaptureInvalidated func()
 }
 
 func NewContentSplitWidget() *ContentSplitWidget {
@@ -35,14 +36,24 @@ func (cs *ContentSplitWidget) Focusable() bool { return false }
 func (cs *ContentSplitWidget) Render(surface Surface) {
 	w, h := surface.Size()
 	r := cs.GetRect()
+	if w <= 0 || h <= 0 {
+		cs.InvalidatePointerInteraction()
+		return
+	}
 
 	if !cs.ShowBottom || cs.Bottom == nil {
+		widgets.InvalidatePointerInteraction(cs.Bottom)
+		if cs.capturedChild == cs.Bottom {
+			cs.capturedChild = nil
+		}
 		if cs.RightBorderStartY != nil {
 			*cs.RightBorderStartY = 2
 		}
 		if cs.Top != nil && w > 0 && h > 0 {
 			cs.Top.SetRect(Rect{X: r.X, Y: r.Y, W: r.W, H: r.H})
 			cs.Top.Render(surface)
+		} else {
+			widgets.InvalidatePointerInteraction(cs.Top)
 		}
 		return
 	}
@@ -73,6 +84,11 @@ func (cs *ContentSplitWidget) Render(surface Surface) {
 		cs.Top.SetRect(Rect{X: r.X, Y: r.Y, W: r.W, H: topH})
 		topSurface := surface.Sub(Rect{X: 0, Y: 0, W: w, H: topH})
 		cs.Top.Render(topSurface)
+	} else {
+		widgets.InvalidatePointerInteraction(cs.Top)
+		if cs.capturedChild == cs.Top {
+			cs.capturedChild = nil
+		}
 	}
 
 	// Horizontal divider
@@ -86,6 +102,11 @@ func (cs *ContentSplitWidget) Render(surface Surface) {
 		cs.Bottom.SetRect(Rect{X: r.X, Y: r.Y + divY + 1, W: r.W, H: bottomContentH})
 		bottomSurface := surface.Sub(Rect{X: 0, Y: divY + 1, W: w, H: bottomContentH})
 		cs.Bottom.Render(bottomSurface)
+	} else {
+		widgets.InvalidatePointerInteraction(cs.Bottom)
+		if cs.capturedChild == cs.Bottom {
+			cs.capturedChild = nil
+		}
 	}
 }
 
@@ -206,19 +227,62 @@ func (cs *ContentSplitWidget) DividerScreenY() int {
 	return r.Y + r.H - needed
 }
 
+func (cs *ContentSplitWidget) TopContentHeight() int {
+	r := cs.GetRect()
+	if r.W <= 0 || r.H <= 0 {
+		return 0
+	}
+	if !cs.ShowBottom || cs.Bottom == nil {
+		return r.H
+	}
+	needed := min(cs.BottomH+1, r.H)
+	return max(r.H-needed, 0)
+}
+
 func (cs *ContentSplitWidget) CancelPointerCapture() bool {
-	children := []Widget{cs.capturedChild, cs.Top, cs.Bottom}
-	for _, child := range children {
+	canceled := cs.dragging || cs.capturedChild != nil
+	cs.dragging = false
+	cs.wasPressed = false
+	cs.capturedChild = nil
+	for _, child := range []Widget{cs.Top, cs.Bottom} {
 		if child == nil {
 			continue
 		}
-		if canceler, ok := child.(widgets.PointerCaptureCanceler); ok && canceler.CancelPointerCapture() {
-			cs.capturedChild = nil
-			cs.wasPressed = false
-			return true
-		}
+		canceled = widgets.CancelPointerCapture(child) || canceled
 	}
-	return false
+	if canceled && cs.pointerCaptureInvalidated != nil {
+		cs.pointerCaptureInvalidated()
+	}
+	return canceled
+}
+
+func (cs *ContentSplitWidget) InvalidatePointerInteraction() bool {
+	invalidated := cs.dragging || cs.capturedChild != nil
+	cs.dragging = false
+	cs.wasPressed = false
+	cs.capturedChild = nil
+	invalidated = widgets.InvalidatePointerInteraction(cs.Top) || invalidated
+	invalidated = widgets.InvalidatePointerInteraction(cs.Bottom) || invalidated
+	if invalidated && cs.pointerCaptureInvalidated != nil {
+		cs.pointerCaptureInvalidated()
+	}
+	return invalidated
+}
+
+func (cs *ContentSplitWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	cs.pointerCaptureInvalidated = invalidated
+	for _, child := range []Widget{cs.Top, cs.Bottom} {
+		capturedChild := child
+		widgets.SetPointerCaptureInvalidated(child, func() {
+			if cs.capturedChild == capturedChild {
+				cs.capturedChild = nil
+			}
+			cs.wasPressed = false
+			if cs.pointerCaptureInvalidated != nil {
+				cs.pointerCaptureInvalidated()
+			}
+		})
+	}
 }
 
 func (cs *ContentSplitWidget) OwnsPointerCapture() bool {

--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -203,4 +204,39 @@ func (cs *ContentSplitWidget) DividerScreenY() int {
 		needed = r.H
 	}
 	return r.Y + r.H - needed
+}
+
+func (cs *ContentSplitWidget) CancelPointerCapture() bool {
+	children := []Widget{cs.capturedChild, cs.Top, cs.Bottom}
+	for _, child := range children {
+		if child == nil {
+			continue
+		}
+		if canceler, ok := child.(widgets.PointerCaptureCanceler); ok && canceler.CancelPointerCapture() {
+			cs.capturedChild = nil
+			cs.wasPressed = false
+			return true
+		}
+	}
+	return false
+}
+
+func (cs *ContentSplitWidget) OwnsPointerCapture() bool {
+	if cs.dragging {
+		return true
+	}
+	if cs.capturedChild != nil {
+		owner, ok := cs.capturedChild.(widgets.PointerCaptureOwner)
+		if !ok || owner.OwnsPointerCapture() {
+			return true
+		}
+		cs.capturedChild = nil
+		cs.wasPressed = false
+	}
+	for _, child := range []Widget{cs.Top, cs.Bottom} {
+		if owner, ok := child.(widgets.PointerCaptureOwner); ok && owner.OwnsPointerCapture() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -625,6 +625,9 @@ func (g *EditorGroupWidget) SetUseTabs(useTabs bool) {
 
 func (g *EditorGroupWidget) SwitchTab(idx int) {
 	if idx >= 0 && idx < len(g.tabs) {
+		if idx != g.active && g.TabBar.OwnsPointerCapture() {
+			g.TabBar.CancelPointerCapture()
+		}
 		if t := g.activeTab(); t != nil && t.Content != nil {
 			if setter, ok := t.Content.(interface{ SetFocused(bool) }); ok {
 				setter.SetFocused(false)
@@ -1724,6 +1727,7 @@ func (g *EditorGroupWidget) syncTabs() {
 			name = ts.Title
 		}
 		uiTabs = append(uiTabs, Tab{
+			ID:       ts.FilePath,
 			Name:     name,
 			Active:   i == g.active,
 			Dirty:    dirty,
@@ -1740,8 +1744,8 @@ func (g *EditorGroupWidget) Render(surface Surface) {
 	r := g.GetRect()
 
 	const tabBarH = 3
-	if h <= tabBarH {
-		g.TabBar.ClearRenderedGeometry()
+	if w <= 0 || h <= tabBarH {
+		g.TabBar.InvalidatePointerInteraction()
 		return
 	}
 
@@ -1793,6 +1797,14 @@ func (g *EditorGroupWidget) CancelPointerCapture() bool {
 
 func (g *EditorGroupWidget) OwnsPointerCapture() bool {
 	return g.TabBar.OwnsPointerCapture()
+}
+
+func (g *EditorGroupWidget) InvalidatePointerInteraction() bool {
+	return g.TabBar.InvalidatePointerInteraction()
+}
+
+func (g *EditorGroupWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	g.TabBar.SetPointerCaptureInvalidated(invalidated)
 }
 
 func (g *EditorGroupWidget) HandleEvent(ev tcell.Event) EventResult {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -59,9 +59,9 @@ type editorTab struct {
 	Folds       *fold.State
 	TabSize     int
 	UseTabs     bool
-	Content Widget
-	Preview bool
-	Virtual bool
+	Content     Widget
+	Preview     bool
+	Virtual     bool
 	LineChanges []diff.LineChangeKind
 	ReadOnly    bool
 }
@@ -129,6 +129,9 @@ func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool
 	}
 	tabBar.OnTabClick = func(index int) {
 		g.SwitchTab(index)
+	}
+	tabBar.OnTabReorder = func(from, to int) {
+		g.MoveTab(from, to)
 	}
 	tabBar.OnNextTab = func() { g.NextTab() }
 	tabBar.OnPrevTab = func() { g.PrevTab() }
@@ -236,6 +239,53 @@ func (g *EditorGroupWidget) TogglePinTab() {
 
 func (g *EditorGroupWidget) IsActiveTabPinned() bool {
 	return g.active < g.pinnedCount
+}
+
+func (g *EditorGroupWidget) MoveTab(from, to int) bool {
+	if from < 0 || from >= len(g.tabs) || to < 0 || to >= len(g.tabs) {
+		return false
+	}
+	if from < g.pinnedCount {
+		to = min(to, g.pinnedCount-1)
+	} else {
+		to = max(to, g.pinnedCount)
+	}
+	if from == to {
+		return false
+	}
+
+	tab := g.tabs[from]
+	tab.Preview = false
+	g.tabs = append(g.tabs[:from], g.tabs[from+1:]...)
+	g.tabs = slices.Insert(g.tabs, to, tab)
+	switch {
+	case g.active == from:
+		g.active = to
+	case from < g.active && to >= g.active:
+		g.active--
+	case from > g.active && to <= g.active:
+		g.active++
+	}
+	g.syncTabs()
+	return true
+}
+
+func (g *EditorGroupWidget) CanMoveActiveTab(direction int) bool {
+	to := g.active + direction
+	if direction == 0 || to < 0 || to >= len(g.tabs) {
+		return false
+	}
+	if g.active < g.pinnedCount {
+		return to < g.pinnedCount
+	}
+	return to >= g.pinnedCount
+}
+
+func (g *EditorGroupWidget) MoveActiveTab(direction int) bool {
+	if !g.CanMoveActiveTab(direction) {
+		return false
+	}
+	return g.MoveTab(g.active, g.active+direction)
 }
 
 func (g *EditorGroupWidget) OpenFile(path string) {
@@ -1753,8 +1803,8 @@ func (g *EditorGroupWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 	result := g.TabBar.HandleEvent(ev)
 	slog.Debug("editorGroup", "tabBarResult", result)
-	if result == EventConsumed {
-		return EventConsumed
+	if result != EventIgnored {
+		return result
 	}
 	t := g.activeTab()
 	if t == nil {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -46,6 +46,7 @@ type Diagnostic struct {
 }
 
 type editorTab struct {
+	ID          string
 	FilePath    string
 	Title       string
 	Buf         *buffer.Buffer
@@ -74,6 +75,7 @@ type EditorGroupWidget struct {
 	Hover                   *HoverWidget
 	SignatureHelp           *SignatureHelpWidget
 	tabs                    []editorTab
+	nextTabIdentity         uint64
 	active                  int
 	pinnedCount             int
 	TabSize                 int
@@ -1683,6 +1685,7 @@ func (g *EditorGroupWidget) PasteText(text string) {
 }
 
 func (g *EditorGroupWidget) syncTabs() {
+	g.ensureTabIdentities()
 	t := g.activeTab()
 	if t == nil {
 		g.TabBar.SetTabs(nil)
@@ -1727,7 +1730,7 @@ func (g *EditorGroupWidget) syncTabs() {
 			name = ts.Title
 		}
 		uiTabs = append(uiTabs, Tab{
-			ID:       ts.FilePath,
+			ID:       ts.ID,
 			Name:     name,
 			Active:   i == g.active,
 			Dirty:    dirty,
@@ -1736,6 +1739,26 @@ func (g *EditorGroupWidget) syncTabs() {
 		})
 	}
 	g.TabBar.SetTabs(uiTabs)
+}
+
+func (g *EditorGroupWidget) ensureTabIdentities() {
+	seen := make(map[string]bool, len(g.tabs))
+	for i := range g.tabs {
+		id := g.tabs[i].ID
+		if id != "" && !seen[id] {
+			seen[id] = true
+			continue
+		}
+		for {
+			g.nextTabIdentity++
+			id = fmt.Sprintf("editor-tab-%d", g.nextTabIdentity)
+			if !seen[id] {
+				break
+			}
+		}
+		g.tabs[i].ID = id
+		seen[id] = true
+	}
 }
 
 func (g *EditorGroupWidget) Render(surface Surface) {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -133,6 +133,7 @@ func NewEditorGroupWidget(borders *term.BorderSet, tabSize int, lineNumbers bool
 	tabBar.OnTabReorder = func(from, to int) {
 		g.MoveTab(from, to)
 	}
+	tabBar.NormalizeDropTarget = g.NormalizeTabMoveTarget
 	tabBar.OnNextTab = func() { g.NextTab() }
 	tabBar.OnPrevTab = func() { g.PrevTab() }
 	tabBar.OnDoubleClick = func() { g.NewFile() }
@@ -241,14 +242,20 @@ func (g *EditorGroupWidget) IsActiveTabPinned() bool {
 	return g.active < g.pinnedCount
 }
 
-func (g *EditorGroupWidget) MoveTab(from, to int) bool {
+func (g *EditorGroupWidget) NormalizeTabMoveTarget(from, to int) int {
 	if from < 0 || from >= len(g.tabs) || to < 0 || to >= len(g.tabs) {
-		return false
+		return -1
 	}
 	if from < g.pinnedCount {
-		to = min(to, g.pinnedCount-1)
-	} else {
-		to = max(to, g.pinnedCount)
+		return min(to, g.pinnedCount-1)
+	}
+	return max(to, g.pinnedCount)
+}
+
+func (g *EditorGroupWidget) MoveTab(from, to int) bool {
+	to = g.NormalizeTabMoveTarget(from, to)
+	if to < 0 {
+		return false
 	}
 	if from == to {
 		return false
@@ -1734,6 +1741,7 @@ func (g *EditorGroupWidget) Render(surface Surface) {
 
 	const tabBarH = 3
 	if h <= tabBarH {
+		g.TabBar.ClearRenderedGeometry()
 		return
 	}
 
@@ -1777,6 +1785,14 @@ func (g *EditorGroupWidget) Render(surface Surface) {
 		g.Hover.Borders = g.Borders
 		g.Hover.Render(surface)
 	}
+}
+
+func (g *EditorGroupWidget) CancelPointerCapture() bool {
+	return g.TabBar.CancelPointerCapture()
+}
+
+func (g *EditorGroupWidget) OwnsPointerCapture() bool {
+	return g.TabBar.OwnsPointerCapture()
 }
 
 func (g *EditorGroupWidget) HandleEvent(ev tcell.Event) EventResult {

--- a/internal/ui/editor_group_tab_reorder_test.go
+++ b/internal/ui/editor_group_tab_reorder_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/buffer"
+	"github.com/eugenioenko/ttt/internal/core/cursor"
+	"github.com/eugenioenko/ttt/internal/core/selection"
+	"github.com/eugenioenko/ttt/internal/core/undo"
+	"github.com/eugenioenko/ttt/internal/view"
+)
+
+func reorderTestTab(path string, preview bool) editorTab {
+	return editorTab{
+		FilePath: path,
+		Buf:      &buffer.Buffer{Lines: []string{""}},
+		Cur:      &cursor.Cursor{},
+		Vp:       &view.Viewport{},
+		Undo:     &undo.UndoStack{},
+		Sel:      &selection.Selection{},
+		Preview:  preview,
+	}
+}
+
+func tabPaths(g *EditorGroupWidget) []string {
+	paths := make([]string, len(g.tabs))
+	for i := range g.tabs {
+		paths[i] = g.tabs[i].FilePath
+	}
+	return paths
+}
+
+func TestEditorGroupMoveTabPreservesActiveDocumentAndCommitsPreview(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, true, "relative")
+	g.tabs = []editorTab{
+		reorderTestTab("one.go", true),
+		reorderTestTab("two.go", false),
+		reorderTestTab("three.go", false),
+	}
+	g.active = 1
+
+	if !g.MoveTab(0, 2) {
+		t.Fatal("MoveTab should reorder distinct unpinned positions")
+	}
+	want := []string{"two.go", "three.go", "one.go"}
+	if got := tabPaths(g); !slices.Equal(got, want) {
+		t.Fatalf("tab order = %v, want %v", got, want)
+	}
+	if g.active != 0 || g.tabs[g.active].FilePath != "two.go" {
+		t.Fatalf("active tab = %d %q, want two.go at 0", g.active, g.tabs[g.active].FilePath)
+	}
+	if g.tabs[2].Preview {
+		t.Fatal("dragged preview should become a regular tab")
+	}
+}
+
+func TestEditorGroupMoveTabKeepsPinnedBoundary(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, true, "relative")
+	g.tabs = []editorTab{
+		reorderTestTab("pin-one.go", false),
+		reorderTestTab("pin-two.go", false),
+		reorderTestTab("one.go", false),
+		reorderTestTab("two.go", false),
+	}
+	g.pinnedCount = 2
+	g.active = 2
+
+	if g.MoveTab(2, 0) {
+		t.Fatal("unpinned tab should not cross into the pinned block")
+	}
+	if g.MoveTab(1, 3) {
+		t.Fatal("pinned tab should not cross into the unpinned block")
+	}
+	if !g.MoveTab(0, 1) {
+		t.Fatal("pinned tabs should reorder within their block")
+	}
+	want := []string{"pin-two.go", "pin-one.go", "one.go", "two.go"}
+	if got := tabPaths(g); !slices.Equal(got, want) {
+		t.Fatalf("tab order = %v, want %v", got, want)
+	}
+	if g.active != 2 || !g.CanMoveActiveTab(1) || g.CanMoveActiveTab(-1) {
+		t.Fatalf("active movement availability is wrong: active=%d left=%v right=%v",
+			g.active, g.CanMoveActiveTab(-1), g.CanMoveActiveTab(1))
+	}
+}

--- a/internal/ui/editor_group_tab_reorder_test.go
+++ b/internal/ui/editor_group_tab_reorder_test.go
@@ -112,3 +112,20 @@ func TestEditorGroupEffectivePinnedTargetControlsPreviewCommit(t *testing.T) {
 		t.Fatal("effective move should insert at the boundary and commit its preview")
 	}
 }
+
+func TestEditorGroupConstructorsAssignUniqueTabIdentities(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, true, "relative")
+	g.OpenBufferReadOnly("First", "shared.txt", []string{"first"})
+	g.OpenBufferReadOnly("Second", "shared.txt", []string{"second"})
+
+	seen := make(map[string]bool, len(g.TabBar.Tabs))
+	for _, tab := range g.TabBar.Tabs {
+		if tab.ID == "" {
+			t.Fatal("constructor assigned an empty tab identity")
+		}
+		if seen[tab.ID] {
+			t.Fatalf("constructor assigned duplicate tab identity %q", tab.ID)
+		}
+		seen[tab.ID] = true
+	}
+}

--- a/internal/ui/editor_group_tab_reorder_test.go
+++ b/internal/ui/editor_group_tab_reorder_test.go
@@ -84,3 +84,31 @@ func TestEditorGroupMoveTabKeepsPinnedBoundary(t *testing.T) {
 			g.active, g.CanMoveActiveTab(-1), g.CanMoveActiveTab(1))
 	}
 }
+
+func TestEditorGroupEffectivePinnedTargetControlsPreviewCommit(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, true, "relative")
+	g.tabs = []editorTab{
+		reorderTestTab("pin-one.go", false),
+		reorderTestTab("pin-two.go", false),
+		reorderTestTab("preview.go", true),
+		reorderTestTab("later.go", true),
+	}
+	g.pinnedCount = 2
+	g.active = 2
+
+	if g.MoveTab(2, 0) {
+		t.Fatal("first unpinned tab should be an effective no-op at the boundary")
+	}
+	if !g.tabs[2].Preview {
+		t.Fatal("an effective no-op should not commit a preview tab")
+	}
+	if got := g.NormalizeTabMoveTarget(3, 0); got != 2 {
+		t.Fatalf("effective target = %d, want pinned boundary 2", got)
+	}
+	if !g.MoveTab(3, 0) {
+		t.Fatal("a later unpinned tab should move to the pinned boundary")
+	}
+	if g.tabs[2].FilePath != "later.go" || g.tabs[2].Preview {
+		t.Fatal("effective move should insert at the boundary and commit its preview")
+	}
+}

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -5,6 +5,7 @@ import (
 	"unicode"
 
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -53,9 +54,33 @@ func NewRoot(main Widget) *Root {
 }
 
 func (r *Root) SetSize(w, h int) {
+	if w != r.Width || h != r.Height {
+		r.CancelPointerCapture()
+	}
 	r.Width = w
 	r.Height = h
 	r.Main.SetRect(Rect{X: 0, Y: 0, W: w, H: h})
+}
+
+func (r *Root) CancelPointerCapture() bool {
+	canceler, ok := r.Main.(widgets.PointerCaptureCanceler)
+	if ok && canceler.CancelPointerCapture() {
+		r.capturedWidget = nil
+		return true
+	}
+	return r.reconcilePointerCapture()
+}
+
+func (r *Root) reconcilePointerCapture() bool {
+	if r.capturedWidget == nil {
+		return false
+	}
+	owner, ok := r.capturedWidget.(widgets.PointerCaptureOwner)
+	if !ok || owner.OwnsPointerCapture() {
+		return false
+	}
+	r.capturedWidget = nil
+	return true
 }
 
 func (r *Root) AddGlobalKey(key tcell.Key, mod tcell.ModMask, rn rune, handler func()) {
@@ -247,6 +272,10 @@ func (r *Root) handleMouse(ev tcell.Event) EventResult {
 	btn := mev.Buttons()
 
 	if r.capturedWidget != nil {
+		r.reconcilePointerCapture()
+	}
+
+	if r.capturedWidget != nil {
 		if btn == tcell.ButtonNone {
 			r.capturedWidget.HandleEvent(ev)
 			r.capturedWidget = nil
@@ -334,6 +363,7 @@ func (r *Root) handleGlobalKeys(kev *tcell.EventKey) EventResult {
 func (r *Root) Render(cells [][]term.Cell) {
 	surface := NewRenderSurface(cells, Rect{X: 0, Y: 0, W: r.Width, H: r.Height})
 	r.Main.Render(surface)
+	r.reconcilePointerCapture()
 
 	for _, overlay := range r.Overlays {
 		overlay.Widget.SetRect(Rect{X: 0, Y: 0, W: r.Width, H: r.Height})

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -50,12 +50,17 @@ type Root struct {
 }
 
 func NewRoot(main Widget) *Root {
-	return &Root{Main: main}
+	r := &Root{Main: main}
+	widgets.SetPointerCaptureInvalidated(main, func() {
+		r.capturedWidget = nil
+	})
+	return r
 }
 
 func (r *Root) SetSize(w, h int) {
 	if w != r.Width || h != r.Height {
-		r.CancelPointerCapture()
+		widgets.InvalidatePointerInteraction(r.Main)
+		r.capturedWidget = nil
 	}
 	r.Width = w
 	r.Height = h
@@ -63,12 +68,12 @@ func (r *Root) SetSize(w, h int) {
 }
 
 func (r *Root) CancelPointerCapture() bool {
-	canceler, ok := r.Main.(widgets.PointerCaptureCanceler)
-	if ok && canceler.CancelPointerCapture() {
+	canceled := widgets.CancelPointerCapture(r.Main)
+	if r.capturedWidget != nil {
+		canceled = true
 		r.capturedWidget = nil
-		return true
 	}
-	return r.reconcilePointerCapture()
+	return canceled
 }
 
 func (r *Root) reconcilePointerCapture() bool {
@@ -81,6 +86,11 @@ func (r *Root) reconcilePointerCapture() bool {
 	}
 	r.capturedWidget = nil
 	return true
+}
+
+func (r *Root) PointerCaptureActive() bool {
+	r.reconcilePointerCapture()
+	return r.capturedWidget != nil
 }
 
 func (r *Root) AddGlobalKey(key tcell.Key, mod tcell.ModMask, rn rune, handler func()) {
@@ -392,6 +402,7 @@ func (r *Root) TopOverlayWidget() Widget {
 }
 
 func (r *Root) PushOverlay(o Overlay) {
+	r.CancelPointerCapture()
 	r.Overlays = append(r.Overlays, o)
 	slog.Debug("root", "action", "pushOverlay", "count", len(r.Overlays), "modal", o.Modal)
 }
@@ -420,6 +431,9 @@ func (r *Root) RemoveOverlay(w Widget) {
 func (r *Root) SetFocus(w Widget) {
 	if r.Focused == w {
 		return
+	}
+	if r.capturedWidget != nil {
+		r.CancelPointerCapture()
 	}
 	if r.Focused != nil {
 		if setter, ok := r.Focused.(interface{ SetFocused(bool) }); ok {

--- a/internal/ui/root_test.go
+++ b/internal/ui/root_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	"testing"
 
 	"github.com/gdamore/tcell/v3"
@@ -64,6 +65,30 @@ func TestRootRoutesToFocused(t *testing.T) {
 	}
 	if main.eventCount != 0 {
 		t.Fatal("event incorrectly routed to main widget")
+	}
+}
+
+func TestRootSetSizeClearsBothDividerCaptures(t *testing.T) {
+	content := NewContentSplitWidget()
+	content.Top = &mockWidget{}
+	content.Bottom = &mockWidget{}
+	content.dragging = true
+	split := NewSplitPanelWidget()
+	split.Left = &mockWidget{}
+	split.Right = content
+	split.dragging = true
+	main := widgets.NewVStackWidget(split)
+	root := NewRoot(main)
+	root.Width = 80
+	root.Height = 24
+	root.capturedWidget = main
+
+	root.SetSize(100, 30)
+	if split.dragging || content.dragging {
+		t.Fatalf("resize retained divider capture: split=%v content=%v", split.dragging, content.dragging)
+	}
+	if root.PointerCaptureActive() {
+		t.Fatal("resize retained Root capture")
 	}
 }
 

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -29,8 +29,8 @@ func (s *SidebarWidget) Render(surface Surface) {
 	r := s.GetRect()
 
 	tabH := 2
-	if h <= tabH {
-		s.Tabs.ClearRenderedGeometry()
+	if !s.Visible || w <= 0 || h <= tabH {
+		s.Tabs.InvalidatePointerInteraction()
 		return
 	}
 
@@ -52,6 +52,14 @@ func (s *SidebarWidget) CancelPointerCapture() bool {
 
 func (s *SidebarWidget) OwnsPointerCapture() bool {
 	return s.Tabs.OwnsPointerCapture()
+}
+
+func (s *SidebarWidget) InvalidatePointerInteraction() bool {
+	return s.Tabs.InvalidatePointerInteraction()
+}
+
+func (s *SidebarWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	s.Tabs.SetPointerCaptureInvalidated(invalidated)
 }
 
 func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -49,11 +49,8 @@ func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
 	if tev, ok := ev.(*tcell.EventMouse); ok {
 		_, my := tev.Position()
 		r := s.GetRect()
-		if my == r.Y {
-			if s.Tabs.HandleEvent(ev) == EventConsumed {
-				return EventConsumed
-			}
-			return EventIgnored
+		if my == r.Y || s.Tabs.PointerGestureActive() {
+			return s.Tabs.HandleEvent(ev)
 		}
 	}
 	active := s.ActiveWidget()

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -30,6 +30,7 @@ func (s *SidebarWidget) Render(surface Surface) {
 
 	tabH := 2
 	if h <= tabH {
+		s.Tabs.ClearRenderedGeometry()
 		return
 	}
 
@@ -43,6 +44,14 @@ func (s *SidebarWidget) Render(surface Surface) {
 		sub := surface.Sub(Rect{X: 0, Y: tabH, W: w, H: contentH})
 		active.Render(sub)
 	}
+}
+
+func (s *SidebarWidget) CancelPointerCapture() bool {
+	return s.Tabs.CancelPointerCapture()
+}
+
+func (s *SidebarWidget) OwnsPointerCapture() bool {
+	return s.Tabs.OwnsPointerCapture()
 }
 
 func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {

--- a/internal/ui/split_panel.go
+++ b/internal/ui/split_panel.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	"log/slog"
 
 	"github.com/gdamore/tcell/v3"
@@ -285,4 +286,39 @@ func (s *SplitPanelWidget) HandleEvent(ev tcell.Event) EventResult {
 func (s *SplitPanelWidget) DividerScreenX() int {
 	r := s.GetRect()
 	return r.X + s.DividerPos + 1
+}
+
+func (s *SplitPanelWidget) CancelPointerCapture() bool {
+	children := []Widget{s.capturedChild, s.Left, s.Right}
+	for _, child := range children {
+		if child == nil {
+			continue
+		}
+		if canceler, ok := child.(widgets.PointerCaptureCanceler); ok && canceler.CancelPointerCapture() {
+			s.capturedChild = nil
+			s.wasPressed = false
+			return true
+		}
+	}
+	return false
+}
+
+func (s *SplitPanelWidget) OwnsPointerCapture() bool {
+	if s.dragging {
+		return true
+	}
+	if s.capturedChild != nil {
+		owner, ok := s.capturedChild.(widgets.PointerCaptureOwner)
+		if !ok || owner.OwnsPointerCapture() {
+			return true
+		}
+		s.capturedChild = nil
+		s.wasPressed = false
+	}
+	for _, child := range []Widget{s.Left, s.Right} {
+		if owner, ok := child.(widgets.PointerCaptureOwner); ok && owner.OwnsPointerCapture() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ui/split_panel.go
+++ b/internal/ui/split_panel.go
@@ -17,18 +17,19 @@ const MinSidebarWidth = 10
 
 type SplitPanelWidget struct {
 	BaseWidget
-	Left              Widget
-	Right             Widget
-	DividerPos        int
-	Borders           *term.BorderSet
-	ShowLeft          bool
-	RightBorderStartY int
-	OnResize          func(width int)
-	OnLeftClick       func()
-	OnRightClick      func()
-	dragging          bool
-	wasPressed        bool
-	capturedChild     Widget
+	Left                      Widget
+	Right                     Widget
+	DividerPos                int
+	Borders                   *term.BorderSet
+	ShowLeft                  bool
+	RightBorderStartY         int
+	OnResize                  func(width int)
+	OnLeftClick               func()
+	OnRightClick              func()
+	dragging                  bool
+	wasPressed                bool
+	capturedChild             Widget
+	pointerCaptureInvalidated func()
 }
 
 func NewSplitPanelWidget() *SplitPanelWidget {
@@ -43,6 +44,7 @@ func (s *SplitPanelWidget) Focusable() bool { return false }
 func (s *SplitPanelWidget) Render(surface Surface) {
 	w, h := surface.Size()
 	if w < 4 || h < 3 {
+		s.InvalidatePointerInteraction()
 		return
 	}
 
@@ -54,6 +56,10 @@ func (s *SplitPanelWidget) Render(surface Surface) {
 	r := s.GetRect()
 
 	if !s.ShowLeft {
+		widgets.InvalidatePointerInteraction(s.Left)
+		if s.capturedChild == s.Left {
+			s.capturedChild = nil
+		}
 		s.renderSinglePanel(surface, w, h, b, bs)
 		return
 	}
@@ -114,6 +120,8 @@ func (s *SplitPanelWidget) Render(surface Surface) {
 		s.Left.SetRect(Rect{X: r.X + 1, Y: r.Y + 1, W: leftW, H: leftH})
 		leftSurface := surface.Sub(Rect{X: 1, Y: 1, W: leftW, H: leftH})
 		s.Left.Render(leftSurface)
+	} else {
+		widgets.InvalidatePointerInteraction(s.Left)
 	}
 
 	// Right content — right of divider, full height (no top border), above bottom border
@@ -124,6 +132,8 @@ func (s *SplitPanelWidget) Render(surface Surface) {
 		s.Right.SetRect(Rect{X: r.X + rightX, Y: r.Y, W: rightW, H: rightH})
 		rightSurface := surface.Sub(Rect{X: rightX, Y: 0, W: rightW, H: rightH})
 		s.Right.Render(rightSurface)
+	} else {
+		widgets.InvalidatePointerInteraction(s.Right)
 	}
 }
 
@@ -289,18 +299,49 @@ func (s *SplitPanelWidget) DividerScreenX() int {
 }
 
 func (s *SplitPanelWidget) CancelPointerCapture() bool {
-	children := []Widget{s.capturedChild, s.Left, s.Right}
-	for _, child := range children {
+	canceled := s.dragging || s.capturedChild != nil
+	s.dragging = false
+	s.wasPressed = false
+	s.capturedChild = nil
+	for _, child := range []Widget{s.Left, s.Right} {
 		if child == nil {
 			continue
 		}
-		if canceler, ok := child.(widgets.PointerCaptureCanceler); ok && canceler.CancelPointerCapture() {
-			s.capturedChild = nil
-			s.wasPressed = false
-			return true
-		}
+		canceled = widgets.CancelPointerCapture(child) || canceled
 	}
-	return false
+	if canceled && s.pointerCaptureInvalidated != nil {
+		s.pointerCaptureInvalidated()
+	}
+	return canceled
+}
+
+func (s *SplitPanelWidget) InvalidatePointerInteraction() bool {
+	invalidated := s.dragging || s.capturedChild != nil
+	s.dragging = false
+	s.wasPressed = false
+	s.capturedChild = nil
+	invalidated = widgets.InvalidatePointerInteraction(s.Left) || invalidated
+	invalidated = widgets.InvalidatePointerInteraction(s.Right) || invalidated
+	if invalidated && s.pointerCaptureInvalidated != nil {
+		s.pointerCaptureInvalidated()
+	}
+	return invalidated
+}
+
+func (s *SplitPanelWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	s.pointerCaptureInvalidated = invalidated
+	for _, child := range []Widget{s.Left, s.Right} {
+		capturedChild := child
+		widgets.SetPointerCaptureInvalidated(child, func() {
+			if s.capturedChild == capturedChild {
+				s.capturedChild = nil
+			}
+			s.wasPressed = false
+			if s.pointerCaptureInvalidated != nil {
+				s.pointerCaptureInvalidated()
+			}
+		})
+	}
 }
 
 func (s *SplitPanelWidget) OwnsPointerCapture() bool {

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -25,31 +25,42 @@ type Tab struct {
 	Pinned   bool
 }
 
+type TabDragAutoScrollTick struct {
+	Generation uint64
+}
+
 type TabBarWidget struct {
 	BaseWidget
-	Tabs             []Tab
-	Borders          *term.BorderSet
-	ScrollOffset     int
-	MoreButton       *MoreButtonWidget
-	OnTabClick       func(index int)
-	OnTabClose       func(index int)
-	OnTabUnpin       func(index int)
-	OnTabReorder     func(from, to int)
-	OnTabRightClick  func(index, screenX, screenY int)
-	OnPrevTab        func()
-	OnNextTab        func()
-	OnDoubleClick    func()
-	tabSpans         []tabSpan
-	renderArrowW     int // arrow-gutter width from the last Render, reused by HandleEvent
-	renderInnerRight int // right edge of the tab zone from the last Render, reused by HandleEvent
-	hasOverflowLeft  bool
-	hasOverflowRight bool
-	totalTabWidth    int
-	closeDownX       int // screen X where mouse-down hit a close button, -1 if none
-	closeDownY       int
-	wasPressed       bool
-	lastClickTime    int64
-	drag             widgets.TabDragState
+	Tabs                   []Tab
+	Borders                *term.BorderSet
+	ScrollOffset           int
+	MoreButton             *MoreButtonWidget
+	OnTabClick             func(index int)
+	OnTabClose             func(index int)
+	OnTabUnpin             func(index int)
+	OnTabReorder           func(from, to int)
+	NormalizeDropTarget    func(from, to int) int
+	PostDragAutoScrollTick func(generation uint64)
+	OnTabRightClick        func(index, screenX, screenY int)
+	OnPrevTab              func()
+	OnNextTab              func()
+	OnDoubleClick          func()
+	tabSpans               []tabSpan
+	renderArrowW           int // arrow-gutter width from the last Render, reused by HandleEvent
+	renderInnerRight       int // right edge of the tab zone from the last Render, reused by HandleEvent
+	hasOverflowLeft        bool
+	hasOverflowRight       bool
+	totalTabWidth          int
+	closeDownX             int // screen X where mouse-down hit a close button, -1 if none
+	closeDownY             int
+	wasPressed             bool
+	lastClickTime          int64
+	drag                   widgets.TabDragState
+	dragPointerX           int
+	autoScrollTimer        *time.Timer
+	autoScrollGeneration   uint64
+	autoScrollDirection    int
+	dragAutoScrollDelay    time.Duration
 }
 
 func NewTabBarWidget() *TabBarWidget {
@@ -58,6 +69,9 @@ func NewTabBarWidget() *TabBarWidget {
 
 func (t *TabBarWidget) SetTabs(tabs []Tab) {
 	t.Tabs = tabs
+	if t.drag.Active() && t.drag.From() >= len(tabs) {
+		t.CancelPointerCapture()
+	}
 }
 
 func (t *TabBarWidget) tabLabel(tab Tab) string {
@@ -99,7 +113,11 @@ func drawTabLabel(surface Surface, x, innerLeft, innerRight int, label string, d
 }
 
 func (t *TabBarWidget) Render(surface Surface) {
-	w, _ := surface.Size()
+	w, h := surface.Size()
+	if w <= 0 || h < 3 {
+		t.ClearRenderedGeometry()
+		return
+	}
 
 	b := term.SingleBorderSet()
 	if t.Borders != nil {
@@ -143,10 +161,11 @@ func (t *TabBarWidget) Render(surface Surface) {
 	t.renderArrowW = arrowW
 	innerRight := w - moreW - arrowW
 	t.renderInnerRight = innerRight
-	innerW := innerRight - innerLeft
-	if innerW < 1 {
-		innerW = 1
+	if innerRight <= innerLeft {
+		t.ClearRenderedGeometry()
+		return
 	}
+	innerW := innerRight - innerLeft
 
 	// Scroll to keep active tab visible within the inner zone
 	if activeIdx >= 0 && !t.drag.Active() {
@@ -269,6 +288,7 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 
 	if btn == tcell.ButtonNone && t.drag.Active() {
 		t.wasPressed = false
+		t.cancelAutoScroll()
 		from, to, dragged := t.drag.End()
 		if dragged && from != to && t.OnTabReorder != nil {
 			t.OnTabReorder(from, to)
@@ -279,9 +299,11 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventIgnored
 	}
 	if t.drag.Active() && btn&tcell.Button1 != 0 {
-		if t.drag.Update(mx, t.dropTargetAt(mx)) {
-			t.autoScrollDrag(mx)
-			t.drag.Update(mx, t.dropTargetAt(mx))
+		if t.drag.Update(mx, t.effectiveDropTarget(t.dropTargetAt(mx))) {
+			t.dragPointerX = mx
+			t.scrollDragOnce(mx)
+			t.drag.Update(mx, t.effectiveDropTarget(t.dropTargetAt(mx)))
+			t.updateAutoScrollZone(mx)
 			t.closeDownX = -1
 			return EventCaptured
 		}
@@ -389,6 +411,7 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 			}
 			if t.OnTabReorder != nil {
 				t.drag.Begin(i, mx)
+				return EventCaptured
 			}
 			return EventConsumed
 		}
@@ -402,6 +425,41 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		t.lastClickTime = now
 	}
 	return EventConsumed
+}
+
+func (t *TabBarWidget) effectiveDropTarget(target int) int {
+	if target < 0 || !t.drag.Active() {
+		return target
+	}
+	if t.NormalizeDropTarget != nil {
+		return t.NormalizeDropTarget(t.drag.From(), target)
+	}
+	return target
+}
+
+func (t *TabBarWidget) CancelPointerCapture() bool {
+	t.cancelAutoScroll()
+	if !t.drag.Active() {
+		return false
+	}
+	t.drag.Cancel()
+	t.wasPressed = false
+	t.closeDownX = -1
+	return true
+}
+
+func (t *TabBarWidget) OwnsPointerCapture() bool {
+	return t.drag.Active()
+}
+
+func (t *TabBarWidget) ClearRenderedGeometry() {
+	t.tabSpans = nil
+	t.renderArrowW = 0
+	t.renderInnerRight = 0
+	t.hasOverflowLeft = false
+	t.hasOverflowRight = false
+	t.totalTabWidth = 0
+	t.CancelPointerCapture()
 }
 
 func (t *TabBarWidget) dropTargetAt(screenX int) int {
@@ -432,21 +490,37 @@ func (t *TabBarWidget) dropIndicatorX() int {
 	return logicalX - t.ScrollOffset + t.renderArrowW
 }
 
-func (t *TabBarWidget) autoScrollDrag(screenX int) {
-	if t.renderArrowW == 0 {
-		return
+func (t *TabBarWidget) dragScrollDirection(screenX int) int {
+	if !t.drag.Dragging() || t.renderArrowW == 0 || len(t.tabSpans) == 0 {
+		return 0
 	}
-	r := t.GetRect()
 	innerW := t.renderInnerRight - t.renderArrowW
 	if innerW < 1 {
-		return
+		return 0
+	}
+	maxScroll := t.totalTabWidth - innerW
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	r := t.GetRect()
+	if screenX <= r.X+t.renderArrowW {
+		if t.ScrollOffset > 0 {
+			return -1
+		}
+	} else if screenX >= r.X+t.renderInnerRight-1 && t.ScrollOffset < maxScroll {
+		return 1
+	}
+	return 0
+}
+
+func (t *TabBarWidget) scrollDragOnce(screenX int) bool {
+	direction := t.dragScrollDirection(screenX)
+	if direction == 0 {
+		return false
 	}
 	const scrollStep = 3
-	if screenX <= r.X+t.renderArrowW {
-		t.ScrollOffset -= scrollStep
-	} else if screenX >= r.X+t.renderInnerRight-1 {
-		t.ScrollOffset += scrollStep
-	}
+	t.ScrollOffset += direction * scrollStep
+	innerW := t.renderInnerRight - t.renderArrowW
 	maxScroll := t.totalTabWidth - innerW
 	if t.ScrollOffset > maxScroll {
 		t.ScrollOffset = maxScroll
@@ -454,4 +528,65 @@ func (t *TabBarWidget) autoScrollDrag(screenX int) {
 	if t.ScrollOffset < 0 {
 		t.ScrollOffset = 0
 	}
+	return true
+}
+
+func (t *TabBarWidget) updateAutoScrollZone(screenX int) {
+	direction := t.dragScrollDirection(screenX)
+	if direction == 0 {
+		t.cancelAutoScroll()
+		return
+	}
+	if direction == t.autoScrollDirection && t.autoScrollTimer != nil {
+		return
+	}
+	t.cancelAutoScroll()
+	if t.PostDragAutoScrollTick == nil {
+		return
+	}
+	t.autoScrollDirection = direction
+	t.autoScrollGeneration++
+	t.armAutoScrollTick(t.autoScrollGeneration)
+}
+
+func (t *TabBarWidget) armAutoScrollTick(generation uint64) {
+	delay := t.dragAutoScrollDelay
+	if delay <= 0 {
+		delay = 75 * time.Millisecond
+	}
+	post := t.PostDragAutoScrollTick
+	t.autoScrollTimer = time.AfterFunc(delay, func() {
+		post(generation)
+	})
+}
+
+func (t *TabBarWidget) cancelAutoScroll() {
+	t.autoScrollGeneration++
+	if t.autoScrollTimer != nil {
+		t.autoScrollTimer.Stop()
+		t.autoScrollTimer = nil
+	}
+	t.autoScrollDirection = 0
+}
+
+func (t *TabBarWidget) HandleDragAutoScrollTick(generation uint64) bool {
+	if generation != t.autoScrollGeneration {
+		return false
+	}
+	t.autoScrollTimer = nil
+	if !t.drag.Active() || !t.drag.Dragging() || t.autoScrollDirection == 0 {
+		t.cancelAutoScroll()
+		return false
+	}
+	if !t.scrollDragOnce(t.dragPointerX) {
+		t.cancelAutoScroll()
+		return false
+	}
+	t.drag.Update(t.dragPointerX, t.effectiveDropTarget(t.dropTargetAt(t.dragPointerX)))
+	if t.dragScrollDirection(t.dragPointerX) != t.autoScrollDirection {
+		t.updateAutoScrollZone(t.dragPointerX)
+	} else {
+		t.armAutoScrollTick(generation)
+	}
+	return true
 }

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -18,6 +18,7 @@ type tabSpan struct {
 }
 
 type Tab struct {
+	ID       string
 	Name     string
 	Dirty    bool
 	Active   bool
@@ -31,36 +32,38 @@ type TabDragAutoScrollTick struct {
 
 type TabBarWidget struct {
 	BaseWidget
-	Tabs                   []Tab
-	Borders                *term.BorderSet
-	ScrollOffset           int
-	MoreButton             *MoreButtonWidget
-	OnTabClick             func(index int)
-	OnTabClose             func(index int)
-	OnTabUnpin             func(index int)
-	OnTabReorder           func(from, to int)
-	NormalizeDropTarget    func(from, to int) int
-	PostDragAutoScrollTick func(generation uint64)
-	OnTabRightClick        func(index, screenX, screenY int)
-	OnPrevTab              func()
-	OnNextTab              func()
-	OnDoubleClick          func()
-	tabSpans               []tabSpan
-	renderArrowW           int // arrow-gutter width from the last Render, reused by HandleEvent
-	renderInnerRight       int // right edge of the tab zone from the last Render, reused by HandleEvent
-	hasOverflowLeft        bool
-	hasOverflowRight       bool
-	totalTabWidth          int
-	closeDownX             int // screen X where mouse-down hit a close button, -1 if none
-	closeDownY             int
-	wasPressed             bool
-	lastClickTime          int64
-	drag                   widgets.TabDragState
-	dragPointerX           int
-	autoScrollTimer        *time.Timer
-	autoScrollGeneration   uint64
-	autoScrollDirection    int
-	dragAutoScrollDelay    time.Duration
+	Tabs                      []Tab
+	Borders                   *term.BorderSet
+	ScrollOffset              int
+	MoreButton                *MoreButtonWidget
+	OnTabClick                func(index int)
+	OnTabClose                func(index int)
+	OnTabUnpin                func(index int)
+	OnTabReorder              func(from, to int)
+	NormalizeDropTarget       func(from, to int) int
+	PostDragAutoScrollTick    func(generation uint64)
+	PointerInteractionValid   func() bool
+	OnTabRightClick           func(index, screenX, screenY int)
+	OnPrevTab                 func()
+	OnNextTab                 func()
+	OnDoubleClick             func()
+	tabSpans                  []tabSpan
+	renderArrowW              int // arrow-gutter width from the last Render, reused by HandleEvent
+	renderInnerRight          int // right edge of the tab zone from the last Render, reused by HandleEvent
+	hasOverflowLeft           bool
+	hasOverflowRight          bool
+	totalTabWidth             int
+	closeDownX                int // screen X where mouse-down hit a close button, -1 if none
+	closeDownY                int
+	wasPressed                bool
+	lastClickTime             int64
+	drag                      widgets.TabDragState
+	dragPointerX              int
+	autoScrollTimer           *time.Timer
+	autoScrollGeneration      uint64
+	autoScrollDirection       int
+	dragAutoScrollDelay       time.Duration
+	pointerCaptureInvalidated func()
 }
 
 func NewTabBarWidget() *TabBarWidget {
@@ -69,9 +72,7 @@ func NewTabBarWidget() *TabBarWidget {
 
 func (t *TabBarWidget) SetTabs(tabs []Tab) {
 	t.Tabs = tabs
-	if t.drag.Active() && t.drag.From() >= len(tabs) {
-		t.CancelPointerCapture()
-	}
+	t.validateGestureSource()
 }
 
 func (t *TabBarWidget) tabLabel(tab Tab) string {
@@ -113,6 +114,7 @@ func drawTabLabel(surface Surface, x, innerLeft, innerRight int, label string, d
 }
 
 func (t *TabBarWidget) Render(surface Surface) {
+	t.validateGestureSource()
 	w, h := surface.Size()
 	if w <= 0 || h < 3 {
 		t.ClearRenderedGeometry()
@@ -289,6 +291,9 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	if btn == tcell.ButtonNone && t.drag.Active() {
 		t.wasPressed = false
 		t.cancelAutoScroll()
+		if !t.validateGestureSource() {
+			return EventIgnored
+		}
 		from, to, dragged := t.drag.End()
 		if dragged && from != to && t.OnTabReorder != nil {
 			t.OnTabReorder(from, to)
@@ -299,6 +304,9 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventIgnored
 	}
 	if t.drag.Active() && btn&tcell.Button1 != 0 {
+		if !t.validateGestureSource() {
+			return EventIgnored
+		}
 		if t.drag.Update(mx, t.effectiveDropTarget(t.dropTargetAt(mx))) {
 			t.dragPointerX = mx
 			t.scrollDragOnce(mx)
@@ -410,7 +418,7 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 				t.OnTabClick(i)
 			}
 			if t.OnTabReorder != nil {
-				t.drag.Begin(i, mx)
+				t.drag.Begin(i, tabIdentity(t.Tabs[i]), mx)
 				return EventCaptured
 			}
 			return EventConsumed
@@ -439,17 +447,24 @@ func (t *TabBarWidget) effectiveDropTarget(target int) int {
 
 func (t *TabBarWidget) CancelPointerCapture() bool {
 	t.cancelAutoScroll()
-	if !t.drag.Active() {
-		return false
+	active := t.drag.Active()
+	if active {
+		t.drag.Cancel()
 	}
-	t.drag.Cancel()
 	t.wasPressed = false
 	t.closeDownX = -1
-	return true
+	if active && t.pointerCaptureInvalidated != nil {
+		t.pointerCaptureInvalidated()
+	}
+	return active
+}
+
+func (t *TabBarWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	t.pointerCaptureInvalidated = invalidated
 }
 
 func (t *TabBarWidget) OwnsPointerCapture() bool {
-	return t.drag.Active()
+	return t.validateGestureSource()
 }
 
 func (t *TabBarWidget) ClearRenderedGeometry() {
@@ -460,6 +475,38 @@ func (t *TabBarWidget) ClearRenderedGeometry() {
 	t.hasOverflowRight = false
 	t.totalTabWidth = 0
 	t.CancelPointerCapture()
+}
+
+func (t *TabBarWidget) InvalidatePointerInteraction() bool {
+	active := t.drag.Active()
+	t.ClearRenderedGeometry()
+	return active
+}
+
+func (t *TabBarWidget) validateGestureSource() bool {
+	if !t.drag.Active() {
+		return false
+	}
+	if t.PointerInteractionValid != nil && !t.PointerInteractionValid() {
+		t.CancelPointerCapture()
+		return false
+	}
+	sourceID := t.drag.SourceID()
+	for i := range t.Tabs {
+		if tabIdentity(t.Tabs[i]) == sourceID {
+			t.drag.SetSourceIndex(i)
+			return true
+		}
+	}
+	t.CancelPointerCapture()
+	return false
+}
+
+func tabIdentity(tab Tab) string {
+	if tab.ID != "" {
+		return tab.ID
+	}
+	return tab.Name
 }
 
 func (t *TabBarWidget) dropTargetAt(screenX int) int {
@@ -574,7 +621,7 @@ func (t *TabBarWidget) HandleDragAutoScrollTick(generation uint64) bool {
 		return false
 	}
 	t.autoScrollTimer = nil
-	if !t.drag.Active() || !t.drag.Dragging() || t.autoScrollDirection == 0 {
+	if !t.validateGestureSource() || !t.drag.Dragging() || t.autoScrollDirection == 0 {
 		t.cancelAutoScroll()
 		return false
 	}

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/textwidth"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -33,6 +34,7 @@ type TabBarWidget struct {
 	OnTabClick       func(index int)
 	OnTabClose       func(index int)
 	OnTabUnpin       func(index int)
+	OnTabReorder     func(from, to int)
 	OnTabRightClick  func(index, screenX, screenY int)
 	OnPrevTab        func()
 	OnNextTab        func()
@@ -47,6 +49,7 @@ type TabBarWidget struct {
 	closeDownY       int
 	wasPressed       bool
 	lastClickTime    int64
+	drag             widgets.TabDragState
 }
 
 func NewTabBarWidget() *TabBarWidget {
@@ -146,7 +149,7 @@ func (t *TabBarWidget) Render(surface Surface) {
 	}
 
 	// Scroll to keep active tab visible within the inner zone
-	if activeIdx >= 0 {
+	if activeIdx >= 0 && !t.drag.Active() {
 		s := spans[activeIdx]
 		if s.end-t.ScrollOffset > innerW {
 			t.ScrollOffset = s.end - innerW
@@ -245,6 +248,12 @@ func (t *TabBarWidget) Render(surface Surface) {
 		moreSurface := surface.Sub(Rect{X: w - 4, Y: 1, W: 3, H: 1})
 		t.MoreButton.Render(moreSurface)
 	}
+
+	if x := t.dropIndicatorX(); x >= innerLeft && x < innerRight {
+		for y := 0; y < 3; y++ {
+			surface.SetCell(x, y, term.Cell{Ch: '│', Style: term.StyleBorderActive})
+		}
+	}
 }
 
 func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -257,6 +266,27 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	btn := mev.Buttons()
 
 	slog.Debug("tabBar", "mx", mx, "my", my, "btn", btn, "rect", r, "hasMore", t.MoreButton != nil)
+
+	if btn == tcell.ButtonNone && t.drag.Active() {
+		t.wasPressed = false
+		from, to, dragged := t.drag.End()
+		if dragged && from != to && t.OnTabReorder != nil {
+			t.OnTabReorder(from, to)
+		}
+		if dragged {
+			return EventConsumed
+		}
+		return EventIgnored
+	}
+	if t.drag.Active() && btn&tcell.Button1 != 0 {
+		if t.drag.Update(mx, t.dropTargetAt(mx)) {
+			t.autoScrollDrag(mx)
+			t.drag.Update(mx, t.dropTargetAt(mx))
+			t.closeDownX = -1
+			return EventCaptured
+		}
+		return EventConsumed
+	}
 
 	if t.MoreButton != nil {
 		if t.MoreButton.HandleEvent(ev) == EventConsumed {
@@ -357,6 +387,9 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 			if t.OnTabClick != nil {
 				t.OnTabClick(i)
 			}
+			if t.OnTabReorder != nil {
+				t.drag.Begin(i, mx)
+			}
 			return EventConsumed
 		}
 	}
@@ -369,4 +402,56 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		t.lastClickTime = now
 	}
 	return EventConsumed
+}
+
+func (t *TabBarWidget) dropTargetAt(screenX int) int {
+	localX := screenX - t.GetRect().X - t.renderArrowW + t.ScrollOffset
+	last := -1
+	for i, span := range t.tabSpans {
+		last = i
+		if localX < span.start+(span.end-span.start)/2 {
+			return i
+		}
+	}
+	return last
+}
+
+func (t *TabBarWidget) dropIndicatorX() int {
+	if !t.drag.Dragging() || t.drag.From() == t.drag.Target() {
+		return -1
+	}
+	target := t.drag.Target()
+	if target < 0 || target >= len(t.tabSpans) {
+		return -1
+	}
+	span := t.tabSpans[target]
+	logicalX := span.end - 1
+	if target < t.drag.From() {
+		logicalX = span.start
+	}
+	return logicalX - t.ScrollOffset + t.renderArrowW
+}
+
+func (t *TabBarWidget) autoScrollDrag(screenX int) {
+	if t.renderArrowW == 0 {
+		return
+	}
+	r := t.GetRect()
+	innerW := t.renderInnerRight - t.renderArrowW
+	if innerW < 1 {
+		return
+	}
+	const scrollStep = 3
+	if screenX <= r.X+t.renderArrowW {
+		t.ScrollOffset -= scrollStep
+	} else if screenX >= r.X+t.renderInnerRight-1 {
+		t.ScrollOffset += scrollStep
+	}
+	maxScroll := t.totalTabWidth - innerW
+	if t.ScrollOffset > maxScroll {
+		t.ScrollOffset = maxScroll
+	}
+	if t.ScrollOffset < 0 {
+		t.ScrollOffset = 0
+	}
 }

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -362,6 +363,84 @@ func TestTabBarInvalidatedSourceDoesNotCaptureNextClick(t *testing.T) {
 
 	if clicked != 0 {
 		t.Fatalf("first click after invalidation activated %d, want 0", clicked)
+	}
+}
+
+func TestTabBarRemovedSourceDoesNotRetargetReplacementAtSameIndex(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{
+		{ID: "a", Name: "a.go"},
+		{ID: "b", Name: "b.go", Active: true},
+		{ID: "c", Name: "c.go"},
+	})
+	root := NewRoot(tb)
+	root.SetSize(40, 3)
+	tb.Render(NewRenderSurface(makeGrid(40, 3), Rect{X: 0, Y: 0, W: 40, H: 3}))
+	var moves [][2]int
+	tb.OnTabReorder = func(from, to int) { moves = append(moves, [2]int{from, to}) }
+
+	pressX := tb.tabSpans[1].start + 2
+	if got := root.HandleEvent(tcell.NewEventMouse(pressX, 1, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("b mouse down = %v, want consumed by Root", got)
+	}
+	if got := tb.drag.SourceID(); got != "b" {
+		t.Fatalf("pressed source = %q, want b", got)
+	}
+
+	tb.SetTabs([]Tab{{ID: "a", Name: "a.go"}, {ID: "c", Name: "c.go"}, {ID: "d", Name: "d.go"}})
+	if root.capturedWidget != nil {
+		t.Fatal("removed b did not synchronously clear Root capture")
+	}
+	if tb.OwnsPointerCapture() {
+		t.Fatal("removed b retained capture when c occupied index 1")
+	}
+	tb.HandleEvent(tcell.NewEventMouse(tb.tabSpans[2].start+2, 1, tcell.ButtonNone, 0))
+	if len(moves) != 0 {
+		t.Fatalf("release after source removal reordered replacement: %v", moves)
+	}
+}
+
+func TestTabBarRapidRemoveReopenDoesNotReviveGesture(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{{ID: "a", Name: "a.go"}, {ID: "b", Name: "b.go"}})
+	tb.SetRect(Rect{X: 0, Y: 0, W: 30, H: 3})
+	tb.Render(NewRenderSurface(makeGrid(30, 3), Rect{X: 0, Y: 0, W: 30, H: 3}))
+	reordered := false
+	tb.OnTabReorder = func(_, _ int) { reordered = true }
+	tb.HandleEvent(tcell.NewEventMouse(tb.tabSpans[1].start+2, 1, tcell.Button1, 0))
+
+	tb.SetTabs([]Tab{{ID: "a", Name: "a.go"}})
+	tb.SetTabs([]Tab{{ID: "a", Name: "a.go"}, {ID: "b", Name: "b.go"}})
+	tb.HandleEvent(tcell.NewEventMouse(0, 1, tcell.ButtonNone, 0))
+	if tb.OwnsPointerCapture() || reordered {
+		t.Fatal("remove/reopen revived the canceled b gesture")
+	}
+}
+
+func TestTabBarSourceRemovalSynchronouslyClearsNestedCaptureChain(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{{ID: "a", Name: "a.go"}, {ID: "b", Name: "b.go"}, {ID: "c", Name: "c.go"}})
+	tb.OnTabReorder = func(_, _ int) {}
+	content := NewContentSplitWidget()
+	content.Top = tb
+	split := NewSplitPanelWidget()
+	split.ShowLeft = false
+	split.Right = content
+	main := widgets.NewVStackWidget(split)
+	root := NewRoot(main)
+	root.SetSize(50, 6)
+	root.Render(makeGrid(50, 6))
+
+	pressX := tb.GetRect().X + tb.tabSpans[1].start + 2
+	pressY := tb.GetRect().Y + 1
+	root.HandleEvent(tcell.NewEventMouse(pressX, pressY, tcell.Button1, 0))
+	if root.capturedWidget == nil || split.capturedChild == nil || content.capturedChild == nil {
+		t.Fatal("test setup did not establish the nested capture chain")
+	}
+
+	tb.SetTabs([]Tab{{ID: "a", Name: "a.go"}, {ID: "c", Name: "c.go"}, {ID: "d", Name: "d.go"}})
+	if root.capturedWidget != nil || split.capturedChild != nil || content.capturedChild != nil {
+		t.Fatal("source removal did not synchronously clear every capture layer")
 	}
 }
 

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -92,6 +92,65 @@ func TestTabBarOverflowScrollLeft(t *testing.T) {
 	}
 }
 
+func TestTabBarDragCapturesAfterThresholdWithThemedIndicator(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{
+		{Name: "one.go", Active: true},
+		{Name: "two.go"},
+		{Name: "three.go"},
+	})
+	tb.SetRect(Rect{X: 4, Y: 2, W: 50, H: 3})
+	grid := makeGrid(50, 3)
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 50, H: 3}))
+
+	fromX := tb.GetRect().X + tb.tabSpans[0].start + 2
+	toX := tb.GetRect().X + tb.tabSpans[2].end - 2
+	var gotFrom, gotTo = -1, -1
+	tb.OnTabReorder = func(from, to int) { gotFrom, gotTo = from, to }
+
+	if got := tb.HandleEvent(tcell.NewEventMouse(fromX, 3, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("mouse down = %v, want consumed", got)
+	}
+	if got := tb.HandleEvent(tcell.NewEventMouse(fromX+1, 3, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("jitter = %v, want consumed", got)
+	}
+	if got := tb.HandleEvent(tcell.NewEventMouse(toX, 3, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("drag = %v, want captured", got)
+	}
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 50, H: 3}))
+	indicatorX := tb.dropIndicatorX()
+	if indicatorX < 0 || grid[1][indicatorX].Ch != '│' || grid[1][indicatorX].Style != term.StyleBorderActive {
+		t.Fatal("drag should render a themed drop indicator")
+	}
+	tb.HandleEvent(tcell.NewEventMouse(toX, 3, tcell.ButtonNone, 0))
+	if gotFrom != 0 || gotTo != 2 {
+		t.Fatalf("reorder = %d -> %d, want 0 -> 2", gotFrom, gotTo)
+	}
+}
+
+func TestTabBarDragAutoScrollsOverflow(t *testing.T) {
+	tb := NewTabBarWidget()
+	tabs := make([]Tab, 10)
+	for i := range tabs {
+		tabs[i] = Tab{Name: fmt.Sprintf("file-%d.go", i), Active: i == 0}
+	}
+	tb.SetTabs(tabs)
+	tb.SetRect(Rect{X: 0, Y: 0, W: 30, H: 3})
+	grid := makeGrid(30, 3)
+	tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 30, H: 3}))
+	tb.OnTabReorder = func(_, _ int) {}
+
+	startX := tb.renderArrowW + 2
+	tb.HandleEvent(tcell.NewEventMouse(startX, 1, tcell.Button1, 0))
+	for range 3 {
+		tb.HandleEvent(tcell.NewEventMouse(tb.renderInnerRight-1, 1, tcell.Button1, 0))
+		tb.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 30, H: 3}))
+	}
+	if tb.ScrollOffset == 0 {
+		t.Fatal("dragging at the right edge should scroll hidden tabs into view")
+	}
+}
+
 // renderInMoreButtonWindow sizes the bar to exactly the total tab width with a
 // MoreButton present, so tabs overflow the inner zone but not the full width —
 // the #354 window. Returns the rendered grid and the bar width.

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -2,7 +2,9 @@ package ui
 
 import (
 	"fmt"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/gdamore/tcell/v3"
@@ -92,7 +94,7 @@ func TestTabBarOverflowScrollLeft(t *testing.T) {
 	}
 }
 
-func TestTabBarDragCapturesAfterThresholdWithThemedIndicator(t *testing.T) {
+func TestTabBarDragCapturesPendingPressWithThemedIndicator(t *testing.T) {
 	tb := NewTabBarWidget()
 	tb.SetTabs([]Tab{
 		{Name: "one.go", Active: true},
@@ -108,8 +110,8 @@ func TestTabBarDragCapturesAfterThresholdWithThemedIndicator(t *testing.T) {
 	var gotFrom, gotTo = -1, -1
 	tb.OnTabReorder = func(from, to int) { gotFrom, gotTo = from, to }
 
-	if got := tb.HandleEvent(tcell.NewEventMouse(fromX, 3, tcell.Button1, 0)); got != EventConsumed {
-		t.Fatalf("mouse down = %v, want consumed", got)
+	if got := tb.HandleEvent(tcell.NewEventMouse(fromX, 3, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down = %v, want captured", got)
 	}
 	if got := tb.HandleEvent(tcell.NewEventMouse(fromX+1, 3, tcell.Button1, 0)); got != EventConsumed {
 		t.Fatalf("jitter = %v, want consumed", got)
@@ -125,6 +127,89 @@ func TestTabBarDragCapturesAfterThresholdWithThemedIndicator(t *testing.T) {
 	tb.HandleEvent(tcell.NewEventMouse(toX, 3, tcell.ButtonNone, 0))
 	if gotFrom != 0 || gotTo != 2 {
 		t.Fatalf("reorder = %d -> %d, want 0 -> 2", gotFrom, gotTo)
+	}
+}
+
+func TestTabBarCapturedClickActivatesWithoutReorder(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{{Name: "one.go", Active: true}, {Name: "two.go"}})
+	tb.SetRect(Rect{X: 0, Y: 0, W: 30, H: 3})
+	tb.Render(NewRenderSurface(makeGrid(30, 3), Rect{X: 0, Y: 0, W: 30, H: 3}))
+
+	clicked, reordered := -1, false
+	tb.OnTabClick = func(index int) { clicked = index }
+	tb.OnTabReorder = func(_, _ int) { reordered = true }
+	x := tb.tabSpans[1].start + 2
+	if got := tb.HandleEvent(tcell.NewEventMouse(x, 1, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down = %v, want captured", got)
+	}
+	tb.HandleEvent(tcell.NewEventMouse(x+1, 1, tcell.Button1, 0))
+	tb.HandleEvent(tcell.NewEventMouse(x+1, 1, tcell.ButtonNone, 0))
+
+	if clicked != 1 {
+		t.Fatalf("clicked tab = %d, want 1", clicked)
+	}
+	if reordered {
+		t.Fatal("one-column jitter reordered a tab")
+	}
+	if tb.drag.Active() {
+		t.Fatal("click release left a pending tab gesture")
+	}
+}
+
+func TestTabBarPinnedTargetUsesEffectiveMarkerAndCommitTarget(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{
+		{Name: "pin-one.go", Pinned: true},
+		{Name: "pin-two.go", Pinned: true},
+		{Name: "preview.go"},
+		{Name: "later.go"},
+	})
+	tb.SetRect(Rect{X: 0, Y: 0, W: 80, H: 3})
+	tb.Render(NewRenderSurface(makeGrid(80, 3), Rect{X: 0, Y: 0, W: 80, H: 3}))
+	tb.NormalizeDropTarget = func(from, to int) int {
+		if from >= 2 && to < 2 {
+			return 2
+		}
+		return to
+	}
+	var moves [][2]int
+	tb.OnTabReorder = func(from, to int) { moves = append(moves, [2]int{from, to}) }
+
+	press := func(index int) int {
+		x := tb.tabSpans[index].start + 2
+		if got := tb.HandleEvent(tcell.NewEventMouse(x, 1, tcell.Button1, 0)); got != EventCaptured {
+			t.Fatalf("tab %d mouse down = %v, want captured", index, got)
+		}
+		return x
+	}
+	dropX := tb.tabSpans[0].start
+
+	press(2)
+	tb.HandleEvent(tcell.NewEventMouse(dropX, 1, tcell.Button1, 0))
+	if got := tb.drag.Target(); got != 2 {
+		t.Fatalf("first unpinned effective target = %d, want 2", got)
+	}
+	if got := tb.dropIndicatorX(); got != -1 {
+		t.Fatalf("effective no-op indicator = %d, want hidden", got)
+	}
+	tb.HandleEvent(tcell.NewEventMouse(dropX, 1, tcell.ButtonNone, 0))
+	if len(moves) != 0 {
+		t.Fatalf("effective no-op committed moves %v", moves)
+	}
+
+	press(3)
+	tb.HandleEvent(tcell.NewEventMouse(dropX, 1, tcell.Button1, 0))
+	if got := tb.drag.Target(); got != 2 {
+		t.Fatalf("later unpinned effective target = %d, want 2", got)
+	}
+	wantIndicator := tb.tabSpans[2].start - tb.ScrollOffset + tb.renderArrowW
+	if got := tb.dropIndicatorX(); got != wantIndicator {
+		t.Fatalf("boundary indicator = %d, want %d", got, wantIndicator)
+	}
+	tb.HandleEvent(tcell.NewEventMouse(dropX, 1, tcell.ButtonNone, 0))
+	if !slices.Equal(moves, [][2]int{{3, 2}}) {
+		t.Fatalf("committed moves = %v, want [[3 2]]", moves)
 	}
 }
 
@@ -148,6 +233,135 @@ func TestTabBarDragAutoScrollsOverflow(t *testing.T) {
 	}
 	if tb.ScrollOffset == 0 {
 		t.Fatal("dragging at the right edge should scroll hidden tabs into view")
+	}
+}
+
+func TestTabBarDragAutoScrollContinuesAtStationaryEdge(t *testing.T) {
+	tb := NewTabBarWidget()
+	tabs := make([]Tab, 20)
+	for i := range tabs {
+		tabs[i] = Tab{Name: fmt.Sprintf("file-%02d.go", i), Active: i == 0}
+	}
+	tb.SetTabs(tabs)
+	tb.SetRect(Rect{X: 0, Y: 0, W: 30, H: 3})
+	tb.Render(NewRenderSurface(makeGrid(30, 3), Rect{X: 0, Y: 0, W: 30, H: 3}))
+	tb.OnTabReorder = func(_, _ int) {}
+	tb.dragAutoScrollDelay = time.Millisecond
+	ticks := make(chan uint64, 4)
+	tb.PostDragAutoScrollTick = func(generation uint64) { ticks <- generation }
+	t.Cleanup(func() { tb.CancelPointerCapture() })
+
+	startX := tb.renderArrowW + 2
+	if got := tb.HandleEvent(tcell.NewEventMouse(startX, 1, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down = %v, want captured", got)
+	}
+	edgeX := tb.renderInnerRight - 1
+	tb.HandleEvent(tcell.NewEventMouse(edgeX, 1, tcell.Button1, 0))
+	afterMove := tb.ScrollOffset
+
+	var generation uint64
+	select {
+	case generation = <-ticks:
+	case <-time.After(time.Second):
+		t.Fatal("stationary edge did not schedule an auto-scroll tick")
+	}
+	if !tb.HandleDragAutoScrollTick(generation) {
+		t.Fatal("current auto-scroll tick was not applied")
+	}
+	if tb.ScrollOffset <= afterMove {
+		t.Fatalf("stationary pointer scroll offset = %d, want greater than %d", tb.ScrollOffset, afterMove)
+	}
+
+	tb.HandleEvent(tcell.NewEventMouse(edgeX, 1, tcell.ButtonNone, 0))
+	if tb.HandleDragAutoScrollTick(generation) {
+		t.Fatal("release should generation-drop an old auto-scroll tick")
+	}
+}
+
+func TestTabBarDragAutoScrollDropsTickAfterEdgeExit(t *testing.T) {
+	tb := NewTabBarWidget()
+	tabs := make([]Tab, 12)
+	for i := range tabs {
+		tabs[i] = Tab{Name: fmt.Sprintf("file-%02d.go", i), Active: i == 0}
+	}
+	tb.SetTabs(tabs)
+	tb.SetRect(Rect{X: 0, Y: 0, W: 30, H: 3})
+	tb.Render(NewRenderSurface(makeGrid(30, 3), Rect{X: 0, Y: 0, W: 30, H: 3}))
+	tb.OnTabReorder = func(_, _ int) {}
+	tb.dragAutoScrollDelay = time.Hour
+	tb.PostDragAutoScrollTick = func(uint64) {}
+	t.Cleanup(func() { tb.CancelPointerCapture() })
+
+	startX := tb.renderArrowW + 2
+	tb.HandleEvent(tcell.NewEventMouse(startX, 1, tcell.Button1, 0))
+	tb.HandleEvent(tcell.NewEventMouse(tb.renderInnerRight-1, 1, tcell.Button1, 0))
+	generation := tb.autoScrollGeneration
+	if tb.autoScrollTimer == nil {
+		t.Fatal("test setup: edge drag did not arm auto-scroll")
+	}
+
+	centerX := (tb.renderArrowW + tb.renderInnerRight) / 2
+	tb.HandleEvent(tcell.NewEventMouse(centerX, 1, tcell.Button1, 0))
+	if tb.autoScrollTimer != nil || tb.autoScrollDirection != 0 {
+		t.Fatal("leaving the edge did not cancel auto-scroll")
+	}
+	if tb.HandleDragAutoScrollTick(generation) {
+		t.Fatal("edge exit should generation-drop the old tick")
+	}
+}
+
+func TestTabBarResizeCancelsCapturedGestureAndClearsGeometry(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{{Name: "one.go", Active: true}, {Name: "two.go"}})
+	root := NewRoot(tb)
+	root.SetSize(30, 3)
+	tb.Render(NewRenderSurface(makeGrid(30, 3), Rect{X: 0, Y: 0, W: 30, H: 3}))
+	tb.OnTabReorder = func(_, _ int) {}
+
+	x := tb.tabSpans[0].start + 2
+	root.HandleEvent(tcell.NewEventMouse(x, 1, tcell.Button1, 0))
+	if root.capturedWidget == nil || !tb.drag.Active() {
+		t.Fatal("test setup: pending tab press was not captured")
+	}
+
+	root.SetSize(0, 0)
+	root.Render(makeGrid(0, 0))
+	if root.capturedWidget != nil || tb.drag.Active() {
+		t.Fatal("resize did not cancel the captured tab gesture")
+	}
+	if len(tb.tabSpans) != 0 || tb.renderArrowW != 0 || tb.renderInnerRight != 0 {
+		t.Fatal("non-renderable resize retained old tab geometry")
+	}
+}
+
+func TestTabBarInvalidatedSourceDoesNotCaptureNextClick(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{{Name: "one.go"}, {Name: "two.go", Active: true}})
+	root := NewRoot(tb)
+	root.SetSize(30, 3)
+	tb.Render(NewRenderSurface(makeGrid(30, 3), Rect{X: 0, Y: 0, W: 30, H: 3}))
+	clicked := -1
+	tb.OnTabClick = func(index int) { clicked = index }
+	tb.OnTabReorder = func(_, _ int) {}
+
+	secondX := tb.tabSpans[1].start + 2
+	root.HandleEvent(tcell.NewEventMouse(secondX, 1, tcell.Button1, 0))
+	if root.capturedWidget == nil {
+		t.Fatal("test setup: second tab press was not captured")
+	}
+
+	tb.SetTabs([]Tab{{Name: "one.go", Active: true}})
+	root.Render(makeGrid(30, 3))
+	if root.capturedWidget != nil {
+		t.Fatal("invalidated source retained root capture after render")
+	}
+	clicked = -1
+	firstX := tb.tabSpans[0].start + 2
+	root.HandleEvent(tcell.NewEventMouse(firstX, 1, tcell.Button1, 0))
+	root.HandleEvent(tcell.NewEventMouse(firstX, 1, tcell.ButtonNone, 0))
+
+	if clicked != 0 {
+		t.Fatalf("first click after invalidation activated %d, want 0", clicked)
 	}
 }
 

--- a/internal/ui/tabbed_panel.go
+++ b/internal/ui/tabbed_panel.go
@@ -42,6 +42,9 @@ func (tp *TabbedPanel) InitTabClick() {
 }
 
 func (tp *TabbedPanel) AddPanel(id, title string, w Widget) {
+	if tp.HasPanel(id) {
+		return
+	}
 	tp.panels = append(tp.panels, panelEntry{ID: id, Title: title, W: w})
 	if tp.ActivePanel == "" {
 		tp.ActivePanel = id

--- a/internal/ui/tabbed_panel.go
+++ b/internal/ui/tabbed_panel.go
@@ -1,6 +1,9 @@
 package ui
 
 import (
+	"slices"
+	"sort"
+
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/widgets"
 )
@@ -12,11 +15,13 @@ type panelEntry struct {
 }
 
 type TabbedPanel struct {
-	ActivePanel   string
-	Tabs          *widgets.TabsWidget
-	OnPanelChange func(id string)
+	ActivePanel    string
+	Tabs           *widgets.TabsWidget
+	OnPanelChange  func(id string)
+	OnPanelReorder func(ids []string)
 
-	panels []panelEntry
+	panels         []panelEntry
+	preferredOrder []string
 }
 
 func NewTabbedPanel() TabbedPanel {
@@ -31,6 +36,9 @@ func (tp *TabbedPanel) InitTabClick() {
 			tp.SetActivePanel(tp.panels[index].ID)
 		}
 	}
+	tp.Tabs.Config.OnReorder = func(from, to int) {
+		tp.MovePanel(from, to)
+	}
 }
 
 func (tp *TabbedPanel) AddPanel(id, title string, w Widget) {
@@ -38,7 +46,110 @@ func (tp *TabbedPanel) AddPanel(id, title string, w Widget) {
 	if tp.ActivePanel == "" {
 		tp.ActivePanel = id
 	}
+	tp.applyPreferredOrder()
 	tp.syncTabs()
+}
+
+func (tp *TabbedPanel) SetPanelOrder(order []string) {
+	tp.preferredOrder = tp.normalizedPanelOrder(order)
+	tp.applyPreferredOrder()
+	tp.syncTabs()
+}
+
+func (tp *TabbedPanel) normalizedPanelOrder(order []string) []string {
+	seen := make(map[string]bool, len(order))
+	normalized := make([]string, 0, len(order))
+	for _, id := range order {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		normalized = append(normalized, id)
+	}
+	return normalized
+}
+
+func (tp *TabbedPanel) applyPreferredOrder() {
+	if len(tp.preferredOrder) == 0 || len(tp.panels) < 2 {
+		return
+	}
+	rank := make(map[string]int, len(tp.preferredOrder))
+	for i, id := range tp.preferredOrder {
+		if _, exists := rank[id]; !exists {
+			rank[id] = i
+		}
+	}
+	sort.SliceStable(tp.panels, func(i, j int) bool {
+		ri, iKnown := rank[tp.panels[i].ID]
+		rj, jKnown := rank[tp.panels[j].ID]
+		switch {
+		case iKnown && jKnown:
+			return ri < rj
+		case iKnown:
+			return true
+		case jKnown:
+			return false
+		default:
+			return false
+		}
+	})
+}
+
+func (tp *TabbedPanel) MovePanel(from, to int) bool {
+	if from < 0 || from >= len(tp.panels) || to < 0 || to >= len(tp.panels) || from == to {
+		return false
+	}
+	panel := tp.panels[from]
+	tp.panels = append(tp.panels[:from], tp.panels[from+1:]...)
+	tp.panels = slices.Insert(tp.panels, to, panel)
+	tp.preferredOrder = tp.mergePreferredOrder()
+	tp.syncTabs()
+	if tp.OnPanelReorder != nil {
+		tp.OnPanelReorder(slices.Clone(tp.preferredOrder))
+	}
+	return true
+}
+
+func (tp *TabbedPanel) mergePreferredOrder() []string {
+	current := tp.PanelIDs()
+	known := make(map[string]bool, len(current))
+	for _, id := range current {
+		known[id] = true
+	}
+	merged := make([]string, 0, len(current)+len(tp.preferredOrder))
+	next := 0
+	for _, id := range tp.preferredOrder {
+		if known[id] {
+			merged = append(merged, current[next])
+			next++
+		} else {
+			merged = append(merged, id)
+		}
+	}
+	merged = append(merged, current[next:]...)
+	return merged
+}
+
+func (tp *TabbedPanel) ActivePanelIndex() int {
+	for i, panel := range tp.panels {
+		if panel.ID == tp.ActivePanel {
+			return i
+		}
+	}
+	return -1
+}
+
+func (tp *TabbedPanel) CanMoveActivePanel(dir int) bool {
+	idx := tp.ActivePanelIndex()
+	return idx >= 0 && idx+dir >= 0 && idx+dir < len(tp.panels)
+}
+
+func (tp *TabbedPanel) MoveActivePanel(dir int) bool {
+	idx := tp.ActivePanelIndex()
+	if idx < 0 {
+		return false
+	}
+	return tp.MovePanel(idx, idx+dir)
 }
 
 func (tp *TabbedPanel) RemovePanel(id string) {

--- a/internal/ui/tabbed_panel.go
+++ b/internal/ui/tabbed_panel.go
@@ -176,6 +176,9 @@ func (tp *TabbedPanel) RemovePanel(id string) {
 func (tp *TabbedPanel) SetActivePanel(id string) {
 	for _, p := range tp.panels {
 		if p.ID == id {
+			if id != tp.ActivePanel && tp.Tabs.OwnsPointerCapture() {
+				tp.Tabs.CancelPointerCapture()
+			}
 			tp.ActivePanel = id
 			tp.syncTabs()
 			if tp.OnPanelChange != nil {
@@ -289,7 +292,7 @@ func (tp *TabbedPanel) syncTabs() {
 			Dirty:  dirty[p.ID],
 		}
 	}
-	tp.Tabs.Config.Items = items
+	tp.Tabs.SetItems(items)
 }
 
 func (tp *TabbedPanel) RenderTabs(surface Surface, r Rect) {

--- a/internal/ui/tabbed_panel_test.go
+++ b/internal/ui/tabbed_panel_test.go
@@ -44,3 +44,46 @@ func TestTabbedPanelMovePreservesActiveIdentity(t *testing.T) {
 		t.Fatalf("active panel = %q at %d", tp.ActivePanel, tp.ActivePanelIndex())
 	}
 }
+
+func TestTabbedPanelDuplicateAddIsIdempotent(t *testing.T) {
+	tp := NewTabbedPanel()
+	tp.InitTabClick()
+	original := &mockWidget{}
+	replacement := &mockWidget{}
+	tp.AddPanel("explorer", "Explore", original)
+	tp.AddPanel("search", "Find", &mockWidget{})
+	tp.SetActivePanel("explorer")
+
+	tp.AddPanel("explorer", "Replacement", replacement)
+
+	if got := tp.PanelIDs(); !slices.Equal(got, []string{"explorer", "search"}) {
+		t.Fatalf("panel IDs = %v, want unique original order", got)
+	}
+	if tp.ActivePanel != "explorer" || tp.ActiveWidget() != original {
+		t.Fatal("duplicate add replaced the active panel surface")
+	}
+	if got := tp.PanelEntries()[0].Title; got != "Explore" {
+		t.Fatalf("duplicate add changed title to %q", got)
+	}
+}
+
+func TestTabbedPanelLateDuplicatePreservesPersistedOrder(t *testing.T) {
+	tp := NewTabbedPanel()
+	tp.InitTabClick()
+	tp.SetPanelOrder([]string{"changes", "plugin.todo", "plugin.todo", "explorer", ""})
+	tp.AddPanel("explorer", "Explore", &mockWidget{})
+	tp.AddPanel("changes", "Changes", &mockWidget{})
+	original := &mockWidget{}
+	tp.AddPanel("plugin.todo", "Todo", original)
+	tp.SetActivePanel("plugin.todo")
+
+	tp.AddPanel("plugin.todo", "Replacement", &mockWidget{})
+
+	want := []string{"changes", "plugin.todo", "explorer"}
+	if got := tp.PanelIDs(); !slices.Equal(got, want) {
+		t.Fatalf("late plugin panel order = %v, want %v", got, want)
+	}
+	if tp.ActivePanel != "plugin.todo" || tp.ActiveWidget() != original {
+		t.Fatal("late duplicate changed active plugin identity")
+	}
+}

--- a/internal/ui/tabbed_panel_test.go
+++ b/internal/ui/tabbed_panel_test.go
@@ -1,0 +1,46 @@
+package ui
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestTabbedPanelMergesSavedAndLatePanelOrder(t *testing.T) {
+	tp := NewTabbedPanel()
+	tp.InitTabClick()
+	tp.SetPanelOrder([]string{"changes", "plugin.todo", "explorer"})
+	tp.AddPanel("explorer", "Explore", &mockWidget{})
+	tp.AddPanel("search", "Find", &mockWidget{})
+	tp.AddPanel("changes", "Changes", &mockWidget{})
+	if got := tp.PanelIDs(); !slices.Equal(got, []string{"changes", "explorer", "search"}) {
+		t.Fatalf("core panel order = %v", got)
+	}
+	var reported []string
+	tp.OnPanelReorder = func(ids []string) { reported = ids }
+	if !tp.MovePanel(0, 1) {
+		t.Fatal("MovePanel returned false")
+	}
+	wantPreference := []string{"explorer", "plugin.todo", "changes", "search"}
+	if !slices.Equal(reported, wantPreference) {
+		t.Fatalf("reported preference = %v, want %v", reported, wantPreference)
+	}
+	tp.AddPanel("plugin.todo", "Todo", &mockWidget{})
+	if got := tp.PanelIDs(); !slices.Equal(got, wantPreference) {
+		t.Fatalf("late plugin panel order = %v, want %v", got, wantPreference)
+	}
+}
+
+func TestTabbedPanelMovePreservesActiveIdentity(t *testing.T) {
+	tp := NewTabbedPanel()
+	tp.InitTabClick()
+	for _, id := range []string{"explorer", "search", "changes"} {
+		tp.AddPanel(id, id, &mockWidget{})
+	}
+	tp.SetActivePanel("changes")
+	if !tp.MovePanel(2, 0) {
+		t.Fatal("MovePanel returned false")
+	}
+	if tp.ActivePanel != "changes" || tp.ActivePanelIndex() != 0 {
+		t.Fatalf("active panel = %q at %d", tp.ActivePanel, tp.ActivePanelIndex())
+	}
+}

--- a/internal/widgets/input_test.go
+++ b/internal/widgets/input_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -31,13 +32,24 @@ func (s *testSurface) SetCell(x, y int, c term.Cell) {
 	}
 }
 func (s *testSurface) DrawText(x, y int, text string, maxW int, style term.Style) int {
-	for i, ch := range []rune(text) {
-		if i >= maxW {
+	limit := s.w
+	if maxW > 0 && maxW < limit {
+		limit = maxW
+	}
+	for _, ch := range text {
+		if x >= limit {
 			break
 		}
-		s.SetCell(x+i, y, term.Cell{Ch: ch, Style: style})
+		width := textwidth.Rune(ch)
+		if x+width > limit {
+			s.SetCell(x, y, term.Cell{Ch: ' ', Style: style})
+			x++
+			break
+		}
+		s.SetCell(x, y, term.Cell{Ch: ch, Style: style})
+		x += width
 	}
-	return len([]rune(text))
+	return x
 }
 func (s *testSurface) DrawBorder(x, y, w, h int, b term.BorderSet, style term.Style) {
 	for i := x + 1; i < x+w-1; i++ {

--- a/internal/widgets/surface.go
+++ b/internal/widgets/surface.go
@@ -51,6 +51,34 @@ type PointerCaptureOwner interface {
 	OwnsPointerCapture() bool
 }
 
+type PointerInteractionInvalidator interface {
+	InvalidatePointerInteraction() bool
+}
+
+type PointerCaptureInvalidationSetter interface {
+	SetPointerCaptureInvalidated(func())
+}
+
+func CancelPointerCapture(w Widget) bool {
+	if canceler, ok := w.(PointerCaptureCanceler); ok {
+		return canceler.CancelPointerCapture()
+	}
+	return false
+}
+
+func InvalidatePointerInteraction(w Widget) bool {
+	if invalidator, ok := w.(PointerInteractionInvalidator); ok {
+		return invalidator.InvalidatePointerInteraction()
+	}
+	return CancelPointerCapture(w)
+}
+
+func SetPointerCaptureInvalidated(w Widget, invalidated func()) {
+	if setter, ok := w.(PointerCaptureInvalidationSetter); ok {
+		setter.SetPointerCaptureInvalidated(invalidated)
+	}
+}
+
 func hasFocusedChild(w Widget) bool {
 	if fw, ok := w.(FocusableWidget); ok && fw.IsFocused() {
 		return true

--- a/internal/widgets/surface.go
+++ b/internal/widgets/surface.go
@@ -43,6 +43,14 @@ type CursorPositioner interface {
 	CursorPosition() (x, y int, visible bool)
 }
 
+type PointerCaptureCanceler interface {
+	CancelPointerCapture() bool
+}
+
+type PointerCaptureOwner interface {
+	OwnsPointerCapture() bool
+}
+
 func hasFocusedChild(w Widget) bool {
 	if fw, ok := w.(FocusableWidget); ok && fw.IsFocused() {
 		return true

--- a/internal/widgets/tab_drag.go
+++ b/internal/widgets/tab_drag.go
@@ -1,0 +1,58 @@
+package widgets
+
+const TabDragThreshold = 2
+
+type TabDragState struct {
+	pressedIndex int
+	targetIndex  int
+	pressX       int
+	active       bool
+	dragging     bool
+}
+
+func (d *TabDragState) Begin(index, screenX int) {
+	d.pressedIndex = index
+	d.targetIndex = index
+	d.pressX = screenX
+	d.active = true
+	d.dragging = false
+}
+
+func (d *TabDragState) Update(screenX, targetIndex int) bool {
+	if !d.active {
+		return false
+	}
+	distance := screenX - d.pressX
+	if distance < 0 {
+		distance = -distance
+	}
+	if !d.dragging && distance >= TabDragThreshold {
+		d.dragging = true
+	}
+	if d.dragging && targetIndex >= 0 {
+		d.targetIndex = targetIndex
+	}
+	return d.dragging
+}
+
+func (d *TabDragState) End() (from, to int, dragged bool) {
+	if !d.active {
+		return 0, 0, false
+	}
+	from, to, dragged = d.pressedIndex, d.targetIndex, d.dragging
+	d.Cancel()
+	return from, to, dragged
+}
+
+func (d *TabDragState) Cancel() {
+	d.pressedIndex = 0
+	d.targetIndex = 0
+	d.pressX = 0
+	d.active = false
+	d.dragging = false
+}
+
+func (d *TabDragState) Active() bool   { return d.active }
+func (d *TabDragState) Dragging() bool { return d.dragging }
+func (d *TabDragState) From() int      { return d.pressedIndex }
+func (d *TabDragState) Target() int    { return d.targetIndex }

--- a/internal/widgets/tab_drag.go
+++ b/internal/widgets/tab_drag.go
@@ -5,17 +5,23 @@ const TabDragThreshold = 2
 type TabDragState struct {
 	pressedIndex int
 	targetIndex  int
+	sourceID     string
 	pressX       int
 	active       bool
 	dragging     bool
 }
 
-func (d *TabDragState) Begin(index, screenX int) {
+func (d *TabDragState) Begin(index int, sourceID string, screenX int) {
 	d.pressedIndex = index
 	d.targetIndex = index
+	d.sourceID = sourceID
 	d.pressX = screenX
 	d.active = true
 	d.dragging = false
+}
+
+func (d *TabDragState) SetSourceIndex(index int) {
+	d.pressedIndex = index
 }
 
 func (d *TabDragState) Update(screenX, targetIndex int) bool {
@@ -47,12 +53,14 @@ func (d *TabDragState) End() (from, to int, dragged bool) {
 func (d *TabDragState) Cancel() {
 	d.pressedIndex = 0
 	d.targetIndex = 0
+	d.sourceID = ""
 	d.pressX = 0
 	d.active = false
 	d.dragging = false
 }
 
-func (d *TabDragState) Active() bool   { return d.active }
-func (d *TabDragState) Dragging() bool { return d.dragging }
-func (d *TabDragState) From() int      { return d.pressedIndex }
-func (d *TabDragState) Target() int    { return d.targetIndex }
+func (d *TabDragState) Active() bool     { return d.active }
+func (d *TabDragState) Dragging() bool   { return d.dragging }
+func (d *TabDragState) From() int        { return d.pressedIndex }
+func (d *TabDragState) Target() int      { return d.targetIndex }
+func (d *TabDragState) SourceID() string { return d.sourceID }

--- a/internal/widgets/tab_drag_test.go
+++ b/internal/widgets/tab_drag_test.go
@@ -1,0 +1,21 @@
+package widgets
+
+import "testing"
+
+func TestTabDragStateRequiresIntentionalMovement(t *testing.T) {
+	var drag TabDragState
+	drag.Begin(1, 10)
+	if drag.Update(11, 2) {
+		t.Fatal("one-column jitter should not start a drag")
+	}
+	if !drag.Update(12, 2) {
+		t.Fatal("two-column movement should start a drag")
+	}
+	from, to, dragged := drag.End()
+	if !dragged || from != 1 || to != 2 {
+		t.Fatalf("drag result = %d -> %d, dragged=%v", from, to, dragged)
+	}
+	if drag.Active() {
+		t.Fatal("End should reset the gesture")
+	}
+}

--- a/internal/widgets/tab_drag_test.go
+++ b/internal/widgets/tab_drag_test.go
@@ -4,7 +4,10 @@ import "testing"
 
 func TestTabDragStateRequiresIntentionalMovement(t *testing.T) {
 	var drag TabDragState
-	drag.Begin(1, 10)
+	drag.Begin(1, "b", 10)
+	if drag.SourceID() != "b" {
+		t.Fatalf("source ID = %q, want b", drag.SourceID())
+	}
 	if drag.Update(11, 2) {
 		t.Fatal("one-column jitter should not start a drag")
 	}

--- a/internal/widgets/tabs.go
+++ b/internal/widgets/tabs.go
@@ -83,9 +83,13 @@ func (t *TabsWidget) ActiveID() string {
 }
 
 func (t *TabsWidget) Render(surface Surface) {
+	if t.drag.Active() && t.drag.From() >= len(t.Config.Items) {
+		t.CancelPointerCapture()
+	}
 	inner := t.RenderBox(surface)
 	w, _ := inner.Size()
 	if w <= 0 {
+		t.ClearRenderedGeometry()
 		return
 	}
 
@@ -115,6 +119,10 @@ func (t *TabsWidget) Render(surface Surface) {
 	tabAreaW := w - actionsW
 	if hasOverflow {
 		tabAreaW -= overflowW
+	}
+	if tabAreaW <= 0 {
+		t.ClearRenderedGeometry()
+		return
 	}
 
 	t.tabSpans = make([][2]int, len(t.Config.Items))
@@ -364,6 +372,7 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 			}
 			if t.Config.Reorderable && t.Config.OnReorder != nil {
 				t.drag.Begin(i, mx)
+				return EventCaptured
 			}
 			return EventConsumed
 		}
@@ -373,6 +382,27 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 
 func (t *TabsWidget) PointerGestureActive() bool {
 	return t.drag.Active()
+}
+
+func (t *TabsWidget) OwnsPointerCapture() bool {
+	return t.drag.Active()
+}
+
+func (t *TabsWidget) CancelPointerCapture() bool {
+	if !t.drag.Active() {
+		return false
+	}
+	t.drag.Cancel()
+	t.wasPressed = false
+	return true
+}
+
+func (t *TabsWidget) ClearRenderedGeometry() {
+	t.tabSpans = nil
+	t.overSpan = [2]int{}
+	t.actionSpans = nil
+	t.hiddenTabs = nil
+	t.CancelPointerCapture()
 }
 
 func (t *TabsWidget) dropTargetAt(localX int) int {

--- a/internal/widgets/tabs.go
+++ b/internal/widgets/tabs.go
@@ -19,31 +19,38 @@ type TabAction struct {
 }
 
 type TabsConfig struct {
-	Items       []TabItem   `json:"items"`
-	Actions     []TabAction `json:"-"`
-	Style       term.Style  `json:"-"`
-	Align       string      `json:"align,omitempty"`
-	Reorderable bool        `json:"-"`
-	OnTabClick  func(index int)
-	OnOverflow  func(screenX, screenY int)
-	OnReorder   func(from, to int)
+	Items                   []TabItem   `json:"items"`
+	Actions                 []TabAction `json:"-"`
+	Style                   term.Style  `json:"-"`
+	Align                   string      `json:"align,omitempty"`
+	Reorderable             bool        `json:"-"`
+	PointerInteractionValid func() bool `json:"-"`
+	OnTabClick              func(index int)
+	OnOverflow              func(screenX, screenY int)
+	OnReorder               func(from, to int)
 }
 
 type TabsWidget struct {
 	BaseWidget
-	Config      TabsConfig
-	tabSpans    [][2]int
-	overSpan    [2]int
-	actionSpans [][2]int
-	hiddenTabs  []int
-	wasPressed  bool
-	focused     bool
-	selected    int
-	drag        TabDragState
+	Config                    TabsConfig
+	tabSpans                  [][2]int
+	overSpan                  [2]int
+	actionSpans               [][2]int
+	hiddenTabs                []int
+	wasPressed                bool
+	focused                   bool
+	selected                  int
+	drag                      TabDragState
+	pointerCaptureInvalidated func()
 }
 
 func NewTabsWidget(config TabsConfig) *TabsWidget {
 	return &TabsWidget{Config: config}
+}
+
+func (t *TabsWidget) SetItems(items []TabItem) {
+	t.Config.Items = items
+	t.validateGestureSource()
 }
 
 func (t *TabsWidget) Height() int { return 1 + t.BoxOverheadH() }
@@ -83,9 +90,7 @@ func (t *TabsWidget) ActiveID() string {
 }
 
 func (t *TabsWidget) Render(surface Surface) {
-	if t.drag.Active() && t.drag.From() >= len(t.Config.Items) {
-		t.CancelPointerCapture()
-	}
+	t.validateGestureSource()
 	inner := t.RenderBox(surface)
 	w, _ := inner.Size()
 	if w <= 0 {
@@ -324,6 +329,9 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 	if mev.Buttons() == tcell.ButtonNone {
 		t.wasPressed = false
 		if t.drag.Active() {
+			if !t.validateGestureSource() {
+				return EventIgnored
+			}
 			from, to, dragged := t.drag.End()
 			if dragged && from != to && t.Config.OnReorder != nil {
 				t.Config.OnReorder(from, to)
@@ -335,6 +343,9 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 		return EventIgnored
 	}
 	if t.drag.Active() && pressed {
+		if !t.validateGestureSource() {
+			return EventIgnored
+		}
 		if t.drag.Update(mx, t.dropTargetAt(lx)) {
 			return EventCaptured
 		}
@@ -371,7 +382,7 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 				t.Config.OnTabClick(i)
 			}
 			if t.Config.Reorderable && t.Config.OnReorder != nil {
-				t.drag.Begin(i, mx)
+				t.drag.Begin(i, tabItemIdentity(t.Config.Items[i]), mx)
 				return EventCaptured
 			}
 			return EventConsumed
@@ -381,20 +392,27 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 }
 
 func (t *TabsWidget) PointerGestureActive() bool {
-	return t.drag.Active()
+	return t.validateGestureSource()
 }
 
 func (t *TabsWidget) OwnsPointerCapture() bool {
-	return t.drag.Active()
+	return t.validateGestureSource()
 }
 
 func (t *TabsWidget) CancelPointerCapture() bool {
-	if !t.drag.Active() {
-		return false
+	active := t.drag.Active()
+	if active {
+		t.drag.Cancel()
 	}
-	t.drag.Cancel()
 	t.wasPressed = false
-	return true
+	if active && t.pointerCaptureInvalidated != nil {
+		t.pointerCaptureInvalidated()
+	}
+	return active
+}
+
+func (t *TabsWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	t.pointerCaptureInvalidated = invalidated
 }
 
 func (t *TabsWidget) ClearRenderedGeometry() {
@@ -403,6 +421,38 @@ func (t *TabsWidget) ClearRenderedGeometry() {
 	t.actionSpans = nil
 	t.hiddenTabs = nil
 	t.CancelPointerCapture()
+}
+
+func (t *TabsWidget) InvalidatePointerInteraction() bool {
+	active := t.drag.Active()
+	t.ClearRenderedGeometry()
+	return active
+}
+
+func (t *TabsWidget) validateGestureSource() bool {
+	if !t.drag.Active() {
+		return false
+	}
+	if t.Config.PointerInteractionValid != nil && !t.Config.PointerInteractionValid() {
+		t.CancelPointerCapture()
+		return false
+	}
+	sourceID := t.drag.SourceID()
+	for i := range t.Config.Items {
+		if tabItemIdentity(t.Config.Items[i]) == sourceID {
+			t.drag.SetSourceIndex(i)
+			return true
+		}
+	}
+	t.CancelPointerCapture()
+	return false
+}
+
+func tabItemIdentity(item TabItem) string {
+	if item.ID != "" {
+		return item.ID
+	}
+	return item.Label
 }
 
 func (t *TabsWidget) dropTargetAt(localX int) int {

--- a/internal/widgets/tabs.go
+++ b/internal/widgets/tabs.go
@@ -2,6 +2,7 @@ package widgets
 
 import (
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -18,12 +19,14 @@ type TabAction struct {
 }
 
 type TabsConfig struct {
-	Items      []TabItem   `json:"items"`
-	Actions    []TabAction `json:"-"`
-	Style      term.Style  `json:"-"`
-	Align      string      `json:"align,omitempty"`
-	OnTabClick func(index int)
-	OnOverflow func(screenX, screenY int)
+	Items       []TabItem   `json:"items"`
+	Actions     []TabAction `json:"-"`
+	Style       term.Style  `json:"-"`
+	Align       string      `json:"align,omitempty"`
+	Reorderable bool        `json:"-"`
+	OnTabClick  func(index int)
+	OnOverflow  func(screenX, screenY int)
+	OnReorder   func(from, to int)
 }
 
 type TabsWidget struct {
@@ -36,6 +39,7 @@ type TabsWidget struct {
 	wasPressed  bool
 	focused     bool
 	selected    int
+	drag        TabDragState
 }
 
 func NewTabsWidget(config TabsConfig) *TabsWidget {
@@ -91,7 +95,7 @@ func (t *TabsWidget) Render(surface Surface) {
 
 	actionsW := 0
 	for _, a := range t.Config.Actions {
-		actionsW += len([]rune(a.Icon)) + 2
+		actionsW += textwidth.String(a.Icon) + 2
 	}
 
 	overflowW := 3
@@ -99,7 +103,7 @@ func (t *TabsWidget) Render(surface Surface) {
 	tabWidths := make([]int, len(t.Config.Items))
 	total := 0
 	for i, item := range t.Config.Items {
-		tw := len([]rune(item.Label)) + 2
+		tw := textwidth.String(item.Label) + 2
 		if item.Dirty {
 			tw += 2
 		}
@@ -166,13 +170,7 @@ func (t *TabsWidget) Render(surface Surface) {
 				inner.SetCell(x, 0, term.Cell{Ch: ' ', Style: style})
 				x++
 			}
-			for _, ch := range item.Label {
-				if x >= tabAreaW {
-					break
-				}
-				inner.SetCell(x, 0, term.Cell{Ch: ch, Style: style})
-				x++
-			}
+			x = inner.DrawText(x, 0, item.Label, tabAreaW, style)
 			if x < tabAreaW {
 				inner.SetCell(x, 0, term.Cell{Ch: ' ', Style: style})
 				x++
@@ -203,13 +201,7 @@ func (t *TabsWidget) Render(surface Surface) {
 				inner.SetCell(x, 0, term.Cell{Ch: ' ', Style: style})
 				x++
 			}
-			for _, ch := range item.Label {
-				if x >= tabAreaW {
-					break
-				}
-				inner.SetCell(x, 0, term.Cell{Ch: ch, Style: style})
-				x++
-			}
+			x = inner.DrawText(x, 0, item.Label, tabAreaW, style)
 			if x < tabAreaW {
 				inner.SetCell(x, 0, term.Cell{Ch: ' ', Style: style})
 				x++
@@ -234,18 +226,17 @@ func (t *TabsWidget) Render(surface Surface) {
 	t.actionSpans = t.actionSpans[:0]
 	ax := w - actionsW
 	for _, action := range t.Config.Actions {
-		iconRunes := []rune(action.Icon)
-		aw := len(iconRunes) + 2
 		startX := ax
 		inner.SetCell(ax, 0, term.Cell{Ch: ' ', Style: term.StyleInactiveTab})
 		ax++
-		for _, ch := range iconRunes {
-			inner.SetCell(ax, 0, term.Cell{Ch: ch, Style: term.StyleInactiveTab})
-			ax++
-		}
+		ax = inner.DrawText(ax, 0, action.Icon, w, term.StyleInactiveTab)
 		inner.SetCell(ax, 0, term.Cell{Ch: ' ', Style: term.StyleInactiveTab})
 		ax++
-		t.actionSpans = append(t.actionSpans, [2]int{startX, startX + aw})
+		t.actionSpans = append(t.actionSpans, [2]int{startX, ax})
+	}
+
+	if x := t.dropIndicatorX(); x >= 0 && x < w {
+		inner.SetCell(x, 0, term.Cell{Ch: '│', Style: term.StyleBorderActive})
 	}
 }
 
@@ -318,17 +309,38 @@ func (t *TabsWidget) handleKey(ev *tcell.EventKey) EventResult {
 
 func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 	pressed := mev.Buttons()&tcell.Button1 != 0
+	mx, my := mev.Position()
+	r := t.GetRect()
+	lx := mx - r.X - t.Box.MarginLeft - t.Box.PaddingLeft
+
+	if mev.Buttons() == tcell.ButtonNone {
+		t.wasPressed = false
+		if t.drag.Active() {
+			from, to, dragged := t.drag.End()
+			if dragged && from != to && t.Config.OnReorder != nil {
+				t.Config.OnReorder(from, to)
+			}
+			if dragged {
+				return EventConsumed
+			}
+		}
+		return EventIgnored
+	}
+	if t.drag.Active() && pressed {
+		if t.drag.Update(mx, t.dropTargetAt(lx)) {
+			return EventCaptured
+		}
+		return EventConsumed
+	}
+
 	freshClick := pressed && !t.wasPressed
 	t.wasPressed = pressed
 	if !freshClick {
 		return EventIgnored
 	}
-	mx, my := mev.Position()
-	r := t.GetRect()
 	if my < r.Y || my >= r.Y+r.H || mx < r.X || mx >= r.X+r.W {
 		return EventIgnored
 	}
-	lx := mx - r.X - t.Box.MarginLeft - t.Box.PaddingLeft
 
 	for i, span := range t.actionSpans {
 		if lx >= span[0] && lx < span[1] {
@@ -350,8 +362,47 @@ func (t *TabsWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 			if t.Config.OnTabClick != nil {
 				t.Config.OnTabClick(i)
 			}
+			if t.Config.Reorderable && t.Config.OnReorder != nil {
+				t.drag.Begin(i, mx)
+			}
 			return EventConsumed
 		}
 	}
 	return EventIgnored
+}
+
+func (t *TabsWidget) PointerGestureActive() bool {
+	return t.drag.Active()
+}
+
+func (t *TabsWidget) dropTargetAt(localX int) int {
+	last := -1
+	for i, span := range t.tabSpans {
+		if span[1] <= span[0] {
+			continue
+		}
+		last = i
+		if localX < span[0]+(span[1]-span[0])/2 {
+			return i
+		}
+	}
+	return last
+}
+
+func (t *TabsWidget) dropIndicatorX() int {
+	if !t.drag.Dragging() || t.drag.From() == t.drag.Target() {
+		return -1
+	}
+	target := t.drag.Target()
+	if target < 0 || target >= len(t.tabSpans) {
+		return -1
+	}
+	span := t.tabSpans[target]
+	if span[1] <= span[0] {
+		return -1
+	}
+	if target < t.drag.From() {
+		return span[0]
+	}
+	return span[1] - 1
 }

--- a/internal/widgets/tabs_test.go
+++ b/internal/widgets/tabs_test.go
@@ -3,6 +3,9 @@ package widgets
 import (
 	"strings"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v3"
 )
 
 func tabsRowText(s *testSurface, y int) string {
@@ -18,6 +21,84 @@ func tabsRowText(s *testSurface, y int) string {
 		}
 	}
 	return string(runes)
+}
+
+func TestTabsDragCapturesOnlyAfterThreshold(t *testing.T) {
+	var from, to = -1, -1
+	tw := NewTabsWidget(TabsConfig{
+		Items: []TabItem{
+			{ID: "explorer", Label: "Explore", Active: true},
+			{ID: "search", Label: "Find"},
+			{ID: "changes", Label: "Changes"},
+		},
+		Reorderable: true,
+		OnReorder: func(f, target int) {
+			from, to = f, target
+		},
+	})
+	s := renderWidget(tw, 0, 0, 40, 1)
+	start := tw.tabSpans[0][0] + 2
+	end := tw.tabSpans[2][0] + 2
+	if got := tw.HandleEvent(tcell.NewEventMouse(start, 0, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("mouse down result = %v, want EventConsumed", got)
+	}
+	if got := tw.HandleEvent(tcell.NewEventMouse(start+1, 0, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("jitter result = %v, want EventConsumed", got)
+	}
+	if got := tw.HandleEvent(tcell.NewEventMouse(end, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("drag result = %v, want EventCaptured", got)
+	}
+	tw.Render(s)
+	foundIndicator := false
+	for _, cell := range s.cells[0] {
+		if cell.Ch == '│' && cell.Style == term.StyleBorderActive {
+			foundIndicator = true
+		}
+	}
+	if !foundIndicator {
+		t.Fatal("drag should render a themed drop indicator")
+	}
+	tw.HandleEvent(tcell.NewEventMouse(end, 0, tcell.ButtonNone, 0))
+	if from != 0 || to != 2 {
+		t.Fatalf("reorder = %d -> %d, want 0 -> 2", from, to)
+	}
+}
+
+func TestTabsClickJitterActivatesWithoutReorder(t *testing.T) {
+	clicked, reordered := -1, false
+	tw := NewTabsWidget(TabsConfig{
+		Items:       []TabItem{{ID: "a", Label: "Alpha"}, {ID: "b", Label: "Beta"}},
+		Reorderable: true,
+		OnTabClick:  func(i int) { clicked = i },
+		OnReorder:   func(_, _ int) { reordered = true },
+	})
+	renderWidget(tw, 0, 0, 30, 1)
+	x := tw.tabSpans[0][0] + 2
+	tw.HandleEvent(tcell.NewEventMouse(x, 0, tcell.Button1, 0))
+	tw.HandleEvent(tcell.NewEventMouse(x+1, 0, tcell.Button1, 0))
+	tw.HandleEvent(tcell.NewEventMouse(x+1, 0, tcell.ButtonNone, 0))
+	if clicked != 0 {
+		t.Fatalf("clicked = %d, want 0", clicked)
+	}
+	if reordered {
+		t.Fatal("one-column jitter reordered a tab")
+	}
+}
+
+func TestTabsWideLabelsStoreDisplayColumnSpans(t *testing.T) {
+	clicked := -1
+	tw := NewTabsWidget(TabsConfig{
+		Items:      []TabItem{{ID: "search", Label: "検索"}, {ID: "changes", Label: "Changes"}},
+		OnTabClick: func(i int) { clicked = i },
+	})
+	renderWidget(tw, 0, 0, 30, 1)
+	if got := tw.tabSpans[1][0]; got != 6 {
+		t.Fatalf("second tab starts at column %d, want 6 after two fullwidth runes", got)
+	}
+	tw.HandleEvent(tcell.NewEventMouse(7, 0, tcell.Button1, 0))
+	if clicked != 1 {
+		t.Fatalf("wide-label hit test activated %d, want 1", clicked)
+	}
 }
 
 func TestTabsAllFit(t *testing.T) {

--- a/internal/widgets/tabs_test.go
+++ b/internal/widgets/tabs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -21,6 +22,14 @@ func tabsRowText(s *testSurface, y int) string {
 		}
 	}
 	return string(runes)
+}
+
+func tabsTextColumn(row, label string) int {
+	byteOffset := strings.Index(row, label)
+	if byteOffset < 0 {
+		return -1
+	}
+	return textwidth.String(row[:byteOffset])
 }
 
 func TestTabsDragCapturesPendingPressBeforeThreshold(t *testing.T) {
@@ -111,6 +120,32 @@ func TestTabsNonRenderableResizeClearsGestureAndGeometry(t *testing.T) {
 	}
 }
 
+func TestTabsRemovedSourceDoesNotRetargetReplacementAtSameIndex(t *testing.T) {
+	tw := NewTabsWidget(TabsConfig{
+		Items:       []TabItem{{ID: "a", Label: "A"}, {ID: "b", Label: "B"}, {ID: "c", Label: "C"}},
+		Reorderable: true,
+	})
+	var moves [][2]int
+	tw.Config.OnReorder = func(from, to int) { moves = append(moves, [2]int{from, to}) }
+	renderWidget(tw, 0, 0, 30, 1)
+	pressX := tw.tabSpans[1][0] + 1
+	if got := tw.HandleEvent(tcell.NewEventMouse(pressX, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("b mouse down = %v, want captured", got)
+	}
+	if got := tw.drag.SourceID(); got != "b" {
+		t.Fatalf("pressed source = %q, want b", got)
+	}
+
+	tw.SetItems([]TabItem{{ID: "a", Label: "A"}, {ID: "c", Label: "C"}, {ID: "d", Label: "D"}})
+	if tw.OwnsPointerCapture() {
+		t.Fatal("removed b retained capture when c occupied index 1")
+	}
+	tw.HandleEvent(tcell.NewEventMouse(tw.tabSpans[2][0]+1, 0, tcell.ButtonNone, 0))
+	if len(moves) != 0 {
+		t.Fatalf("release after source removal reordered replacement: %v", moves)
+	}
+}
+
 func TestTabsWideLabelsStoreDisplayColumnSpans(t *testing.T) {
 	clicked := -1
 	tw := NewTabsWidget(TabsConfig{
@@ -180,8 +215,8 @@ func TestTabsOverflowPreservesOrder(t *testing.T) {
 		t.Fatalf("active tab should be visible, got: %q", row)
 	}
 	// Visible tabs should maintain their original order
-	explorerPos := strings.Index(row, "Explorer")
-	changesPos := strings.Index(row, "Changes")
+	explorerPos := tabsTextColumn(row, "Explorer")
+	changesPos := tabsTextColumn(row, "Changes")
 	if explorerPos >= 0 && changesPos >= 0 && explorerPos > changesPos {
 		t.Fatalf("visible tabs should maintain original order, got: %q", row)
 	}

--- a/internal/widgets/tabs_test.go
+++ b/internal/widgets/tabs_test.go
@@ -23,7 +23,7 @@ func tabsRowText(s *testSurface, y int) string {
 	return string(runes)
 }
 
-func TestTabsDragCapturesOnlyAfterThreshold(t *testing.T) {
+func TestTabsDragCapturesPendingPressBeforeThreshold(t *testing.T) {
 	var from, to = -1, -1
 	tw := NewTabsWidget(TabsConfig{
 		Items: []TabItem{
@@ -39,8 +39,8 @@ func TestTabsDragCapturesOnlyAfterThreshold(t *testing.T) {
 	s := renderWidget(tw, 0, 0, 40, 1)
 	start := tw.tabSpans[0][0] + 2
 	end := tw.tabSpans[2][0] + 2
-	if got := tw.HandleEvent(tcell.NewEventMouse(start, 0, tcell.Button1, 0)); got != EventConsumed {
-		t.Fatalf("mouse down result = %v, want EventConsumed", got)
+	if got := tw.HandleEvent(tcell.NewEventMouse(start, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down result = %v, want EventCaptured", got)
 	}
 	if got := tw.HandleEvent(tcell.NewEventMouse(start+1, 0, tcell.Button1, 0)); got != EventConsumed {
 		t.Fatalf("jitter result = %v, want EventConsumed", got)
@@ -74,7 +74,9 @@ func TestTabsClickJitterActivatesWithoutReorder(t *testing.T) {
 	})
 	renderWidget(tw, 0, 0, 30, 1)
 	x := tw.tabSpans[0][0] + 2
-	tw.HandleEvent(tcell.NewEventMouse(x, 0, tcell.Button1, 0))
+	if got := tw.HandleEvent(tcell.NewEventMouse(x, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down result = %v, want EventCaptured", got)
+	}
 	tw.HandleEvent(tcell.NewEventMouse(x+1, 0, tcell.Button1, 0))
 	tw.HandleEvent(tcell.NewEventMouse(x+1, 0, tcell.ButtonNone, 0))
 	if clicked != 0 {
@@ -82,6 +84,30 @@ func TestTabsClickJitterActivatesWithoutReorder(t *testing.T) {
 	}
 	if reordered {
 		t.Fatal("one-column jitter reordered a tab")
+	}
+	if tw.PointerGestureActive() {
+		t.Fatal("click release left a pending tab gesture")
+	}
+}
+
+func TestTabsNonRenderableResizeClearsGestureAndGeometry(t *testing.T) {
+	tw := NewTabsWidget(TabsConfig{
+		Items:       []TabItem{{ID: "a", Label: "Alpha"}, {ID: "b", Label: "Beta"}},
+		Reorderable: true,
+		OnReorder:   func(_, _ int) {},
+	})
+	renderWidget(tw, 0, 0, 30, 1)
+	x := tw.tabSpans[0][0] + 2
+	if got := tw.HandleEvent(tcell.NewEventMouse(x, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("mouse down = %v, want captured", got)
+	}
+
+	renderWidget(tw, 0, 0, 0, 1)
+	if tw.PointerGestureActive() {
+		t.Fatal("non-renderable tabs retained a pending gesture")
+	}
+	if len(tw.tabSpans) != 0 || len(tw.actionSpans) != 0 || tw.overSpan != [2]int{} {
+		t.Fatal("non-renderable tabs retained old hit geometry")
 	}
 }
 

--- a/internal/widgets/vstack.go
+++ b/internal/widgets/vstack.go
@@ -83,6 +83,7 @@ func (v *VStackWidget) Render(surface Surface) {
 	inner := v.RenderBox(surface)
 	w, h := inner.Size()
 	if len(v.Children) == 0 || w <= 0 || h <= 0 {
+		v.InvalidatePointerInteraction()
 		return
 	}
 
@@ -144,6 +145,7 @@ func (v *VStackWidget) Render(surface Surface) {
 			growIndex++
 		}
 		if ch <= 0 || y >= h {
+			InvalidatePointerInteraction(child)
 			continue
 		}
 		if y+ch > h {
@@ -169,12 +171,25 @@ func (v *VStackWidget) HandleEvent(ev tcell.Event) EventResult {
 }
 
 func (v *VStackWidget) CancelPointerCapture() bool {
+	canceled := false
 	for _, child := range v.Children {
-		if canceler, ok := child.(PointerCaptureCanceler); ok && canceler.CancelPointerCapture() {
-			return true
-		}
+		canceled = CancelPointerCapture(child) || canceled
 	}
-	return false
+	return canceled
+}
+
+func (v *VStackWidget) InvalidatePointerInteraction() bool {
+	invalidated := false
+	for _, child := range v.Children {
+		invalidated = InvalidatePointerInteraction(child) || invalidated
+	}
+	return invalidated
+}
+
+func (v *VStackWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	for _, child := range v.Children {
+		SetPointerCaptureInvalidated(child, invalidated)
+	}
 }
 
 func (v *VStackWidget) OwnsPointerCapture() bool {

--- a/internal/widgets/vstack.go
+++ b/internal/widgets/vstack.go
@@ -167,3 +167,21 @@ func (v *VStackWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 	return EventIgnored
 }
+
+func (v *VStackWidget) CancelPointerCapture() bool {
+	for _, child := range v.Children {
+		if canceler, ok := child.(PointerCaptureCanceler); ok && canceler.CancelPointerCapture() {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *VStackWidget) OwnsPointerCapture() bool {
+	for _, child := range v.Children {
+		if owner, ok := child.(PointerCaptureOwner); ok && owner.OwnsPointerCapture() {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e/editor_tab_reorder_test.go
+++ b/tests/e2e/editor_tab_reorder_test.go
@@ -1,10 +1,12 @@
 package e2e
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/gdamore/tcell/v3"
@@ -21,13 +23,16 @@ func TestEditorTabDragReordersThroughRootAndKeepsActiveFile(t *testing.T) {
 
 	tabsY := h.app.EditorGroup.TabBar.GetRect().Y + 1
 	row := h.screenRow(tabsY)
-	gammaX := strings.Index(row, "gamma.txt")
-	if !strings.Contains(row, "alpha.txt") || gammaX < 0 {
+	gammaX := displayColumnOf(row, "gamma.txt")
+	if displayColumnOf(row, "alpha.txt") < 0 || gammaX < 0 {
 		t.Fatalf("tab labels not visible in %q", row)
 	}
 
 	if got := h.app.Root.HandleEvent(tcell.NewEventMouse(gammaX+2, tabsY, tcell.Button1, 0)); got != ui.EventConsumed {
 		t.Fatalf("mouse down result = %v, want EventConsumed", got)
+	}
+	if got := filepath.Base(h.app.EditorGroup.ActiveFilePath()); got != "gamma.txt" {
+		t.Fatalf("pressed source = %q, want gamma.txt", got)
 	}
 	dropX := h.app.EditorGroup.TabBar.GetRect().X
 	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.Button1, 0))
@@ -35,18 +40,117 @@ func TestEditorTabDragReordersThroughRootAndKeepsActiveFile(t *testing.T) {
 	h.redraw()
 
 	path0, _ := h.app.EditorGroup.TabInfo(0)
-	if !strings.HasSuffix(path0, "gamma.txt") {
+	if filepath.Base(path0) != "gamma.txt" {
 		t.Fatalf("first tab = %q, want gamma.txt", path0)
 	}
-	if got := h.app.EditorGroup.ActiveFilePath(); !strings.HasSuffix(got, "gamma.txt") {
+	if got := h.app.EditorGroup.ActiveFilePath(); filepath.Base(got) != "gamma.txt" {
 		t.Fatalf("active file = %q, want gamma.txt", got)
 	}
 
 	h.exec("tab.moveRight")
 	path1, _ := h.app.EditorGroup.TabInfo(1)
-	if !strings.HasSuffix(path1, "gamma.txt") {
+	if filepath.Base(path1) != "gamma.txt" {
 		t.Fatalf("command fallback moved tab to %q, want gamma.txt at index 1", path1)
 	}
+}
+
+func TestEditorRemovedDragSourceDoesNotRetargetSameIndex(t *testing.T) {
+	h := newTestHarness(t, 120, 30)
+	defer h.stop()
+	for _, name := range []string{"alpha.txt", "beta.txt", "gamma.txt"} {
+		h.app.EditorGroup.OpenFile(filepath.Join(h.dir, name))
+		h.app.EditorGroup.CommitActiveTab()
+	}
+	h.redraw()
+
+	tabsY := h.app.EditorGroup.TabBar.GetRect().Y + 1
+	betaX := displayColumnOf(h.screenRow(tabsY), "beta.txt")
+	if betaX < 0 {
+		t.Fatal("beta tab is not visible")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(betaX+2, tabsY, tcell.Button1, 0))
+	if got := filepath.Base(h.app.EditorGroup.ActiveFilePath()); got != "beta.txt" {
+		t.Fatalf("pressed source = %q, want beta.txt", got)
+	}
+
+	h.app.EditorGroup.CloseTab()
+	postRemoval := editorTabPaths(h)
+	if slices.ContainsFunc(postRemoval, func(path string) bool { return filepath.Base(path) == "beta.txt" }) {
+		t.Fatal("test setup did not remove beta")
+	}
+	if h.app.Root.PointerCaptureActive() || h.app.EditorGroup.TabBar.OwnsPointerCapture() {
+		t.Fatal("removing beta retained pointer capture")
+	}
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "beta.txt"))
+	h.app.EditorGroup.CommitActiveTab()
+	postReopen := editorTabPaths(h)
+	h.app.Root.HandleEvent(tcell.NewEventMouse(betaX+20, tabsY, tcell.ButtonNone, 0))
+	if got := editorTabPaths(h); !slices.Equal(got, postReopen) {
+		t.Fatalf("release after rapid beta reopen reordered tabs: got %v, want %v", got, postReopen)
+	}
+}
+
+func TestEditorFullscreenHideCancelsQueuedAutoScrollGeneration(t *testing.T) {
+	h := newTestHarness(t, 70, 24)
+	defer h.stop()
+	for i := range 12 {
+		name := fmt.Sprintf("overflow-%02d.txt", i)
+		path := filepath.Join(h.dir, name)
+		if err := os.WriteFile(path, []byte(name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		h.app.EditorGroup.OpenFile(path)
+		h.app.EditorGroup.CommitActiveTab()
+	}
+	first := filepath.Join(h.dir, "overflow-00.txt")
+	if !h.app.EditorGroup.SwitchToTabByPath(first) {
+		t.Fatal("could not activate first overflow tab")
+	}
+	h.redraw()
+
+	ticks := make(chan uint64, 2)
+	h.app.EditorGroup.TabBar.PostDragAutoScrollTick = func(generation uint64) { ticks <- generation }
+	tabsRect := h.app.EditorGroup.TabBar.GetRect()
+	tabsY := tabsRect.Y + 1
+	firstX := displayColumnOf(h.screenRow(tabsY), "overflow-00.txt")
+	if firstX < 0 {
+		t.Fatal("first overflow tab is not visible")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(firstX+2, tabsY, tcell.Button1, 0))
+	if got := filepath.Base(h.app.EditorGroup.ActiveFilePath()); got != "overflow-00.txt" {
+		t.Fatalf("pressed source = %q, want overflow-00.txt", got)
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(tabsRect.X+tabsRect.W-6, tabsY, tcell.Button1, 0))
+
+	var generation uint64
+	select {
+	case generation = <-ticks:
+	case <-time.After(time.Second):
+		t.Fatal("edge drag did not queue an auto-scroll tick")
+	}
+	h.app.ContentSplit.ShowBottom = true
+	h.app.ContentSplit.BottomH = h.app.ContentSplit.GetRect().H - 1
+	if h.app.EditorGroup.TabBar.HandleDragAutoScrollTick(generation) {
+		t.Fatal("fullscreen-hidden editor accepted an old auto-scroll generation")
+	}
+	if h.app.Root.PointerCaptureActive() || h.app.EditorGroup.TabBar.OwnsPointerCapture() {
+		t.Fatal("fullscreen-hidden editor retained pointer capture")
+	}
+	h.redraw()
+	h.app.Root.HandleEvent(tcell.NewEventMouse(firstX+20, tabsY, tcell.ButtonNone, 0))
+	select {
+	case next := <-ticks:
+		t.Fatalf("old auto-scroll generation rearmed tick %d", next)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func editorTabPaths(h *testHarness) []string {
+	paths := make([]string, h.app.EditorGroup.TabCount())
+	for i := range paths {
+		paths[i], _ = h.app.EditorGroup.TabInfo(i)
+	}
+	return paths
 }
 
 func TestEditorPendingTabDragOwnsCrossContentSplitRelease(t *testing.T) {
@@ -61,7 +165,7 @@ func TestEditorPendingTabDragOwnsCrossContentSplitRelease(t *testing.T) {
 
 	tabsY := h.app.EditorGroup.TabBar.GetRect().Y + 1
 	row := h.screenRow(tabsY)
-	gammaX := strings.Index(row, "gamma.txt")
+	gammaX := displayColumnOf(row, "gamma.txt")
 	if gammaX < 0 {
 		t.Fatalf("gamma tab not visible in %q", row)
 	}
@@ -80,13 +184,13 @@ func TestEditorPendingTabDragOwnsCrossContentSplitRelease(t *testing.T) {
 		afterRelease[i], _ = h.app.EditorGroup.TabInfo(i)
 	}
 	row = h.screenRow(tabsY)
-	alphaX := strings.Index(row, "alpha.txt")
+	alphaX := displayColumnOf(row, "alpha.txt")
 	if alphaX < 0 {
 		t.Fatalf("alpha tab not visible after release in %q", row)
 	}
 	h.click(alphaX+2, tabsY)
 
-	if got := h.app.EditorGroup.ActiveFilePath(); !strings.HasSuffix(got, "alpha.txt") {
+	if got := h.app.EditorGroup.ActiveFilePath(); filepath.Base(got) != "alpha.txt" {
 		t.Fatalf("active file = %q, want alpha.txt", got)
 	}
 	afterClick := make([]string, h.app.EditorGroup.TabCount())

--- a/tests/e2e/editor_tab_reorder_test.go
+++ b/tests/e2e/editor_tab_reorder_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestEditorTabDragReordersThroughRootAndKeepsActiveFile(t *testing.T) {
+	h := newTestHarness(t, 120, 30)
+	defer h.stop()
+	for _, name := range []string{"alpha.txt", "beta.txt", "gamma.txt"} {
+		h.app.EditorGroup.OpenFile(filepath.Join(h.dir, name))
+		h.app.EditorGroup.CommitActiveTab()
+	}
+	h.redraw()
+
+	tabsY := h.app.EditorGroup.TabBar.GetRect().Y + 1
+	row := h.screenRow(tabsY)
+	gammaX := strings.Index(row, "gamma.txt")
+	if !strings.Contains(row, "alpha.txt") || gammaX < 0 {
+		t.Fatalf("tab labels not visible in %q", row)
+	}
+
+	if got := h.app.Root.HandleEvent(tcell.NewEventMouse(gammaX+2, tabsY, tcell.Button1, 0)); got != ui.EventConsumed {
+		t.Fatalf("mouse down result = %v, want EventConsumed", got)
+	}
+	dropX := h.app.EditorGroup.TabBar.GetRect().X
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.Button1, 0))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.ButtonNone, 0))
+	h.redraw()
+
+	path0, _ := h.app.EditorGroup.TabInfo(0)
+	if !strings.HasSuffix(path0, "gamma.txt") {
+		t.Fatalf("first tab = %q, want gamma.txt", path0)
+	}
+	if got := h.app.EditorGroup.ActiveFilePath(); !strings.HasSuffix(got, "gamma.txt") {
+		t.Fatalf("active file = %q, want gamma.txt", got)
+	}
+
+	h.exec("tab.moveRight")
+	path1, _ := h.app.EditorGroup.TabInfo(1)
+	if !strings.HasSuffix(path1, "gamma.txt") {
+		t.Fatalf("command fallback moved tab to %q, want gamma.txt at index 1", path1)
+	}
+}

--- a/tests/e2e/editor_tab_reorder_test.go
+++ b/tests/e2e/editor_tab_reorder_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -45,5 +46,54 @@ func TestEditorTabDragReordersThroughRootAndKeepsActiveFile(t *testing.T) {
 	path1, _ := h.app.EditorGroup.TabInfo(1)
 	if !strings.HasSuffix(path1, "gamma.txt") {
 		t.Fatalf("command fallback moved tab to %q, want gamma.txt at index 1", path1)
+	}
+}
+
+func TestEditorPendingTabDragOwnsCrossContentSplitRelease(t *testing.T) {
+	h := newTestHarness(t, 120, 30)
+	defer h.stop()
+	for _, name := range []string{"alpha.txt", "beta.txt", "gamma.txt"} {
+		h.app.EditorGroup.OpenFile(filepath.Join(h.dir, name))
+		h.app.EditorGroup.CommitActiveTab()
+	}
+	h.app.ShowBottomPanel()
+	h.redraw()
+
+	tabsY := h.app.EditorGroup.TabBar.GetRect().Y + 1
+	row := h.screenRow(tabsY)
+	gammaX := strings.Index(row, "gamma.txt")
+	if gammaX < 0 {
+		t.Fatalf("gamma tab not visible in %q", row)
+	}
+
+	h.app.Root.HandleEvent(tcell.NewEventMouse(gammaX+2, tabsY, tcell.Button1, 0))
+	bottomY := h.app.ContentSplit.DividerScreenY() + 2
+	h.app.Root.HandleEvent(tcell.NewEventMouse(gammaX+2, bottomY, tcell.Button1, 0))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(gammaX+2, bottomY, tcell.ButtonNone, 0))
+	h.redraw()
+
+	if h.app.EditorGroup.TabBar.OwnsPointerCapture() {
+		t.Fatal("cross-content release left a stale editor tab gesture")
+	}
+	afterRelease := make([]string, h.app.EditorGroup.TabCount())
+	for i := range afterRelease {
+		afterRelease[i], _ = h.app.EditorGroup.TabInfo(i)
+	}
+	row = h.screenRow(tabsY)
+	alphaX := strings.Index(row, "alpha.txt")
+	if alphaX < 0 {
+		t.Fatalf("alpha tab not visible after release in %q", row)
+	}
+	h.click(alphaX+2, tabsY)
+
+	if got := h.app.EditorGroup.ActiveFilePath(); !strings.HasSuffix(got, "alpha.txt") {
+		t.Fatalf("active file = %q, want alpha.txt", got)
+	}
+	afterClick := make([]string, h.app.EditorGroup.TabCount())
+	for i := range afterClick {
+		afterClick[i], _ = h.app.EditorGroup.TabInfo(i)
+	}
+	if !slices.Equal(afterClick, afterRelease) {
+		t.Fatalf("ordinary alpha click reordered tabs: got %v, want %v", afterClick, afterRelease)
 	}
 }

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -28,6 +28,14 @@ type testHarness struct {
 	dir      string
 }
 
+func displayColumnOf(row, label string) int {
+	byteOffset := strings.Index(row, label)
+	if byteOffset < 0 {
+		return -1
+	}
+	return textwidth.String(row[:byteOffset])
+}
+
 func newTestHarness(t *testing.T, w, h int) *testHarness {
 	t.Helper()
 

--- a/tests/e2e/sidebar_reorder_test.go
+++ b/tests/e2e/sidebar_reorder_test.go
@@ -143,3 +143,53 @@ func TestSidebarPendingTabDragOwnsCrossDividerRelease(t *testing.T) {
 		t.Fatalf("ordinary Explore click reordered panels: got %v, want %v", got, afterRelease)
 	}
 }
+
+func TestSidebarDuplicatePluginAddDuringDragCannotRetargetRelease(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	original := newEmptyWidget()
+	replacement := newEmptyWidget()
+	h.app.Sidebar.SetPanelOrder([]string{"changes", "plugin.late", "explorer", "search", "outline"})
+	h.app.Sidebar.AddPanel("plugin.late", "Late", original)
+	h.app.Sidebar.SetActivePanel("plugin.late")
+	h.redraw()
+
+	tabsY := h.app.Sidebar.Tabs.GetRect().Y
+	lateX := displayColumnOf(h.screenRow(tabsY), "Late")
+	if lateX < 0 {
+		t.Fatal("late plugin tab is not visible")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(lateX+2, tabsY, tcell.Button1, 0))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(lateX+8, tabsY, tcell.Button1, 0))
+	if !h.app.Root.PointerCaptureActive() || !h.app.Sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("test setup did not establish a captured plugin tab drag")
+	}
+	h.app.Sidebar.AddPanel("plugin.late", "Replacement", replacement)
+
+	wantWithPlugin := []string{"changes", "plugin.late", "explorer", "search", "outline"}
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, wantWithPlugin) {
+		t.Fatalf("duplicate add panel order = %v, want %v", got, wantWithPlugin)
+	}
+	if h.app.Sidebar.ActivePanel != "plugin.late" || h.app.Sidebar.ActiveWidget() != original {
+		t.Fatal("duplicate add replaced the active plugin surface")
+	}
+
+	h.app.Sidebar.RemovePanel("plugin.late")
+	afterRemoval := slices.Clone(h.app.Sidebar.PanelIDs())
+	if h.app.Root.PointerCaptureActive() || h.app.Sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("removing duplicate-add source retained pointer capture")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(lateX+15, tabsY, tcell.ButtonNone, 0))
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, afterRemoval) {
+		t.Fatalf("release retargeted surviving panel: got %v, want %v", got, afterRemoval)
+	}
+
+	h.app.Sidebar.AddPanel("plugin.late", "Reloaded", replacement)
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, wantWithPlugin) {
+		t.Fatalf("reloaded plugin order = %v, want %v", got, wantWithPlugin)
+	}
+	h.app.Sidebar.SetActivePanel("plugin.late")
+	if h.app.Sidebar.ActiveWidget() != replacement {
+		t.Fatal("remove and re-add did not wire the reloaded plugin surface")
+	}
+}

--- a/tests/e2e/sidebar_reorder_test.go
+++ b/tests/e2e/sidebar_reorder_test.go
@@ -48,3 +48,40 @@ func TestSidebarHeaderDragReordersAndPersists(t *testing.T) {
 		t.Fatalf("command panel order = %v, want %v", got, want)
 	}
 }
+
+func TestSidebarPendingTabDragOwnsCrossDividerRelease(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	h.exec("sidebar.changes")
+
+	tabsY := h.app.Sidebar.Tabs.GetRect().Y
+	row := h.screenRow(tabsY)
+	changesX := strings.Index(row, "Changes")
+	if changesX < 0 {
+		t.Fatalf("Changes tab not visible in %q", row)
+	}
+
+	h.app.Root.HandleEvent(tcell.NewEventMouse(changesX+2, tabsY, tcell.Button1, 0))
+	crossX := h.app.SplitPanel.DividerScreenX() + 2
+	h.app.Root.HandleEvent(tcell.NewEventMouse(crossX, tabsY, tcell.Button1, 0))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(crossX, tabsY, tcell.ButtonNone, 0))
+	h.redraw()
+
+	if h.app.Sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("cross-divider release left a stale sidebar tab gesture")
+	}
+	afterRelease := slices.Clone(h.app.Sidebar.PanelIDs())
+	row = h.screenRow(tabsY)
+	explorerX := strings.Index(row, "Explore")
+	if explorerX < 0 {
+		t.Fatalf("Explore tab not visible after release in %q", row)
+	}
+	h.click(explorerX+2, tabsY)
+
+	if h.app.Sidebar.ActivePanel != "explorer" {
+		t.Fatalf("active panel = %q, want explorer", h.app.Sidebar.ActivePanel)
+	}
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, afterRelease) {
+		t.Fatalf("ordinary Explore click reordered panels: got %v, want %v", got, afterRelease)
+	}
+}

--- a/tests/e2e/sidebar_reorder_test.go
+++ b/tests/e2e/sidebar_reorder_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/config"
@@ -17,14 +16,17 @@ func TestSidebarHeaderDragReordersAndPersists(t *testing.T) {
 
 	tabsY := h.app.Sidebar.Tabs.GetRect().Y
 	row := h.screenRow(tabsY)
-	changesX := strings.Index(row, "Changes")
-	explorerX := strings.Index(row, "Explore")
+	changesX := displayColumnOf(row, "Changes")
+	explorerX := displayColumnOf(row, "Explore")
 	if changesX < 0 || explorerX < 0 {
 		t.Fatalf("tab labels not visible in %q", row)
 	}
 
 	if got := h.app.Root.HandleEvent(tcell.NewEventMouse(changesX+2, tabsY, tcell.Button1, 0)); got != ui.EventConsumed {
 		t.Fatalf("mouse down result = %v, want EventConsumed", got)
+	}
+	if got := h.app.Sidebar.ActivePanel; got != "changes" {
+		t.Fatalf("pressed source = %q, want changes", got)
 	}
 	dropX := h.app.Sidebar.Tabs.GetRect().X
 	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.Button1, 0))
@@ -49,6 +51,62 @@ func TestSidebarHeaderDragReordersAndPersists(t *testing.T) {
 	}
 }
 
+func TestSidebarRemovedDragSourceDoesNotRetargetSameIndex(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	h.redraw()
+
+	tabsY := h.app.Sidebar.Tabs.GetRect().Y
+	searchX := displayColumnOf(h.screenRow(tabsY), "Find")
+	if searchX < 0 {
+		t.Fatal("Find panel tab is not visible")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(searchX+2, tabsY, tcell.Button1, 0))
+	if got := h.app.Sidebar.ActivePanel; got != "search" {
+		t.Fatalf("pressed source = %q, want search", got)
+	}
+
+	h.app.Sidebar.RemovePanel("search")
+	postRemoval := slices.Clone(h.app.Sidebar.PanelIDs())
+	if slices.Contains(postRemoval, "search") || len(postRemoval) < 2 || postRemoval[1] != "changes" {
+		t.Fatalf("test setup did not replace numeric index 1 with changes: %v", postRemoval)
+	}
+	if h.app.Root.PointerCaptureActive() || h.app.Sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("removing search retained pointer capture")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(searchX+15, tabsY, tcell.ButtonNone, 0))
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, postRemoval) {
+		t.Fatalf("release reordered search's replacement: got %v, want %v", got, postRemoval)
+	}
+}
+
+func TestHiddenSidebarCancelsGestureAndReleaseIsNoOp(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	h.redraw()
+
+	tabsY := h.app.Sidebar.Tabs.GetRect().Y
+	changesX := displayColumnOf(h.screenRow(tabsY), "Changes")
+	if changesX < 0 {
+		t.Fatal("Changes panel tab is not visible")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(changesX+2, tabsY, tcell.Button1, 0))
+	if got := h.app.Sidebar.ActivePanel; got != "changes" {
+		t.Fatalf("pressed source = %q, want changes", got)
+	}
+	before := slices.Clone(h.app.Sidebar.PanelIDs())
+
+	h.app.HideSidebar()
+	h.redraw()
+	if h.app.Root.PointerCaptureActive() || h.app.Sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("hidden sidebar retained pointer capture")
+	}
+	h.app.Root.HandleEvent(tcell.NewEventMouse(changesX+15, tabsY, tcell.ButtonNone, 0))
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, before) {
+		t.Fatalf("release after hide reordered panels: got %v, want %v", got, before)
+	}
+}
+
 func TestSidebarPendingTabDragOwnsCrossDividerRelease(t *testing.T) {
 	h := newTestHarness(t, 100, 24)
 	defer h.stop()
@@ -56,7 +114,7 @@ func TestSidebarPendingTabDragOwnsCrossDividerRelease(t *testing.T) {
 
 	tabsY := h.app.Sidebar.Tabs.GetRect().Y
 	row := h.screenRow(tabsY)
-	changesX := strings.Index(row, "Changes")
+	changesX := displayColumnOf(row, "Changes")
 	if changesX < 0 {
 		t.Fatalf("Changes tab not visible in %q", row)
 	}
@@ -72,7 +130,7 @@ func TestSidebarPendingTabDragOwnsCrossDividerRelease(t *testing.T) {
 	}
 	afterRelease := slices.Clone(h.app.Sidebar.PanelIDs())
 	row = h.screenRow(tabsY)
-	explorerX := strings.Index(row, "Explore")
+	explorerX := displayColumnOf(row, "Explore")
 	if explorerX < 0 {
 		t.Fatalf("Explore tab not visible after release in %q", row)
 	}

--- a/tests/e2e/sidebar_reorder_test.go
+++ b/tests/e2e/sidebar_reorder_test.go
@@ -1,0 +1,50 @@
+package e2e
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestSidebarHeaderDragReordersAndPersists(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	h.exec("sidebar.changes")
+
+	tabsY := h.app.Sidebar.Tabs.GetRect().Y
+	row := h.screenRow(tabsY)
+	changesX := strings.Index(row, "Changes")
+	explorerX := strings.Index(row, "Explore")
+	if changesX < 0 || explorerX < 0 {
+		t.Fatalf("tab labels not visible in %q", row)
+	}
+
+	if got := h.app.Root.HandleEvent(tcell.NewEventMouse(changesX+2, tabsY, tcell.Button1, 0)); got != ui.EventConsumed {
+		t.Fatalf("mouse down result = %v, want EventConsumed", got)
+	}
+	dropX := h.app.Sidebar.Tabs.GetRect().X
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.Button1, 0))
+	h.app.Root.HandleEvent(tcell.NewEventMouse(dropX, tabsY, tcell.ButtonNone, 0))
+	h.redraw()
+
+	want := []string{"changes", "explorer", "search", "outline"}
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, want) {
+		t.Fatalf("panel order = %v, want %v", got, want)
+	}
+	if h.app.Sidebar.ActivePanel != "changes" {
+		t.Fatalf("active panel = %q, want changes", h.app.Sidebar.ActivePanel)
+	}
+	if got := config.LoadSettings().Sidebar.PanelOrder; !slices.Equal(got, want) {
+		t.Fatalf("saved panel order = %v, want %v", got, want)
+	}
+
+	h.exec("sidebar.movePanelRight")
+	want = []string{"explorer", "changes", "search", "outline"}
+	if got := h.app.Sidebar.PanelIDs(); !slices.Equal(got, want) {
+		t.Fatalf("command panel order = %v, want %v", got, want)
+	}
+}

--- a/tests/functional/editor-tab-reorder.test.js
+++ b/tests/functional/editor-tab-reorder.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("editor tab order", () => {
+  it("drags visible file tabs and supports the command fallback", () => {
+    dir = createTempDir();
+    const alpha = createTempFile(dir, "alpha.txt", "alpha\n");
+    const beta = createTempFile(dir, "beta.txt", "beta\n");
+    const gamma = createTempFile(dir, "gamma.txt", "gamma\n");
+
+    tui.start(alpha, beta, gamma);
+    const before = tui.snapshot();
+    tui.drag(38, 2, 2, 2);
+    tui.waitStable();
+    const dragged = tui.snapshot();
+    tui.exec("View: Move Tab Right");
+    tui.waitStable();
+    const moved = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    const beforeHeader = snapshots[before].split("\n")[2];
+    const draggedHeader = snapshots[dragged].split("\n")[2];
+    const movedHeader = snapshots[moved].split("\n")[2];
+    expect(beforeHeader.indexOf("gamma.txt")).toBeGreaterThan(beforeHeader.indexOf("untitled"));
+    expect(draggedHeader.indexOf("gamma.txt")).toBeLessThan(draggedHeader.indexOf("untitled"));
+    expect(movedHeader.indexOf("gamma.txt")).toBeGreaterThan(movedHeader.indexOf("untitled"));
+  });
+});

--- a/tests/functional/sidebar-tab-reorder.test.js
+++ b/tests/functional/sidebar-tab-reorder.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { createTempDir, createTempFile, cleanupDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("sidebar tab order", () => {
+  it("drags Changes before Explore and persists the order", () => {
+    dir = createTempDir();
+    const file = createTempFile(dir, "file.txt", "hello\n");
+    const configDir = join(dir, "config");
+    mkdirSync(configDir, { recursive: true });
+
+    tui.start(file);
+    tui.setEnv({ TTT_CONFIG_DIR: configDir });
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable();
+    const before = tui.snapshot();
+    tui.drag(16, 2, 1, 2);
+    tui.waitStable();
+    const after = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    const beforeHeader = snapshots[before].split("\n")[2];
+    const afterHeader = snapshots[after].split("\n")[2];
+    expect(beforeHeader.indexOf("Changes")).toBeGreaterThan(beforeHeader.indexOf("Explore"));
+    expect(afterHeader.indexOf("Changes")).toBeLessThan(afterHeader.indexOf("Explore"));
+
+    const saved = JSON.parse(readFileSync(join(configDir, "settings.json"), "utf8"));
+    expect(saved.sidebar.panelOrder.slice(0, 2)).toEqual(["changes", "explorer"]);
+  });
+});

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -22,6 +22,7 @@ let args = [];
 let snapCount = 0;
 let tmpDir = "";
 let size = "120x40";
+let extraEnv = {};
 
 export function start(...startArgs) {
   commands = [];
@@ -29,9 +30,14 @@ export function start(...startArgs) {
   size = "120x40";
   tmpDir = mkdtempSync(join(tmpdir(), "ttt-bb-"));
   args = [];
+  extraEnv = {};
   for (const a of startArgs) {
     args.push(a);
   }
+}
+
+export function setEnv(vars) {
+  extraEnv = { ...extraEnv, ...vars };
 }
 
 // Override the terminal size for this run (default 120x40). Reset by start().
@@ -42,6 +48,10 @@ export function setSize(w, h) {
 // Simulate a mouse click at screen coordinates (col x, row y).
 export function click(x, y) {
   commands.push(`click ${x} ${y}`);
+}
+
+export function drag(x1, y1, x2, y2) {
+  commands.push(`drag ${x1} ${y1} ${x2} ${y2}`);
 }
 
 // Simulate a right-click (opens context menus) at screen coordinates.
@@ -129,7 +139,7 @@ export function run(timeout = 15000) {
       timeout,
       stdio: "pipe",
       // Isolate from the real ~/.config/ttt — settings toggles persist and race across test files.
-      env: { ...process.env, TTT_CONFIG_DIR: join(tmpDir, "config") },
+      env: { ...process.env, TTT_CONFIG_DIR: join(tmpDir, "config"), ...extraEnv },
     });
   } catch (err) {
     runError = err;


### PR DESCRIPTION
## Summary

- let users drag visible sidebar and editor tab headers to reorder them, with render-derived drop targets and indicators
- persist sidebar panel order while preserving late plugin panels, and provide command and menu fallbacks for keyboard-driven reordering
- preserve editor active identity, preview commitment, and pinned-tab boundaries during moves
- capture drag ownership on press across root and split boundaries, with lifecycle-safe cancellation and stationary overflow auto-scroll
- bind gestures to stable unique tab identities so removal, replacement, duplicate panel registration, resize, and hidden geometry cannot retarget a pending drag

This is the focused tab-reordering extraction from #474.

## Verification

- `make build`
- focused widget, UI, and E2E tab-reorder suites
- focused race tests repeated 10 times for capture, identity, duplicate registration, and timer lifecycle
- functional `editor-tab-reorder.test.js` and `sidebar-tab-reorder.test.js`
- full functional suite before final rebase: 88 files, 289 passed, 27 expected failures
- independent adversarial review with fail-before/pass-after duplicate-ID coverage and current-main merge-tree proof
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reorder editor tabs by dragging or using move-left/move-right commands.
  - Reorder sidebar panels by dragging or using directional commands.
  - Configure and persist sidebar panel order with `sidebar.panelOrder`.
  - Dragging tabs now supports edge auto-scrolling and visual drop indicators.

- **Bug Fixes**
  - Improved cancellation of drag interactions when views resize, hide, switch, or change.
  - Improved handling of wide-character tab labels and narrow layouts.

- **Documentation**
  - Added configuration details and examples for sidebar panel ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->