### PR TITLE
test(functional): fix sidebar action menu clicks

### DIFF
--- a/tests/functional/plugin-menu-checked.test.js
+++ b/tests/functional/plugin-menu-checked.test.js
@@ -107,13 +107,11 @@ ttt.register({
     tui.click(29, 5);
     tui.waitStable();
     tui.click(29, 2);
-    tui.click(29, 2);
     tui.waitStable();
     const mixed = tui.snapshot();
     tui.press("arrow_down");
     tui.press("enter");
     const uncheckedCallback = tui.snapshot();
-    tui.click(29, 2);
     tui.click(29, 2);
     tui.press("arrow_down");
     tui.press("arrow_down");


### PR DESCRIPTION
## Summary

- remove obsolete duplicate clicks from the checked sidebar-action menu functional test
- align the script with the one-click menu behavior retained after tab drag gesture ownership landed
- restore a green current-main functional baseline before the remaining focused #474 slices are submitted

The product interaction is unchanged: one click opens the sidebar action menu. With #480 and #482 both merged, the old second click now correctly dismisses that menu.

## Verification

- fail-before reproduced on untouched current main: plugin-menu-checked.test.js fails because the second click closes the menu
- corrected focused file: 3 tests passed
- full functional suite: 91 files passed, 304 passed, 27 expected failures
- make build
- git diff --check

Follow-up integration repair for #480 and #482. Part of the #474 split workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a redundant sidebar menu interaction from a functional test.
  * Streamlined the checked-state navigation test without changing product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->