### PR TITLE
feat(git): add commit history detail review

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,6 +80,9 @@ type App struct {
 	Watcher                *watcher.Watcher
 	GitGutterGen           int
 	GitGutterTimer         *time.Timer
+	commitDetailMu         sync.Mutex
+	commitDetailNext       uint64
+	commitDetailRequests   map[string]commitDetailRequest
 	Version                string
 	PluginManager          *plugin.Manager
 	PendingPluginApprovals []*plugin.Plugin

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -436,6 +436,14 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 	}
 	a.StartWatcher()
 
+	if a.Changes != nil {
+		a.Changes.Screen = screen
+		a.Changes.OnRefreshed = func() {
+			a.Sidebar.SetPanelDirty("changes", a.Changes.TotalChanges() > 0)
+		}
+		a.Changes.Refresh()
+	}
+
 	a.EditorGroup.OnError = func(msg string) {
 		a.StatusError(msg)
 	}

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -598,6 +598,7 @@ func registerWidgetCallbacks(app *App) {
 	app.Changes.OnOpenDiff = func(dir string, status git.FileStatus, extended bool) {
 		app.OpenChangeDiff(dir, status, extended)
 	}
+	app.Changes.OnOpenCommit = app.OpenCommitDetail
 	app.Changes.OnOpenPRDiff = func(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
 		app.OpenPRDiff(group, status, extended)
 	}

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -26,6 +28,23 @@ type eventPoster interface {
 // commitLogLimit is how many commits the log shows.
 const commitLogLimit = 10
 
+const (
+	commitHistoryTimeout = 15 * time.Second
+	commitFilesTimeout   = 15 * time.Second
+	commitDetailTimeout  = 30 * time.Second
+)
+
+type commitFilesRequest struct {
+	ID     uint64
+	Cancel context.CancelFunc
+}
+
+type commitDetailRequest struct {
+	Incarnation uint64
+	Context     context.Context
+	Cancel      context.CancelFunc
+}
+
 // CommitLogResult carries a finished read of one repository's recent commits.
 type CommitLogResult struct {
 	Gen         int
@@ -34,30 +53,35 @@ type CommitLogResult struct {
 	Entries     []git.LogEntry
 	Err         error
 	Unavailable bool
+	Canceled    bool
 }
 
 // CommitFilesResult carries the file list of a single commit back to the node
 // that asked for it.
 type CommitFilesResult struct {
-	Dir    string
-	Ref    string
-	Short  string
-	NodeID string
-	Files  []git.FileStatus
-	Err    error
+	Request  uint64
+	Dir      string
+	Ref      string
+	Short    string
+	NodeID   string
+	Files    []git.FileStatus
+	Err      error
+	Canceled bool
 }
 
 // CommitDetailResult carries the complete message and every per-file diff for
-// one immutable commit. Dir and Ref are the result identity; ApplyCommitDetail
-// only installs it into the loading tab created for that exact pair.
+// one immutable commit. Incarnation distinguishes repeated openings of the same
+// repository and ref so a closed request can never target its replacement.
 type CommitDetailResult struct {
-	Dir        string
-	Ref        string
-	Short      string
-	Message    string
-	AuthoredAt time.Time
-	Files      []ui.CommitDetailFile
-	Err        string
+	Incarnation uint64
+	Dir         string
+	Ref         string
+	Short       string
+	Message     string
+	AuthoredAt  time.Time
+	Files       []ui.CommitDetailFile
+	Err         string
+	Canceled    bool
 }
 
 func readChangesGroups(dirs []string) []changesGroup {
@@ -93,22 +117,37 @@ func readChangesGroups(dirs []string) []changesGroup {
 	return groups
 }
 
-func readCommitLog(dir string, gen int) *CommitLogResult {
-	if !git.IsRepo(dir) {
+func readCommitLog(ctx context.Context, dir string, gen int) *CommitLogResult {
+	if !git.IsRepoContext(ctx, dir) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return &CommitLogResult{Gen: gen, Dir: dir, Err: ctxErr, Canceled: errors.Is(ctxErr, context.Canceled)}
+		}
 		return &CommitLogResult{Gen: gen, Dir: dir, Unavailable: true}
 	}
-	entries, err := git.LogWithError(dir, commitLogLimit)
+	entries, err := git.LogWithErrorContext(ctx, dir, commitLogLimit)
+	if errors.Is(err, context.Canceled) {
+		return &CommitLogResult{Gen: gen, Dir: dir, Canceled: true}
+	}
+	if err != nil {
+		return &CommitLogResult{Gen: gen, Dir: dir, Err: err}
+	}
+	branch := git.BranchNameContext(ctx, dir)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return &CommitLogResult{Gen: gen, Dir: dir, Err: ctxErr, Canceled: errors.Is(ctxErr, context.Canceled)}
+	}
 	return &CommitLogResult{
 		Gen:     gen,
 		Dir:     dir,
-		Branch:  git.BranchName(dir),
+		Branch:  branch,
 		Entries: entries,
-		Err:     err,
 	}
 }
 
 // ApplyCommitLog rebuilds the commit log from a finished read.
 func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
+	if r == nil || r.Canceled {
+		return
+	}
 	// Both checks, not one: the counter catches a superseded read, and the
 	// directory catches a counter that agrees for some reason it should not.
 	if r.Gen != cp.logGen || r.Dir != cp.lastLogDir {
@@ -200,7 +239,7 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 	// gone from this log, so the inert branch header is the safe resting place.
 	if parentID, ref, isCommitFile := commitFileParent(selected); isCommitFile {
 		key := r.Dir + "\x00" + ref
-		if cp.commitNode(parentID) != nil && cp.commitFilesPending[key] {
+		if _, pending := cp.commitFilesPending[key]; cp.commitNode(parentID) != nil && pending {
 			cp.selectLogNode(parentID)
 			cp.pendingLogSelection = selected
 			return
@@ -236,9 +275,12 @@ func (cp *ChangesPanel) selectLogNode(id string) bool {
 	return false
 }
 
-func readCommitFiles(dir, ref, short, nodeID string) *CommitFilesResult {
-	files, err := git.CommitFiles(dir, ref)
-	return &CommitFilesResult{Dir: dir, Ref: ref, Short: short, NodeID: nodeID, Files: files, Err: err}
+func readCommitFiles(ctx context.Context, request uint64, dir, ref, short, nodeID string) *CommitFilesResult {
+	files, err := git.CommitFilesContext(ctx, dir, ref)
+	return &CommitFilesResult{
+		Request: request, Dir: dir, Ref: ref, Short: short, NodeID: nodeID, Files: files, Err: err,
+		Canceled: errors.Is(err, context.Canceled),
+	}
 }
 
 // recordCommitFiles caches a finished read and clears its in-flight mark.
@@ -247,12 +289,19 @@ func readCommitFiles(dir, ref, short, nodeID string) *CommitFilesResult {
 // which is what makes the cache safe — but a failure is not a fact about the
 // commit, it is a fact about the moment, and index.lock or a mid-rebase repo
 // clears on its own. Caching one would leave that commit permanently empty.
-func (cp *ChangesPanel) recordCommitFiles(r *CommitFilesResult) {
+func (cp *ChangesPanel) recordCommitFiles(r *CommitFilesResult) bool {
 	key := r.Dir + "\x00" + r.Ref
-	delete(cp.commitFilesPending, key)
+	if r.Request != 0 {
+		request, ok := cp.commitFilesPending[key]
+		if !ok || request.ID != r.Request {
+			return false
+		}
+		delete(cp.commitFilesPending, key)
+	}
 	if r.Err == nil {
 		cp.cacheCommitFiles(key, r.Files)
 	}
+	return true
 }
 
 func (cp *ChangesPanel) childrenFor(r *CommitFilesResult) []*widgets.TreeNode {
@@ -267,13 +316,16 @@ func (cp *ChangesPanel) childrenFor(r *CommitFilesResult) []*widgets.TreeNode {
 // key cannot start a run of identical git processes.
 func (cp *ChangesPanel) fetchCommitFiles(dir, ref, short, nodeID string) {
 	key := dir + "\x00" + ref
-	if cp.commitFilesPending[key] {
+	if _, pending := cp.commitFilesPending[key]; pending {
 		return
 	}
-	cp.commitFilesPending[key] = true
+	cp.commitFilesNext++
+	requestID := cp.commitFilesNext
+	ctx, cancel := context.WithTimeout(context.Background(), commitFilesTimeout)
+	cp.commitFilesPending[key] = commitFilesRequest{ID: requestID, Cancel: cancel}
 	screen := cp.Screen
 	go func() {
-		screen.PostEvent(tcell.NewEventInterrupt(readCommitFiles(dir, ref, short, nodeID)))
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitFiles(ctx, requestID, dir, ref, short, nodeID)))
 	}()
 }
 
@@ -281,7 +333,9 @@ func (cp *ChangesPanel) fetchCommitFiles(dir, ref, short, nodeID string) {
 // it. The node is looked up by ID rather than held as a pointer: the log may
 // have been rebuilt, or moved to another repository, while git was running.
 func (cp *ChangesPanel) ApplyCommitFiles(r *CommitFilesResult) {
-	cp.recordCommitFiles(r)
+	if r == nil || r.Canceled || !cp.recordCommitFiles(r) {
+		return
+	}
 	if r.Dir != cp.logDir {
 		return
 	}
@@ -324,26 +378,42 @@ func commitDetailTabID(dir, ref string) string {
 	return "commit:" + dir + "\x00" + ref
 }
 
-func readCommitDetail(dir, ref, short string) *CommitDetailResult {
-	result := &CommitDetailResult{Dir: dir, Ref: ref, Short: short}
-	message, err := git.CommitMessage(dir, ref)
+func readCommitDetail(ctx context.Context, incarnation uint64, dir, ref, short string) *CommitDetailResult {
+	result := &CommitDetailResult{Incarnation: incarnation, Dir: dir, Ref: ref, Short: short}
+	message, err := git.CommitMessageContext(ctx, dir, ref)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			result.Canceled = true
+			return result
+		}
 		result.Err = fmt.Sprintf("Could not read commit %s", short)
 		return result
 	}
 	result.Message = message
-	result.AuthoredAt, _ = git.CommitAuthoredAt(dir, ref)
+	result.AuthoredAt, err = git.CommitAuthoredAtContext(ctx, dir, ref)
+	if errors.Is(err, context.Canceled) {
+		result.Canceled = true
+		return result
+	}
 
-	files, err := git.CommitFiles(dir, ref)
+	files, err := git.CommitFilesContext(ctx, dir, ref)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			result.Canceled = true
+			return result
+		}
 		result.Err = fmt.Sprintf("Could not read files for commit %s", short)
 		return result
 	}
 	result.Files = make([]ui.CommitDetailFile, 0, len(files))
 	for _, file := range files {
-		detail := ui.CommitDetailFile{Path: file.Path, OldPath: file.OldPath}
-		diffText, err := git.CommitFileDiff(dir, ref, file)
+		detail := ui.CommitDetailFile{Status: file.Status, Path: file.Path, OldPath: file.OldPath}
+		diffText, err := git.CommitFileDiffContext(ctx, dir, ref, file)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				result.Canceled = true
+				return result
+			}
 			detail.Error = fmt.Sprintf("Could not read diff for %s", file.Path)
 		} else {
 			detail.Diff = diff.Parse(diffText)
@@ -364,30 +434,83 @@ func (a *App) OpenCommitDetail(dir, ref, short string) {
 		return
 	}
 
+	request := a.beginCommitDetailRequest(tabID)
 	detail := ui.NewCommitDetailWidget(dir, ref, short, a.EditorGroup.SyntaxHighlight)
-	a.wireCommitDetailContext(tabID, detail)
+	detail.Incarnation = request.Incarnation
+	detail.OnClose = func() {
+		a.cancelCommitDetailRequest(tabID, request.Incarnation)
+	}
+	a.wireCommitDetailContext(tabID, detail, request)
 	a.EditorGroup.ApplyDiffDefaults(detail)
 	a.EditorGroup.OpenPluginTab(tabID, "Commit "+short, detail)
 	a.FocusEditorIfEnabled()
+	read := func() *CommitDetailResult {
+		ctx, cancel := context.WithTimeout(request.Context, commitDetailTimeout)
+		defer cancel()
+		return readCommitDetail(ctx, request.Incarnation, dir, ref, short)
+	}
 	if a.Screen == nil {
-		a.ApplyCommitDetail(readCommitDetail(dir, ref, short))
+		a.ApplyCommitDetail(read())
 		return
 	}
 	screen := a.Screen
 	go func() {
-		screen.PostEvent(tcell.NewEventInterrupt(readCommitDetail(dir, ref, short)))
+		screen.PostEvent(tcell.NewEventInterrupt(read()))
 	}()
 }
 
-// ApplyCommitDetail fills only the still-open tab whose repository and full
-// hash match the result. Closing the tab while Git runs supersedes the request.
+func (a *App) beginCommitDetailRequest(tabID string) commitDetailRequest {
+	a.commitDetailMu.Lock()
+	defer a.commitDetailMu.Unlock()
+	if a.commitDetailRequests == nil {
+		a.commitDetailRequests = make(map[string]commitDetailRequest)
+	}
+	if previous, ok := a.commitDetailRequests[tabID]; ok {
+		previous.Cancel()
+	}
+	a.commitDetailNext++
+	ctx, cancel := context.WithCancel(context.Background())
+	request := commitDetailRequest{Incarnation: a.commitDetailNext, Context: ctx, Cancel: cancel}
+	a.commitDetailRequests[tabID] = request
+	return request
+}
+
+func (a *App) cancelCommitDetailRequest(tabID string, incarnation uint64) {
+	a.commitDetailMu.Lock()
+	defer a.commitDetailMu.Unlock()
+	request, ok := a.commitDetailRequests[tabID]
+	if !ok || request.Incarnation != incarnation {
+		return
+	}
+	delete(a.commitDetailRequests, tabID)
+	request.Cancel()
+}
+
+func (a *App) ShutdownGitReads() {
+	a.commitDetailMu.Lock()
+	requests := a.commitDetailRequests
+	a.commitDetailRequests = nil
+	a.commitDetailMu.Unlock()
+	for _, request := range requests {
+		request.Cancel()
+	}
+	if a.Changes != nil {
+		a.Changes.Shutdown()
+	}
+}
+
+// ApplyCommitDetail fills only the still-open incarnation whose repository and
+// full hash match the result. Closing the tab while Git runs supersedes it.
 func (a *App) ApplyCommitDetail(result *CommitDetailResult) {
+	if result == nil || result.Canceled {
+		return
+	}
 	detail := a.EditorGroup.CommitDetailWidgetByTab(commitDetailTabID(result.Dir, result.Ref))
-	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref {
+	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref || detail.Incarnation != result.Incarnation {
 		return
 	}
 	if !result.AuthoredAt.IsZero() {
-		detail.Metadata = "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04 PM -0700")
+		detail.Metadata = "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04:05 PM -0700")
 	}
 	detail.SetDetail(result.Message, result.Files, result.Err)
 }

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -1,0 +1,393 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+// Commit history and detail reads run off the event loop and apply their widget
+// state after returning through it. Working-tree refresh remains synchronous so
+// command-triggered Git mutations preserve their existing exec lifecycle.
+
+// eventPoster is the one thing the panel needs from the screen: a way to hand a
+// finished read back to the event loop. Narrow so a test can stand in for it.
+type eventPoster interface {
+	PostEvent(tcell.Event) error
+}
+
+// commitLogLimit is how many commits the log shows.
+const commitLogLimit = 10
+
+// CommitLogResult carries a finished read of one repository's recent commits.
+type CommitLogResult struct {
+	Gen         int
+	Dir         string
+	Branch      string
+	Entries     []git.LogEntry
+	Err         error
+	Unavailable bool
+}
+
+// CommitFilesResult carries the file list of a single commit back to the node
+// that asked for it.
+type CommitFilesResult struct {
+	Dir    string
+	Ref    string
+	Short  string
+	NodeID string
+	Files  []git.FileStatus
+	Err    error
+}
+
+// CommitDetailResult carries the complete message and every per-file diff for
+// one immutable commit. Dir and Ref are the result identity; ApplyCommitDetail
+// only installs it into the loading tab created for that exact pair.
+type CommitDetailResult struct {
+	Dir        string
+	Ref        string
+	Short      string
+	Message    string
+	AuthoredAt time.Time
+	Files      []ui.CommitDetailFile
+	Err        string
+}
+
+func readChangesGroups(dirs []string) []changesGroup {
+	var groups []changesGroup
+	seen := make(map[string]bool)
+	for _, dir := range dirs {
+		if root := git.RepoRoot(dir); root != "" {
+			dir = root
+		}
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		files, err := git.StatusFiles(dir)
+		if err != nil {
+			files = nil
+		}
+		var staged, unstaged []git.FileStatus
+		for _, f := range files {
+			if f.Staged {
+				staged = append(staged, f)
+			} else {
+				unstaged = append(unstaged, f)
+			}
+		}
+		groups = append(groups, changesGroup{
+			Dir:      dir,
+			Name:     filepath.Base(dir),
+			Staged:   staged,
+			Unstaged: unstaged,
+		})
+	}
+	return groups
+}
+
+func readCommitLog(dir string, gen int) *CommitLogResult {
+	if !git.IsRepo(dir) {
+		return &CommitLogResult{Gen: gen, Dir: dir, Unavailable: true}
+	}
+	entries, err := git.LogWithError(dir, commitLogLimit)
+	return &CommitLogResult{
+		Gen:     gen,
+		Dir:     dir,
+		Branch:  git.BranchName(dir),
+		Entries: entries,
+		Err:     err,
+	}
+}
+
+// ApplyCommitLog rebuilds the commit log from a finished read.
+func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
+	// Both checks, not one: the counter catches a superseded read, and the
+	// directory catches a counter that agrees for some reason it should not.
+	if r.Gen != cp.logGen || r.Dir != cp.lastLogDir {
+		return
+	}
+	if r.Unavailable {
+		cp.logDir = ""
+		cp.logCommits = make(map[string]commitFileRef)
+		cp.logFiles = make(map[string]commitFileRef)
+		cp.CommitLog.SetItems(nil)
+		return
+	}
+	if r.Err != nil {
+		cp.lastLogDir = ""
+		if cp.logDir != r.Dir {
+			cp.CommitLog.SetItems([]*widgets.TreeNode{{ID: "history:error", Label: "Could not read history", Muted: true}})
+		}
+		if cp.OnError != nil {
+			cp.OnError("Could not refresh commit history: " + r.Err.Error())
+		}
+		return
+	}
+	name := filepath.Base(r.Dir)
+	if r.Branch != "" {
+		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s (%s)", name, r.Branch)
+	} else {
+		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s", name)
+	}
+
+	// Record what was open before the rebuild, so a Refresh triggered by
+	// staging a file does not collapse the commit the reader was in the middle
+	// of — and so does switching to another root and back.
+	cp.saveCommitLogState()
+	cp.logDir = r.Dir
+	selected := cp.logSelected[r.Dir]
+	cp.logCommits = make(map[string]commitFileRef)
+	cp.logFiles = make(map[string]commitFileRef)
+
+	branchLabel := name
+	if r.Branch != "" {
+		branchLabel = fmt.Sprintf("%s · %s", name, r.Branch)
+	}
+	nodes := make([]*widgets.TreeNode, 0, len(r.Entries)+1)
+	nodes = append(nodes, &widgets.TreeNode{
+		ID:    "branch",
+		Label: branchLabel,
+		Icon:  "⎇",
+		Muted: true,
+	})
+	for _, e := range r.Entries {
+		// Keyed on the full hash: the abbreviation git prints can change length
+		// as the repo grows, which would silently orphan both the expansion
+		// state below and the file cache.
+		id := "commit:" + e.Ref
+		cp.logCommits[id] = commitFileRef{Dir: r.Dir, Ref: e.Ref, Short: e.Hash}
+		node := &widgets.TreeNode{
+			ID:         id,
+			Label:      e.Message,
+			Icon:       "●",
+			Badge:      e.Hash,
+			Expandable: true,
+		}
+		if cp.logExpanded[commitLogStateKey(r.Dir, id)] {
+			node.Expanded = true
+			node.Children = cp.commitChildren(r.Dir, e.Ref, e.Hash, id)
+		}
+		nodes = append(nodes, node)
+	}
+	if len(r.Entries) == 0 {
+		nodes = append(nodes, &widgets.TreeNode{ID: "history:empty", Label: "No commits", Muted: true})
+	}
+	cp.CommitLog.SetItems(nodes)
+
+	// Restore by identity, never by the index SetItems happened to preserve.
+	// Committing prepends rows, and rewriting history can remove them entirely;
+	// in either case the old index now names something the reader did not pick.
+	cp.pendingLogSelection = ""
+	if selected == "" {
+		cp.CommitLog.SetSelectedIndex(0)
+		return
+	}
+	if cp.selectLogNode(selected) {
+		return
+	}
+
+	// A commit file can be absent temporarily while its surviving parent is
+	// expanded and the file list is in flight. Rest on that parent and restore
+	// the child when it arrives. Every other missing identity is permanently
+	// gone from this log, so the inert branch header is the safe resting place.
+	if parentID, ref, isCommitFile := commitFileParent(selected); isCommitFile {
+		key := r.Dir + "\x00" + ref
+		if cp.commitNode(parentID) != nil && cp.commitFilesPending[key] {
+			cp.selectLogNode(parentID)
+			cp.pendingLogSelection = selected
+			return
+		}
+	}
+	delete(cp.logSelected, r.Dir)
+	cp.CommitLog.SetSelectedIndex(0)
+}
+
+// commitFileParent extracts only the stable parent identity from a commit-file
+// node ID. The path after the hash may itself contain colons, so it remains
+// opaque; full Git object IDs cannot contain the separator.
+func commitFileParent(id string) (parentID, ref string, ok bool) {
+	rest, ok := strings.CutPrefix(id, "cfile:commit:")
+	if !ok {
+		return "", "", false
+	}
+	ref, _, ok = strings.Cut(rest, ":")
+	if !ok || ref == "" {
+		return "", "", false
+	}
+	return "commit:" + ref, ref, true
+}
+
+// selectLogNode selects a node by ID, reporting whether it was there to select.
+func (cp *ChangesPanel) selectLogNode(id string) bool {
+	for i, node := range cp.CommitLog.FlatList() {
+		if node.ID == id {
+			cp.CommitLog.SetSelectedIndex(i)
+			return true
+		}
+	}
+	return false
+}
+
+func readCommitFiles(dir, ref, short, nodeID string) *CommitFilesResult {
+	files, err := git.CommitFiles(dir, ref)
+	return &CommitFilesResult{Dir: dir, Ref: ref, Short: short, NodeID: nodeID, Files: files, Err: err}
+}
+
+// recordCommitFiles caches a finished read and clears its in-flight mark.
+//
+// A failure is deliberately not cached. A commit's contents are immutable,
+// which is what makes the cache safe — but a failure is not a fact about the
+// commit, it is a fact about the moment, and index.lock or a mid-rebase repo
+// clears on its own. Caching one would leave that commit permanently empty.
+func (cp *ChangesPanel) recordCommitFiles(r *CommitFilesResult) {
+	key := r.Dir + "\x00" + r.Ref
+	delete(cp.commitFilesPending, key)
+	if r.Err == nil {
+		cp.cacheCommitFiles(key, r.Files)
+	}
+}
+
+func (cp *ChangesPanel) childrenFor(r *CommitFilesResult) []*widgets.TreeNode {
+	if r.Err != nil {
+		return []*widgets.TreeNode{errorNode(r.NodeID)}
+	}
+	return cp.commitFileNodes(r.Dir, r.Ref, r.Short, r.NodeID, r.Files)
+}
+
+// fetchCommitFiles reads one commit's file list in the background. A commit
+// already being read is skipped rather than queued, so holding down the expand
+// key cannot start a run of identical git processes.
+func (cp *ChangesPanel) fetchCommitFiles(dir, ref, short, nodeID string) {
+	key := dir + "\x00" + ref
+	if cp.commitFilesPending[key] {
+		return
+	}
+	cp.commitFilesPending[key] = true
+	screen := cp.Screen
+	go func() {
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitFiles(dir, ref, short, nodeID)))
+	}()
+}
+
+// ApplyCommitFiles installs a commit's file list under the node that asked for
+// it. The node is looked up by ID rather than held as a pointer: the log may
+// have been rebuilt, or moved to another repository, while git was running.
+func (cp *ChangesPanel) ApplyCommitFiles(r *CommitFilesResult) {
+	cp.recordCommitFiles(r)
+	if r.Dir != cp.logDir {
+		return
+	}
+	node := cp.commitNode(r.NodeID)
+	if node == nil {
+		return
+	}
+	node.Children = cp.childrenFor(r)
+	// Same slice, but the widget has to re-flatten now that it has children.
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+
+	if cp.pendingLogSelection != "" {
+		parentID, _, isCommitFile := commitFileParent(cp.pendingLogSelection)
+		if !isCommitFile || parentID != r.NodeID {
+			return
+		}
+		if cp.selectLogNode(cp.pendingLogSelection) {
+			cp.pendingLogSelection = ""
+			return
+		}
+		// This parent's read completed without the selected child, so that
+		// identity can no longer arrive. Keep the cursor on the surviving parent
+		// and stop carrying the dead selection into later rebuilds.
+		cp.pendingLogSelection = ""
+		cp.selectLogNode(r.NodeID)
+		cp.logSelected[r.Dir] = r.NodeID
+	}
+}
+
+func (cp *ChangesPanel) commitNode(id string) *widgets.TreeNode {
+	for _, node := range cp.CommitLog.Config.Items {
+		if node.ID == id {
+			return node
+		}
+	}
+	return nil
+}
+
+func commitDetailTabID(dir, ref string) string {
+	return "commit:" + dir + "\x00" + ref
+}
+
+func readCommitDetail(dir, ref, short string) *CommitDetailResult {
+	result := &CommitDetailResult{Dir: dir, Ref: ref, Short: short}
+	message, err := git.CommitMessage(dir, ref)
+	if err != nil {
+		result.Err = fmt.Sprintf("Could not read commit %s", short)
+		return result
+	}
+	result.Message = message
+	result.AuthoredAt, _ = git.CommitAuthoredAt(dir, ref)
+
+	files, err := git.CommitFiles(dir, ref)
+	if err != nil {
+		result.Err = fmt.Sprintf("Could not read files for commit %s", short)
+		return result
+	}
+	result.Files = make([]ui.CommitDetailFile, 0, len(files))
+	for _, file := range files {
+		detail := ui.CommitDetailFile{Path: file.Path, OldPath: file.OldPath}
+		diffText, err := git.CommitFileDiff(dir, ref, file)
+		if err != nil {
+			detail.Error = fmt.Sprintf("Could not read diff for %s", file.Path)
+		} else {
+			detail.Diff = diff.Parse(diffText)
+		}
+		result.Files = append(result.Files, detail)
+	}
+	return result
+}
+
+// OpenCommitDetail puts a loading tab in front of the reader immediately, then
+// performs every Git read off the event loop. Reopening an immutable commit
+// reuses its full-hash tab and never starts a duplicate read.
+func (a *App) OpenCommitDetail(dir, ref, short string) {
+	tabID := commitDetailTabID(dir, ref)
+	if a.EditorGroup.CommitDetailWidgetByTab(tabID) != nil {
+		a.EditorGroup.SwitchToTabByPath(tabID)
+		a.FocusEditorIfEnabled()
+		return
+	}
+
+	detail := ui.NewCommitDetailWidget(dir, ref, short, a.EditorGroup.SyntaxHighlight)
+	a.wireCommitDetailContext(tabID, detail)
+	a.EditorGroup.ApplyDiffDefaults(detail)
+	a.EditorGroup.OpenPluginTab(tabID, "Commit "+short, detail)
+	a.FocusEditorIfEnabled()
+	if a.Screen == nil {
+		a.ApplyCommitDetail(readCommitDetail(dir, ref, short))
+		return
+	}
+	screen := a.Screen
+	go func() {
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitDetail(dir, ref, short)))
+	}()
+}
+
+// ApplyCommitDetail fills only the still-open tab whose repository and full
+// hash match the result. Closing the tab while Git runs supersedes the request.
+func (a *App) ApplyCommitDetail(result *CommitDetailResult) {
+	detail := a.EditorGroup.CommitDetailWidgetByTab(commitDetailTabID(result.Dir, result.Ref))
+	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref {
+		return
+	}
+	if !result.AuthoredAt.IsZero() {
+		detail.Metadata = "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04 PM -0700")
+	}
+	detail.SetDetail(result.Message, result.Files, result.Err)
+}

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -42,7 +43,9 @@ type ChangesPanel struct {
 	commitFilesOrder []string
 	// commitFilesPending marks reads already in flight, so repeated expands of
 	// one commit do not each start their own git process.
-	commitFilesPending map[string]bool
+	commitFilesPending map[string]commitFilesRequest
+	commitFilesNext    uint64
+	logCancel          context.CancelFunc
 	logCommits         map[string]commitFileRef
 	logFiles           map[string]commitFileRef
 	// logGen lets a finished read tell whether a newer one has superseded it.
@@ -124,7 +127,7 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 		logExpanded: make(map[string]bool),
 		logSelected: make(map[string]string),
 
-		commitFilesPending: make(map[string]bool),
+		commitFilesPending: make(map[string]commitFilesRequest),
 	}
 
 	cp.Input = widgets.NewInputWidget(widgets.InputConfig{
@@ -249,6 +252,7 @@ func filePaths(files []git.FileStatus) []string {
 }
 
 func (cp *ChangesPanel) Refresh() {
+	cp.cancelHistoryReads()
 	dirs := append([]string(nil), cp.Dirs...)
 	cp.saveExpanded()
 	cp.groups = readChangesGroups(dirs)
@@ -270,6 +274,7 @@ func (cp *ChangesPanel) refreshCommitLog() {
 		// Emptying the log is a desired state too, so it has to invalidate a
 		// read still running — otherwise that read arrives and resurrects the
 		// repository that was just cleared.
+		cp.cancelHistoryReads()
 		cp.logGen++
 		cp.saveCommitLogState()
 		cp.lastLogDir = ""
@@ -281,6 +286,7 @@ func (cp *ChangesPanel) refreshCommitLog() {
 		return
 	}
 	if dir != cp.logDir {
+		cp.cancelCommitFileReads()
 		cp.saveCommitLogState()
 		cp.logDir = ""
 		cp.logCommits = make(map[string]commitFileRef)
@@ -290,14 +296,41 @@ func (cp *ChangesPanel) refreshCommitLog() {
 	cp.lastLogDir = dir
 	cp.logGen++
 	gen := cp.logGen
+	cp.cancelLogRead()
+	ctx, cancel := context.WithTimeout(context.Background(), commitHistoryTimeout)
+	cp.logCancel = cancel
 	if cp.Screen == nil {
-		cp.ApplyCommitLog(readCommitLog(dir, gen))
+		cp.ApplyCommitLog(readCommitLog(ctx, dir, gen))
+		cancel()
 		return
 	}
 	screen := cp.Screen
 	go func() {
-		screen.PostEvent(tcell.NewEventInterrupt(readCommitLog(dir, gen)))
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitLog(ctx, dir, gen)))
 	}()
+}
+
+func (cp *ChangesPanel) cancelLogRead() {
+	if cp.logCancel != nil {
+		cp.logCancel()
+		cp.logCancel = nil
+	}
+}
+
+func (cp *ChangesPanel) cancelCommitFileReads() {
+	for _, request := range cp.commitFilesPending {
+		request.Cancel()
+	}
+	cp.commitFilesPending = make(map[string]commitFilesRequest)
+}
+
+func (cp *ChangesPanel) cancelHistoryReads() {
+	cp.cancelLogRead()
+	cp.cancelCommitFileReads()
+}
+
+func (cp *ChangesPanel) Shutdown() {
+	cp.cancelHistoryReads()
 }
 
 // saveCommitLogState records the currently rendered log's expansion and
@@ -379,7 +412,9 @@ func (cp *ChangesPanel) commitChildren(dir, ref, short, parentID string) []*widg
 		return cp.commitFileNodes(dir, ref, short, parentID, files)
 	}
 	if cp.Screen == nil {
-		r := readCommitFiles(dir, ref, short, parentID)
+		ctx, cancel := context.WithTimeout(context.Background(), commitFilesTimeout)
+		defer cancel()
+		r := readCommitFiles(ctx, 0, dir, ref, short, parentID)
 		cp.recordCommitFiles(r)
 		return cp.childrenFor(r)
 	}

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -17,14 +17,47 @@ type ChangesPanel struct {
 	Input     *widgets.InputWidget
 	CommitLog *widgets.TreeWidget
 	Adapter   *ui.WidgetAdapter
+	Split     *ui.ContentSplitWidget
 	Dirs      []string
+	// Screen is how a finished background read gets back onto the event loop.
+	// With no screen the panel reads git inline instead — see changes_async.go.
+	Screen eventPoster
 
 	groups     []changesGroup
 	multiRoot  bool
 	expanded   map[string]bool
 	lastLogDir string
+	// commandContext remembers which tree the reader last acted in. Modal
+	// widgets temporarily take focus before running a command, so live widget
+	// focus cannot reliably identify the selection the command should use.
+	commandContext changesCommandContext
+
+	// logDir is the repo the commit log currently displays, as opposed to
+	// lastLogDir which only guards redundant rebuilds. They differ because
+	// Refresh clears the guard while the rendered log stays put.
+	logDir string
+	// commitFiles caches a commit's file list. A commit's contents never
+	// change, so an entry can never go stale — only numerous, hence the bound.
+	commitFiles      map[string][]git.FileStatus
+	commitFilesOrder []string
+	// commitFilesPending marks reads already in flight, so repeated expands of
+	// one commit do not each start their own git process.
+	commitFilesPending map[string]bool
+	logCommits         map[string]commitFileRef
+	logFiles           map[string]commitFileRef
+	// logGen lets a finished read tell whether a newer one has superseded it.
+	logGen int
+	// pendingLogSelection is a selection that could not be restored yet because
+	// the node it names is a commit's child and those children are still being
+	// read.
+	pendingLogSelection string
+	// logExpanded and logSelected outlive any one repo's log, so switching
+	// between roots in a workspace and back returns to what was open.
+	logExpanded map[string]bool
+	logSelected map[string]string
 
 	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
+	OnOpenCommit     func(dir, ref, short string)
 	OnOpenPRDiff     func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
 	OnOpenFile       func(path string)
 	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
@@ -34,15 +67,38 @@ type ChangesPanel struct {
 	OnRefreshPR      func(url string)
 	OnConfirmDiscard func(message string, onConfirm func())
 	OnError          func(message string)
+	OnRefreshed      func()
 
 	PRGroups []prGroup
 }
+
+type changesCommandContext uint8
+
+const (
+	changesWorkingTree changesCommandContext = iota
+	changesCommitLog
+
+	changesHistoryMinHeight     = 4 // title plus three usable log rows
+	changesWorkingTreeMinHeight = 5 // input, divider, and three tree rows
+)
 
 type changesGroup struct {
 	Dir      string
 	Name     string
 	Staged   []git.FileStatus
 	Unstaged []git.FileStatus
+}
+
+// commitFileRef ties a commit-log node back to the file it stands for. The
+// panel keeps a map rather than encoding dir, hash and path into the node ID:
+// all three can contain a colon, and parseFileNode's reverse scan is already at
+// its limit with two fields.
+type commitFileRef struct {
+	Dir string
+	// Ref is the full hash, which is what git is asked with and what the tab
+	// key is built from. Short is only ever shown to the reader.
+	Ref   string
+	Short string
 }
 
 type prGroup struct {
@@ -59,9 +115,16 @@ type prGroup struct {
 
 func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp := &ChangesPanel{
-		Dirs:      dirs,
-		multiRoot: len(dirs) > 1,
-		expanded:  make(map[string]bool),
+		Dirs:        dirs,
+		multiRoot:   len(dirs) > 1,
+		expanded:    make(map[string]bool),
+		commitFiles: make(map[string][]git.FileStatus),
+		logCommits:  make(map[string]commitFileRef),
+		logFiles:    make(map[string]commitFileRef),
+		logExpanded: make(map[string]bool),
+		logSelected: make(map[string]string),
+
+		commitFilesPending: make(map[string]bool),
 	}
 
 	cp.Input = widgets.NewInputWidget(widgets.InputConfig{
@@ -85,24 +148,67 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 		OnSelect: func(node *widgets.TreeNode) {
 			cp.refreshCommitLog()
 		},
+		OnFocus: func() {
+			cp.commandContext = changesWorkingTree
+		},
 		OnKey: func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
 			return cp.handleKey(ev)
 		},
 	})
 
-	cp.CommitLog = widgets.NewListWidget(nil)
+	cp.CommitLog = widgets.NewTreeWidget(widgets.TreeConfig{
+		Indent:             1,
+		EmptyText:          "No commits",
+		ActivateExpandable: true,
+		OnSelect: func(_ *widgets.TreeNode) {
+			// A deferred restore belongs to the selection that existed before the
+			// rebuild. Once the reader moves, their newer choice owns the cursor.
+			cp.pendingLogSelection = ""
+		},
+		OnFocus: func() {
+			cp.commandContext = changesCommitLog
+		},
+		OnExpand: func(node *widgets.TreeNode) {
+			cp.loadCommitFiles(node)
+		},
+		OnCommand: func(cmd string, node *widgets.TreeNode) {
+			if cmd == "activate" {
+				cp.openCommitLogNode(node)
+			}
+		},
+		OnKey: func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
+			return cp.handleCommitLogKey(ev, node)
+		},
+	})
 
-	logBox := &widgets.BoxWidget{FixedHeight: 7}
+	logTitle := widgets.NewTitleWidget(widgets.TitleConfig{Title: "Commit History"})
+
+	logBox := &widgets.BoxWidget{}
 	logBox.Child = cp.CommitLog
 
 	divTop := widgets.NewDividerWidget(widgets.DividerConfig{})
-	divBottom := widgets.NewDividerWidget(widgets.DividerConfig{})
 
-	vstack := widgets.NewVStackWidget(cp.Tree, divBottom, cp.Input, divTop, logBox)
+	top := widgets.NewVStackWidget(cp.Tree, divTop, cp.Input)
+	bottom := widgets.NewVStackWidget(logTitle, logBox)
 
-	cp.Adapter = ui.NewWidgetAdapter(vstack)
+	cp.Split = ui.NewContentSplitWidget()
+	cp.Split.Top = top
+	cp.Split.Bottom = bottom
+	cp.Split.ShowBottom = true
+	cp.Split.BottomH = 0
+	cp.Split.BottomRatio = 0.5
+	cp.Split.MinBottomH = changesHistoryMinHeight
+	cp.Split.MinTopH = changesWorkingTreeMinHeight
+	cp.Split.OnResize = func(height int) {
+		// Like the sidebar width, this value lives for the panel's lifetime but is
+		// not written to settings. The split itself applies both child minimums.
+		cp.Split.BottomH = height
+	}
 
-	cp.Refresh()
+	cp.Adapter = ui.NewWidgetAdapter(cp.Split)
+
+	// App.Init installs the event poster before the first refresh so history can
+	// load asynchronously. Tests without an event loop can call Refresh inline.
 	return cp
 }
 
@@ -143,40 +249,16 @@ func filePaths(files []git.FileStatus) []string {
 }
 
 func (cp *ChangesPanel) Refresh() {
-	cp.lastLogDir = ""
+	dirs := append([]string(nil), cp.Dirs...)
 	cp.saveExpanded()
-	cp.groups = nil
-	seen := make(map[string]bool)
-	for _, dir := range cp.Dirs {
-		if root := git.RepoRoot(dir); root != "" {
-			dir = root
-		}
-		if seen[dir] {
-			continue
-		}
-		seen[dir] = true
-		files, err := git.StatusFiles(dir)
-		if err != nil {
-			files = nil
-		}
-		var staged, unstaged []git.FileStatus
-		for _, f := range files {
-			if f.Staged {
-				staged = append(staged, f)
-			} else {
-				unstaged = append(unstaged, f)
-			}
-		}
-		cp.groups = append(cp.groups, changesGroup{
-			Dir:      dir,
-			Name:     filepath.Base(dir),
-			Staged:   staged,
-			Unstaged: unstaged,
-		})
-	}
+	cp.groups = readChangesGroups(dirs)
 	cp.multiRoot = len(cp.groups)+len(cp.PRGroups) > 1
 	cp.buildTree()
+	cp.lastLogDir = ""
 	cp.refreshCommitLog()
+	if cp.OnRefreshed != nil {
+		cp.OnRefreshed()
+	}
 }
 
 func (cp *ChangesPanel) refreshCommitLog() {
@@ -185,44 +267,203 @@ func (cp *ChangesPanel) refreshCommitLog() {
 		dir = cp.groups[0].Dir
 	}
 	if dir == "" {
+		// Emptying the log is a desired state too, so it has to invalidate a
+		// read still running — otherwise that read arrives and resurrects the
+		// repository that was just cleared.
+		cp.logGen++
+		cp.saveCommitLogState()
 		cp.lastLogDir = ""
+		cp.logDir = ""
 		cp.CommitLog.SetItems(nil)
 		return
 	}
 	if dir == cp.lastLogDir {
 		return
 	}
+	if dir != cp.logDir {
+		cp.saveCommitLogState()
+		cp.logDir = ""
+		cp.logCommits = make(map[string]commitFileRef)
+		cp.logFiles = make(map[string]commitFileRef)
+		cp.CommitLog.SetItems([]*widgets.TreeNode{{ID: "history:loading", Label: "Loading…", Muted: true}})
+	}
 	cp.lastLogDir = dir
-	branch := git.BranchName(dir)
-	name := filepath.Base(dir)
-
-	if branch != "" {
-		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s (%s)", name, branch)
-	} else {
-		cp.Input.Config.Placeholder = fmt.Sprintf("Commit to %s", name)
+	cp.logGen++
+	gen := cp.logGen
+	if cp.Screen == nil {
+		cp.ApplyCommitLog(readCommitLog(dir, gen))
+		return
 	}
+	screen := cp.Screen
+	go func() {
+		screen.PostEvent(tcell.NewEventInterrupt(readCommitLog(dir, gen)))
+	}()
+}
 
-	entries := git.Log(dir, 10)
-	nodes := make([]*widgets.TreeNode, 0, len(entries)+1)
-	branchLabel := name
-	if branch != "" {
-		branchLabel = fmt.Sprintf("%s · %s", name, branch)
+// saveCommitLogState records the currently rendered log's expansion and
+// selection before it is thrown away. Collapsed entries are dropped rather than
+// stored as false: absent already means collapsed, and that keeps the map the
+// size of what is open rather than of everything ever opened.
+func (cp *ChangesPanel) saveCommitLogState() {
+	if cp.logDir == "" {
+		return
 	}
-	nodes = append(nodes, &widgets.TreeNode{
-		ID:    "branch",
-		Label: branchLabel,
-		Icon:  "⎇",
+	for _, node := range cp.CommitLog.Config.Items {
+		if _, ok := cp.logCommits[node.ID]; !ok {
+			continue
+		}
+		key := commitLogStateKey(cp.logDir, node.ID)
+		if node.Expanded {
+			cp.logExpanded[key] = true
+		} else {
+			delete(cp.logExpanded, key)
+		}
+	}
+	if cp.pendingLogSelection != "" {
+		// A second rebuild can land while the selected child's read is still in
+		// flight. Preserve the identity that can still arrive, not the parent row
+		// where the cursor is resting temporarily.
+		cp.logSelected[cp.logDir] = cp.pendingLogSelection
+	} else if node := cp.CommitLog.Selected(); node != nil {
+		cp.logSelected[cp.logDir] = node.ID
+	}
+}
+
+func commitLogStateKey(dir, nodeID string) string {
+	return dir + "\x00" + nodeID
+}
+
+// commitFilesCacheMax bounds the file-list cache. Entries are small and never
+// go stale, so the only reason to evict is that a long session browsing history
+// would otherwise grow one entry per commit ever opened, without limit.
+const commitFilesCacheMax = 256
+
+func (cp *ChangesPanel) cacheCommitFiles(key string, files []git.FileStatus) {
+	if _, exists := cp.commitFiles[key]; !exists {
+		cp.commitFilesOrder = append(cp.commitFilesOrder, key)
+	}
+	cp.commitFiles[key] = files
+	for len(cp.commitFilesOrder) > commitFilesCacheMax {
+		oldest := cp.commitFilesOrder[0]
+		cp.commitFilesOrder = cp.commitFilesOrder[1:]
+		delete(cp.commitFiles, oldest)
+	}
+}
+
+// loadCommitFiles fills in a commit's children when it is expanded. TreeWidget
+// calls this before it re-flattens, so mutating Children here is enough — no
+// second SetItems.
+func (cp *ChangesPanel) loadCommitFiles(node *widgets.TreeNode) {
+	commit, ok := cp.logCommits[node.ID]
+	if !ok {
+		return
+	}
+	// A read still running keeps its placeholder; one that failed is retried,
+	// since the failure was never cached.
+	if len(node.Children) > 0 {
+		first := node.Children[0].ID
+		if first != node.ID+errorSuffix {
+			return
+		}
+	}
+	node.Children = cp.commitChildren(commit.Dir, commit.Ref, commit.Short, node.ID)
+}
+
+// commitChildren returns what to render under a commit. A cached list renders
+// straight away; anything else has to be read, and git must not run on the
+// event path — so the read is started and a placeholder stands in until it
+// lands. A panel with no screen has no event loop to come back through and
+// reads inline instead.
+func (cp *ChangesPanel) commitChildren(dir, ref, short, parentID string) []*widgets.TreeNode {
+	if files, cached := cp.commitFiles[dir+"\x00"+ref]; cached {
+		return cp.commitFileNodes(dir, ref, short, parentID, files)
+	}
+	if cp.Screen == nil {
+		r := readCommitFiles(dir, ref, short, parentID)
+		cp.recordCommitFiles(r)
+		return cp.childrenFor(r)
+	}
+	cp.fetchCommitFiles(dir, ref, short, parentID)
+	return []*widgets.TreeNode{{
+		ID:    parentID + loadingSuffix,
+		Label: "Loading…",
 		Muted: true,
-	})
-	for _, e := range entries {
+	}}
+}
+
+const (
+	loadingSuffix = ":loading"
+	errorSuffix   = ":error"
+	emptySuffix   = ":empty"
+)
+
+func errorNode(parentID string) *widgets.TreeNode {
+	return &widgets.TreeNode{ID: parentID + errorSuffix, Label: "Could not read commit", Muted: true}
+}
+
+func (cp *ChangesPanel) commitFileNodes(dir, ref, short, parentID string, files []git.FileStatus) []*widgets.TreeNode {
+	if len(files) == 0 {
+		// An expandable node that opens onto nothing reads as broken. A merge
+		// that changed nothing against its first parent is the usual cause.
+		return []*widgets.TreeNode{{ID: parentID + emptySuffix, Label: "No files", Muted: true}}
+	}
+	nodes := make([]*widgets.TreeNode, 0, len(files))
+	for _, f := range files {
+		id := fmt.Sprintf("cfile:%s:%s", parentID, f.Path)
+		cp.logFiles[id] = commitFileRef{Dir: dir, Ref: ref, Short: short}
 		nodes = append(nodes, &widgets.TreeNode{
-			ID:    e.Hash,
-			Label: e.Message,
-			Icon:  "●",
-			Badge: e.Hash,
+			ID:           id,
+			Label:        f.Path,
+			Icon:         ui.StatusBadge(f.Status),
+			IconStyle:    ui.StatusStyle(f.Status),
+			TruncateLeft: true,
 		})
 	}
-	cp.CommitLog.SetItems(nodes)
+	return nodes
+}
+
+func (cp *ChangesPanel) openCommitFile(node *widgets.TreeNode, _ bool) {
+	if node == nil {
+		return
+	}
+	ref, ok := cp.logFiles[node.ID]
+	if !ok {
+		return
+	}
+	if cp.OnOpenCommit != nil {
+		cp.OnOpenCommit(ref.Dir, ref.Ref, ref.Short)
+	}
+}
+
+func (cp *ChangesPanel) openCommitLogNode(node *widgets.TreeNode) {
+	if node == nil {
+		return
+	}
+	if commit, ok := cp.logCommits[node.ID]; ok {
+		if cp.OnOpenCommit != nil {
+			cp.OnOpenCommit(commit.Dir, commit.Ref, commit.Short)
+		}
+		return
+	}
+	cp.openCommitFile(node, false)
+}
+
+func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.TreeNode) bool {
+	if ev.Key() != tcell.KeyRune {
+		return false
+	}
+	switch term.KeyRune(ev) {
+	case 'r', 'R':
+		cp.Refresh()
+		return true
+	case 'c', 'o', 'v':
+		cp.openCommitFile(node, false)
+		return true
+	case 'e':
+		cp.openCommitFile(node, true)
+		return true
+	}
+	return false
 }
 
 func (cp *ChangesPanel) saveExpanded() {
@@ -722,6 +963,9 @@ func (cp *ChangesPanel) confirmDiscardAll(gi int) {
 }
 
 func (cp *ChangesPanel) SelectedFile() (dir string, status git.FileStatus, ok bool) {
+	if cp.commandContext != changesWorkingTree {
+		return
+	}
 	node := cp.Tree.Selected()
 	if node == nil {
 		return
@@ -820,6 +1064,9 @@ func (cp *ChangesPanel) RemovePRGroups() {
 }
 
 func (cp *ChangesPanel) DiscardSelected() {
+	if cp.commandContext != changesWorkingTree {
+		return
+	}
 	dir, status, _, ok := cp.parseFileNode(cp.Tree.Selected())
 	if !ok || status.Staged {
 		return
@@ -828,6 +1075,9 @@ func (cp *ChangesPanel) DiscardSelected() {
 }
 
 func (cp *ChangesPanel) ToggleStageSelected() {
+	if cp.commandContext != changesWorkingTree {
+		return
+	}
 	node := cp.Tree.Selected()
 	if node == nil {
 		return
@@ -844,6 +1094,10 @@ func (cp *ChangesPanel) ToggleStageSelected() {
 }
 
 func (cp *ChangesPanel) OpenSelectedDiff(extended bool) {
+	if cp.commandContext == changesCommitLog {
+		cp.openCommitFile(cp.CommitLog.Selected(), extended)
+		return
+	}
 	node := cp.Tree.Selected()
 	if node == nil {
 		return
@@ -856,6 +1110,10 @@ func (cp *ChangesPanel) OpenSelectedDiff(extended bool) {
 }
 
 func (cp *ChangesPanel) ActivateSelected() {
+	if cp.commandContext == changesCommitLog {
+		cp.openCommitLogNode(cp.CommitLog.Selected())
+		return
+	}
 	if cp.selectedInPR() {
 		cp.OpenSelectedDiff(false)
 	} else {

--- a/internal/app/commit_detail_context.go
+++ b/internal/app/commit_detail_context.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -13,22 +15,25 @@ import (
 const commitDetailContextTimeout = 15 * time.Second
 
 type CommitDetailContextResult struct {
-	TabID     string
-	Dir       string
-	Ref       string
-	FileIndex int
-	FileKey   string
-	OldLines  []string
-	NewLines  []string
+	Incarnation uint64
+	TabID       string
+	Dir         string
+	Ref         string
+	FileIndex   int
+	FileKey     string
+	OldLines    []string
+	NewLines    []string
+	Err         string
+	Canceled    bool
 }
 
-func (a *App) wireCommitDetailContext(tabID string, detail *ui.CommitDetailWidget) {
+func (a *App) wireCommitDetailContext(tabID string, detail *ui.CommitDetailWidget, request commitDetailRequest) {
 	detail.OnFetchContext = func(fileIndex int, file ui.CommitDetailFile) {
 		dir, ref := detail.Dir, detail.Ref
 		read := func() *CommitDetailContextResult {
-			ctx, cancel := context.WithTimeout(context.Background(), commitDetailContextTimeout)
+			ctx, cancel := context.WithTimeout(request.Context, commitDetailContextTimeout)
 			defer cancel()
-			return readCommitDetailContext(ctx, tabID, dir, ref, fileIndex, file)
+			return readCommitDetailContext(ctx, request.Incarnation, tabID, dir, ref, fileIndex, file)
 		}
 		if a.Screen == nil {
 			a.ApplyCommitDetailContext(read())
@@ -41,20 +46,38 @@ func (a *App) wireCommitDetailContext(tabID string, detail *ui.CommitDetailWidge
 	}
 }
 
-func readCommitDetailContext(ctx context.Context, tabID, dir, ref string, fileIndex int, file ui.CommitDetailFile) *CommitDetailContextResult {
+func readCommitDetailContext(ctx context.Context, incarnation uint64, tabID, dir, ref string, fileIndex int, file ui.CommitDetailFile) *CommitDetailContextResult {
 	result := &CommitDetailContextResult{
-		TabID: tabID, Dir: dir, Ref: ref, FileIndex: fileIndex,
+		Incarnation: incarnation, TabID: tabID, Dir: dir, Ref: ref, FileIndex: fileIndex,
 		FileKey: ui.CommitDetailContextKey(file),
 	}
 	oldPath := file.Path
 	if file.OldPath != "" {
 		oldPath = file.OldPath
 	}
-	if content, err := git.ShowFileContext(ctx, dir, oldPath, ref+"^"); err == nil {
-		result.OldLines = splitCommitDetailLines(content)
+	if file.Status != "A" {
+		content, err := git.ShowFileContext(ctx, dir, oldPath, ref+"^")
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				result.Canceled = true
+				return result
+			}
+			result.Err = fmt.Sprintf("Could not load full file for %s", file.Path)
+		} else {
+			result.OldLines = splitCommitDetailLines(content)
+		}
 	}
-	if content, err := git.ShowFileContext(ctx, dir, file.Path, ref); err == nil {
-		result.NewLines = splitCommitDetailLines(content)
+	if file.Status != "D" {
+		content, err := git.ShowFileContext(ctx, dir, file.Path, ref)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				result.Canceled = true
+				return result
+			}
+			result.Err = fmt.Sprintf("Could not load full file for %s", file.Path)
+		} else {
+			result.NewLines = splitCommitDetailLines(content)
+		}
 	}
 	return result
 }
@@ -68,9 +91,12 @@ func splitCommitDetailLines(content string) []string {
 }
 
 func (a *App) ApplyCommitDetailContext(result *CommitDetailContextResult) {
-	detail := a.EditorGroup.CommitDetailWidgetByTab(result.TabID)
-	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref {
+	if result == nil || result.Canceled {
 		return
 	}
-	detail.ApplyFileContext(result.FileIndex, result.FileKey, result.OldLines, result.NewLines)
+	detail := a.EditorGroup.CommitDetailWidgetByTab(result.TabID)
+	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref || detail.Incarnation != result.Incarnation {
+		return
+	}
+	detail.ApplyFileContext(result.FileIndex, result.FileKey, result.OldLines, result.NewLines, result.Err)
 }

--- a/internal/app/commit_detail_context.go
+++ b/internal/app/commit_detail_context.go
@@ -1,0 +1,76 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+const commitDetailContextTimeout = 15 * time.Second
+
+type CommitDetailContextResult struct {
+	TabID     string
+	Dir       string
+	Ref       string
+	FileIndex int
+	FileKey   string
+	OldLines  []string
+	NewLines  []string
+}
+
+func (a *App) wireCommitDetailContext(tabID string, detail *ui.CommitDetailWidget) {
+	detail.OnFetchContext = func(fileIndex int, file ui.CommitDetailFile) {
+		dir, ref := detail.Dir, detail.Ref
+		read := func() *CommitDetailContextResult {
+			ctx, cancel := context.WithTimeout(context.Background(), commitDetailContextTimeout)
+			defer cancel()
+			return readCommitDetailContext(ctx, tabID, dir, ref, fileIndex, file)
+		}
+		if a.Screen == nil {
+			a.ApplyCommitDetailContext(read())
+			return
+		}
+		screen := a.Screen
+		go func() {
+			screen.PostEvent(tcell.NewEventInterrupt(read()))
+		}()
+	}
+}
+
+func readCommitDetailContext(ctx context.Context, tabID, dir, ref string, fileIndex int, file ui.CommitDetailFile) *CommitDetailContextResult {
+	result := &CommitDetailContextResult{
+		TabID: tabID, Dir: dir, Ref: ref, FileIndex: fileIndex,
+		FileKey: ui.CommitDetailContextKey(file),
+	}
+	oldPath := file.Path
+	if file.OldPath != "" {
+		oldPath = file.OldPath
+	}
+	if content, err := git.ShowFileContext(ctx, dir, oldPath, ref+"^"); err == nil {
+		result.OldLines = splitCommitDetailLines(content)
+	}
+	if content, err := git.ShowFileContext(ctx, dir, file.Path, ref); err == nil {
+		result.NewLines = splitCommitDetailLines(content)
+	}
+	return result
+}
+
+func splitCommitDetailLines(content string) []string {
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func (a *App) ApplyCommitDetailContext(result *CommitDetailContextResult) {
+	detail := a.EditorGroup.CommitDetailWidgetByTab(result.TabID)
+	if detail == nil || detail.Dir != result.Dir || detail.Ref != result.Ref {
+		return
+	}
+	detail.ApplyFileContext(result.FileIndex, result.FileKey, result.OldLines, result.NewLines)
+}

--- a/internal/app/commit_history_layer_test.go
+++ b/internal/app/commit_history_layer_test.go
@@ -90,7 +90,7 @@ func TestApplyCommitDetailUsesRepositoryHashIdentityAndPreciseTimestamp(t *testi
 	app.ApplyCommitDetail(&CommitDetailResult{
 		Dir: "/repo", Ref: ref, Message: "subject", AuthoredAt: authored,
 	})
-	if detail.Loading || detail.Metadata != "Authored Aug 22, 2026 at 3:14 AM -0400" {
+	if detail.Loading || detail.Metadata != "Authored Aug 22, 2026 at 3:14:15 AM -0400" {
 		t.Fatalf("applied detail loading=%v metadata=%q", detail.Loading, detail.Metadata)
 	}
 }

--- a/internal/app/commit_history_layer_test.go
+++ b/internal/app/commit_history_layer_test.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func TestCommitLogRestoresSelectionByFullHashAfterAsyncRebuild(t *testing.T) {
+	cp := NewChangesPanel()
+	dir := "/repo"
+	cp.logGen = 1
+	cp.lastLogDir = dir
+	cp.ApplyCommitLog(&CommitLogResult{Gen: 1, Dir: dir, Branch: "main", Entries: []git.LogEntry{
+		{Ref: strings.Repeat("a", 40), Hash: "aaaaaaa", Message: "selected"},
+		{Ref: strings.Repeat("b", 40), Hash: "bbbbbbb", Message: "older"},
+	}})
+	selectedID := "commit:" + strings.Repeat("a", 40)
+	if !cp.selectLogNode(selectedID) {
+		t.Fatal("initial full-hash row missing")
+	}
+
+	cp.logGen = 2
+	cp.lastLogDir = dir
+	cp.ApplyCommitLog(&CommitLogResult{Gen: 2, Dir: dir, Branch: "main", Entries: []git.LogEntry{
+		{Ref: strings.Repeat("c", 40), Hash: "ccccccc", Message: "newest"},
+		{Ref: strings.Repeat("a", 40), Hash: "aaaaaaa", Message: "selected"},
+		{Ref: strings.Repeat("b", 40), Hash: "bbbbbbb", Message: "older"},
+	}})
+	if got := cp.CommitLog.Selected(); got == nil || got.ID != selectedID {
+		t.Fatalf("selection after prepend = %#v, want %s", got, selectedID)
+	}
+}
+
+func TestCommitLogExpansionIdentityIncludesRepository(t *testing.T) {
+	cp := NewChangesPanel()
+	ref := strings.Repeat("a", 40)
+	cp.logExpanded[commitLogStateKey("/first", "commit:"+ref)] = true
+	cp.logGen = 1
+	cp.lastLogDir = "/second"
+	cp.ApplyCommitLog(&CommitLogResult{Gen: 1, Dir: "/second", Entries: []git.LogEntry{{Ref: ref, Hash: "aaaaaaa", Message: "same object"}}})
+	if node := cp.commitNode("commit:" + ref); node == nil || node.Expanded {
+		t.Fatalf("second repository inherited expansion: %#v", node)
+	}
+}
+
+func TestCommitLogDropsStaleGenerationAndShowsFirstLoadError(t *testing.T) {
+	cp := NewChangesPanel()
+	cp.logGen = 2
+	cp.lastLogDir = "/new"
+	cp.CommitLog.SetItems(nil)
+	cp.ApplyCommitLog(&CommitLogResult{Gen: 1, Dir: "/old", Entries: []git.LogEntry{{Ref: strings.Repeat("a", 40), Hash: "aaaaaaa", Message: "stale"}}})
+	if cp.CommitLog.ItemCount() != 0 {
+		t.Fatal("stale history result changed the tree")
+	}
+
+	cp.ApplyCommitLog(&CommitLogResult{Gen: 2, Dir: "/new", Err: errors.New("git unavailable")})
+	if got := cp.CommitLog.Selected(); got == nil || got.Label != "Could not read history" {
+		t.Fatalf("first-load error row = %#v", got)
+	}
+	if cp.lastLogDir != "" {
+		t.Fatalf("failed history remained non-retryable: %q", cp.lastLogDir)
+	}
+}
+
+func TestApplyCommitDetailUsesRepositoryHashIdentityAndPreciseTimestamp(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("d", 40)
+	detail := ui.NewCommitDetailWidget("/repo", ref, "ddddddd", false)
+	other := ui.NewCommitDetailWidget("/other", ref, "ddddddd", false)
+	group.OpenPluginTab(commitDetailTabID("/repo", ref), "Commit ddddddd", detail)
+	group.OpenPluginTab(commitDetailTabID("/other", ref), "Commit ddddddd", other)
+	app := &App{EditorGroup: group}
+
+	app.ApplyCommitDetail(&CommitDetailResult{
+		Dir: "/other", Ref: ref, Message: "other repository",
+	})
+	if !detail.Loading {
+		t.Fatal("mismatched repository populated loading detail")
+	}
+	if other.Loading || other.Message != "other repository" {
+		t.Fatal("same-hash repository detail did not populate its exact tab")
+	}
+
+	authored := time.Date(2026, time.August, 22, 3, 14, 15, 0, time.FixedZone("EDT", -4*60*60))
+	app.ApplyCommitDetail(&CommitDetailResult{
+		Dir: "/repo", Ref: ref, Message: "subject", AuthoredAt: authored,
+	})
+	if detail.Loading || detail.Metadata != "Authored Aug 22, 2026 at 3:14 AM -0400" {
+		t.Fatalf("applied detail loading=%v metadata=%q", detail.Loading, detail.Metadata)
+	}
+}

--- a/internal/app/commit_history_release_review_test.go
+++ b/internal/app/commit_history_release_review_test.go
@@ -2,18 +2,11 @@ package app
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
-	"github.com/eugenioenko/ttt/internal/config"
-	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
-	"github.com/gdamore/tcell/v3"
 )
 
 func TestCommitDetailClosedRequestCannotOverwriteReopenedCommit(t *testing.T) {
@@ -125,52 +118,6 @@ func TestCommitDetailAuthoredTimestampPreservesGitSecondPrecision(t *testing.T) 
 	}
 }
 
-func TestClosingCommitDetailCancelsItsGitProcess(t *testing.T) {
-	binDir := t.TempDir()
-	pidPath := filepath.Join(binDir, "git.pid")
-	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$REVIEW_GIT_PID\"\nexec sleep 30\n"
-	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
-	t.Setenv("REVIEW_GIT_PID", pidPath)
-
-	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
-	sim := term.NewSimScreen()
-	app := &App{
-		EditorGroup: group,
-		Screen:      term.NewTcellScreenFrom(sim),
-		Settings:    &config.Settings{},
-	}
-	ref := strings.Repeat("d", 40)
-	app.OpenCommitDetail("/repo", ref, "ddddddd")
-	tabID := commitDetailTabID("/repo", ref)
-
-	deadline := time.Now().Add(time.Second)
-	var pid int
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(pidPath)
-		if err == nil {
-			pid, err = strconv.Atoi(string(data))
-			if err != nil {
-				t.Fatal(err)
-			}
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if pid == 0 {
-		t.Fatal("fake git did not start")
-	}
-	defer syscall.Kill(pid, syscall.SIGKILL)
-
-	group.ClosePluginTab(tabID)
-	time.Sleep(50 * time.Millisecond)
-	if err := syscall.Kill(pid, 0); err == nil {
-		t.Fatalf("git process %d is still alive after its detail tab closed", pid)
-	}
-}
-
 func TestCommitDetailIncarnationsIncreaseAcrossRepeatedCloseReopen(t *testing.T) {
 	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
 	app := &App{EditorGroup: group}
@@ -196,43 +143,6 @@ func TestCommitDetailIncarnationsIncreaseAcrossRepeatedCloseReopen(t *testing.T)
 	}
 }
 
-func TestSupersededCommitHistoryCancelsItsGitProcess(t *testing.T) {
-	binDir := t.TempDir()
-	pidPath := filepath.Join(binDir, "history.pid")
-	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$REVIEW_HISTORY_PID\"\nexec sleep 30\n"
-	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
-	t.Setenv("REVIEW_HISTORY_PID", pidPath)
-
-	panel := NewChangesPanel()
-	sim := term.NewSimScreen()
-	panel.Screen = term.NewTcellScreenFrom(sim)
-	panel.groups = []changesGroup{{Dir: "/repo"}}
-	panel.refreshCommitLog()
-	pid := waitReviewPID(t, pidPath)
-	defer syscall.Kill(pid, syscall.SIGKILL)
-
-	panel.groups = nil
-	panel.lastLogDir = ""
-	panel.refreshCommitLog()
-	waitReviewProcessExit(t, pid)
-	select {
-	case event := <-sim.EventQ():
-		interrupt, ok := event.(*tcell.EventInterrupt)
-		if !ok {
-			t.Fatalf("history cancellation event = %T", event)
-		}
-		result, ok := interrupt.Data().(*CommitLogResult)
-		if !ok || !result.Canceled {
-			t.Fatalf("history cancellation result = %#v", interrupt.Data())
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("canceled history command was not reaped")
-	}
-}
-
 func TestShutdownGitReadsCancelsEveryLiveRequest(t *testing.T) {
 	app := &App{Changes: NewChangesPanel()}
 	first := app.beginCommitDetailRequest("first")
@@ -252,34 +162,4 @@ func TestShutdownGitReadsCancelsEveryLiveRequest(t *testing.T) {
 			t.Fatalf("%s request remained live after shutdown", name)
 		}
 	}
-}
-
-func waitReviewPID(t *testing.T, path string) int {
-	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(path)
-		if err == nil {
-			pid, err := strconv.Atoi(string(data))
-			if err != nil {
-				t.Fatal(err)
-			}
-			return pid
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("fake git did not start")
-	return 0
-}
-
-func waitReviewProcessExit(t *testing.T, pid int) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(pid, 0); err != nil {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("git process %d is still alive", pid)
 }

--- a/internal/app/commit_history_release_review_test.go
+++ b/internal/app/commit_history_release_review_test.go
@@ -1,0 +1,285 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestCommitDetailClosedRequestCannotOverwriteReopenedCommit(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("a", 40)
+	tabID := commitDetailTabID("/repo", ref)
+
+	first := ui.NewCommitDetailWidget("/repo", ref, "aaaaaaa", false)
+	first.Incarnation = 1
+	group.OpenPluginTab(tabID, "Commit aaaaaaa", first)
+	group.ClosePluginTab(tabID)
+
+	reopened := ui.NewCommitDetailWidget("/repo", ref, "aaaaaaa", false)
+	reopened.Incarnation = 2
+	group.OpenPluginTab(tabID, "Commit aaaaaaa", reopened)
+	app := &App{EditorGroup: group}
+
+	app.ApplyCommitDetail(&CommitDetailResult{Incarnation: 2, Dir: "/repo", Ref: ref, Message: "new request succeeded"})
+	app.ApplyCommitDetail(&CommitDetailResult{Incarnation: 1, Dir: "/repo", Ref: ref, Err: "older request failed"})
+
+	if reopened.Error != "" || reopened.Message != "new request succeeded" {
+		t.Fatalf("older closed-tab result overwrote reopened success: message=%q error=%q", reopened.Message, reopened.Error)
+	}
+}
+
+func TestCommitDetailStaleSuccessCannotOverwriteReopenedFailure(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("f", 40)
+	tabID := commitDetailTabID("/repo", ref)
+	reopened := ui.NewCommitDetailWidget("/repo", ref, "fffffff", false)
+	reopened.Incarnation = 2
+	group.OpenPluginTab(tabID, "Commit fffffff", reopened)
+	app := &App{EditorGroup: group}
+
+	app.ApplyCommitDetail(&CommitDetailResult{Incarnation: 2, Dir: "/repo", Ref: ref, Err: "new request failed"})
+	app.ApplyCommitDetail(&CommitDetailResult{Incarnation: 1, Dir: "/repo", Ref: ref, Message: "older request succeeded"})
+	if reopened.Error != "new request failed" || reopened.Message != "" {
+		t.Fatalf("stale success overwrote reopened failure: message=%q error=%q", reopened.Message, reopened.Error)
+	}
+}
+
+func TestCommitDetailClosedContextRequestCannotOverwriteReopenedCommit(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("b", 40)
+	tabID := commitDetailTabID("/repo", ref)
+
+	first := ui.NewCommitDetailWidget("/repo", ref, "bbbbbbb", false)
+	first.Incarnation = 1
+	group.OpenPluginTab(tabID, "Commit bbbbbbb", first)
+	group.ClosePluginTab(tabID)
+
+	reopened := ui.NewCommitDetailWidget("/repo", ref, "bbbbbbb", false)
+	reopened.Incarnation = 2
+	reopened.SetDetail("subject", []ui.CommitDetailFile{{Path: "file.txt"}}, "")
+	group.OpenPluginTab(tabID, "Commit bbbbbbb", reopened)
+	app := &App{EditorGroup: group}
+	key := ui.CommitDetailContextKey(reopened.Files[0])
+
+	app.ApplyCommitDetailContext(&CommitDetailContextResult{
+		Incarnation: 2, TabID: tabID, Dir: "/repo", Ref: ref, FileIndex: 0, FileKey: key,
+		OldLines: []string{"old"}, NewLines: []string{"new"},
+	})
+	app.ApplyCommitDetailContext(&CommitDetailContextResult{
+		Incarnation: 1, TabID: tabID, Dir: "/repo", Ref: ref, FileIndex: 0, FileKey: key,
+		Err: "older request failed",
+	})
+
+	if reopened.Files[0].FullFileState != ui.CommitDetailFullFileLoaded {
+		t.Fatal("older closed-tab context result erased the reopened tab's successful context")
+	}
+}
+
+func TestCommitDetailStaleContextSuccessCannotOverwriteReopenedFailure(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("0", 40)
+	tabID := commitDetailTabID("/repo", ref)
+	reopened := ui.NewCommitDetailWidget("/repo", ref, "0000000", false)
+	reopened.Incarnation = 2
+	reopened.SetDetail("subject", []ui.CommitDetailFile{{Path: "file.txt"}}, "")
+	group.OpenPluginTab(tabID, "Commit 0000000", reopened)
+	app := &App{EditorGroup: group}
+	key := ui.CommitDetailContextKey(reopened.Files[0])
+
+	app.ApplyCommitDetailContext(&CommitDetailContextResult{
+		Incarnation: 2, TabID: tabID, Dir: "/repo", Ref: ref, FileIndex: 0, FileKey: key,
+		Err: "new request failed",
+	})
+	app.ApplyCommitDetailContext(&CommitDetailContextResult{
+		Incarnation: 1, TabID: tabID, Dir: "/repo", Ref: ref, FileIndex: 0, FileKey: key,
+		OldLines: []string{"old"}, NewLines: []string{"new"},
+	})
+	if reopened.Files[0].FullFileState != ui.CommitDetailFullFileFailed || reopened.Files[0].FullFileErr != "new request failed" {
+		t.Fatalf("stale context success overwrote failure: state=%v err=%q", reopened.Files[0].FullFileState, reopened.Files[0].FullFileErr)
+	}
+}
+
+func TestCommitDetailAuthoredTimestampPreservesGitSecondPrecision(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("c", 40)
+	detail := ui.NewCommitDetailWidget("/repo", ref, "ccccccc", false)
+	group.OpenPluginTab(commitDetailTabID("/repo", ref), "Commit ccccccc", detail)
+	app := &App{EditorGroup: group}
+	authored := time.Date(2026, time.August, 22, 3, 14, 15, 0, time.FixedZone("EDT", -4*60*60))
+
+	app.ApplyCommitDetail(&CommitDetailResult{Dir: "/repo", Ref: ref, Message: "subject", AuthoredAt: authored})
+
+	if detail.Metadata != "Authored Aug 22, 2026 at 3:14:15 AM -0400" {
+		t.Fatalf("authored timestamp lost precision: %q", detail.Metadata)
+	}
+}
+
+func TestClosingCommitDetailCancelsItsGitProcess(t *testing.T) {
+	binDir := t.TempDir()
+	pidPath := filepath.Join(binDir, "git.pid")
+	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$REVIEW_GIT_PID\"\nexec sleep 30\n"
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("REVIEW_GIT_PID", pidPath)
+
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	sim := term.NewSimScreen()
+	app := &App{
+		EditorGroup: group,
+		Screen:      term.NewTcellScreenFrom(sim),
+		Settings:    &config.Settings{},
+	}
+	ref := strings.Repeat("d", 40)
+	app.OpenCommitDetail("/repo", ref, "ddddddd")
+	tabID := commitDetailTabID("/repo", ref)
+
+	deadline := time.Now().Add(time.Second)
+	var pid int
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidPath)
+		if err == nil {
+			pid, err = strconv.Atoi(string(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if pid == 0 {
+		t.Fatal("fake git did not start")
+	}
+	defer syscall.Kill(pid, syscall.SIGKILL)
+
+	group.ClosePluginTab(tabID)
+	time.Sleep(50 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err == nil {
+		t.Fatalf("git process %d is still alive after its detail tab closed", pid)
+	}
+}
+
+func TestCommitDetailIncarnationsIncreaseAcrossRepeatedCloseReopen(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	app := &App{EditorGroup: group}
+	ref := strings.Repeat("e", 40)
+	tabID := commitDetailTabID("/repo", ref)
+	var previous uint64
+	for range 25 {
+		request := app.beginCommitDetailRequest(tabID)
+		if request.Incarnation <= previous {
+			t.Fatalf("incarnation %d did not increase after %d", request.Incarnation, previous)
+		}
+		previous = request.Incarnation
+		detail := ui.NewCommitDetailWidget("/repo", ref, "eeeeeee", false)
+		detail.Incarnation = request.Incarnation
+		detail.OnClose = func() { app.cancelCommitDetailRequest(tabID, request.Incarnation) }
+		group.OpenPluginTab(tabID, "Commit eeeeeee", detail)
+		group.ClosePluginTab(tabID)
+		select {
+		case <-request.Context.Done():
+		default:
+			t.Fatalf("incarnation %d remained live after close", request.Incarnation)
+		}
+	}
+}
+
+func TestSupersededCommitHistoryCancelsItsGitProcess(t *testing.T) {
+	binDir := t.TempDir()
+	pidPath := filepath.Join(binDir, "history.pid")
+	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$REVIEW_HISTORY_PID\"\nexec sleep 30\n"
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("REVIEW_HISTORY_PID", pidPath)
+
+	panel := NewChangesPanel()
+	sim := term.NewSimScreen()
+	panel.Screen = term.NewTcellScreenFrom(sim)
+	panel.groups = []changesGroup{{Dir: "/repo"}}
+	panel.refreshCommitLog()
+	pid := waitReviewPID(t, pidPath)
+	defer syscall.Kill(pid, syscall.SIGKILL)
+
+	panel.groups = nil
+	panel.lastLogDir = ""
+	panel.refreshCommitLog()
+	waitReviewProcessExit(t, pid)
+	select {
+	case event := <-sim.EventQ():
+		interrupt, ok := event.(*tcell.EventInterrupt)
+		if !ok {
+			t.Fatalf("history cancellation event = %T", event)
+		}
+		result, ok := interrupt.Data().(*CommitLogResult)
+		if !ok || !result.Canceled {
+			t.Fatalf("history cancellation result = %#v", interrupt.Data())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled history command was not reaped")
+	}
+}
+
+func TestShutdownGitReadsCancelsEveryLiveRequest(t *testing.T) {
+	app := &App{Changes: NewChangesPanel()}
+	first := app.beginCommitDetailRequest("first")
+	second := app.beginCommitDetailRequest("second")
+	fileContext, cancelFile := context.WithCancel(context.Background())
+	app.Changes.commitFilesPending["file"] = commitFilesRequest{ID: 1, Cancel: cancelFile}
+
+	app.ShutdownGitReads()
+	for name, done := range map[string]<-chan struct{}{
+		"first detail":  first.Context.Done(),
+		"second detail": second.Context.Done(),
+		"history file":  fileContext.Done(),
+	} {
+		select {
+		case <-done:
+		default:
+			t.Fatalf("%s request remained live after shutdown", name)
+		}
+	}
+}
+
+func waitReviewPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(string(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return pid
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("fake git did not start")
+	return 0
+}
+
+func waitReviewProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("git process %d is still alive", pid)
+}

--- a/internal/app/commit_history_release_review_unix_test.go
+++ b/internal/app/commit_history_release_review_unix_test.go
@@ -1,0 +1,131 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestClosingCommitDetailCancelsItsGitProcess(t *testing.T) {
+	binDir := t.TempDir()
+	pidPath := filepath.Join(binDir, "git.pid")
+	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$REVIEW_GIT_PID\"\nexec sleep 30\n"
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("REVIEW_GIT_PID", pidPath)
+
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	sim := term.NewSimScreen()
+	app := &App{
+		EditorGroup: group,
+		Screen:      term.NewTcellScreenFrom(sim),
+		Settings:    &config.Settings{},
+	}
+	ref := strings.Repeat("d", 40)
+	app.OpenCommitDetail("/repo", ref, "ddddddd")
+	tabID := commitDetailTabID("/repo", ref)
+
+	deadline := time.Now().Add(time.Second)
+	var pid int
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidPath)
+		if err == nil {
+			pid, err = strconv.Atoi(string(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if pid == 0 {
+		t.Fatal("fake git did not start")
+	}
+	defer syscall.Kill(pid, syscall.SIGKILL)
+
+	group.ClosePluginTab(tabID)
+	time.Sleep(50 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err == nil {
+		t.Fatalf("git process %d is still alive after its detail tab closed", pid)
+	}
+}
+
+func TestSupersededCommitHistoryCancelsItsGitProcess(t *testing.T) {
+	binDir := t.TempDir()
+	pidPath := filepath.Join(binDir, "history.pid")
+	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$REVIEW_HISTORY_PID\"\nexec sleep 30\n"
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("REVIEW_HISTORY_PID", pidPath)
+
+	panel := NewChangesPanel()
+	sim := term.NewSimScreen()
+	panel.Screen = term.NewTcellScreenFrom(sim)
+	panel.groups = []changesGroup{{Dir: "/repo"}}
+	panel.refreshCommitLog()
+	pid := waitReviewPID(t, pidPath)
+	defer syscall.Kill(pid, syscall.SIGKILL)
+
+	panel.groups = nil
+	panel.lastLogDir = ""
+	panel.refreshCommitLog()
+	waitReviewProcessExit(t, pid)
+	select {
+	case event := <-sim.EventQ():
+		interrupt, ok := event.(*tcell.EventInterrupt)
+		if !ok {
+			t.Fatalf("history cancellation event = %T", event)
+		}
+		result, ok := interrupt.Data().(*CommitLogResult)
+		if !ok || !result.Canceled {
+			t.Fatalf("history cancellation result = %#v", interrupt.Data())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled history command was not reaped")
+	}
+}
+
+func waitReviewPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(string(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return pid
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("fake git did not start")
+	return 0
+}
+
+func waitReviewProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("git process %d is still alive", pid)
+}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -377,6 +377,14 @@ func RunEventLoop(
 				app.SyncLanguageSegment()
 			case *RepoOpResult:
 				app.HandleRepoOpResult(v)
+			case *CommitLogResult:
+				app.Changes.ApplyCommitLog(v)
+			case *CommitFilesResult:
+				app.Changes.ApplyCommitFiles(v)
+			case *CommitDetailResult:
+				app.ApplyCommitDetail(v)
+			case *CommitDetailContextResult:
+				app.ApplyCommitDetailContext(v)
 			case *FileChangedResult:
 				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -29,6 +29,7 @@ func RunEventLoop(
 	app.eventLoopDoneSignal()
 	defer app.closeEventLoopDone()
 	defer app.Root.CancelPointerCapture()
+	defer app.ShutdownGitReads()
 	if app.Watcher != nil {
 		defer app.Watcher.Close()
 	}

--- a/internal/app/settings_apply_test.go
+++ b/internal/app/settings_apply_test.go
@@ -57,3 +57,26 @@ func TestCommitToCoversEveryField(t *testing.T) {
 		}
 	}
 }
+
+func TestShowSettingsReopenPreservesPendingWorkingView(t *testing.T) {
+	a := buildTestApp(t, config.DefaultSettings())
+	a.EditorGroup.OnContentTabClose = func(id string) {
+		a.cleanupPluginDetailTab(id)
+		a.cleanupSettingsTab(id)
+	}
+	a.ShowSettings()
+	first := a.settingsView
+	if first == nil {
+		t.Fatal("opening settings did not create a working view")
+	}
+	first.working.Editor.TabSize = 7
+
+	a.ShowSettings()
+
+	if a.settingsView != first {
+		t.Fatalf("reopening settings discarded working view: got %p, want %p", a.settingsView, first)
+	}
+	if got := a.settingsView.working.Editor.TabSize; got != 7 {
+		t.Fatalf("reopening settings discarded pending tab size: got %d, want 7", got)
+	}
+}

--- a/internal/app/settings_view.go
+++ b/internal/app/settings_view.go
@@ -240,7 +240,9 @@ func (v *settingsView) closeSelectsExcept(keep *widgets.SelectWidget) {
 func (a *App) ShowSettings() {
 	// Reopening while the tab is already open must not discard pending edits.
 	if v := a.settingsView; v != nil {
-		a.EditorGroup.OpenPluginTab(settingsTabID, "Settings", v.adapter)
+		if !a.EditorGroup.SwitchToTabByPath(settingsTabID) {
+			a.EditorGroup.OpenPluginTab(settingsTabID, "Settings", v.adapter)
+		}
 		a.FocusEditor()
 		v.adapter.SetFocused(true)
 		return

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -26,6 +26,7 @@ func BuildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	m[term.StyleSelection] = base.Reverse(true)
 
 	applyStyleDef(&m, term.StyleStatusBar, theme.StatusBar)
+	applyStyleDef(&m, term.StyleCommitMessage, theme.CommitMessage)
 	applyStyleDef(&m, term.StyleActiveTab, theme.Tabs.Active)
 	applyStyleDef(&m, term.StyleInactiveTab, theme.Tabs.Inactive)
 	selectedTab := theme.Tabs.Selected

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -205,27 +205,28 @@ type HoverStyles struct {
 }
 
 type ThemeConfig struct {
-	Default      StyleDef       `json:"default"`
-	Muted        StyleDef       `json:"muted"`
-	Success      StyleDef       `json:"success"`
-	Danger       StyleDef       `json:"danger"`
-	Warning      StyleDef       `json:"warning"`
-	StatusBar    StyleDef       `json:"statusBar"`
-	Tabs         TabStyles      `json:"tabs"`
-	Sidebar      SidebarStyles  `json:"sidebar"`
-	Dialog       DialogStyles   `json:"dialog"`
-	Editor       EditorStyles   `json:"editor"`
-	Menu         MenuStyles     `json:"menu"`
-	Input        InputStyles    `json:"input"`
-	Button       ButtonStyles   `json:"button"`
-	Hover        HoverStyles    `json:"hover"`
-	Border       StyleDef       `json:"border"`
-	BorderActive StyleDef       `json:"borderActive"`
-	Diff         DiffStyles     `json:"diff"`
-	Scrollbar    StyleDef       `json:"scrollbar"`
-	Syntax       SyntaxStyles   `json:"syntax"`
-	Borders      BorderChars    `json:"borders"`
-	Terminal     TerminalColors `json:"terminal,omitempty"`
+	Default       StyleDef       `json:"default"`
+	Muted         StyleDef       `json:"muted"`
+	Success       StyleDef       `json:"success"`
+	Danger        StyleDef       `json:"danger"`
+	Warning       StyleDef       `json:"warning"`
+	StatusBar     StyleDef       `json:"statusBar"`
+	CommitMessage StyleDef       `json:"commitMessage"`
+	Tabs          TabStyles      `json:"tabs"`
+	Sidebar       SidebarStyles  `json:"sidebar"`
+	Dialog        DialogStyles   `json:"dialog"`
+	Editor        EditorStyles   `json:"editor"`
+	Menu          MenuStyles     `json:"menu"`
+	Input         InputStyles    `json:"input"`
+	Button        ButtonStyles   `json:"button"`
+	Hover         HoverStyles    `json:"hover"`
+	Border        StyleDef       `json:"border"`
+	BorderActive  StyleDef       `json:"borderActive"`
+	Diff          DiffStyles     `json:"diff"`
+	Scrollbar     StyleDef       `json:"scrollbar"`
+	Syntax        SyntaxStyles   `json:"syntax"`
+	Borders       BorderChars    `json:"borders"`
+	Terminal      TerminalColors `json:"terminal,omitempty"`
 }
 
 func DefaultTheme() ThemeConfig {
@@ -237,7 +238,8 @@ func DefaultTheme() ThemeConfig {
 		Menu: MenuStyles{
 			Active: StyleDef{Fg: "#ffffff", Bg: "#505050", Bold: true},
 		},
-		StatusBar: StyleDef{},
+		StatusBar:     StyleDef{},
+		CommitMessage: StyleDef{Fg: "#fafafa", Bg: "#2a2f3a"},
 
 		Tabs: TabStyles{
 			Active:   StyleDef{Fg: "#ffffff", Bold: true},

--- a/internal/git/command_context_other.go
+++ b/internal/git/command_context_other.go
@@ -1,0 +1,15 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package git
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+func gitCommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.WaitDelay = time.Second
+	return cmd
+}

--- a/internal/git/command_context_test.go
+++ b/internal/git/command_context_test.go
@@ -1,0 +1,78 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestCommitMessageContextCancellationKillsAndReapsProcessGroup(t *testing.T) {
+	binDir := t.TempDir()
+	parentPath := filepath.Join(binDir, "parent.pid")
+	childPath := filepath.Join(binDir, "child.pid")
+	script := "#!/bin/sh\nprintf '%s' \"$$\" > \"$FAKE_GIT_PARENT\"\nsleep 30 &\nprintf '%s' \"$!\" > \"$FAKE_GIT_CHILD\"\nwait\n"
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("FAKE_GIT_PARENT", parentPath)
+	t.Setenv("FAKE_GIT_CHILD", childPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := CommitMessageContext(ctx, "/repo", strings.Repeat("a", 40))
+		errCh <- err
+	}()
+	parent := waitFakeGitPID(t, parentPath)
+	child := waitFakeGitPID(t, childPath)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled git returned %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled git command was not reaped")
+	}
+	waitFakeGitExit(t, parent)
+	waitFakeGitExit(t, child)
+}
+
+func waitFakeGitPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(string(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return pid
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("fake git did not write %s", filepath.Base(path))
+	return 0
+}
+
+func waitFakeGitExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	defer syscall.Kill(pid, syscall.SIGKILL)
+	t.Fatalf("fake git process %d is still alive", pid)
+}

--- a/internal/git/command_context_unix.go
+++ b/internal/git/command_context_unix.go
@@ -1,0 +1,29 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func gitCommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	cmd.WaitDelay = time.Second
+	return cmd
+}

--- a/internal/git/command_context_unix_test.go
+++ b/internal/git/command_context_unix_test.go
@@ -1,3 +1,5 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
 package git
 
 import (

--- a/internal/git/commit_shapes_test.go
+++ b/internal/git/commit_shapes_test.go
@@ -1,0 +1,110 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func commitShapeGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Review", "GIT_AUTHOR_EMAIL=review@example.com",
+		"GIT_COMMITTER_NAME=Review", "GIT_COMMITTER_EMAIL=review@example.com",
+		"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func commitShapeWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCommitShapesRootRenameMergeUnicodeAndBinary(t *testing.T) {
+	dir := t.TempDir()
+	commitShapeGit(t, dir, "init", "-q", "-b", "main")
+	commitShapeWrite(t, filepath.Join(dir, "old name.txt"), []byte("old line\nshared line\n"))
+	commitShapeWrite(t, filepath.Join(dir, "blob.bin"), bytes.Repeat([]byte{0, 1, 2, 3}, 32))
+	commitShapeGit(t, dir, "add", "-A")
+	cmd := exec.Command("git", "commit", "-qm", "root")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Review", "GIT_AUTHOR_EMAIL=review@example.com",
+		"GIT_COMMITTER_NAME=Review", "GIT_COMMITTER_EMAIL=review@example.com",
+		"GIT_AUTHOR_DATE=2026-08-22T03:14:15-04:00", "GIT_COMMITTER_DATE=2026-08-22T03:14:15-04:00",
+		"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("root commit: %v\n%s", err, out)
+	}
+	root := commitShapeGit(t, dir, "rev-parse", "HEAD")
+	files, err := CommitFiles(dir, root)
+	if err != nil || len(files) != 2 {
+		t.Fatalf("root files: files=%+v err=%v", files, err)
+	}
+	when, err := CommitAuthoredAt(dir, root)
+	_, offset := when.Zone()
+	if err != nil || when.Second() != 15 || offset != -4*60*60 {
+		t.Fatalf("authored time=%v err=%v", when, err)
+	}
+	for _, file := range files {
+		text, err := CommitFileDiff(dir, root, file)
+		if err != nil || !strings.Contains(text, file.Path) {
+			t.Fatalf("root diff %q: err=%v\n%s", file.Path, err, text)
+		}
+	}
+
+	commitShapeGit(t, dir, "mv", "old name.txt", "renamed:界.txt")
+	commitShapeGit(t, dir, "commit", "-qm", "rename")
+	renameRef := commitShapeGit(t, dir, "rev-parse", "HEAD")
+	renames, err := CommitFiles(dir, renameRef)
+	if err != nil || len(renames) != 1 || renames[0].Status != "R" || renames[0].OldPath != "old name.txt" || renames[0].Path != "renamed:界.txt" {
+		t.Fatalf("rename files=%+v err=%v", renames, err)
+	}
+	if text, err := CommitFileDiff(dir, renameRef, renames[0]); err != nil || !strings.Contains(text, "rename from old name.txt") || !strings.Contains(text, "rename to ") {
+		t.Fatalf("rename diff err=%v\n%s", err, text)
+	}
+
+	commitShapeGit(t, dir, "checkout", "-qb", "topic")
+	commitShapeWrite(t, filepath.Join(dir, "topic.txt"), []byte("topic\n"))
+	commitShapeGit(t, dir, "add", "topic.txt")
+	commitShapeGit(t, dir, "commit", "-qm", "topic")
+	commitShapeGit(t, dir, "checkout", "-q", "main")
+	commitShapeWrite(t, filepath.Join(dir, "main.txt"), []byte("main\n"))
+	commitShapeGit(t, dir, "add", "main.txt")
+	commitShapeGit(t, dir, "commit", "-qm", "main")
+	commitShapeGit(t, dir, "merge", "--no-ff", "-qm", "merge", "topic")
+	mergeRef := commitShapeGit(t, dir, "rev-parse", "HEAD")
+	mergeFiles, err := CommitFiles(dir, mergeRef)
+	if err != nil || len(mergeFiles) != 1 || mergeFiles[0].Path != "topic.txt" {
+		t.Fatalf("first-parent merge files=%+v err=%v", mergeFiles, err)
+	}
+}
+
+func TestCommitLogUnbornAndNonRepo(t *testing.T) {
+	unborn := t.TempDir()
+	commitShapeGit(t, unborn, "init", "-q", "-b", "main")
+	entries, err := LogWithError(unborn, 10)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("unborn entries=%+v err=%v", entries, err)
+	}
+	if _, err := LogWithError(t.TempDir(), 10); err == nil {
+		t.Fatal("non-repository log unexpectedly succeeded")
+	}
+	if got, err := time.Parse(time.RFC3339, "2026-08-22T03:14:15-04:00"); err != nil || got.Second() != 15 {
+		t.Fatal("test timestamp invalid")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -154,25 +155,107 @@ func BranchName(dir string) string {
 }
 
 type LogEntry struct {
+	// Hash is presentation-only; Ref is the stable full object identity.
 	Hash    string
+	Ref     string
 	Message string
 }
 
 func Log(dir string, n int) []LogEntry {
-	cmd := exec.Command("git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%h %s")
+	entries, _ := LogWithError(dir, n)
+	return entries
+}
+
+func LogWithError(dir string, n int) ([]LogEntry, error) {
+	if err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "HEAD").Run(); err != nil {
+		if IsRepo(dir) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	cmd := exec.Command("git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
 	out, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	var entries []LogEntry
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		if line == "" {
 			continue
 		}
-		hash, msg, _ := strings.Cut(line, " ")
-		entries = append(entries, LogEntry{Hash: hash, Message: msg})
+		ref, rest, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		hash, msg, _ := strings.Cut(rest, " ")
+		entries = append(entries, LogEntry{Hash: hash, Ref: ref, Message: msg})
 	}
-	return entries
+	return entries, nil
+}
+
+func CommitAuthoredAt(dir, ref string) (time.Time, error) {
+	out, err := exec.Command("git", "-C", dir, "show", "-s", "--format=%aI", ref).Output()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Parse(time.RFC3339, strings.TrimSpace(string(out)))
+}
+
+func CommitFiles(dir, hash string) ([]FileStatus, error) {
+	out, err := exec.Command("git", "-C", dir, "show", "--name-status",
+		"--diff-merges=first-parent", "-M", "--format=", "-z", hash).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseNameStatusZ(out), nil
+}
+
+func parseNameStatusZ(out []byte) []FileStatus {
+	fields := strings.Split(strings.TrimSuffix(string(out), "\x00"), "\x00")
+	var files []FileStatus
+	for i := 0; i < len(fields); {
+		code := fields[i]
+		if code == "" {
+			i++
+			continue
+		}
+		status := code[:1]
+		if status == "R" || status == "C" {
+			if i+2 >= len(fields) {
+				break
+			}
+			files = append(files, FileStatus{Status: status, OldPath: fields[i+1], Path: fields[i+2]})
+			i += 3
+			continue
+		}
+		if i+1 >= len(fields) {
+			break
+		}
+		files = append(files, FileStatus{Status: status, Path: fields[i+1]})
+		i += 2
+	}
+	return files
+}
+
+func CommitFileDiff(dir, hash string, file FileStatus) (string, error) {
+	args := []string{"-C", dir, "--literal-pathspecs", "show", "--diff-merges=first-parent", "-M", "--format=", hash, "--"}
+	if file.OldPath != "" {
+		args = append(args, file.OldPath)
+	}
+	args = append(args, file.Path)
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func CommitMessage(dir, hash string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "show", "-s", "--format=%B", hash).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
 }
 
 type BlameInfo struct {
@@ -320,8 +403,12 @@ func IgnoredFiles(dir string, paths []string) map[string]bool {
 }
 
 func ShowFile(dir, path, ref string) (string, error) {
+	return ShowFileContext(context.Background(), dir, path, ref)
+}
+
+func ShowFileContext(ctx context.Context, dir, path, ref string) (string, error) {
 	spec := ref + ":" + path
-	cmd := exec.Command("git", "-C", dir, "show", spec)
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "show", spec)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -27,7 +27,11 @@ func RepoRoot(dir string) string {
 }
 
 func IsRepo(dir string) bool {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--is-inside-work-tree")
+	return IsRepoContext(context.Background(), dir)
+}
+
+func IsRepoContext(ctx context.Context, dir string) bool {
+	cmd := gitCommandContext(ctx, "-C", dir, "rev-parse", "--is-inside-work-tree")
 	out, err := cmd.Output()
 	return err == nil && strings.TrimSpace(string(out)) == "true"
 }
@@ -146,7 +150,11 @@ func Push(dir string) error {
 }
 
 func BranchName(dir string) string {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
+	return BranchNameContext(context.Background(), dir)
+}
+
+func BranchNameContext(ctx context.Context, dir string) string {
+	cmd := gitCommandContext(ctx, "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -167,15 +175,25 @@ func Log(dir string, n int) []LogEntry {
 }
 
 func LogWithError(dir string, n int) ([]LogEntry, error) {
-	if err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "HEAD").Run(); err != nil {
-		if IsRepo(dir) {
+	return LogWithErrorContext(context.Background(), dir, n)
+}
+
+func LogWithErrorContext(ctx context.Context, dir string, n int) ([]LogEntry, error) {
+	if err := gitCommandContext(ctx, "-C", dir, "rev-parse", "--verify", "HEAD").Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if IsRepoContext(ctx, dir) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	cmd := exec.Command("git", "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
+	cmd := gitCommandContext(ctx, "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
 	out, err := cmd.Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return nil, err
 	}
 	var entries []LogEntry
@@ -194,17 +212,31 @@ func LogWithError(dir string, n int) ([]LogEntry, error) {
 }
 
 func CommitAuthoredAt(dir, ref string) (time.Time, error) {
-	out, err := exec.Command("git", "-C", dir, "show", "-s", "--format=%aI", ref).Output()
+	return CommitAuthoredAtContext(context.Background(), dir, ref)
+}
+
+func CommitAuthoredAtContext(ctx context.Context, dir, ref string) (time.Time, error) {
+	out, err := gitCommandContext(ctx, "-C", dir, "show", "-s", "--format=%aI", ref).Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return time.Time{}, ctx.Err()
+		}
 		return time.Time{}, err
 	}
 	return time.Parse(time.RFC3339, strings.TrimSpace(string(out)))
 }
 
 func CommitFiles(dir, hash string) ([]FileStatus, error) {
-	out, err := exec.Command("git", "-C", dir, "show", "--name-status",
+	return CommitFilesContext(context.Background(), dir, hash)
+}
+
+func CommitFilesContext(ctx context.Context, dir, hash string) ([]FileStatus, error) {
+	out, err := gitCommandContext(ctx, "-C", dir, "show", "--name-status",
 		"--diff-merges=first-parent", "-M", "--format=", "-z", hash).Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return nil, err
 	}
 	return parseNameStatusZ(out), nil
@@ -238,21 +270,35 @@ func parseNameStatusZ(out []byte) []FileStatus {
 }
 
 func CommitFileDiff(dir, hash string, file FileStatus) (string, error) {
+	return CommitFileDiffContext(context.Background(), dir, hash, file)
+}
+
+func CommitFileDiffContext(ctx context.Context, dir, hash string, file FileStatus) (string, error) {
 	args := []string{"-C", dir, "--literal-pathspecs", "show", "--diff-merges=first-parent", "-M", "--format=", hash, "--"}
 	if file.OldPath != "" {
 		args = append(args, file.OldPath)
 	}
 	args = append(args, file.Path)
-	out, err := exec.Command("git", args...).Output()
+	out, err := gitCommandContext(ctx, args...).Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
 		return "", err
 	}
 	return string(out), nil
 }
 
 func CommitMessage(dir, hash string) (string, error) {
-	out, err := exec.Command("git", "-C", dir, "show", "-s", "--format=%B", hash).Output()
+	return CommitMessageContext(context.Background(), dir, hash)
+}
+
+func CommitMessageContext(ctx context.Context, dir, hash string) (string, error) {
+	out, err := gitCommandContext(ctx, "-C", dir, "show", "-s", "--format=%B", hash).Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
 		return "", err
 	}
 	return strings.TrimRight(string(out), "\r\n"), nil
@@ -408,9 +454,12 @@ func ShowFile(dir, path, ref string) (string, error) {
 
 func ShowFileContext(ctx context.Context, dir, path, ref string) (string, error) {
 	spec := ref + ":" + path
-	cmd := exec.CommandContext(ctx, "git", "-C", dir, "show", spec)
+	cmd := gitCommandContext(ctx, "-C", dir, "show", spec)
 	out, err := cmd.Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
 		return "", err
 	}
 	return string(out), nil

--- a/internal/term/screen.go
+++ b/internal/term/screen.go
@@ -5,6 +5,7 @@ type Style int
 const (
 	StyleDefault Style = iota
 	StyleStatusBar
+	StyleCommitMessage
 	StyleActiveTab
 	StyleInactiveTab
 	StyleSidebarSelected

--- a/internal/ui/commit_detail_context_state_test.go
+++ b/internal/ui/commit_detail_context_state_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+)
+
+func TestCommitDetailFailedFullFileContextCanRetryWithoutModeRoundTrip(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full", "abcdef0", false)
+	detail.SetDetail("subject", []CommitDetailFile{{
+		Path: "file.txt",
+		Diff: diff.Parse("--- a/file.txt\n+++ b/file.txt\n@@ -2 +2 @@\n-old\n+new\n"),
+	}}, "")
+	fetches := 0
+	detail.OnFetchContext = func(int, CommitDetailFile) { fetches++ }
+
+	detail.SetContextMode(DiffContextFullFile)
+	if fetches != 1 {
+		t.Fatalf("first full-file request count = %d", fetches)
+	}
+	detail.ApplyFileContext(0, CommitDetailContextKey(detail.Files[0]), nil, nil, "Could not load full file for file.txt")
+	if detail.Files[0].FullFileState != CommitDetailFullFileFailed {
+		t.Fatalf("failed request state = %v", detail.Files[0].FullFileState)
+	}
+
+	detail.SetContextMode(DiffContextFullFile)
+	if fetches != 2 {
+		t.Fatalf("failed full-file request is not retryable: fetches=%d mode=%v", fetches, detail.ContextMode())
+	}
+}
+
+func TestCommitDetailLegitimateEmptyFullFileIsLoaded(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full", "abcdef0", false)
+	detail.SetDetail("subject", []CommitDetailFile{{Status: "A", Path: "empty.txt"}}, "")
+	detail.SetContextMode(DiffContextFullFile)
+	detail.ApplyFileContext(0, CommitDetailContextKey(detail.Files[0]), nil, []string{})
+	if detail.Files[0].FullFileState != CommitDetailFullFileLoaded || detail.Files[0].FullFileErr != "" {
+		t.Fatalf("empty file state=%v err=%q", detail.Files[0].FullFileState, detail.Files[0].FullFileErr)
+	}
+}
+
+func TestCommitDetailFailedFullFileIsVisibleAlongsideCompactDiff(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full", "abcdef0", false)
+	detail.OnFetchContext = func(int, CommitDetailFile) {}
+	detail.SetDetail("subject", []CommitDetailFile{{
+		Path: "file.txt",
+		Diff: diff.Parse("--- a/file.txt\n+++ b/file.txt\n@@ -2 +2 @@\n-old\n+new\n"),
+	}}, "")
+	detail.SetContextMode(DiffContextFullFile)
+	detail.ApplyFileContext(0, CommitDetailContextKey(detail.Files[0]), nil, nil, "Could not load full file for file.txt")
+	detail.SetRect(Rect{W: 80, H: 12})
+	cells := makeGrid(80, 12)
+	detail.Render(NewRenderSurface(cells, Rect{W: 80, H: 12}))
+	text := detailTestText(cells)
+	for _, want := range []string{"Could not load full file for file.txt", "old", "new"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("failed Full File view missing %q:\n%s", want, text)
+		}
+	}
+}

--- a/internal/ui/commit_detail_history_test.go
+++ b/internal/ui/commit_detail_history_test.go
@@ -1,0 +1,165 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v3"
+)
+
+func detailTestText(cells [][]term.Cell) string {
+	var out strings.Builder
+	for rowIndex, row := range cells {
+		if rowIndex > 0 {
+			out.WriteByte('\n')
+		}
+		for _, cell := range row {
+			if cell.Ch == 0 {
+				out.WriteByte(' ')
+			} else {
+				out.WriteRune(cell.Ch)
+			}
+		}
+	}
+	return out.String()
+}
+
+func TestCommitDetailInheritsEverySharedPresentationPreference(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full", "abc1234", false)
+	detail.ApplyDefaultMode(DiffModeUnified)
+	detail.ApplyDefaultContextMode(DiffContextFullFile)
+	detail.ApplyDefaultWrapMode(DiffWrapOn)
+	detail.SetDiffHighContrast(true)
+	if detail.Mode() != DiffModeUnified || detail.ContextMode() != DiffContextFullFile || detail.WrapMode() != DiffWrapOn || !detail.DiffHighContrast() {
+		t.Fatalf("inherited detail state = mode %v context %v wrap %v contrast %v", detail.Mode(), detail.ContextMode(), detail.WrapMode(), detail.DiffHighContrast())
+	}
+	detail.SetMode(DiffModeSplit)
+	detail.SetContextMode(DiffContextChangesOnly)
+	detail.SetWrapMode(DiffWrapOff)
+	detail.ApplyDefaultMode(DiffModeUnified)
+	detail.ApplyDefaultContextMode(DiffContextFullFile)
+	detail.ApplyDefaultWrapMode(DiffWrapOn)
+	if detail.Mode() != DiffModeSplit || detail.ContextMode() != DiffContextChangesOnly || detail.WrapMode() != DiffWrapOff {
+		t.Fatal("shared defaults replaced explicit detail choices")
+	}
+}
+
+func TestCommitDetailRendersMetadataAndAllFilesInOneDocument(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full", "abc1234", false)
+	detail.Metadata = "Authored Aug 22, 2026 at 3:14 AM -0400"
+	detail.SetDetail("Subject\n\nBody", []CommitDetailFile{
+		{Path: "first.txt", Diff: diff.Parse("--- a/first.txt\n+++ b/first.txt\n@@ -1 +1 @@\n-old first\n+new first\n")},
+		{Path: "second.txt", Diff: diff.Parse("--- a/second.txt\n+++ b/second.txt\n@@ -1 +1 @@\n-old second\n+new second\n")},
+	}, "")
+	detail.SetRect(Rect{W: 80, H: 20})
+	cells := makeGrid(80, 20)
+	detail.Render(NewRenderSurface(cells, Rect{W: 80, H: 20}))
+	text := detailTestText(cells)
+	for _, want := range []string{"Authored Aug 22, 2026 at 3:14 AM -0400", "Subject", "Body", "first.txt", "old first", "new first", "second.txt", "new second"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("detail document missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestCommitDetailWholeFullwidthHeadingRowTogglesAtNarrowWidth(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{
+		Path: "資料/界面.txt",
+		Diff: diff.Parse("--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n"),
+	}}, "")
+	detail.SetRect(Rect{X: 7, Y: 4, W: 12, H: 8})
+	detail.Render(NewRenderSurface(makeGrid(12, 8), Rect{X: 7, Y: 4, W: 12, H: 8}))
+	if len(detail.fileControls) == 0 || detail.fileControls[0].rect.W != 12 {
+		t.Fatalf("heading hit region = %+v, want whole 12-column row", detail.fileControls)
+	}
+	control := detail.fileControls[0]
+	result := detail.HandleEvent(tcell.NewEventMouse(control.rect.X+control.rect.W-1, control.rect.Y, tcell.Button1, tcell.ModNone))
+	if result != EventConsumed || !detail.collapsedFiles[0] {
+		t.Fatalf("far-edge title click result=%v collapsed=%v", result, detail.collapsedFiles[0])
+	}
+}
+
+func TestCommitDetailUsesSharedContextProjectionAndHighContrastPainter(t *testing.T) {
+	fileDiff := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -2 +2 @@\n-old\n+new\n")
+	detail := NewCommitDetailWidget("/repo", "full", "abc1234", false)
+	requested := -1
+	detail.OnFetchContext = func(fileIndex int, _ CommitDetailFile) { requested = fileIndex }
+	detail.ApplyDefaultContextMode(DiffContextFullFile)
+	detail.SetDetail("Subject", []CommitDetailFile{{Path: "test.go", Diff: fileDiff}}, "")
+	if requested != 0 {
+		t.Fatalf("full context requested file %d, want 0", requested)
+	}
+	if !detail.ApplyFileContext(0, CommitDetailContextKey(detail.Files[0]), []string{"before", "old", "after"}, []string{"before", "new", "after"}) {
+		t.Fatal("context result was rejected")
+	}
+	if len(detail.Files[0].lines) != 3 {
+		t.Fatalf("shared full-file projection has %d lines, want 3", len(detail.Files[0].lines))
+	}
+	detail.SetDiffHighContrast(true)
+	detail.SetRect(Rect{W: 60, H: 10})
+	cells := makeGrid(60, 10)
+	detail.Render(NewRenderSurface(cells, Rect{W: 60, H: 10}))
+	foundSharedForeground := false
+	for _, row := range cells {
+		for _, cell := range row {
+			if cell.Style == term.StyleGutterAdded && cell.BgStyle == term.StyleDiffAdded {
+				foundSharedForeground = true
+			}
+		}
+	}
+	if !foundSharedForeground {
+		t.Fatal("detail did not route high-contrast diff text through the shared painter")
+	}
+}
+
+func TestCommitDetailCollapsedContextUsesSharedExpansionControl(t *testing.T) {
+	detail := NewCommitDetailWidget("/repo", "full", "abc1234", false)
+	detail.SetDetail("Subject", []CommitDetailFile{{
+		Path: "test.go",
+		Diff: diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n-old one\n+new one\n@@ -10,1 +10,1 @@\n-old ten\n+new ten\n"),
+	}}, "")
+	requests := 0
+	detail.OnFetchContext = func(fileIndex int, _ CommitDetailFile) {
+		if fileIndex != 0 {
+			t.Fatalf("context request file = %d, want 0", fileIndex)
+		}
+		requests++
+	}
+	detail.SetRect(Rect{X: 4, Y: 3, W: 60, H: 15})
+	detail.Render(NewRenderSurface(makeGrid(60, 15), Rect{X: 4, Y: 3, W: 60, H: 15}))
+
+	gapRow, gap := -1, -1
+	for rowIndex, row := range detail.rows {
+		if row.kind != commitDetailDiffRow {
+			continue
+		}
+		if candidate, ok := detail.Files[0].gapByLine[row.lineIndex]; ok {
+			gapRow, gap = rowIndex, candidate
+			break
+		}
+	}
+	if gapRow < 0 {
+		t.Fatalf("commit detail has no collapsed context row: hunks=%d lines=%+v gaps=%v", len(detail.Files[0].Diff.Hunks), detail.Files[0].lines, detail.Files[0].gapByLine)
+	}
+	press := tcell.NewEventMouse(20, detail.GetRect().Y+gapRow, tcell.Button1, tcell.ModNone)
+	if result := detail.HandleEvent(press); result != EventConsumed {
+		t.Fatalf("collapsed context click result = %v", result)
+	}
+	detail.HandleEvent(press)
+	if requests != 1 {
+		t.Fatalf("held click started %d context reads, want 1", requests)
+	}
+	detail.HandleEvent(tcell.NewEventMouse(20, detail.GetRect().Y+gapRow, tcell.ButtonNone, tcell.ModNone))
+
+	oldLines := []string{"old one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "old ten"}
+	newLines := []string{"new one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "new ten"}
+	if !detail.ApplyFileContext(0, CommitDetailContextKey(detail.Files[0]), oldLines, newLines) {
+		t.Fatal("collapsed context result was rejected")
+	}
+	if !detail.Files[0].expandedGaps[gap] || len(detail.Files[0].gapByLine) != 0 {
+		t.Fatalf("shared context gap remained collapsed: expanded=%v gaps=%v", detail.Files[0].expandedGaps, detail.Files[0].gapByLine)
+	}
+}

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -17,22 +17,33 @@ import (
 // the order Git reports them; a failed or hunk-less diff still gets a heading
 // and an explanatory row so a touched path never silently disappears.
 type CommitDetailFile struct {
+	Status  string
 	Path    string
 	OldPath string
 	Diff    diff.FileDiff
 	Error   string
 
-	highlighter    *highlight.Highlighter
-	lines          []diff.DiffLine
-	unified        []diffUnifiedLine
-	oldLines       []string
-	newLines       []string
-	contextLoaded  bool
-	contextLoading bool
-	expandedGaps   map[int]bool
-	gapByLine      map[int]int
-	pendingGap     int
+	FullFileState CommitDetailFullFileState
+	FullFileErr   string
+
+	highlighter  *highlight.Highlighter
+	lines        []diff.DiffLine
+	unified      []diffUnifiedLine
+	oldLines     []string
+	newLines     []string
+	expandedGaps map[int]bool
+	gapByLine    map[int]int
+	pendingGap   int
 }
+
+type CommitDetailFullFileState uint8
+
+const (
+	CommitDetailFullFileIdle CommitDetailFullFileState = iota
+	CommitDetailFullFileLoading
+	CommitDetailFullFileLoaded
+	CommitDetailFullFileFailed
+)
 
 type commitDetailRowKind uint8
 
@@ -50,6 +61,7 @@ type commitDetailRow struct {
 	kind      commitDetailRowKind
 	text      string
 	bold      bool
+	danger    bool
 	fileIndex int
 	lineIndex int
 }
@@ -72,11 +84,12 @@ type commitDetailControl struct {
 // full-screen cell grid for every changed line on every redraw.
 type CommitDetailWidget struct {
 	BaseWidget
-	Dir     string
-	Ref     string
-	Short   string
-	Loading bool
-	Error   string
+	Dir         string
+	Ref         string
+	Short       string
+	Incarnation uint64
+	Loading     bool
+	Error       string
 
 	Message  string
 	Metadata string
@@ -129,6 +142,7 @@ type CommitDetailWidget struct {
 	disclosurePressed bool
 
 	OnFetchContext func(fileIndex int, file CommitDetailFile)
+	OnClose        func()
 }
 
 func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *CommitDetailWidget {
@@ -143,6 +157,15 @@ func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *Commit
 
 func (d *CommitDetailWidget) Focusable() bool { return true }
 
+func (d *CommitDetailWidget) Close() {
+	if d.OnClose == nil {
+		return
+	}
+	onClose := d.OnClose
+	d.OnClose = nil
+	onClose()
+}
+
 func (d *CommitDetailWidget) SetDiffHighContrast(enabled bool) { d.highContrast = enabled }
 
 func (d *CommitDetailWidget) DiffHighContrast() bool { return d.highContrast }
@@ -151,6 +174,14 @@ func (d *CommitDetailWidget) ContextMode() DiffContextMode { return d.contextMod
 
 func (d *CommitDetailWidget) SetContextMode(mode DiffContextMode) {
 	d.contextExplicit = true
+	if d.contextMode == mode {
+		if mode == DiffContextFullFile {
+			for i := range d.Files {
+				d.requestFileContext(i, -1)
+			}
+		}
+		return
+	}
 	d.applyContextMode(mode)
 }
 
@@ -188,7 +219,7 @@ func (d *CommitDetailWidget) requestFileContext(fileIndex, gap int) {
 		return
 	}
 	file := &d.Files[fileIndex]
-	if file.contextLoaded {
+	if file.FullFileState == CommitDetailFullFileLoaded {
 		if gap >= 0 {
 			file.expandedGaps[gap] = true
 			d.rebuildRows()
@@ -199,23 +230,36 @@ func (d *CommitDetailWidget) requestFileContext(fileIndex, gap int) {
 	if gap >= 0 {
 		file.pendingGap = gap
 	}
-	if file.contextLoading || d.OnFetchContext == nil {
+	if file.FullFileState == CommitDetailFullFileLoading || d.OnFetchContext == nil {
 		return
 	}
-	file.contextLoading = true
+	file.FullFileState = CommitDetailFullFileLoading
+	file.FullFileErr = ""
+	d.rebuildRows()
 	d.OnFetchContext(fileIndex, *file)
 }
 
-func (d *CommitDetailWidget) ApplyFileContext(fileIndex int, key string, oldLines, newLines []string) bool {
+func (d *CommitDetailWidget) ApplyFileContext(fileIndex int, key string, oldLines, newLines []string, contextErr ...string) bool {
 	if fileIndex < 0 || fileIndex >= len(d.Files) || commitDetailFileKey(d.Files[fileIndex]) != key {
 		return false
 	}
 	file := &d.Files[fileIndex]
-	file.oldLines = oldLines
-	file.newLines = newLines
-	file.contextLoaded = oldLines != nil || newLines != nil
-	file.contextLoading = false
-	if file.contextLoaded && file.pendingGap >= 0 {
+	errText := ""
+	if len(contextErr) > 0 {
+		errText = contextErr[0]
+	} else if oldLines == nil && newLines == nil {
+		errText = "Could not load full file"
+	}
+	if errText == "" {
+		file.oldLines = oldLines
+		file.newLines = newLines
+		file.FullFileState = CommitDetailFullFileLoaded
+		file.FullFileErr = ""
+	} else {
+		file.FullFileState = CommitDetailFullFileFailed
+		file.FullFileErr = errText
+	}
+	if file.FullFileState == CommitDetailFullFileLoaded && file.pendingGap >= 0 {
 		file.expandedGaps[file.pendingGap] = true
 	}
 	file.pendingGap = -1
@@ -394,7 +438,7 @@ func (d *CommitDetailWidget) rebuildRows() {
 	maxLine := 0
 	for fileIndex := range d.Files {
 		file := &d.Files[fileIndex]
-		if d.contextMode == DiffContextFullFile && file.contextLoaded {
+		if d.contextMode == DiffContextFullFile && file.FullFileState == CommitDetailFullFileLoaded {
 			file.lines = diff.FullDiffLines(file.oldLines, file.newLines)
 			file.gapByLine = nil
 		} else {
@@ -409,6 +453,26 @@ func (d *CommitDetailWidget) rebuildRows() {
 		d.recordWidth(heading)
 		if fileIndex < len(d.collapsedFiles) && d.collapsedFiles[fileIndex] {
 			continue
+		}
+		if d.contextMode == DiffContextFullFile {
+			var notice string
+			var danger bool
+			switch file.FullFileState {
+			case CommitDetailFullFileIdle:
+				notice = "Full file not loaded"
+			case CommitDetailFullFileLoading:
+				notice = "Loading full file…"
+			case CommitDetailFullFileFailed:
+				notice = file.FullFileErr
+				if notice == "" {
+					notice = "Could not load full file"
+				}
+				danger = true
+			}
+			if notice != "" {
+				d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: notice, danger: danger, fileIndex: fileIndex})
+				d.recordWidth(notice)
+			}
 		}
 
 		switch {
@@ -671,7 +735,7 @@ func (d *CommitDetailWidget) renderRow(surface Surface, rowIndex int, row commit
 		d.renderHeading(surface, rowIndex, row, visual, y, viewW)
 	case commitDetailNoticeRow:
 		style := term.StyleMuted
-		if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && d.Files[row.fileIndex].Error != "" {
+		if row.danger || row.fileIndex >= 0 && row.fileIndex < len(d.Files) && d.Files[row.fileIndex].Error != "" {
 			style = term.StyleDanger
 		}
 		d.drawTextRow(surface, 0, y, viewW, row.text, style, term.StyleDefault, false, visual.leftStart, rowIndex)

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -1,0 +1,1253 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/core/highlight"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/textwidth"
+	"github.com/gdamore/tcell/v3"
+)
+
+// CommitDetailFile is one file section in a commit detail view. Files remain in
+// the order Git reports them; a failed or hunk-less diff still gets a heading
+// and an explanatory row so a touched path never silently disappears.
+type CommitDetailFile struct {
+	Path    string
+	OldPath string
+	Diff    diff.FileDiff
+	Error   string
+
+	highlighter    *highlight.Highlighter
+	lines          []diff.DiffLine
+	unified        []diffUnifiedLine
+	oldLines       []string
+	newLines       []string
+	contextLoaded  bool
+	contextLoading bool
+	expandedGaps   map[int]bool
+	gapByLine      map[int]int
+	pendingGap     int
+}
+
+type commitDetailRowKind uint8
+
+const (
+	commitDetailMessageHeaderRow commitDetailRowKind = iota
+	commitDetailMetadataRow
+	commitDetailMessageRow
+	commitDetailSpacerRow
+	commitDetailHeadingRow
+	commitDetailNoticeRow
+	commitDetailDiffRow
+)
+
+type commitDetailRow struct {
+	kind      commitDetailRowKind
+	text      string
+	bold      bool
+	fileIndex int
+	lineIndex int
+}
+
+type commitDetailVisualRow struct {
+	row          int
+	leftStart    int
+	rightStart   int
+	continuation bool
+}
+
+type commitDetailControl struct {
+	rect      Rect
+	fileIndex int
+}
+
+// CommitDetailWidget renders an entire commit as one virtualized scrollable
+// document. Unlike stacking several DiffViewWidgets, it owns one vertical
+// viewport and only draws visible rows, so a large commit does not allocate a
+// full-screen cell grid for every changed line on every redraw.
+type CommitDetailWidget struct {
+	BaseWidget
+	Dir     string
+	Ref     string
+	Short   string
+	Loading bool
+	Error   string
+
+	Message  string
+	Metadata string
+	Files    []CommitDetailFile
+
+	SyntaxHighlight bool
+	TopLine         int
+	LeftCol         int
+	wrapMode        DiffWrapMode
+	wrapExplicit    bool
+	mode            DiffMode
+	modeExplicit    bool
+	contextMode     DiffContextMode
+	contextExplicit bool
+	highContrast    bool
+	collapsedFiles  []bool
+
+	rows            []commitDetailRow
+	visualRows      []commitDetailVisualRow
+	visualRowsW     int
+	totalVisualRows int
+	maxLineW        int
+	gutterW         int
+	viewH           int
+	contentW        int
+	scrollbar       Scrollbar
+	hscrollbar      HScrollbar
+	rhscroll        HScrollbar
+
+	// Render owns these layout values. Mouse hit-testing and sticky-heading
+	// controls reuse them rather than trying to reconstruct the viewport.
+	layoutViewW      int
+	layoutLeftStart  int
+	layoutLeftW      int
+	layoutRightStart int
+	layoutRightW     int
+	fileControls     []commitDetailControl
+	topControl       Rect
+	stickyRect       Rect
+	stickyControl    commitDetailControl
+
+	// Selection positions point into logical rows and original, unwrapped text.
+	selecting         bool
+	hasSelection      bool
+	selRight          bool
+	selection         diffTextSelection
+	lastClickTime     time.Time
+	lastClickPos      diffSelPos
+	primaryPressed    bool
+	disclosurePressed bool
+
+	OnFetchContext func(fileIndex int, file CommitDetailFile)
+}
+
+func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *CommitDetailWidget {
+	return &CommitDetailWidget{
+		Dir:             dir,
+		Ref:             ref,
+		Short:           short,
+		Loading:         true,
+		SyntaxHighlight: syntaxHighlight,
+	}
+}
+
+func (d *CommitDetailWidget) Focusable() bool { return true }
+
+func (d *CommitDetailWidget) SetDiffHighContrast(enabled bool) { d.highContrast = enabled }
+
+func (d *CommitDetailWidget) DiffHighContrast() bool { return d.highContrast }
+
+func (d *CommitDetailWidget) ContextMode() DiffContextMode { return d.contextMode }
+
+func (d *CommitDetailWidget) SetContextMode(mode DiffContextMode) {
+	d.contextExplicit = true
+	d.applyContextMode(mode)
+}
+
+func (d *CommitDetailWidget) ApplyDefaultContextMode(mode DiffContextMode) {
+	if d.contextExplicit {
+		return
+	}
+	d.applyContextMode(mode)
+}
+
+func (d *CommitDetailWidget) applyContextMode(mode DiffContextMode) {
+	if d.contextMode == mode {
+		return
+	}
+	d.contextMode = mode
+	if mode == DiffContextChangesOnly {
+		for i := range d.Files {
+			clear(d.Files[i].expandedGaps)
+			d.Files[i].pendingGap = -1
+		}
+	}
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+	d.rebuildRows()
+	if mode == DiffContextFullFile {
+		for i := range d.Files {
+			d.requestFileContext(i, -1)
+		}
+	}
+}
+
+func (d *CommitDetailWidget) requestFileContext(fileIndex, gap int) {
+	if fileIndex < 0 || fileIndex >= len(d.Files) {
+		return
+	}
+	file := &d.Files[fileIndex]
+	if file.contextLoaded {
+		if gap >= 0 {
+			file.expandedGaps[gap] = true
+			d.rebuildRows()
+			d.ClearSelection()
+		}
+		return
+	}
+	if gap >= 0 {
+		file.pendingGap = gap
+	}
+	if file.contextLoading || d.OnFetchContext == nil {
+		return
+	}
+	file.contextLoading = true
+	d.OnFetchContext(fileIndex, *file)
+}
+
+func (d *CommitDetailWidget) ApplyFileContext(fileIndex int, key string, oldLines, newLines []string) bool {
+	if fileIndex < 0 || fileIndex >= len(d.Files) || commitDetailFileKey(d.Files[fileIndex]) != key {
+		return false
+	}
+	file := &d.Files[fileIndex]
+	file.oldLines = oldLines
+	file.newLines = newLines
+	file.contextLoaded = oldLines != nil || newLines != nil
+	file.contextLoading = false
+	if file.contextLoaded && file.pendingGap >= 0 {
+		file.expandedGaps[file.pendingGap] = true
+	}
+	file.pendingGap = -1
+	d.rebuildRows()
+	d.ClearSelection()
+	return true
+}
+
+func CommitDetailContextKey(file CommitDetailFile) string { return commitDetailFileKey(file) }
+
+func commitDetailFileKey(file CommitDetailFile) string {
+	return file.OldPath + "\x00" + file.Path
+}
+
+func (d *CommitDetailWidget) IsWrapped() bool { return d.wrapMode == DiffWrapOn }
+
+func (d *CommitDetailWidget) SetWrapped(wrapped bool) {
+	mode := DiffWrapOff
+	if wrapped {
+		mode = DiffWrapOn
+	}
+	d.SetWrapMode(mode)
+}
+
+func (d *CommitDetailWidget) WrapMode() DiffWrapMode { return d.wrapMode }
+
+func (d *CommitDetailWidget) SetWrapMode(mode DiffWrapMode) {
+	d.wrapExplicit = true
+	d.applyWrapMode(mode)
+}
+
+func (d *CommitDetailWidget) ApplyDefaultWrapMode(mode DiffWrapMode) {
+	if d.wrapExplicit {
+		return
+	}
+	d.applyWrapMode(mode)
+}
+
+func (d *CommitDetailWidget) applyWrapMode(mode DiffWrapMode) {
+	if mode == d.wrapMode {
+		return
+	}
+	d.wrapMode = mode
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.visualRowsW = -1
+	d.ClearSelection()
+}
+
+func (d *CommitDetailWidget) Mode() DiffMode { return d.mode }
+
+func (d *CommitDetailWidget) SetMode(mode DiffMode) {
+	d.modeExplicit = true
+	d.applyMode(mode)
+}
+
+func (d *CommitDetailWidget) ApplyDefaultMode(mode DiffMode) {
+	if d.modeExplicit {
+		return
+	}
+	d.applyMode(mode)
+}
+
+func (d *CommitDetailWidget) applyMode(mode DiffMode) {
+	if mode == d.mode {
+		return
+	}
+	d.mode = mode
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+	d.rebuildRows()
+	if d.contextMode == DiffContextFullFile {
+		for i := range d.Files {
+			d.requestFileContext(i, -1)
+		}
+	}
+}
+
+func (d *CommitDetailWidget) SetDetail(message string, files []CommitDetailFile, errText string) {
+	d.Loading = false
+	d.Error = errText
+	d.Message = message
+	d.Files = files
+	d.collapsedFiles = make([]bool, len(files))
+	for i := range d.Files {
+		d.Files[i].expandedGaps = make(map[int]bool)
+		d.Files[i].pendingGap = -1
+		if d.SyntaxHighlight && d.Files[i].Path != "" {
+			d.Files[i].highlighter = highlight.New(d.Files[i].Path)
+		}
+	}
+	d.TopLine = 0
+	d.LeftCol = 0
+	d.ClearSelection()
+	d.rebuildRows()
+	if d.contextMode == DiffContextFullFile {
+		for i := range d.Files {
+			d.requestFileContext(i, -1)
+		}
+	}
+}
+
+func (d *CommitDetailWidget) allFilesCollapsed() bool {
+	if len(d.Files) == 0 {
+		return false
+	}
+	for fileIndex := range d.Files {
+		if fileIndex >= len(d.collapsedFiles) || !d.collapsedFiles[fileIndex] {
+			return false
+		}
+	}
+	return true
+}
+
+func (d *CommitDetailWidget) CollapseAllFiles() {
+	d.setAllFilesCollapsed(true)
+}
+
+func (d *CommitDetailWidget) ExpandAllFiles() {
+	d.setAllFilesCollapsed(false)
+}
+
+func (d *CommitDetailWidget) setAllFilesCollapsed(collapsed bool) {
+	if len(d.collapsedFiles) != len(d.Files) {
+		d.collapsedFiles = make([]bool, len(d.Files))
+	}
+	for fileIndex := range d.collapsedFiles {
+		d.collapsedFiles[fileIndex] = collapsed
+	}
+	d.afterCollapseChange()
+}
+
+func (d *CommitDetailWidget) toggleFile(fileIndex int) {
+	if fileIndex < 0 || fileIndex >= len(d.Files) {
+		return
+	}
+	if len(d.collapsedFiles) != len(d.Files) {
+		d.collapsedFiles = make([]bool, len(d.Files))
+	}
+	d.collapsedFiles[fileIndex] = !d.collapsedFiles[fileIndex]
+	d.afterCollapseChange()
+}
+
+func (d *CommitDetailWidget) afterCollapseChange() {
+	d.ClearSelection()
+	d.rebuildRows()
+	d.clampScroll()
+}
+
+func (d *CommitDetailWidget) rebuildRows() {
+	d.rows = nil
+	d.visualRows = nil
+	d.visualRowsW = -1
+	d.maxLineW = 0
+	d.gutterW = 4
+	if d.Error != "" {
+		return
+	}
+
+	d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageHeaderRow, text: "Commit message", bold: true})
+	if d.Metadata != "" {
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMetadataRow, text: d.Metadata})
+		d.recordWidth(d.Metadata)
+	}
+	message := strings.TrimRight(d.Message, "\r\n")
+	if message == "" {
+		message = "(No commit message)"
+	}
+	for i, line := range strings.Split(message, "\n") {
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageRow, text: line, bold: i == 0})
+		d.recordWidth(line)
+	}
+	d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
+
+	maxLine := 0
+	for fileIndex := range d.Files {
+		file := &d.Files[fileIndex]
+		if d.contextMode == DiffContextFullFile && file.contextLoaded {
+			file.lines = diff.FullDiffLines(file.oldLines, file.newLines)
+			file.gapByLine = nil
+		} else {
+			file.lines, file.gapByLine = compactDiffLinesWithContext(file.Diff, file.oldLines, file.newLines, file.expandedGaps)
+		}
+		file.unified = buildUnifiedDiffLines(file.lines)
+		if fileIndex > 0 {
+			d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
+		}
+		heading := commitDetailFileHeading(*file)
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailHeadingRow, text: heading, bold: true, fileIndex: fileIndex})
+		d.recordWidth(heading)
+		if fileIndex < len(d.collapsedFiles) && d.collapsedFiles[fileIndex] {
+			continue
+		}
+
+		switch {
+		case file.Error != "":
+			d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: file.Error, fileIndex: fileIndex})
+			d.recordWidth(file.Error)
+		default:
+			if len(file.lines) == 0 {
+				const noChanges = "No line changes"
+				d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: noChanges, fileIndex: fileIndex})
+				d.recordWidth(noChanges)
+				continue
+			}
+			lineCount := len(file.lines)
+			if d.mode == DiffModeUnified {
+				lineCount = len(file.unified)
+			}
+			for lineIndex := 0; lineIndex < lineCount; lineIndex++ {
+				d.rows = append(d.rows, commitDetailRow{kind: commitDetailDiffRow, fileIndex: fileIndex, lineIndex: lineIndex})
+				if d.mode == DiffModeUnified {
+					line := file.unified[lineIndex].side
+					d.recordWidth(line.Text)
+					if line.Num > maxLine {
+						maxLine = line.Num
+					}
+				} else {
+					line := file.lines[lineIndex]
+					d.recordWidth(line.Left.Text)
+					d.recordWidth(line.Right.Text)
+					if line.Left.Num > maxLine {
+						maxLine = line.Left.Num
+					}
+					if line.Right.Num > maxLine {
+						maxLine = line.Right.Num
+					}
+				}
+			}
+		}
+	}
+	if len(d.Files) == 0 {
+		const noFiles = "No files"
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: noFiles})
+		d.recordWidth(noFiles)
+	}
+	if maxLine > 0 {
+		d.gutterW = textwidth.String(strconv.Itoa(maxLine)) + 3
+	}
+	d.totalVisualRows = len(d.rows)
+}
+
+func (d *CommitDetailWidget) recordWidth(text string) {
+	if width := diffLineVisualWidth(text); width > d.maxLineW {
+		d.maxLineW = width
+	}
+}
+
+func commitDetailFileHeading(file CommitDetailFile) string {
+	if file.OldPath != "" && file.OldPath != file.Path {
+		return fmt.Sprintf("%s → %s", file.OldPath, file.Path)
+	}
+	return file.Path
+}
+
+func (d *CommitDetailWidget) Render(surface Surface) {
+	w, h := surface.Size()
+	r := d.GetRect()
+	if w <= 0 || h <= 0 {
+		return
+	}
+	surface.Fill(term.Cell{Ch: ' ', Style: term.StyleDefault})
+
+	if d.Loading {
+		surface.DrawText(0, 0, fmt.Sprintf("Loading commit %s…", d.Short), w, term.StyleMuted)
+		return
+	}
+	if d.Error != "" {
+		surface.DrawText(0, 0, d.Error, w, term.StyleDanger)
+		return
+	}
+
+	viewW, viewH, showV, showH := d.layout(w, h)
+	d.viewH = viewH
+	leftStart, leftW, rightStart, rightW := d.sideGeometry(viewW)
+	d.layoutViewW = viewW
+	d.layoutLeftStart = leftStart
+	d.layoutLeftW = leftW
+	d.layoutRightStart = rightStart
+	d.layoutRightW = rightW
+	d.fileControls = nil
+	d.topControl = Rect{}
+	d.stickyRect = Rect{}
+	d.stickyControl = commitDetailControl{fileIndex: -1}
+	d.contentW = leftW
+	if d.mode == DiffModeSplit {
+		d.contentW = min(leftW, rightW)
+	}
+	d.clampScroll()
+
+	for screenY := 0; screenY < viewH; screenY++ {
+		rowIndex := d.TopLine + screenY
+		visual := commitDetailVisualRow{row: rowIndex, leftStart: 0, rightStart: 0}
+		if d.IsWrapped() {
+			if rowIndex >= len(d.visualRows) {
+				break
+			}
+			visual = d.visualRows[rowIndex]
+			rowIndex = visual.row
+		} else if rowIndex >= len(d.rows) {
+			break
+		}
+		d.renderRow(surface, rowIndex, d.rows[rowIndex], visual, screenY, viewW)
+	}
+	d.renderStickyHeading(surface, viewW)
+
+	if showV {
+		d.scrollbar.X = r.X + viewW
+		d.scrollbar.Y = r.Y
+		d.scrollbar.Height = viewH
+		d.scrollbar.TotalItems = d.totalVisualRows
+		d.scrollbar.TopItem = d.TopLine
+		d.scrollbar.Render(surface, viewW, 0)
+	} else {
+		d.scrollbar.TotalItems = 0
+	}
+	if showH && viewH < h {
+		d.renderHorizontalScrollbars(surface, r, viewW, viewH)
+	} else {
+		d.hscrollbar.TotalCols = 0
+		d.rhscroll.TotalCols = 0
+	}
+}
+
+func (d *CommitDetailWidget) layout(w, h int) (viewW, viewH int, showV, showH bool) {
+	viewH = h
+	if d.IsWrapped() {
+		showV = d.totalVisualRows > viewH
+	}
+	for range 3 {
+		viewW = w
+		if showV {
+			viewW--
+		}
+		if d.IsWrapped() {
+			if d.visualRowsW != viewW {
+				d.visualRows = d.buildVisualRows(viewW)
+				d.visualRowsW = viewW
+			}
+			d.totalVisualRows = len(d.visualRows)
+			showH = false
+		} else {
+			d.visualRows = nil
+			d.totalVisualRows = len(d.rows)
+			_, leftW, _, rightW := d.sideGeometry(viewW)
+			sideW := leftW
+			if d.mode == DiffModeSplit {
+				sideW = min(leftW, rightW)
+			}
+			showH = sideW > 0 && d.maxLineW > sideW
+		}
+		newViewH := h
+		if showH {
+			newViewH--
+		}
+		newShowV := d.totalVisualRows > newViewH
+		if newViewH == viewH && newShowV == showV {
+			break
+		}
+		viewH = newViewH
+		showV = newShowV
+	}
+	if viewW < 0 {
+		viewW = 0
+	}
+	if viewH < 0 {
+		viewH = 0
+	}
+	return
+}
+
+func (d *CommitDetailWidget) buildVisualRows(viewW int) []commitDetailVisualRow {
+	if viewW <= 0 {
+		return nil
+	}
+	_, leftW, _, rightW := d.sideGeometry(viewW)
+	visualRows := make([]commitDetailVisualRow, 0, len(d.rows))
+	for rowIndex, row := range d.rows {
+		leftStarts := []int{0}
+		rightStarts := []int{0}
+		switch row.kind {
+		case commitDetailMessageHeaderRow, commitDetailSpacerRow:
+			rightStarts = nil
+		case commitDetailHeadingRow:
+			leftStarts = diffWrapStarts(row.text, viewW-3)
+			rightStarts = nil
+		case commitDetailDiffRow:
+			if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && row.lineIndex >= 0 && leftW > 0 {
+				file := &d.Files[row.fileIndex]
+				if d.mode == DiffModeUnified && row.lineIndex < len(file.unified) {
+					leftStarts = diffWrapStarts(file.unified[row.lineIndex].side.Text, leftW)
+					rightStarts = nil
+				} else if d.mode == DiffModeSplit && row.lineIndex < len(file.lines) && rightW > 0 {
+					line := file.lines[row.lineIndex]
+					leftStarts = diffWrapStarts(line.Left.Text, leftW)
+					rightStarts = diffWrapStarts(line.Right.Text, rightW)
+				}
+			}
+		default:
+			leftStarts = diffWrapStarts(row.text, viewW)
+			rightStarts = nil
+		}
+
+		rowCount := len(leftStarts)
+		if len(rightStarts) > rowCount {
+			rowCount = len(rightStarts)
+		}
+		for segment := 0; segment < rowCount; segment++ {
+			leftStart, rightStart := -1, -1
+			if segment < len(leftStarts) {
+				leftStart = leftStarts[segment]
+			}
+			if segment < len(rightStarts) {
+				rightStart = rightStarts[segment]
+			}
+			visualRows = append(visualRows, commitDetailVisualRow{
+				row:          rowIndex,
+				leftStart:    leftStart,
+				rightStart:   rightStart,
+				continuation: segment > 0,
+			})
+		}
+	}
+	return visualRows
+}
+
+// sideGeometry returns the content widths used for every diff row. The parent
+// owns these layout values; row renderers and scrollbar placement reuse them.
+func (d *CommitDetailWidget) sideGeometry(viewW int) (leftStart, leftW, rightStart, rightW int) {
+	if d.mode == DiffModeUnified {
+		return d.gutterW, viewW - d.gutterW, 0, 0
+	}
+	dividerX := (viewW - 1) / 2
+	leftStart = d.gutterW
+	leftW = dividerX - d.gutterW
+	rightStart = dividerX + 1 + d.gutterW
+	rightW = viewW - rightStart
+	return
+}
+
+func (d *CommitDetailWidget) renderRow(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	switch row.kind {
+	case commitDetailMessageHeaderRow:
+		d.renderMessageHeader(surface, y, viewW)
+	case commitDetailMetadataRow:
+		d.drawTextRow(surface, 0, y, viewW, row.text, term.StyleMuted, term.StyleCommitMessage, false, visual.leftStart, rowIndex)
+	case commitDetailSpacerRow:
+		return
+	case commitDetailMessageRow:
+		d.drawTextRow(surface, 0, y, viewW, row.text, term.StyleCommitMessage, term.StyleCommitMessage, row.bold, visual.leftStart, rowIndex)
+	case commitDetailHeadingRow:
+		d.renderHeading(surface, rowIndex, row, visual, y, viewW)
+	case commitDetailNoticeRow:
+		style := term.StyleMuted
+		if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && d.Files[row.fileIndex].Error != "" {
+			style = term.StyleDanger
+		}
+		d.drawTextRow(surface, 0, y, viewW, row.text, style, term.StyleDefault, false, visual.leftStart, rowIndex)
+	case commitDetailDiffRow:
+		d.renderDiffRow(surface, rowIndex, row, visual, y, viewW)
+	}
+}
+
+func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) {
+	for column := 0; column < viewW; column++ {
+		surface.SetCell(column, y, term.Cell{Ch: ' ', Style: term.StyleCommitMessage})
+	}
+	d.drawStaticText(surface, 0, y, viewW, "Commit message", term.StyleCommitMessage, term.StyleCommitMessage, true)
+	if len(d.Files) == 0 {
+		return
+	}
+	label := "Collapse all"
+	if d.allFilesCollapsed() {
+		label = "Expand all"
+	}
+	controlW := textwidth.String(label)
+	controlX := viewW - controlW
+	if controlX <= textwidth.String("Commit message") {
+		return
+	}
+	d.drawStaticText(surface, controlX, y, controlW, label, term.StyleCommitMessage, term.StyleCommitMessage, true)
+	r := d.GetRect()
+	d.topControl = Rect{X: r.X + controlX, Y: r.Y + y, W: controlW, H: 1}
+}
+
+func (d *CommitDetailWidget) renderHeading(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	collapsed := row.fileIndex >= 0 && row.fileIndex < len(d.collapsedFiles) && d.collapsedFiles[row.fileIndex]
+	if !visual.continuation {
+		chevron := '▼'
+		if collapsed {
+			chevron = '▶'
+		}
+		surface.SetCell(1, y, term.Cell{Ch: chevron, Style: term.StyleDefault, Bold: true})
+	}
+	r := d.GetRect()
+	d.fileControls = append(d.fileControls, commitDetailControl{
+		rect:      Rect{X: r.X, Y: r.Y + y, W: viewW, H: 1},
+		fileIndex: row.fileIndex,
+	})
+	d.drawTextRow(surface, 3, y, viewW-3, row.text, term.StyleDefault, term.StyleDefault, row.bold, visual.leftStart, rowIndex)
+}
+
+func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	if row.fileIndex < 0 || row.fileIndex >= len(d.Files) {
+		return
+	}
+	file := &d.Files[row.fileIndex]
+	if row.lineIndex < 0 {
+		return
+	}
+	if d.mode == DiffModeUnified {
+		d.renderUnifiedDiffRow(surface, rowIndex, file, row.lineIndex, visual, y, viewW)
+		return
+	}
+	if row.lineIndex >= len(file.lines) {
+		return
+	}
+	line := file.lines[row.lineIndex]
+	leftStart, leftW, rightStart, rightW := d.sideGeometry(viewW)
+	if leftW <= 0 || rightW <= 0 {
+		return
+	}
+	dividerX := (viewW - 1) / 2
+	surface.SetCell(dividerX, y, term.Cell{Ch: '│', Style: term.StyleBorder})
+	leftStyle := diffKindStyle(line.Left.Kind)
+	rightStyle := diffKindStyle(line.Right.Kind)
+	if visual.continuation {
+		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{})
+		renderDiffGutter(surface, dividerX+1, y, d.gutterW, diff.SideLine{})
+	} else {
+		renderDiffGutter(surface, 0, y, d.gutterW, line.Left)
+		renderDiffGutter(surface, dividerX+1, y, d.gutterW, line.Right)
+	}
+
+	var leftSpans, rightSpans []highlight.Span
+	if file.highlighter != nil {
+		if line.Left.Text != "" && line.Left.Kind != diff.Collapsed {
+			leftSpans = file.highlighter.HighlightLine(line.Left.Text)
+		}
+		if line.Right.Text != "" && line.Right.Kind != diff.Collapsed {
+			rightSpans = file.highlighter.HighlightLine(line.Right.Text)
+		}
+	}
+	leftScroll := d.LeftCol
+	if d.IsWrapped() {
+		leftScroll = 0
+	}
+	renderDiffText(surface, leftStart, y, leftW, line.Left.Text, leftStyle, diffKindForeground(line.Left.Kind, d.highContrast), leftSpans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
+	renderDiffText(surface, rightStart, y, rightW, line.Right.Text, rightStyle, diffKindForeground(line.Right.Kind, d.highContrast), rightSpans, visual.rightStart, leftScroll, d.selectionDecorator(rowIndex, true))
+}
+
+func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex int, file *CommitDetailFile, lineIndex int, visual commitDetailVisualRow, y, viewW int) {
+	if lineIndex >= len(file.unified) {
+		return
+	}
+	line := file.unified[lineIndex].side
+	contentStart, contentW, _, _ := d.sideGeometry(viewW)
+	if contentW <= 0 {
+		return
+	}
+	style := diffKindStyle(line.Kind)
+	if visual.continuation {
+		renderDiffGutter(surface, 0, y, d.gutterW, diff.SideLine{})
+	} else {
+		renderDiffGutter(surface, 0, y, d.gutterW, line)
+	}
+	var spans []highlight.Span
+	if file.highlighter != nil && line.Text != "" && line.Kind != diff.Collapsed {
+		spans = file.highlighter.HighlightLine(line.Text)
+	}
+	leftScroll := d.LeftCol
+	if d.IsWrapped() {
+		leftScroll = 0
+	}
+	renderDiffText(surface, contentStart, y, contentW, line.Text, style, diffKindForeground(line.Kind, d.highContrast), spans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
+}
+
+func (d *CommitDetailWidget) drawText(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool, segmentStart int) {
+	d.drawTextRow(surface, x, y, width, text, style, bg, bold, segmentStart, -1)
+}
+
+func (d *CommitDetailWidget) drawStaticText(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool) {
+	blank := term.Cell{Ch: ' ', Style: style, BgStyle: bg}
+	drawTextSegment(surface, x, y, width, text, 0, 0, blank, func(_ int, ch rune) term.Cell {
+		return term.Cell{Ch: ch, Style: style, BgStyle: bg, Bold: bold}
+	})
+}
+
+func (d *CommitDetailWidget) drawTextRow(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool, segmentStart, rowIndex int) {
+	leftScroll := d.LeftCol
+	if d.IsWrapped() {
+		leftScroll = 0
+	}
+	blank := term.Cell{Ch: ' ', Style: term.StyleDefault, BgStyle: bg}
+	drawTextSegment(surface, x, y, width, text, segmentStart, leftScroll, blank, func(runeIndex int, ch rune) term.Cell {
+		cell := term.Cell{Ch: ch, Style: style, BgStyle: bg, Bold: bold}
+		if rowIndex >= 0 && d.hasSelection && d.selection.Contains(rowIndex, runeIndex) {
+			cell.BgStyle = term.StyleSelection
+		}
+		return cell
+	})
+}
+
+func (d *CommitDetailWidget) selectionDecorator(rowIndex int, right bool) diffCellDecorator {
+	if !d.hasSelection || (d.mode == DiffModeSplit && right != d.selRight) {
+		return nil
+	}
+	return func(runeIndex int, cell term.Cell) term.Cell {
+		if d.selection.Contains(rowIndex, runeIndex) {
+			cell.BgStyle = term.StyleSelection
+		}
+		return cell
+	}
+}
+
+func (d *CommitDetailWidget) rowText(rowIndex int, right bool) (string, bool) {
+	if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return "", false
+	}
+	row := d.rows[rowIndex]
+	switch row.kind {
+	case commitDetailMessageRow, commitDetailHeadingRow, commitDetailNoticeRow:
+		return row.text, true
+	case commitDetailDiffRow:
+		if row.fileIndex < 0 || row.fileIndex >= len(d.Files) || row.lineIndex < 0 {
+			return "", false
+		}
+		file := &d.Files[row.fileIndex]
+		if d.mode == DiffModeUnified {
+			if row.lineIndex >= len(file.unified) {
+				return "", false
+			}
+			return file.unified[row.lineIndex].side.Text, true
+		}
+		if row.lineIndex >= len(file.lines) {
+			return "", false
+		}
+		if right {
+			return file.lines[row.lineIndex].Right.Text, true
+		}
+		return file.lines[row.lineIndex].Left.Text, true
+	default:
+		return "", false
+	}
+}
+
+func (d *CommitDetailWidget) screenToSelection(mx, my int) (pos diffSelPos, right bool, ok bool) {
+	if pointInCommitDetailRect(mx, my, d.stickyRect) {
+		return diffSelPos{}, false, false
+	}
+	r := d.GetRect()
+	localX, localY := mx-r.X, my-r.Y
+	if localX < 0 || localX >= d.layoutViewW || localY < 0 || localY >= d.viewH {
+		return diffSelPos{}, false, false
+	}
+	visualIndex := d.TopLine + localY
+	rowIndex := visualIndex
+	visual := commitDetailVisualRow{row: rowIndex, leftStart: 0, rightStart: 0}
+	if d.IsWrapped() {
+		if visualIndex < 0 || visualIndex >= len(d.visualRows) {
+			return diffSelPos{}, false, false
+		}
+		visual = d.visualRows[visualIndex]
+		rowIndex = visual.row
+	} else if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return diffSelPos{}, false, false
+	}
+	row := d.rows[rowIndex]
+	textX, textW, segmentStart := 0, d.layoutViewW, visual.leftStart
+	switch row.kind {
+	case commitDetailMessageRow, commitDetailNoticeRow:
+	case commitDetailHeadingRow:
+		textX, textW = 3, d.layoutViewW-3
+	case commitDetailDiffRow:
+		if d.mode == DiffModeUnified {
+			textX, textW = d.layoutLeftStart, d.layoutLeftW
+		} else if localX >= d.layoutLeftStart && localX < d.layoutLeftStart+d.layoutLeftW {
+			textX, textW = d.layoutLeftStart, d.layoutLeftW
+			right = false
+		} else if localX >= d.layoutRightStart && localX < d.layoutRightStart+d.layoutRightW {
+			textX, textW = d.layoutRightStart, d.layoutRightW
+			segmentStart = visual.rightStart
+			right = true
+		} else {
+			return diffSelPos{}, false, false
+		}
+	default:
+		return diffSelPos{}, false, false
+	}
+	if textW <= 0 || localX < textX || localX >= textX+textW || segmentStart < 0 {
+		return diffSelPos{}, false, false
+	}
+	text, selectable := d.rowText(rowIndex, right)
+	if !selectable {
+		return diffSelPos{}, false, false
+	}
+	visualCol := localX - textX
+	if !d.IsWrapped() {
+		visualCol += d.LeftCol
+	}
+	return diffSelPos{Line: rowIndex, Col: diffSegmentVisualColToRune(text, segmentStart, visualCol)}, right, true
+}
+
+func (d *CommitDetailWidget) selectionText() string {
+	if !d.hasSelection {
+		return ""
+	}
+	return d.selection.Text(len(d.rows), func(rowIndex int) (string, bool) {
+		return d.rowText(rowIndex, d.selRight)
+	})
+}
+
+func (d *CommitDetailWidget) CopySelection() string {
+	text := d.selectionText()
+	if text != "" {
+		d.ClearSelection()
+	}
+	return text
+}
+
+func (d *CommitDetailWidget) ClearSelection() {
+	d.hasSelection = false
+	d.selecting = false
+}
+
+func (d *CommitDetailWidget) selectWordAt(rowIndex, col int) bool {
+	text, ok := d.rowText(rowIndex, d.selRight)
+	if !ok {
+		return false
+	}
+	return d.selection.SelectWord(rowIndex, col, text)
+}
+
+func (d *CommitDetailWidget) renderStickyHeading(surface Surface, viewW int) {
+	if viewW <= 0 || d.TopLine <= 0 {
+		return
+	}
+	rowIndex := d.TopLine
+	if d.IsWrapped() {
+		if d.TopLine >= len(d.visualRows) {
+			return
+		}
+		rowIndex = d.visualRows[d.TopLine].row
+	}
+	if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return
+	}
+	row := d.rows[rowIndex]
+	if row.kind != commitDetailDiffRow && row.kind != commitDetailNoticeRow {
+		return
+	}
+	if row.fileIndex < 0 || row.fileIndex >= len(d.Files) {
+		return
+	}
+	for column := 0; column < viewW; column++ {
+		surface.SetCell(column, 0, term.Cell{Ch: ' ', Style: term.StyleDefault})
+	}
+	surface.SetCell(1, 0, term.Cell{Ch: '▼', Style: term.StyleDefault, Bold: true})
+	path := truncateCommitDetailPath(commitDetailFileHeading(d.Files[row.fileIndex]), viewW-3)
+	drawTextSegment(surface, 3, 0, viewW-3, path, 0, 0, term.Cell{Ch: ' '}, func(_ int, ch rune) term.Cell {
+		return term.Cell{Ch: ch, Style: term.StyleDefault, Bold: true}
+	})
+	r := d.GetRect()
+	d.stickyRect = Rect{X: r.X, Y: r.Y, W: viewW, H: 1}
+	d.stickyControl = commitDetailControl{
+		rect:      d.stickyRect,
+		fileIndex: row.fileIndex,
+	}
+}
+
+func truncateCommitDetailPath(text string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if textwidth.String(text) <= width {
+		return text
+	}
+	runes := []rune(text)
+	tailWidth := 0
+	start := len(runes)
+	for start > 0 {
+		runeWidth := textwidth.Rune(runes[start-1])
+		if tailWidth+runeWidth > width-1 {
+			break
+		}
+		tailWidth += runeWidth
+		start--
+	}
+	return "…" + string(runes[start:])
+}
+
+func (d *CommitDetailWidget) renderHorizontalScrollbars(surface Surface, r Rect, viewW, y int) {
+	leftStart, leftW, rightStart, rightW := d.sideGeometry(viewW)
+	d.hscrollbar.X = r.X + leftStart
+	d.hscrollbar.Y = r.Y + y
+	d.hscrollbar.Width = leftW
+	d.hscrollbar.TotalCols = d.maxLineW
+	d.hscrollbar.LeftCol = d.LeftCol
+	d.hscrollbar.Render(surface, leftStart, y)
+	for column := 0; column < d.gutterW; column++ {
+		surface.SetCell(column, y, term.Cell{Ch: ' '})
+	}
+	if d.mode == DiffModeUnified {
+		d.rhscroll.TotalCols = 0
+		return
+	}
+
+	dividerX := (viewW - 1) / 2
+	d.rhscroll.X = r.X + rightStart
+	d.rhscroll.Y = r.Y + y
+	d.rhscroll.Width = rightW
+	d.rhscroll.TotalCols = d.maxLineW
+	d.rhscroll.LeftCol = d.LeftCol
+	d.rhscroll.Render(surface, rightStart, y)
+
+	surface.SetCell(dividerX, y, term.Cell{Ch: '│', Style: term.StyleBorder})
+	for column := dividerX + 1; column < rightStart; column++ {
+		surface.SetCell(column, y, term.Cell{Ch: ' '})
+	}
+}
+
+func (d *CommitDetailWidget) clampScroll() {
+	maxTop := d.totalVisualRows - d.viewH
+	if maxTop < 0 {
+		maxTop = 0
+	}
+	if d.TopLine < 0 {
+		d.TopLine = 0
+	}
+	if d.TopLine > maxTop {
+		d.TopLine = maxTop
+	}
+	maxLeft := d.maxLineW - d.contentW
+	if d.IsWrapped() {
+		maxLeft = 0
+	}
+	if maxLeft < 0 {
+		maxLeft = 0
+	}
+	if d.LeftCol < 0 {
+		d.LeftCol = 0
+	}
+	if d.LeftCol > maxLeft {
+		d.LeftCol = maxLeft
+	}
+}
+
+func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
+	if newTop, consumed := d.scrollbar.HandleEvent(ev); consumed {
+		d.TopLine = newTop
+		if d.scrollbar.IsDragging() {
+			return EventCaptured
+		}
+		return EventConsumed
+	}
+	if !d.IsWrapped() {
+		if newLeft, consumed := d.hscrollbar.HandleEvent(ev); consumed {
+			d.LeftCol = newLeft
+			if d.hscrollbar.IsDragging() {
+				return EventCaptured
+			}
+			return EventConsumed
+		}
+		if newLeft, consumed := d.rhscroll.HandleEvent(ev); consumed {
+			d.LeftCol = newLeft
+			if d.rhscroll.IsDragging() {
+				return EventCaptured
+			}
+			return EventConsumed
+		}
+	}
+
+	switch event := ev.(type) {
+	case *tcell.EventKey:
+		switch event.Key() {
+		case tcell.KeyUp:
+			d.TopLine--
+		case tcell.KeyDown:
+			d.TopLine++
+		case tcell.KeyLeft:
+			d.LeftCol--
+		case tcell.KeyRight:
+			d.LeftCol++
+		case tcell.KeyPgUp:
+			d.TopLine -= d.viewH
+		case tcell.KeyPgDn:
+			d.TopLine += d.viewH
+		case tcell.KeyHome:
+			d.TopLine = 0
+			d.LeftCol = 0
+		case tcell.KeyEnd:
+			d.TopLine = d.totalVisualRows - d.viewH
+		default:
+			return EventIgnored
+		}
+		d.clampScroll()
+		return EventConsumed
+	case *tcell.EventMouse:
+		buttons := event.Buttons()
+		modifiers := event.Modifiers()
+		switch {
+		case buttons&tcell.WheelUp != 0 && modifiers&tcell.ModShift != 0:
+			d.LeftCol -= 4
+		case buttons&tcell.WheelDown != 0 && modifiers&tcell.ModShift != 0:
+			d.LeftCol += 4
+		case buttons&tcell.WheelUp != 0:
+			d.TopLine -= 3
+		case buttons&tcell.WheelDown != 0:
+			d.TopLine += 3
+		case buttons&tcell.WheelLeft != 0:
+			d.LeftCol -= 4
+		case buttons&tcell.WheelRight != 0:
+			d.LeftCol += 4
+		default:
+			mx, my := event.Position()
+			primaryPressed := buttons&tcell.Button1 != 0
+			freshPrimaryPress := primaryPressed && !d.primaryPressed
+			if buttons == tcell.ButtonNone {
+				d.primaryPressed = false
+				if d.disclosurePressed {
+					d.disclosurePressed = false
+					return EventConsumed
+				}
+			}
+			if primaryPressed {
+				d.primaryPressed = true
+				if d.disclosurePressed {
+					return EventConsumed
+				}
+				if freshPrimaryPress && !d.selecting && pointInCommitDetailRect(mx, my, d.topControl) {
+					if d.allFilesCollapsed() {
+						d.ExpandAllFiles()
+					} else {
+						d.CollapseAllFiles()
+					}
+					d.disclosurePressed = true
+					return EventConsumed
+				}
+				if freshPrimaryPress && !d.selecting && pointInCommitDetailRect(mx, my, d.stickyControl.rect) {
+					d.toggleFile(d.stickyControl.fileIndex)
+					d.disclosurePressed = true
+					return EventConsumed
+				}
+				if freshPrimaryPress && !d.selecting {
+					for _, control := range d.fileControls {
+						if pointInCommitDetailRect(mx, my, control.rect) {
+							d.toggleFile(control.fileIndex)
+							d.disclosurePressed = true
+							return EventConsumed
+						}
+					}
+					if fileIndex, gap, ok := d.contextGapAtScreenY(my); ok {
+						d.requestFileContext(fileIndex, gap)
+						d.disclosurePressed = true
+						return EventConsumed
+					}
+				}
+				pos, right, ok := d.screenToSelection(mx, my)
+				if ok {
+					if !d.selecting {
+						now := time.Now()
+						isDoubleClick := now.Sub(d.lastClickTime) < DoubleClickMs*time.Millisecond &&
+							pos.Line == d.lastClickPos.Line && pos.Col == d.lastClickPos.Col
+						d.lastClickTime = now
+						d.lastClickPos = pos
+						d.selRight = right
+						if isDoubleClick {
+							if d.selectWordAt(pos.Line, pos.Col) {
+								d.hasSelection = true
+							}
+							return EventConsumed
+						}
+						d.selecting = true
+						d.hasSelection = true
+						d.selection.Anchor = pos
+						d.selection.Current = pos
+					} else {
+						d.selection.Current = pos
+					}
+					return EventCaptured
+				}
+			}
+			if d.selecting && buttons == tcell.ButtonNone {
+				d.selecting = false
+				start, end := d.selection.Range()
+				if start.Line == end.Line && start.Col == end.Col {
+					d.hasSelection = false
+				}
+				return EventConsumed
+			}
+			return EventIgnored
+		}
+		d.clampScroll()
+		return EventConsumed
+	}
+	return EventIgnored
+}
+
+func (d *CommitDetailWidget) contextGapAtScreenY(screenY int) (fileIndex, gap int, ok bool) {
+	r := d.GetRect()
+	localY := screenY - r.Y
+	if localY < 0 || localY >= d.viewH {
+		return 0, 0, false
+	}
+	visualRow := d.TopLine + localY
+	rowIndex := visualRow
+	if d.IsWrapped() {
+		if visualRow >= len(d.visualRows) {
+			return 0, 0, false
+		}
+		rowIndex = d.visualRows[visualRow].row
+	}
+	if rowIndex < 0 || rowIndex >= len(d.rows) {
+		return 0, 0, false
+	}
+	row := d.rows[rowIndex]
+	if row.kind != commitDetailDiffRow || row.fileIndex < 0 || row.fileIndex >= len(d.Files) {
+		return 0, 0, false
+	}
+	lineIndex := row.lineIndex
+	file := &d.Files[row.fileIndex]
+	if d.mode == DiffModeUnified {
+		if lineIndex < 0 || lineIndex >= len(file.unified) {
+			return 0, 0, false
+		}
+		lineIndex = file.unified[lineIndex].sourceLine
+	}
+	gap, ok = file.gapByLine[lineIndex]
+	return row.fileIndex, gap, ok
+}
+
+func pointInCommitDetailRect(x, y int, rect Rect) bool {
+	return rect.W > 0 && rect.H > 0 && x >= rect.X && x < rect.X+rect.W && y >= rect.Y && y < rect.Y+rect.H
+}

--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -13,6 +13,9 @@ type ContentSplitWidget struct {
 	Bottom                    Widget
 	ShowBottom                bool
 	BottomH                   int
+	BottomRatio               float64
+	MinTopH                   int
+	MinBottomH                int
 	Borders                   *term.BorderSet
 	OnResize                  func(height int)
 	OnBottomClick             func()
@@ -24,6 +27,17 @@ type ContentSplitWidget struct {
 	pointerCaptureInvalidated func()
 }
 
+func (cs *ContentSplitWidget) WidgetChildren() []Widget {
+	children := make([]Widget, 0, 2)
+	if cs.Top != nil {
+		children = append(children, cs.Top)
+	}
+	if cs.Bottom != nil {
+		children = append(children, cs.Bottom)
+	}
+	return children
+}
+
 func NewContentSplitWidget() *ContentSplitWidget {
 	return &ContentSplitWidget{
 		ShowBottom: false,
@@ -32,6 +46,22 @@ func NewContentSplitWidget() *ContentSplitWidget {
 }
 
 func (cs *ContentSplitWidget) Focusable() bool { return false }
+
+func (cs *ContentSplitWidget) constrainedBottomHeight(totalH, requested int) int {
+	if totalH <= 1 {
+		return 0
+	}
+	maxBottom := max(totalH-1-max(cs.MinTopH, 0), 0)
+	minBottom := min(max(cs.MinBottomH, 0), maxBottom)
+	return min(max(requested, minBottom), maxBottom)
+}
+
+func (cs *ContentSplitWidget) requestedBottomHeight(totalH int) int {
+	if cs.BottomH <= 0 && cs.BottomRatio > 0 {
+		return int(float64(totalH) * cs.BottomRatio)
+	}
+	return cs.BottomH
+}
 
 func (cs *ContentSplitWidget) Render(surface Surface) {
 	w, h := surface.Size()
@@ -64,15 +94,8 @@ func (cs *ContentSplitWidget) Render(surface Surface) {
 	}
 	bs := term.StyleBorder
 
-	// 1 row for divider + bottomH for content
-	needed := cs.BottomH + 1
-	if needed > h {
-		needed = h
-	}
-	divY := h - needed
-	if divY < 0 {
-		divY = 0
-	}
+	bottomH := cs.constrainedBottomHeight(h, cs.requestedBottomHeight(h))
+	divY := h - bottomH - 1
 	topH := divY
 
 	if cs.RightBorderStartY != nil {
@@ -97,7 +120,7 @@ func (cs *ContentSplitWidget) Render(surface Surface) {
 	}
 
 	// Bottom content
-	bottomContentH := h - divY - 1
+	bottomContentH := bottomH
 	if cs.Bottom != nil && bottomContentH > 0 {
 		cs.Bottom.SetRect(Rect{X: r.X, Y: r.Y + divY + 1, W: r.W, H: bottomContentH})
 		bottomSurface := surface.Sub(Rect{X: 0, Y: divY + 1, W: w, H: bottomContentH})
@@ -126,6 +149,8 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 	if cs.dragging {
 		if pressed {
 			newH := r.Y + r.H - my - 1
+			newH = cs.constrainedBottomHeight(r.H, newH)
+			cs.BottomRatio = 0
 			if cs.OnResize != nil {
 				cs.OnResize(newH)
 			}
@@ -149,14 +174,8 @@ func (cs *ContentSplitWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 
 	if cs.ShowBottom {
-		needed := cs.BottomH + 1
-		if needed > r.H {
-			needed = r.H
-		}
-		divY := r.Y + r.H - needed
-		if divY < r.Y {
-			divY = r.Y
-		}
+		bottomH := cs.constrainedBottomHeight(r.H, cs.requestedBottomHeight(r.H))
+		divY := r.Y + r.H - bottomH - 1
 
 		// r.W-1: exclude last column to avoid colliding with editor scrollbar
 		// For divY+1 (tab bar row), let the bottom panel handle clicks first
@@ -220,11 +239,8 @@ func (cs *ContentSplitWidget) DividerScreenY() int {
 		return -1
 	}
 	r := cs.GetRect()
-	needed := cs.BottomH + 1
-	if needed > r.H {
-		needed = r.H
-	}
-	return r.Y + r.H - needed
+	bottomH := cs.constrainedBottomHeight(r.H, cs.requestedBottomHeight(r.H))
+	return r.Y + r.H - bottomH - 1
 }
 
 func (cs *ContentSplitWidget) TopContentHeight() int {

--- a/internal/ui/content_split_history_test.go
+++ b/internal/ui/content_split_history_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestContentSplitRatioTracksLayoutUntilDragged(t *testing.T) {
+	top := &mockWidget{}
+	bottom := &mockWidget{}
+	split := NewContentSplitWidget()
+	split.Top = top
+	split.Bottom = bottom
+	split.ShowBottom = true
+	split.BottomH = 0
+	split.BottomRatio = 0.5
+	split.MinTopH = 5
+	split.MinBottomH = 4
+	split.OnResize = func(height int) { split.BottomH = height }
+
+	render := func(height int) {
+		split.SetRect(Rect{X: 2, Y: 3, W: 30, H: height})
+		split.Render(NewRenderSurface(makeGrid(30, height), Rect{X: 2, Y: 3, W: 30, H: height}))
+	}
+	render(20)
+	if got := bottom.GetRect().H; got != 10 {
+		t.Fatalf("20-row ratio height = %d, want 10", got)
+	}
+	render(30)
+	if got := bottom.GetRect().H; got != 15 {
+		t.Fatalf("30-row ratio height = %d, want 15", got)
+	}
+
+	divider := split.DividerScreenY()
+	split.HandleEvent(tcell.NewEventMouse(4, divider, tcell.Button1, tcell.ModNone))
+	split.HandleEvent(tcell.NewEventMouse(4, divider+5, tcell.Button1, tcell.ModNone))
+	split.HandleEvent(tcell.NewEventMouse(4, divider+5, tcell.ButtonNone, tcell.ModNone))
+	if split.BottomRatio != 0 || split.BottomH != 10 {
+		t.Fatalf("manual split = ratio %.1f height %d, want ratio 0 height 10", split.BottomRatio, split.BottomH)
+	}
+	render(40)
+	if got := bottom.GetRect().H; got != 10 {
+		t.Fatalf("manual height changed after resize: %d", got)
+	}
+}
+
+func TestContentSplitRatioRetainsUsableMinimums(t *testing.T) {
+	split := NewContentSplitWidget()
+	split.Top = &mockWidget{}
+	split.Bottom = &mockWidget{}
+	split.ShowBottom = true
+	split.BottomH = 0
+	split.BottomRatio = 0.5
+	split.MinTopH = 5
+	split.MinBottomH = 4
+
+	if got := split.constrainedBottomHeight(10, split.requestedBottomHeight(10)); got != 4 {
+		t.Fatalf("tight layout bottom = %d, want history minimum 4", got)
+	}
+	if got := split.constrainedBottomHeight(6, split.requestedBottomHeight(6)); got != 0 {
+		t.Fatalf("impossible layout bottom = %d, want primary surface minimum to win", got)
+	}
+}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -602,6 +602,15 @@ func (g *EditorGroupWidget) ActiveDiffWidget() *DiffViewWidget {
 	return nil
 }
 
+func (g *EditorGroupWidget) ActiveCommitDetailWidget() *CommitDetailWidget {
+	t := g.activeTab()
+	if t == nil || t.Content == nil {
+		return nil
+	}
+	detail, _ := t.Content.(*CommitDetailWidget)
+	return detail
+}
+
 func (g *EditorGroupWidget) ActiveDiffModeSurface() DiffModeSurface {
 	t := g.activeTab()
 	if t == nil || t.Content == nil {
@@ -627,6 +636,16 @@ func (g *EditorGroupWidget) DiffWidgetByTab(tabName string) *DiffViewWidget {
 				return dv
 			}
 			return nil
+		}
+	}
+	return nil
+}
+
+func (g *EditorGroupWidget) CommitDetailWidgetByTab(tabName string) *CommitDetailWidget {
+	for _, t := range g.tabs {
+		if t.FilePath == tabName {
+			detail, _ := t.Content.(*CommitDetailWidget)
+			return detail
 		}
 	}
 	return nil
@@ -1682,6 +1701,12 @@ func (g *EditorGroupWidget) Copy() {
 	}
 	if dv, ok := t.Content.(*DiffViewWidget); ok {
 		if text := dv.CopySelection(); text != "" {
+			clipboard.Set(text)
+		}
+		return
+	}
+	if detail, ok := t.Content.(*CommitDetailWidget); ok {
+		if text := detail.CopySelection(); text != "" {
 			clipboard.Set(text)
 		}
 		return

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -466,6 +466,7 @@ func (g *EditorGroupWidget) SetDiffHighContrast(enabled bool) {
 func (g *EditorGroupWidget) OpenPluginTab(id, title string, content Widget) {
 	for i, t := range g.tabs {
 		if t.FilePath == id {
+			g.notifyContentTabClose(t)
 			t.Content = content
 			t.Title = title
 			g.tabs[i] = t
@@ -484,9 +485,7 @@ func (g *EditorGroupWidget) OpenPluginTab(id, title string, content Widget) {
 func (g *EditorGroupWidget) ClosePluginTab(id string) {
 	for i, t := range g.tabs {
 		if t.FilePath == id {
-			if t.Content != nil && g.OnContentTabClose != nil {
-				g.OnContentTabClose(t.FilePath)
-			}
+			g.notifyContentTabClose(t)
 			if i < g.pinnedCount {
 				g.pinnedCount--
 			}
@@ -508,6 +507,18 @@ func (g *EditorGroupWidget) ClosePluginTab(id string) {
 			g.syncTabs()
 			return
 		}
+	}
+}
+
+func (g *EditorGroupWidget) notifyContentTabClose(tab editorTab) {
+	if tab.Content == nil {
+		return
+	}
+	if closer, ok := tab.Content.(interface{ Close() }); ok {
+		closer.Close()
+	}
+	if g.OnContentTabClose != nil {
+		g.OnContentTabClose(tab.FilePath)
 	}
 }
 
@@ -750,9 +761,7 @@ func (g *EditorGroupWidget) CloseTab() {
 	if g.OnFileClose != nil && closing.Highlighter != nil && !closing.Virtual {
 		g.OnFileClose(closing.FilePath, closing.Highlighter.Language())
 	}
-	if closing.Content != nil && g.OnContentTabClose != nil {
-		g.OnContentTabClose(closing.FilePath)
-	}
+	g.notifyContentTabClose(closing)
 	if g.active < g.pinnedCount {
 		g.pinnedCount--
 	}
@@ -786,9 +795,7 @@ func (g *EditorGroupWidget) CloseOtherTabs() {
 			kept = append(kept, tab)
 			continue
 		}
-		if g.OnContentTabClose != nil && tab.Content != nil {
-			g.OnContentTabClose(tab.FilePath)
-		}
+		g.notifyContentTabClose(tab)
 	}
 	g.tabs = kept
 	for i, tab := range g.tabs {
@@ -816,9 +823,7 @@ func (g *EditorGroupWidget) CloseOtherSaved() {
 			kept = append(kept, g.tabs[i])
 			continue
 		}
-		if g.tabs[i].Content != nil && g.OnContentTabClose != nil {
-			g.OnContentTabClose(g.tabs[i].FilePath)
-		}
+		g.notifyContentTabClose(g.tabs[i])
 	}
 	g.tabs = kept
 	for i, tab := range g.tabs {
@@ -843,6 +848,9 @@ func (g *EditorGroupWidget) HasDirtyOtherTabs() bool {
 }
 
 func (g *EditorGroupWidget) CloseAllTabs() {
+	for i := g.pinnedCount; i < len(g.tabs); i++ {
+		g.notifyContentTabClose(g.tabs[i])
+	}
 	kept := slices.Clone(g.tabs[:g.pinnedCount])
 	if len(kept) == 0 {
 		kept = []editorTab{{
@@ -866,11 +874,21 @@ func (g *EditorGroupWidget) CloseAllSaved() {
 	for i := range g.tabs {
 		if i < g.pinnedCount || (g.tabs[i].Buf != nil && g.tabs[i].Buf.Dirty) {
 			kept = append(kept, g.tabs[i])
+			continue
 		}
+		g.notifyContentTabClose(g.tabs[i])
 	}
 	if len(kept) == 0 {
-		g.CloseAllTabs()
-		return
+		kept = []editorTab{{
+			FilePath: "untitled",
+			Buf:      &buffer.Buffer{Lines: []string{""}},
+			Cur:      &cursor.Cursor{},
+			Vp:       &view.Viewport{},
+			Undo:     g.newUndoStack(),
+			Sel:      &selection.Selection{},
+			Virtual:  true,
+		}}
+		g.pinnedCount = 0
 	}
 	g.tabs = kept
 	if g.active >= len(g.tabs) {

--- a/internal/ui/editor_group_test.go
+++ b/internal/ui/editor_group_test.go
@@ -6,6 +6,18 @@ import (
 	"testing"
 )
 
+func TestOpenPluginTabReplacementClosesPreviousContent(t *testing.T) {
+	group := NewEditorGroupWidget(nil, 4, true, "relative")
+	closed := false
+	first := NewCommitDetailWidget("/repo", "ref", "abcdef0", false)
+	first.OnClose = func() { closed = true }
+	group.OpenPluginTab("commit", "Commit", first)
+	group.OpenPluginTab("commit", "Replacement", NewCommitDetailWidget("/repo", "other", "1234567", false))
+	if !closed {
+		t.Fatal("replacing a content tab did not close its previous incarnation")
+	}
+}
+
 func TestInitialTabIsVirtual(t *testing.T) {
 	g := NewEditorGroupWidget(nil, 4, false, "extended")
 	if !g.tabs[0].Virtual {

--- a/internal/ui/editor_group_test.go
+++ b/internal/ui/editor_group_test.go
@@ -9,12 +9,17 @@ import (
 func TestOpenPluginTabReplacementClosesPreviousContent(t *testing.T) {
 	group := NewEditorGroupWidget(nil, 4, true, "relative")
 	closed := false
+	notified := ""
+	group.OnContentTabClose = func(id string) { notified = id }
 	first := NewCommitDetailWidget("/repo", "ref", "abcdef0", false)
 	first.OnClose = func() { closed = true }
 	group.OpenPluginTab("commit", "Commit", first)
 	group.OpenPluginTab("commit", "Replacement", NewCommitDetailWidget("/repo", "other", "1234567", false))
 	if !closed {
 		t.Fatal("replacing a content tab did not close its previous incarnation")
+	}
+	if notified != "commit" {
+		t.Fatalf("replacement close notification = %q, want commit", notified)
 	}
 }
 

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -9,8 +9,9 @@ import (
 type SidebarWidget struct {
 	BaseWidget
 	TabbedPanel
-	Visible bool
-	Borders *term.BorderSet
+	Visible       bool
+	Borders       *term.BorderSet
+	capturedChild Widget
 }
 
 func NewSidebarWidget() *SidebarWidget {
@@ -63,6 +64,13 @@ func (s *SidebarWidget) SetPointerCaptureInvalidated(invalidated func()) {
 }
 
 func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
+	if s.capturedChild != nil {
+		result := s.capturedChild.HandleEvent(ev)
+		if tev, ok := ev.(*tcell.EventMouse); ok && tev.Buttons() == tcell.ButtonNone {
+			s.capturedChild = nil
+		}
+		return result
+	}
 	if tev, ok := ev.(*tcell.EventMouse); ok {
 		_, my := tev.Position()
 		r := s.GetRect()
@@ -72,7 +80,11 @@ func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
 	}
 	active := s.ActiveWidget()
 	if active != nil {
-		return active.HandleEvent(ev)
+		result := active.HandleEvent(ev)
+		if result == EventCaptured {
+			s.capturedChild = active
+		}
+		return result
 	}
 	return EventIgnored
 }

--- a/internal/ui/tree_widget_adapter.go
+++ b/internal/ui/tree_widget_adapter.go
@@ -7,9 +7,10 @@ import (
 
 type WidgetAdapter struct {
 	BaseWidget
-	W      widgets.Widget
-	focus  *widgets.FocusManager
-	popups []widgets.PopupRenderer
+	W            widgets.Widget
+	focus        *widgets.FocusManager
+	popups       []widgets.PopupRenderer
+	rootCaptured bool
 }
 
 func NewWidgetAdapter(w widgets.Widget) *WidgetAdapter {
@@ -69,6 +70,13 @@ func (a *WidgetAdapter) wireTabbedCallbacks(w widgets.Widget) {
 	case *widgets.ScrollViewWidget:
 		if v.Child != nil {
 			a.wireTabbedCallbacks(v.Child)
+		}
+	case *ContentSplitWidget:
+		if v.Top != nil {
+			a.wireTabbedCallbacks(v.Top)
+		}
+		if v.Bottom != nil {
+			a.wireTabbedCallbacks(v.Bottom)
 		}
 	}
 }
@@ -143,6 +151,13 @@ func (a *WidgetAdapter) CursorPosition() (int, int, bool) {
 }
 
 func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
+	if tev, ok := ev.(*tcell.EventMouse); ok && a.rootCaptured {
+		result := a.W.HandleEvent(ev)
+		if tev.Buttons() == tcell.ButtonNone {
+			a.rootCaptured = false
+		}
+		return result
+	}
 	// Popups are painted over the tree, so they must claim clicks over the rows
 	// they cover before those rows get a chance at them.
 	if tev, ok := ev.(*tcell.EventMouse); ok {
@@ -153,5 +168,9 @@ func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
 	if result := a.focus.HandleEvent(ev); result != EventIgnored {
 		return result
 	}
-	return a.W.HandleEvent(ev)
+	result := a.W.HandleEvent(ev)
+	if result == EventCaptured {
+		a.rootCaptured = true
+	}
+	return result
 }

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -67,18 +67,106 @@ func (fm *FocusManager) FocusNext() {
 	if len(fm.items) == 0 {
 		return
 	}
-	fm.setFocus((fm.focused + 1) % len(fm.items))
+	if next := fm.adjacentRendered(1); next >= 0 && next != fm.focused {
+		fm.setFocus(next)
+	}
 }
 
 func (fm *FocusManager) FocusPrev() {
 	if len(fm.items) == 0 {
 		return
 	}
-	next := fm.focused - 1
-	if next < 0 {
-		next = len(fm.items) - 1
+	if next := fm.adjacentRendered(-1); next >= 0 && next != fm.focused {
+		fm.setFocus(next)
 	}
-	fm.setFocus(next)
+}
+
+func (fm *FocusManager) hasRenderedGeometry(item FocusableWidget) bool {
+	if fm.root == nil {
+		return true
+	}
+	rootRect := fm.root.GetRect()
+	if rootRect.W <= 0 || rootRect.H <= 0 {
+		return true
+	}
+	path := make([]Widget, 0, 4)
+	if !collectWidgetPath(fm.root, item, &path) {
+		return false
+	}
+	for _, widget := range path {
+		r := widget.GetRect()
+		if r.W <= 0 || r.H <= 0 {
+			return false
+		}
+	}
+	visible := item.GetRect()
+	for i := len(path) - 2; i >= 0; i-- {
+		if _, scrolls := path[i].(*ScrollViewWidget); scrolls {
+			visible = path[i].GetRect()
+			continue
+		}
+		visible = intersectRects(visible, path[i].GetRect())
+		if visible.W <= 0 || visible.H <= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func collectWidgetPath(widget, target Widget, path *[]Widget) bool {
+	*path = append(*path, widget)
+	if widget == target {
+		return true
+	}
+	if container, ok := widget.(ContainerWidget); ok {
+		for _, child := range container.WidgetChildren() {
+			if collectWidgetPath(child, target, path) {
+				return true
+			}
+		}
+	}
+	*path = (*path)[:len(*path)-1]
+	return false
+}
+
+func (fm *FocusManager) renderedItemCount() int {
+	count := 0
+	for _, item := range fm.items {
+		if fm.hasRenderedGeometry(item) {
+			count++
+		}
+	}
+	return count
+}
+
+func (fm *FocusManager) adjacentRendered(step int) int {
+	if len(fm.items) == 0 {
+		return -1
+	}
+	index := fm.focused
+	if index < 0 || index >= len(fm.items) {
+		if step > 0 {
+			index = -1
+		} else {
+			index = 0
+		}
+	}
+	for range len(fm.items) {
+		index = (index + step + len(fm.items)) % len(fm.items)
+		if fm.hasRenderedGeometry(fm.items[index]) {
+			return index
+		}
+	}
+	return -1
+}
+
+func (fm *FocusManager) ensureFocusedRendered() {
+	if fm.focused >= 0 && fm.focused < len(fm.items) && fm.hasRenderedGeometry(fm.items[fm.focused]) {
+		return
+	}
+	if next := fm.adjacentRendered(1); next >= 0 {
+		fm.setFocus(next)
+	}
 }
 
 // Items are collected pre-order, so a click inside a focusable container (a
@@ -209,14 +297,15 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 	}
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
-		if tev.Key() == tcell.KeyTab && len(fm.items) > 1 {
+		if tev.Key() == tcell.KeyTab && fm.renderedItemCount() > 1 {
 			fm.FocusNext()
 			return EventConsumed
 		}
-		if tev.Key() == tcell.KeyBacktab && len(fm.items) > 1 {
+		if tev.Key() == tcell.KeyBacktab && fm.renderedItemCount() > 1 {
 			fm.FocusPrev()
 			return EventConsumed
 		}
+		fm.ensureFocusedRendered()
 		if fw := fm.Focused(); fw != nil {
 			return fw.HandleEvent(ev)
 		}

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -7,20 +7,22 @@ import (
 )
 
 type TreeNode struct {
-	ID         string      `json:"id"`
-	Label      string      `json:"label"`
-	Icon       string      `json:"icon,omitempty"`
-	IconStyle  term.Style  `json:"-"`
-	Badge      string      `json:"badge,omitempty"`
-	BadgeStyle term.Style  `json:"-"`
-	Children   []*TreeNode `json:"children,omitempty"`
-	Actions    []Action    `json:"actions,omitempty"`
-	Muted      bool        `json:"-"`
-	Expandable bool        `json:"-"`
+	ID           string      `json:"id"`
+	Label        string      `json:"label"`
+	Icon         string      `json:"icon,omitempty"`
+	IconStyle    term.Style  `json:"-"`
+	Badge        string      `json:"badge,omitempty"`
+	BadgeStyle   term.Style  `json:"-"`
+	Children     []*TreeNode `json:"children,omitempty"`
+	Actions      []Action    `json:"actions,omitempty"`
+	Muted        bool        `json:"-"`
+	Expandable   bool        `json:"-"`
+	TruncateLeft bool        `json:"-"`
 
 	Expanded bool `json:"-"`
 	depth    int
 	parent   *TreeNode
+	chevronX int
 }
 
 type Action struct {
@@ -47,12 +49,14 @@ type TreeConfig struct {
 	SelectOnClick  bool        `json:"-"`
 	TruncateLeft   bool        `json:"truncateLeft,omitempty"` // truncate labels from the left (…tail) so the end stays visible
 
-	OnCommand  func(command string, node *TreeNode)
-	OnMenu     func(entries []MenuEntry, node *TreeNode, screenX, screenY int)
-	OnExpand   func(node *TreeNode)
-	OnSelect   func(node *TreeNode)
-	OnKey      func(ev *tcell.EventKey, node *TreeNode) bool
-	RenderItem func(surface Surface, node *TreeNode, idx, y, w int, selected bool)
+	OnCommand          func(command string, node *TreeNode)
+	OnMenu             func(entries []MenuEntry, node *TreeNode, screenX, screenY int)
+	OnExpand           func(node *TreeNode)
+	OnSelect           func(node *TreeNode)
+	OnFocus            func()
+	OnKey              func(ev *tcell.EventKey, node *TreeNode) bool
+	RenderItem         func(surface Surface, node *TreeNode, idx, y, w int, selected bool)
+	ActivateExpandable bool
 }
 
 type TreeWidget struct {
@@ -88,9 +92,14 @@ func (t *TreeWidget) Width() int  { return 0 }
 // ContentHeight reports visible rows so scroll views can measure the tree.
 func (t *TreeWidget) ContentHeight() int { return len(t.flatList) + t.BoxOverheadH() }
 
-func (t *TreeWidget) Focusable() bool   { return true }
-func (t *TreeWidget) SetFocused(f bool) { t.focused = f }
-func (t *TreeWidget) IsFocused() bool   { return t.focused }
+func (t *TreeWidget) Focusable() bool { return true }
+func (t *TreeWidget) SetFocused(f bool) {
+	t.focused = f
+	if f && t.Config.OnFocus != nil {
+		t.Config.OnFocus()
+	}
+}
+func (t *TreeWidget) IsFocused() bool { return t.focused }
 
 func (t *TreeWidget) Selected() *TreeNode {
 	if t.selected >= 0 && t.selected < len(t.flatList) {
@@ -316,6 +325,7 @@ func (t *TreeWidget) rightSideWidth(node *TreeNode) int {
 }
 
 func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) {
+	node.chevronX = -1
 	if t.Config.RenderItem != nil {
 		t.Config.RenderItem(surface, node, idx, y, w, idx == t.selected)
 		return
@@ -344,6 +354,7 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		}
 		if x < w {
 			surface.SetCell(x, y, term.Cell{Ch: chevron, Style: style})
+			node.chevronX = t.contentX + x
 		}
 		x++
 		if x < w {
@@ -372,7 +383,7 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 		labelStyle = term.StyleMuted
 	}
 	labelRunes := []rune(node.Label)
-	if t.Config.TruncateLeft {
+	if t.Config.TruncateLeft || node.TruncateLeft {
 		labelRunes = truncateRunesLeft(labelRunes, maxX-x)
 	}
 	x = drawRunesClipped(surface, x, y, maxX, labelRunes, labelStyle)
@@ -542,7 +553,15 @@ func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {
 		}
 
 		if !t.Config.SelectOnClick {
-			t.ActivateSelected()
+			if t.Config.ActivateExpandable && node.isExpandable() {
+				if mx == node.chevronX {
+					t.toggleExpandedSelected()
+				} else if t.Config.OnCommand != nil {
+					t.Config.OnCommand("activate", node)
+				}
+			} else {
+				t.ActivateSelected()
+			}
 		}
 		return EventConsumed
 	}
@@ -575,7 +594,11 @@ func (t *TreeWidget) handleKey(ev *tcell.EventKey) EventResult {
 			}
 			return EventConsumed
 		}
-		t.ActivateSelected()
+		if t.Config.ActivateExpandable {
+			t.activateSelectedNode()
+		} else {
+			t.ActivateSelected()
+		}
 		return EventConsumed
 	case tcell.KeyRune:
 		if t.Config.OnKey != nil && t.Config.OnKey(ev, t.Selected()) {
@@ -643,14 +666,32 @@ func (t *TreeWidget) ActivateSelected() {
 	}
 	node := t.flatList[t.selected]
 	if node.isExpandable() {
-		node.Expanded = !node.Expanded
-		if node.Expanded && t.Config.OnExpand != nil {
-			t.Config.OnExpand(node)
-		}
-		t.flatten()
+		t.toggleExpandedSelected()
 	} else if t.Config.OnCommand != nil {
 		t.Config.OnCommand("activate", node)
 	}
+}
+
+func (t *TreeWidget) toggleExpandedSelected() {
+	if t.selected < 0 || t.selected >= len(t.flatList) {
+		return
+	}
+	node := t.flatList[t.selected]
+	if !node.isExpandable() {
+		return
+	}
+	node.Expanded = !node.Expanded
+	if node.Expanded && t.Config.OnExpand != nil {
+		t.Config.OnExpand(node)
+	}
+	t.flatten()
+}
+
+func (t *TreeWidget) activateSelectedNode() {
+	if t.selected < 0 || t.selected >= len(t.flatList) || t.Config.OnCommand == nil {
+		return
+	}
+	t.Config.OnCommand("activate", t.flatList[t.selected])
 }
 
 func (t *TreeWidget) collapseOrParent() {

--- a/tests/e2e/commit_history_detail_test.go
+++ b/tests/e2e/commit_history_detail_test.go
@@ -1,0 +1,130 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/app"
+	"github.com/gdamore/tcell/v3"
+)
+
+func runHistoryGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func (h *testHarness) awaitCommitHistoryDetail() *app.CommitDetailResult {
+	h.t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case event := <-h.screen.EventQ():
+			interrupt, ok := event.(*tcell.EventInterrupt)
+			if !ok {
+				continue
+			}
+			result, ok := interrupt.Data().(*app.CommitDetailResult)
+			if !ok {
+				continue
+			}
+			h.app.ApplyCommitDetail(result)
+			h.redraw()
+			return result
+		case <-deadline:
+			h.t.Fatal("timed out waiting for commit detail")
+			return nil
+		}
+	}
+}
+
+func TestChangesHistoryUsesResponsiveHalfLayoutAndKeyboardNavigation(t *testing.T) {
+	h := newTestHarness(t, 100, 28)
+	defer h.stop()
+	h.exec("sidebar.changes")
+	cp := h.app.Changes
+	want := cp.Split.GetRect().H / 2
+	if got := cp.CommitLog.GetRect().H + 1; got != want {
+		t.Fatalf("initial history section height = %d, want half-derived %d", got, want)
+	}
+
+	h.screen.SetSize(100, 40)
+	h.app.Root.SetSize(100, 40)
+	h.redraw()
+	want = cp.Split.GetRect().H / 2
+	if got := cp.CommitLog.GetRect().H + 1; got != want {
+		t.Fatalf("resized history section height = %d, want half-derived %d", got, want)
+	}
+
+	cp.Adapter.SetFocused(true)
+	cp.Adapter.HandleEvent(tcell.NewEventKey(tcell.KeyTab, "", tcell.ModNone))
+	cp.Adapter.HandleEvent(tcell.NewEventKey(tcell.KeyTab, "", tcell.ModNone))
+	if cp.Adapter.FocusedWidget() != cp.CommitLog {
+		t.Fatalf("keyboard focus = %T, want commit history", cp.Adapter.FocusedWidget())
+	}
+}
+
+func TestCommitHistoryOpensMetadataDetailAndWholeHeaderRowCollapses(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+	runHistoryGit(t, h.dir, "init", "-q", "-b", "main")
+	runHistoryGit(t, h.dir, "config", "user.email", "test@test.com")
+	runHistoryGit(t, h.dir, "config", "user.name", "Test User")
+	runHistoryGit(t, h.dir, "config", "commit.gpgsign", "false")
+	runHistoryGit(t, h.dir, "add", "-A")
+	runHistoryGit(t, h.dir, "commit", "-qm", "base")
+	if err := os.WriteFile(filepath.Join(h.dir, "alpha.txt"), []byte("alpha changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(h.dir, "beta.txt"), []byte("beta changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runHistoryGit(t, h.dir, "add", "-A")
+	runHistoryGit(t, h.dir, "commit", "-qm", "Detail subject", "-m", "Detail body.")
+
+	h.app.Changes.Screen = nil
+	h.app.Changes.Refresh()
+	h.exec("sidebar.changes")
+	log := h.app.Changes.CommitLog
+	commitIndex := -1
+	for index, node := range log.FlatList() {
+		if strings.HasPrefix(node.ID, "commit:") {
+			commitIndex = index
+			break
+		}
+	}
+	if commitIndex < 0 {
+		t.Fatal("commit history has no commit row")
+	}
+	rowY := log.GetRect().Y + commitIndex - log.ScrollTop()
+	h.click(log.GetRect().X+4, rowY)
+	result := h.awaitCommitHistoryDetail()
+	metadata := "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04 PM -0700")
+	for _, text := range []string{metadata, "Detail subject", "Detail body.", "alpha.txt", "alpha changed", "beta.txt", "beta changed"} {
+		h.assertContains(text)
+	}
+
+	lines := strings.Split(h.screenText(), "\n")
+	headingY := -1
+	for y, line := range lines {
+		if strings.Contains(line, "alpha.txt") {
+			headingY = y
+			break
+		}
+	}
+	if headingY < 0 {
+		t.Fatal("alpha heading is not visible")
+	}
+	detail := h.app.EditorGroup.ActiveCommitDetailWidget()
+	r := detail.GetRect()
+	h.click(r.X+r.W-2, headingY)
+	h.assertNotContains("alpha changed")
+	h.assertContains("beta changed")
+}

--- a/tests/e2e/commit_history_detail_test.go
+++ b/tests/e2e/commit_history_detail_test.go
@@ -106,7 +106,7 @@ func TestCommitHistoryOpensMetadataDetailAndWholeHeaderRowCollapses(t *testing.T
 	rowY := log.GetRect().Y + commitIndex - log.ScrollTop()
 	h.click(log.GetRect().X+4, rowY)
 	result := h.awaitCommitHistoryDetail()
-	metadata := "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04 PM -0700")
+	metadata := "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04:05 PM -0700")
 	for _, text := range []string{metadata, "Detail subject", "Detail body.", "alpha.txt", "alpha changed", "beta.txt", "beta changed"} {
 		h.assertContains(text)
 	}

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -33,7 +33,7 @@ describe("commit history detail", () => {
     expect(snapshots[detail]).toMatch(/Commit [0-9a-f]{7,}/);
     expect(snapshots[detail]).toContain("detail subject");
     expect(snapshots[detail]).toContain("Full detail body.");
-    expect(snapshots[detail]).toMatch(/Authored [A-Z][a-z]{2} \d{1,2}, \d{4} at \d{1,2}:\d{2} [AP]M [+-]\d{4}/);
+    expect(snapshots[detail]).toMatch(/Authored [A-Z][a-z]{2} \d{1,2}, \d{4} at \d{1,2}:\d{2}:\d{2} [AP]M [+-]\d{4}/);
     expect(snapshots[detail]).toContain("first-detail.txt");
     expect(snapshots[detail]).toContain("first old");
     expect(snapshots[detail]).toContain("second-detail.txt");

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as tui from "./tui.js";
+import { cleanupDir, createGitRepo, createTempDir, createTempFile, git } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("commit history detail", () => {
+  it("opens one read-only document with metadata and every changed file", () => {
+    dir = createGitRepo(createTempDir());
+    createTempFile(dir, "first-detail.txt", "first old\n");
+    createTempFile(dir, "second-detail.txt", "second old\n");
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "detail subject", "-m", "Full detail body.");
+
+    tui.start(dir);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(500);
+    // Changes focus starts in the working tree. The next two stops are the
+    // commit input and the responsive Commit History tree.
+    tui.press("tab");
+    tui.press("tab");
+    tui.press("down");
+    tui.press("enter");
+    tui.waitStable(900);
+    const detail = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[detail]).toMatch(/Commit [0-9a-f]{7,}/);
+    expect(snapshots[detail]).toContain("detail subject");
+    expect(snapshots[detail]).toContain("Full detail body.");
+    expect(snapshots[detail]).toMatch(/Authored [A-Z][a-z]{2} \d{1,2}, \d{4} at \d{1,2}:\d{2} [AP]M [+-]\d{4}/);
+    expect(snapshots[detail]).toContain("first-detail.txt");
+    expect(snapshots[detail]).toContain("first old");
+    expect(snapshots[detail]).toContain("second-detail.txt");
+    expect(snapshots[detail]).toContain("second old");
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> #491 has merged, and this branch is rebased onto current `main`. This is now the active review layer; later drafts remain cumulative and will be narrowed in dependency order.

## Summary

- add commit history to the Changes panel in a resizable lower half, with stable selection and expandable commit file disclosure
- open a complete commit-detail editor tab with authored date and time, message metadata, and all changed files in one scrollable review document
- let the full commit/file heading area toggle disclosure instead of requiring a precise chevron click
- keep asynchronous history, file-list, detail, and full-file context reads bound to full object IDs and tab incarnations so stale results cannot retarget reopened tabs
- cancel Git subprocesses when tabs close or requests are superseded, preserve newer successful data against older failures, and expose explicit full-file loading, loaded, failed, and retry states
- handle hostile paths, renames, merge shapes, mode/type changes, submodule pointers, SHA-256 IDs, and timestamps with seconds intact

This is the focused commit-history and detail extraction from #474. It depends on the shared diff reader but intentionally excludes Git file trees, repository watching, Current Changes, and history pagination.

## Verification

- make build
- focused app, Git, UI, widget, E2E, and functional commit-history/detail coverage
- process-lifecycle and cancellation checks with blocking fake Git commands
- race coverage for asynchronous selection, tab incarnation, close/reopen, failure ordering, and context retries
- hostile-path and merge-shape fixtures
- full Go and functional suites on the final rebased head
- independent adversarial fail-before/pass-after review for stale reopened-tab results, uncancelled Git processes, failed Full File retry, and timestamp precision
- gofmt and git diff --check

## Demo

<img alt="Commit detail review with authored date and time" src="https://github.com/user-attachments/assets/78fbb844-293c-4f01-8c8d-854886dbbd23" />

Part of #474.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive commit history panel with responsive split layout, expandable commits, file listings, and commit-detail views.
  - Added metadata, diffs, syntax highlighting, context expansion, wrapping, selection, copying, and unified/split display modes.
  - Added cancellable background loading for history, files, and commit details.
  - Improved focus navigation, mouse interactions, and tree activation behavior.

- **Bug Fixes**
  - Preserved selections, expansions, pending edits, and detail-tab state during refreshes and reopening.
  - Applied commit-message theme styling and improved process cancellation during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->