### PR TITLE
feat(git): add hierarchical file tree controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Sidebar search panel (Ctrl+K F) powered by [ripgrep](https://github.com/BurntSus
 
 Changes panel in the sidebar (Ctrl+K C) with full staging workflow.
 
+Working-tree files and files under expanded commits can be shown as a compact
+directory **Tree** or a full-path **List** (the default). The choice persists in
+`git.fileView`. Changes, commit details, and Explorer expose safe **Expand All**
+and **Collapse All** actions in their relevant menus.
+
 **Staging:**
 - **Spacebar** — toggle stage/unstage on the selected file
 - **`a`** — stage all unstaged files
@@ -510,7 +515,7 @@ Config files are loaded from `<exe-dir>/config/` (bundled defaults) or `~/.confi
 | [`keybindings.json`](config/keybindings.json) | Custom keybindings (VS Code key format) |
 | `themes/*.json` | Custom color themes |
 
-Most settings can be edited from a form instead of by hand: **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). The form is grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (explorer, terminal, search and plugin options live under Advanced). Changes are held until you press **Apply** (also **Settings: Apply Changes**), which writes `settings.json` and applies everything that does not need a restart; **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Settings marked *(restart)* take effect on next launch. LSP settings and external formatters are not exposed in the form — those stay JSON-only.
+Most settings can be edited from a form instead of by hand: **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). The form is grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (Git, explorer, terminal, search and plugin options live under Advanced). Changes are held until you press **Apply** (also **Settings: Apply Changes**), which writes `settings.json` and applies everything that does not need a restart; **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Settings marked *(restart)* take effect on next launch. LSP settings and external formatters are not exposed in the form — those stay JSON-only.
 
 To edit the raw files, use **Settings: Open settings.json** and **Settings: Open keybindings.json**.
 
@@ -540,6 +545,7 @@ To edit the raw files, use **Settings: Open settings.json** and **Settings: Open
 | `explorer.showHidden` | bool | `true` | Show hidden files (dot-prefixed) in the file explorer |
 | `explorer.showGitIgnored` | bool | `true` | Show gitignored files in the file explorer |
 | `sidebar.panelOrder` | string[] | built-in order | Preferred sidebar panel IDs; updated when headers are dragged or moved with commands |
+| `git.fileView` | string | `"list"` | Show changed and historical files as a compact `"tree"` or full-path `"list"` |
 | `terminal.shell` | string | `""` | Shell command for the integrated terminal (empty = system default) |
 | `terminal.scrollback` | int | `1000` | Number of scrollback lines to retain in the terminal |
 | `lsp.saveOnRename` | bool | `false` | Auto-save all files affected by a rename operation |
@@ -577,6 +583,9 @@ Example `~/.config/ttt/settings.json` (also available at [`config/settings.json`
   },
   "sidebar": {
     "panelOrder": ["explorer", "search", "changes", "outline"]
+  },
+  "git": {
+    "fileView": "list"
   },
   "terminal": {
     "shell": "",

--- a/config/settings.json
+++ b/config/settings.json
@@ -24,6 +24,9 @@
     "showHidden": true,
     "showGitIgnored": true
   },
+  "git": {
+    "fileView": "list"
+  },
   "terminal": {
     "scrollback": 1000
   },

--- a/docs-web/src/content/docs/guides/git.md
+++ b/docs-web/src/content/docs/guides/git.md
@@ -41,7 +41,7 @@ The shared diff reader has two independent presentation choices:
 - **Split** places old and new content side by side; **Unified** stacks removals before additions.
 - **Changes Only** shows changed hunks and surrounding context; quiet disclosure rows expand omitted context in place. **Full File** shows the complete file with changes highlighted inline.
 
-Set global defaults for layout, context, line wrapping, and high contrast from **Options**. The Changes panel menu exposes the same choices contextually. Commands applied directly to an open diff override that surface without changing the saved defaults.
+Set global defaults for layout, context, line wrapping, and high contrast from the **Diff Views** submenu under **Options**. The adjacent **Git Files** submenu chooses a persisted full-path List (the default) or compact Tree and exposes bulk expansion controls. The Changes panel menu exposes the same choices contextually. Commands applied directly to an open diff override that surface without changing the saved defaults.
 
 Untracked files open directly in the editor instead of showing a diff.
 

--- a/docs-web/src/content/docs/reference/settings.md
+++ b/docs-web/src/content/docs/reference/settings.md
@@ -11,7 +11,7 @@ Settings are stored in `~/.config/ttt/settings.json`. A complete example is avai
 
 There are two ways to change settings:
 
-- **Settings editor** — **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). Opens a form in an editor tab, grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (explorer, terminal, search and plugin options live under Advanced). Edits are held until you press **Apply** (also available as **Settings: Apply Changes**), which writes `settings.json` and live-applies everything that does not require a restart. **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Rows marked *(restart)* only take effect on next launch.
+- **Settings editor** — **View → Settings**, **Ctrl+K ,**, or **Settings: Open Editor Settings** from the command palette (**Ctrl+P**). Opens a form in an editor tab, grouped into **Editor**, **Appearance**, **Completion** and **Advanced** (Git, explorer, terminal, search and plugin options live under Advanced). Edits are held until you press **Apply** (also available as **Settings: Apply Changes**), which writes `settings.json` and live-applies everything that does not require a restart. **Cancel** (also **Settings: Discard Changes**) closes the tab and drops them. Rows marked *(restart)* only take effect on next launch.
 - **Raw JSON** — **Settings: Open settings.json** opens the file itself. Needed for the `lsp` settings and `formatters`, neither of which is exposed in the form.
 
 Closing the settings tab with unapplied edits discards them.
@@ -66,6 +66,12 @@ All editor settings are nested under the `editor` key.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `sidebar.panelOrder` | string[] | built-in order | Preferred sidebar panel-header order. Dragging a header or using **Move Panel Left/Right** updates it automatically. Unknown plugin panel IDs are retained until that plugin loads. |
+
+## Git
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `git.fileView` | string | `"list"` | Show working-tree and expanded commit files as a compact `"tree"` or full-path `"list"` |
 
 ## Terminal
 
@@ -176,6 +182,9 @@ When `editor.formatOnSave` is `true`, external formatters take priority over LSP
   },
   "sidebar": {
     "panelOrder": ["explorer", "search", "changes", "outline"]
+  },
+  "git": {
+    "fileView": "list"
   },
   "terminal": {
     "shell": "/bin/zsh",

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -25,6 +25,9 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 			{Label: "Add Folder", Command: "workspace.addFolder"},
 			{Label: "Refresh", Command: "explorer.refresh"},
 			ui.MenuSep(),
+			{Label: "Expand All", Command: "explorer.expandAll"},
+			{Label: "Collapse All", Command: "explorer.collapseAll"},
+			ui.MenuSep(),
 			{Label: "Help", Command: "explorer.help"},
 		}
 	case "search":
@@ -80,7 +83,8 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
 		{Label: "Refresh", Command: "changes.refresh"},
-		{Label: "Diff View", Submenu: a.BuildDiffViewOptions()},
+		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
+		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
 		ui.MenuSep(),
 		{Label: "Pull", Command: "git.pull"},
 		{Label: "Push", Command: "git.push"},
@@ -90,6 +94,18 @@ func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 		ui.MenuSep(),
 		{Label: "Help", Command: "changes.help"},
 	}
+}
+
+func (a *App) BuildChangesContextMenu() []ui.ContextMenuItem {
+	return []ui.ContextMenuItem{
+		{Label: "Refresh", Command: "changes.refresh"},
+		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
+		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
+	}
+}
+
+func (a *App) ShowChangesContextMenu(sx, sy int) {
+	openContextMenu(a, a.BuildChangesContextMenu(), sx, sy)
 }
 
 func (a *App) DiffSearchSources() []ui.DiffSearchSource {
@@ -557,6 +573,9 @@ func registerWidgetCallbacks(app *App) {
 			ui.MenuSep(),
 			{Label: "Rename", Command: "explorer.rename"},
 			{Label: "Delete", Command: "explorer.delete"},
+			ui.MenuSep(),
+			{Label: "Expand All", Command: "explorer.expandAll"},
+			{Label: "Collapse All", Command: "explorer.collapseAll"},
 		}
 		openContextMenu(app, items, sx, sy)
 	}
@@ -567,6 +586,9 @@ func registerWidgetCallbacks(app *App) {
 			{Label: "Copy Path", Command: "explorer.copyAbsolutePath"},
 			ui.MenuSep(),
 			{Label: "Remove from Workspace", Command: "explorer.removeRoot"},
+			ui.MenuSep(),
+			{Label: "Expand All", Command: "explorer.expandAll"},
+			{Label: "Collapse All", Command: "explorer.collapseAll"},
 		}
 		openContextMenu(app, items, sx, sy)
 	}
@@ -584,12 +606,17 @@ func registerWidgetCallbacks(app *App) {
 	app.Search.OnReplaceAll = app.ApplySearchReplaceAll
 
 	app.Changes.OnRightClick = func(dir string, status git.FileStatus, sx, sy int) {
+		var items []ui.ContextMenuItem
 		if status.Staged {
-			openContextMenu(app, changesContextMenuStaged, sx, sy)
+			items = append(items, changesContextMenuStaged...)
 		} else {
-			openContextMenu(app, changesContextMenuUnstaged, sx, sy)
+			items = append(items, changesContextMenuUnstaged...)
 		}
+		items = append(items, ui.MenuSep())
+		items = append(items, app.BuildChangesContextMenu()...)
+		openContextMenu(app, items, sx, sy)
 	}
+	app.Changes.OnPanelMenu = app.ShowChangesContextMenu
 
 	app.Changes.OnOpenFile = func(path string) {
 		app.EditorGroup.OpenFile(path)

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -108,6 +108,18 @@ func (a *App) ShowChangesContextMenu(sx, sy int) {
 	openContextMenu(a, a.BuildChangesContextMenu(), sx, sy)
 }
 
+func (a *App) ShowChangesFileContextMenu(_ string, status git.FileStatus, sx, sy int) {
+	var items []ui.ContextMenuItem
+	if status.Staged {
+		items = append(items, changesContextMenuStaged...)
+	} else {
+		items = append(items, changesContextMenuUnstaged...)
+	}
+	items = append(items, ui.MenuSep())
+	items = append(items, a.BuildChangesContextMenu()...)
+	openContextMenu(a, items, sx, sy)
+}
+
 func (a *App) DiffSearchSources() []ui.DiffSearchSource {
 	seen := map[string]bool{}
 	sources := a.EditorGroup.DiffTabSources()
@@ -605,17 +617,7 @@ func registerWidgetCallbacks(app *App) {
 	app.Search.OnReplace = app.ApplySearchReplace
 	app.Search.OnReplaceAll = app.ApplySearchReplaceAll
 
-	app.Changes.OnRightClick = func(dir string, status git.FileStatus, sx, sy int) {
-		var items []ui.ContextMenuItem
-		if status.Staged {
-			items = append(items, changesContextMenuStaged...)
-		} else {
-			items = append(items, changesContextMenuUnstaged...)
-		}
-		items = append(items, ui.MenuSep())
-		items = append(items, app.BuildChangesContextMenu()...)
-		openContextMenu(app, items, sx, sy)
-	}
+	app.Changes.OnRightClick = app.ShowChangesFileContextMenu
 	app.Changes.OnPanelMenu = app.ShowChangesContextMenu
 
 	app.Changes.OnOpenFile = func(path string) {

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -83,7 +83,7 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
 		{Label: "Refresh", Command: "changes.refresh"},
-		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
+		{Label: "Git Files", Submenu: a.BuildChangesGitFileOptions()},
 		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
 		ui.MenuSep(),
 		{Label: "Pull", Command: "git.pull"},
@@ -99,7 +99,7 @@ func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 func (a *App) BuildChangesContextMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
 		{Label: "Refresh", Command: "changes.refresh"},
-		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
+		{Label: "Git Files", Submenu: a.BuildChangesGitFileOptions()},
 		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
 	}
 }

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -271,13 +271,7 @@ func commitFileParent(id string) (parentID, ref string, ok bool) {
 
 // selectLogNode selects a node by ID, reporting whether it was there to select.
 func (cp *ChangesPanel) selectLogNode(id string) bool {
-	for i, node := range cp.CommitLog.FlatList() {
-		if node.ID == id {
-			cp.CommitLog.SetSelectedIndex(i)
-			return true
-		}
-	}
-	return false
+	return revealTreeSelection(cp.CommitLog, id)
 }
 
 func readCommitFiles(ctx context.Context, request uint64, dir, ref, short, nodeID string) *CommitFilesResult {

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -73,15 +73,16 @@ type CommitFilesResult struct {
 // one immutable commit. Incarnation distinguishes repeated openings of the same
 // repository and ref so a closed request can never target its replacement.
 type CommitDetailResult struct {
-	Incarnation uint64
-	Dir         string
-	Ref         string
-	Short       string
-	Message     string
-	AuthoredAt  time.Time
-	Files       []ui.CommitDetailFile
-	Err         string
-	Canceled    bool
+	Incarnation           uint64
+	Dir                   string
+	Ref                   string
+	Short                 string
+	Message               string
+	AuthoredAt            time.Time
+	AuthoredAtUnavailable bool
+	Files                 []ui.CommitDetailFile
+	Err                   string
+	Canceled              bool
 }
 
 func readChangesGroups(dirs []string) []changesGroup {
@@ -145,12 +146,16 @@ func readCommitLog(ctx context.Context, dir string, gen int) *CommitLogResult {
 
 // ApplyCommitLog rebuilds the commit log from a finished read.
 func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
-	if r == nil || r.Canceled {
+	if r == nil {
 		return
 	}
 	// Both checks, not one: the counter catches a superseded read, and the
 	// directory catches a counter that agrees for some reason it should not.
 	if r.Gen != cp.logGen || r.Dir != cp.lastLogDir {
+		return
+	}
+	cp.cancelLogRead()
+	if r.Canceled {
 		return
 	}
 	if r.Unavailable {
@@ -296,6 +301,7 @@ func (cp *ChangesPanel) recordCommitFiles(r *CommitFilesResult) bool {
 		if !ok || request.ID != r.Request {
 			return false
 		}
+		request.Cancel()
 		delete(cp.commitFilesPending, key)
 	}
 	if r.Err == nil {
@@ -325,7 +331,9 @@ func (cp *ChangesPanel) fetchCommitFiles(dir, ref, short, nodeID string) {
 	cp.commitFilesPending[key] = commitFilesRequest{ID: requestID, Cancel: cancel}
 	screen := cp.Screen
 	go func() {
-		screen.PostEvent(tcell.NewEventInterrupt(readCommitFiles(ctx, requestID, dir, ref, short, nodeID)))
+		result := readCommitFiles(ctx, requestID, dir, ref, short, nodeID)
+		cancel()
+		screen.PostEvent(tcell.NewEventInterrupt(result))
 	}()
 }
 
@@ -394,6 +402,9 @@ func readCommitDetail(ctx context.Context, incarnation uint64, dir, ref, short s
 	if errors.Is(err, context.Canceled) {
 		result.Canceled = true
 		return result
+	}
+	if err != nil {
+		result.AuthoredAtUnavailable = true
 	}
 
 	files, err := git.CommitFilesContext(ctx, dir, ref)
@@ -511,6 +522,8 @@ func (a *App) ApplyCommitDetail(result *CommitDetailResult) {
 	}
 	if !result.AuthoredAt.IsZero() {
 		detail.Metadata = "Authored " + result.AuthoredAt.Format("Jan 2, 2006 at 3:04:05 PM -0700")
+	} else if result.AuthoredAtUnavailable {
+		detail.Metadata = "Authored date unavailable"
 	}
 	detail.SetDetail(result.Message, result.Files, result.Err)
 }

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -60,8 +60,8 @@ type ChangesPanel struct {
 	logExpanded        map[string]bool
 	logSelected        map[string]string
 	logFolderExpanded  map[string]bool
-	workFolderExpanded map[string]bool
-	workFolderKeys     map[string]string
+	workFolderExpanded map[workFolderStateKey]bool
+	workNodes          map[string]workNodeRef
 	workFiles          map[string]workFileRef
 	fileView           string
 
@@ -107,6 +107,21 @@ type workFileRef struct {
 	Staged bool
 }
 
+type workNodeRef struct {
+	Dir    string
+	Path   string
+	Staged bool
+	Kind   workNodeKind
+	Group  int
+	PR     bool
+}
+
+type workFolderStateKey struct {
+	Dir  string
+	Path string
+	PR   bool
+}
+
 // commitFileRef ties a commit-log node back to the immutable commit it belongs
 // to without parsing path content out of the node ID.
 type commitFileRef struct {
@@ -140,8 +155,8 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 		logExpanded:        make(map[string]bool),
 		logSelected:        make(map[string]string),
 		logFolderExpanded:  make(map[string]bool),
-		workFolderExpanded: make(map[string]bool),
-		workFolderKeys:     make(map[string]string),
+		workFolderExpanded: make(map[workFolderStateKey]bool),
+		workNodes:          make(map[string]workNodeRef),
 		workFiles:          make(map[string]workFileRef),
 		fileView:           config.GitFileViewList,
 
@@ -557,8 +572,8 @@ func (cp *ChangesPanel) saveExpanded() {
 			if node.Expandable || len(node.Children) > 0 {
 				cp.expanded[node.ID] = node.Expanded
 			}
-			if key := cp.workFolderKeys[node.ID]; key != "" {
-				cp.workFolderExpanded[key] = node.Expanded
+			if ref, ok := cp.workNodes[node.ID]; ok && (ref.Kind == workNodeFolder || ref.Kind == workNodePRFolder) {
+				cp.workFolderExpanded[workFolderStateKey{Dir: ref.Dir, Path: ref.Path, PR: ref.PR}] = node.Expanded
 			}
 			visit(node.Children)
 		}
@@ -597,8 +612,8 @@ func (cp *ChangesPanel) setCommitFoldersExpanded(expanded bool) {
 }
 
 func (cp *ChangesPanel) restoreExpanded(node *widgets.TreeNode) {
-	if key := cp.workFolderKeys[node.ID]; key != "" {
-		if exp, ok := cp.workFolderExpanded[key]; ok {
+	if ref, ok := cp.workNodes[node.ID]; ok && (ref.Kind == workNodeFolder || ref.Kind == workNodePRFolder) {
+		if exp, ok := cp.workFolderExpanded[workFolderStateKey{Dir: ref.Dir, Path: ref.Path, PR: ref.PR}]; ok {
 			node.Expanded = exp
 		}
 	} else if exp, ok := cp.expanded[node.ID]; ok {
@@ -617,7 +632,7 @@ func (cp *ChangesPanel) buildTree() {
 		selected = node.ID
 		selectedFile, selectedWasFile = cp.workFiles[node.ID]
 	}
-	cp.workFolderKeys = make(map[string]string)
+	cp.workNodes = make(map[string]workNodeRef)
 	cp.workFiles = make(map[string]workFileRef)
 	var roots []*widgets.TreeNode
 
@@ -625,8 +640,10 @@ func (cp *ChangesPanel) buildTree() {
 		var sectionNodes []*widgets.TreeNode
 
 		if len(g.Staged) > 0 {
+			id := workingNodeID(workNodeSection, g.Dir, "", true)
+			cp.workNodes[id] = workNodeRef{Dir: g.Dir, Staged: true, Kind: workNodeSection, Group: gi}
 			stagedNode := &widgets.TreeNode{
-				ID:         fmt.Sprintf("staged:%d", gi),
+				ID:         id,
 				Label:      fmt.Sprintf("Staged (%d)", len(g.Staged)),
 				Expandable: true,
 				Expanded:   true,
@@ -635,13 +652,15 @@ func (cp *ChangesPanel) buildTree() {
 					{Icon: "−", Command: "unstageAll"},
 				},
 			}
-			stagedNode.Children = cp.fileNodes(fmt.Sprintf("work:%d:staged", gi), g.Dir, g.Staged, true)
+			stagedNode.Children = cp.fileNodes(g.Dir, g.Staged, true, gi, false)
 			sectionNodes = append(sectionNodes, stagedNode)
 		}
 
 		if len(g.Unstaged) > 0 {
+			id := workingNodeID(workNodeSection, g.Dir, "", false)
+			cp.workNodes[id] = workNodeRef{Dir: g.Dir, Kind: workNodeSection, Group: gi}
 			changesNode := &widgets.TreeNode{
-				ID:         fmt.Sprintf("changes:%d", gi),
+				ID:         id,
 				Label:      fmt.Sprintf("Changes (%d)", len(g.Unstaged)),
 				Expandable: true,
 				Expanded:   true,
@@ -651,13 +670,15 @@ func (cp *ChangesPanel) buildTree() {
 					{Icon: "+", Command: "stageAll"},
 				},
 			}
-			changesNode.Children = cp.fileNodes(fmt.Sprintf("work:%d:changes", gi), g.Dir, g.Unstaged, false)
+			changesNode.Children = cp.fileNodes(g.Dir, g.Unstaged, false, gi, false)
 			sectionNodes = append(sectionNodes, changesNode)
 		}
 
 		if cp.multiRoot {
+			id := workingNodeID(workNodeRoot, g.Dir, "", false)
+			cp.workNodes[id] = workNodeRef{Dir: g.Dir, Kind: workNodeRoot, Group: gi}
 			root := &widgets.TreeNode{
-				ID:         fmt.Sprintf("root:%d", gi),
+				ID:         id,
 				Label:      g.Name,
 				Expandable: true,
 				Expanded:   true,
@@ -673,8 +694,10 @@ func (cp *ChangesPanel) buildTree() {
 	}
 
 	for pi, pg := range cp.PRGroups {
+		id := workingNodeID(workNodePRRoot, pg.Dir, pg.Name, false)
+		cp.workNodes[id] = workNodeRef{Dir: pg.Dir, Path: pg.Name, Kind: workNodePRRoot, Group: pi, PR: true}
 		prRoot := &widgets.TreeNode{
-			ID:         fmt.Sprintf("pr:%d", pi),
+			ID:         id,
 			Label:      pg.Name,
 			Expandable: true,
 			Expanded:   true,
@@ -682,7 +705,7 @@ func (cp *ChangesPanel) buildTree() {
 				{Icon: "⋮", Command: "prGroupMenu"},
 			},
 		}
-		prRoot.Children = cp.fileNodes(fmt.Sprintf("pr:%d", pi), pg.Dir, pg.Files, false)
+		prRoot.Children = cp.fileNodes(pg.Dir, pg.Files, false, pi, true)
 		clearTreeActions(prRoot.Children)
 		roots = append(roots, prRoot)
 	}
@@ -710,7 +733,7 @@ func clearTreeActions(nodes []*widgets.TreeNode) {
 	}
 }
 
-func (cp *ChangesPanel) fileNode(dir string, f git.FileStatus, staged bool) *widgets.TreeNode {
+func (cp *ChangesPanel) fileNode(dir string, f git.FileStatus, staged bool, kind workNodeKind, group int, pr bool) *widgets.TreeNode {
 	icon := ui.StatusBadge(f.Status)
 	iconStyle := ui.StatusStyle(f.Status)
 	actionIcon := "+"
@@ -719,8 +742,9 @@ func (cp *ChangesPanel) fileNode(dir string, f git.FileStatus, staged bool) *wid
 		actionIcon = "−"
 		actionCmd = "unstage"
 	}
-	id := fmt.Sprintf("file:%s:%s:%v", dir, f.Path, staged)
+	id := workingNodeID(kind, dir, f.Path, staged)
 	cp.workFiles[id] = workFileRef{Dir: dir, Status: f, Staged: staged}
+	cp.workNodes[id] = workNodeRef{Dir: dir, Path: f.Path, Staged: staged, Kind: kind, Group: group, PR: pr}
 	return &widgets.TreeNode{
 		ID:        id,
 		Label:     f.Path,
@@ -769,18 +793,8 @@ func (cp *ChangesPanel) selectedGroupDir() string {
 	if ok {
 		return dir
 	}
-	gi := cp.groupIndexFromNode(node)
-	if gi >= 0 && gi < len(cp.groups) {
-		return cp.groups[gi].Dir
-	}
-	if strings.HasPrefix(node.ID, "root:") {
-		var idx int
-		if _, err := fmt.Sscanf(node.ID, "root:%d", &idx); err == nil && idx < len(cp.groups) {
-			return cp.groups[idx].Dir
-		}
-	}
-	if gi := workingFolderGroupIndex(node); gi >= 0 && gi < len(cp.groups) {
-		return cp.groups[gi].Dir
+	if ref, found := cp.workNodes[node.ID]; found && !ref.PR {
+		return ref.Dir
 	}
 	return ""
 }
@@ -790,27 +804,8 @@ func (cp *ChangesPanel) selectedInPR() bool {
 	if node == nil {
 		return false
 	}
-	dir, _, _, ok := cp.parseFileNode(node)
-	if ok {
-		for _, pg := range cp.PRGroups {
-			if pg.Dir == dir {
-				return true
-			}
-		}
-		return false
-	}
-	return strings.HasPrefix(node.ID, "pr:") || strings.HasPrefix(node.ID, "folder:pr:")
-}
-
-func workingFolderGroupIndex(node *widgets.TreeNode) int {
-	if node == nil || !strings.HasPrefix(node.ID, "folder:work:") {
-		return -1
-	}
-	var gi int
-	if _, err := fmt.Sscanf(node.ID, "folder:work:%d:", &gi); err != nil {
-		return -1
-	}
-	return gi
+	ref, found := cp.workNodes[node.ID]
+	return found && ref.PR
 }
 
 func (cp *ChangesPanel) handleCommand(cmd string, node *widgets.TreeNode) {
@@ -943,22 +938,18 @@ func (cp *ChangesPanel) handleMenu(node *widgets.TreeNode, sx, sy int) {
 		cp.OnRightClick(dir, status, sx, sy)
 		return
 	}
-	for _, pg := range cp.PRGroups {
-		if node.Label == pg.Name {
-			if cp.OnPRGroupMenu != nil {
-				uiGroup := cp.toUIChangesGroup(&pg)
-				cp.OnPRGroupMenu(uiGroup, sx, sy)
-			}
-			return
+	if ref, found := cp.workNodes[node.ID]; found && ref.Kind == workNodePRRoot && ref.Group >= 0 && ref.Group < len(cp.PRGroups) {
+		if cp.OnPRGroupMenu != nil {
+			uiGroup := cp.toUIChangesGroup(&cp.PRGroups[ref.Group])
+			cp.OnPRGroupMenu(uiGroup, sx, sy)
 		}
+		return
 	}
-	for gi, g := range cp.groups {
-		if node.ID == fmt.Sprintf("root:%d", gi) {
-			if cp.OnGroupMenu != nil {
-				cp.OnGroupMenu(g.Dir, sx, sy)
-			}
-			return
+	if ref, found := cp.workNodes[node.ID]; found && ref.Kind == workNodeRoot {
+		if cp.OnGroupMenu != nil {
+			cp.OnGroupMenu(ref.Dir, sx, sy)
 		}
+		return
 	}
 	cp.showPanelMenu(sx, sy)
 }
@@ -996,15 +987,10 @@ func (cp *ChangesPanel) parseFileNode(node *widgets.TreeNode) (dir string, statu
 }
 
 func (cp *ChangesPanel) groupIndexFromNode(node *widgets.TreeNode) int {
-	var gi int
-	if _, err := fmt.Sscanf(node.ID, "changes:%d", &gi); err == nil {
-		return gi
-	}
-	if _, err := fmt.Sscanf(node.ID, "staged:%d", &gi); err == nil {
-		return gi
-	}
-	if _, err := fmt.Sscanf(node.ID, "root:%d", &gi); err == nil {
-		return gi
+	if node != nil {
+		if ref, ok := cp.workNodes[node.ID]; ok && !ref.PR {
+			return ref.Group
+		}
 	}
 	return -1
 }

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -80,7 +80,9 @@ type changesCommandContext uint8
 const (
 	changesWorkingTree changesCommandContext = iota
 	changesCommitLog
+)
 
+const (
 	changesHistoryMinHeight     = 4 // title plus three usable log rows
 	changesWorkingTreeMinHeight = 5 // input, divider, and three tree rows
 )
@@ -300,13 +302,16 @@ func (cp *ChangesPanel) refreshCommitLog() {
 	ctx, cancel := context.WithTimeout(context.Background(), commitHistoryTimeout)
 	cp.logCancel = cancel
 	if cp.Screen == nil {
-		cp.ApplyCommitLog(readCommitLog(ctx, dir, gen))
+		result := readCommitLog(ctx, dir, gen)
 		cancel()
+		cp.ApplyCommitLog(result)
 		return
 	}
 	screen := cp.Screen
 	go func() {
-		screen.PostEvent(tcell.NewEventInterrupt(readCommitLog(ctx, dir, gen)))
+		result := readCommitLog(ctx, dir, gen)
+		cancel()
+		screen.PostEvent(tcell.NewEventInterrupt(result))
 	}()
 }
 
@@ -492,10 +497,14 @@ func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.Tre
 		cp.Refresh()
 		return true
 	case 'c', 'o', 'v':
-		cp.openCommitFile(node, false)
+		cp.openCommitLogNode(node)
 		return true
 	case 'e':
-		cp.openCommitFile(node, true)
+		if _, isCommit := cp.logCommits[node.ID]; isCommit {
+			cp.openCommitLogNode(node)
+		} else {
+			cp.openCommitFile(node, true)
+		}
 		return true
 	}
 	return false

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -105,6 +105,7 @@ type workFileRef struct {
 	Dir    string
 	Status git.FileStatus
 	Staged bool
+	Kind   workNodeKind
 }
 
 type workNodeRef struct {
@@ -718,12 +719,8 @@ func (cp *ChangesPanel) buildTree() {
 	if revealTreeSelection(cp.Tree, selected) || !selectedWasFile {
 		return
 	}
-	for id, ref := range cp.workFiles {
-		if ref.Dir == selectedFile.Dir && ref.Status.Path == selectedFile.Status.Path {
-			revealTreeSelection(cp.Tree, id)
-			return
-		}
-	}
+	fallbackID := workingNodeID(selectedFile.Kind, selectedFile.Dir, selectedFile.Status.Path, !selectedFile.Staged)
+	revealTreeSelection(cp.Tree, fallbackID)
 }
 
 func clearTreeActions(nodes []*widgets.TreeNode) {
@@ -743,7 +740,7 @@ func (cp *ChangesPanel) fileNode(dir string, f git.FileStatus, staged bool, kind
 		actionCmd = "unstage"
 	}
 	id := workingNodeID(kind, dir, f.Path, staged)
-	cp.workFiles[id] = workFileRef{Dir: dir, Status: f, Staged: staged}
+	cp.workFiles[id] = workFileRef{Dir: dir, Status: f, Staged: staged, Kind: kind}
 	cp.workNodes[id] = workNodeRef{Dir: dir, Path: f.Path, Staged: staged, Kind: kind, Group: group, PR: pr}
 	return &widgets.TreeNode{
 		ID:        id,

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
@@ -56,14 +57,20 @@ type ChangesPanel struct {
 	pendingLogSelection string
 	// logExpanded and logSelected outlive any one repo's log, so switching
 	// between roots in a workspace and back returns to what was open.
-	logExpanded map[string]bool
-	logSelected map[string]string
+	logExpanded        map[string]bool
+	logSelected        map[string]string
+	logFolderExpanded  map[string]bool
+	workFolderExpanded map[string]bool
+	workFolderKeys     map[string]string
+	workFiles          map[string]workFileRef
+	fileView           string
 
 	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
 	OnOpenCommit     func(dir, ref, short string)
 	OnOpenPRDiff     func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
 	OnOpenFile       func(path string)
 	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
+	OnPanelMenu      func(screenX, screenY int)
 	OnCommit         func(dir string, message string)
 	OnGroupMenu      func(dir string, screenX, screenY int)
 	OnPRGroupMenu    func(group *ui.ChangesGroup, screenX, screenY int)
@@ -94,10 +101,14 @@ type changesGroup struct {
 	Unstaged []git.FileStatus
 }
 
-// commitFileRef ties a commit-log node back to the file it stands for. The
-// panel keeps a map rather than encoding dir, hash and path into the node ID:
-// all three can contain a colon, and parseFileNode's reverse scan is already at
-// its limit with two fields.
+type workFileRef struct {
+	Dir    string
+	Status git.FileStatus
+	Staged bool
+}
+
+// commitFileRef ties a commit-log node back to the immutable commit it belongs
+// to without parsing path content out of the node ID.
 type commitFileRef struct {
 	Dir string
 	// Ref is the full hash, which is what git is asked with and what the tab
@@ -120,14 +131,19 @@ type prGroup struct {
 
 func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp := &ChangesPanel{
-		Dirs:        dirs,
-		multiRoot:   len(dirs) > 1,
-		expanded:    make(map[string]bool),
-		commitFiles: make(map[string][]git.FileStatus),
-		logCommits:  make(map[string]commitFileRef),
-		logFiles:    make(map[string]commitFileRef),
-		logExpanded: make(map[string]bool),
-		logSelected: make(map[string]string),
+		Dirs:               dirs,
+		multiRoot:          len(dirs) > 1,
+		expanded:           make(map[string]bool),
+		commitFiles:        make(map[string][]git.FileStatus),
+		logCommits:         make(map[string]commitFileRef),
+		logFiles:           make(map[string]commitFileRef),
+		logExpanded:        make(map[string]bool),
+		logSelected:        make(map[string]string),
+		logFolderExpanded:  make(map[string]bool),
+		workFolderExpanded: make(map[string]bool),
+		workFolderKeys:     make(map[string]string),
+		workFiles:          make(map[string]workFileRef),
+		fileView:           config.GitFileViewList,
 
 		commitFilesPending: make(map[string]commitFilesRequest),
 	}
@@ -178,8 +194,16 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 		},
 		OnCommand: func(cmd string, node *widgets.TreeNode) {
 			if cmd == "activate" {
+				if isCommitFolderNode(node) {
+					node.Expanded = !node.Expanded
+					cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+					return
+				}
 				cp.openCommitLogNode(node)
 			}
+		},
+		OnMenu: func(_ []widgets.MenuEntry, _ *widgets.TreeNode, sx, sy int) {
+			cp.showPanelMenu(sx, sy)
 		},
 		OnKey: func(ev *tcell.EventKey, node *widgets.TreeNode) bool {
 			return cp.handleCommitLogKey(ev, node)
@@ -356,6 +380,7 @@ func (cp *ChangesPanel) saveCommitLogState() {
 		} else {
 			delete(cp.logExpanded, key)
 		}
+		cp.saveCommitFolderState(node.Children)
 	}
 	if cp.pendingLogSelection != "" {
 		// A second rebuild can land while the selected child's read is still in
@@ -364,6 +389,15 @@ func (cp *ChangesPanel) saveCommitLogState() {
 		cp.logSelected[cp.logDir] = cp.pendingLogSelection
 	} else if node := cp.CommitLog.Selected(); node != nil {
 		cp.logSelected[cp.logDir] = node.ID
+	}
+}
+
+func (cp *ChangesPanel) saveCommitFolderState(nodes []*widgets.TreeNode) {
+	for _, node := range nodes {
+		if isCommitFolderNode(node) {
+			cp.logFolderExpanded[node.ID] = node.Expanded
+		}
+		cp.saveCommitFolderState(node.Children)
 	}
 }
 
@@ -447,19 +481,25 @@ func (cp *ChangesPanel) commitFileNodes(dir, ref, short, parentID string, files 
 		// that changed nothing against its first parent is the usual cause.
 		return []*widgets.TreeNode{{ID: parentID + emptySuffix, Label: "No files", Muted: true}}
 	}
-	nodes := make([]*widgets.TreeNode, 0, len(files))
-	for _, f := range files {
+	makeLeaf := func(f git.FileStatus) *widgets.TreeNode {
 		id := fmt.Sprintf("cfile:%s:%s", parentID, f.Path)
 		cp.logFiles[id] = commitFileRef{Dir: dir, Ref: ref, Short: short}
-		nodes = append(nodes, &widgets.TreeNode{
+		return &widgets.TreeNode{
 			ID:           id,
 			Label:        f.Path,
 			Icon:         ui.StatusBadge(f.Status),
 			IconStyle:    ui.StatusStyle(f.Status),
 			TruncateLeft: true,
-		})
+		}
 	}
-	return nodes
+	if cp.fileView == config.GitFileViewList {
+		nodes := make([]*widgets.TreeNode, 0, len(files))
+		for _, f := range files {
+			nodes = append(nodes, makeLeaf(f))
+		}
+		return nodes
+	}
+	return compactFileTree("history:"+parentID, files, makeLeaf, cp.logFolderExpanded)
 }
 
 func (cp *ChangesPanel) openCommitFile(node *widgets.TreeNode, _ bool) {
@@ -511,15 +551,57 @@ func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.Tre
 }
 
 func (cp *ChangesPanel) saveExpanded() {
-	for _, node := range cp.Tree.FlatList() {
-		if node.Expandable || len(node.Children) > 0 {
-			cp.expanded[node.ID] = node.Expanded
+	var visit func([]*widgets.TreeNode)
+	visit = func(nodes []*widgets.TreeNode) {
+		for _, node := range nodes {
+			if node.Expandable || len(node.Children) > 0 {
+				cp.expanded[node.ID] = node.Expanded
+			}
+			if key := cp.workFolderKeys[node.ID]; key != "" {
+				cp.workFolderExpanded[key] = node.Expanded
+			}
+			visit(node.Children)
 		}
 	}
+	visit(cp.Tree.Config.Items)
+}
+
+// ExpandAll opens the working-tree hierarchy and every already-loaded folder
+// in commit file trees. Commit rows remain untouched so this never starts a
+// history-wide burst of Git reads.
+func (cp *ChangesPanel) ExpandAll() {
+	cp.Tree.ExpandAll()
+	cp.setCommitFoldersExpanded(true)
+	cp.saveExpanded()
+}
+
+func (cp *ChangesPanel) CollapseAll() {
+	cp.Tree.CollapseAll()
+	cp.setCommitFoldersExpanded(false)
+	cp.saveExpanded()
+}
+
+func (cp *ChangesPanel) setCommitFoldersExpanded(expanded bool) {
+	var visit func([]*widgets.TreeNode)
+	visit = func(nodes []*widgets.TreeNode) {
+		for _, node := range nodes {
+			if isCommitFolderNode(node) {
+				node.Expanded = expanded
+				cp.logFolderExpanded[node.ID] = expanded
+			}
+			visit(node.Children)
+		}
+	}
+	visit(cp.CommitLog.Config.Items)
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
 }
 
 func (cp *ChangesPanel) restoreExpanded(node *widgets.TreeNode) {
-	if exp, ok := cp.expanded[node.ID]; ok {
+	if key := cp.workFolderKeys[node.ID]; key != "" {
+		if exp, ok := cp.workFolderExpanded[key]; ok {
+			node.Expanded = exp
+		}
+	} else if exp, ok := cp.expanded[node.ID]; ok {
 		node.Expanded = exp
 	}
 	for _, child := range node.Children {
@@ -528,6 +610,15 @@ func (cp *ChangesPanel) restoreExpanded(node *widgets.TreeNode) {
 }
 
 func (cp *ChangesPanel) buildTree() {
+	selected := ""
+	var selectedFile workFileRef
+	selectedWasFile := false
+	if node := cp.Tree.Selected(); node != nil {
+		selected = node.ID
+		selectedFile, selectedWasFile = cp.workFiles[node.ID]
+	}
+	cp.workFolderKeys = make(map[string]string)
+	cp.workFiles = make(map[string]workFileRef)
 	var roots []*widgets.TreeNode
 
 	for gi, g := range cp.groups {
@@ -544,10 +635,7 @@ func (cp *ChangesPanel) buildTree() {
 					{Icon: "−", Command: "unstageAll"},
 				},
 			}
-			for _, f := range g.Staged {
-				child := cp.fileNode(g.Dir, f, true)
-				stagedNode.Children = append(stagedNode.Children, child)
-			}
+			stagedNode.Children = cp.fileNodes(fmt.Sprintf("work:%d:staged", gi), g.Dir, g.Staged, true)
 			sectionNodes = append(sectionNodes, stagedNode)
 		}
 
@@ -563,10 +651,7 @@ func (cp *ChangesPanel) buildTree() {
 					{Icon: "+", Command: "stageAll"},
 				},
 			}
-			for _, f := range g.Unstaged {
-				child := cp.fileNode(g.Dir, f, false)
-				changesNode.Children = append(changesNode.Children, child)
-			}
+			changesNode.Children = cp.fileNodes(fmt.Sprintf("work:%d:changes", gi), g.Dir, g.Unstaged, false)
 			sectionNodes = append(sectionNodes, changesNode)
 		}
 
@@ -597,11 +682,8 @@ func (cp *ChangesPanel) buildTree() {
 				{Icon: "⋮", Command: "prGroupMenu"},
 			},
 		}
-		for _, f := range pg.Files {
-			child := cp.fileNode(pg.Dir, f, false)
-			child.Actions = nil
-			prRoot.Children = append(prRoot.Children, child)
-		}
+		prRoot.Children = cp.fileNodes(fmt.Sprintf("pr:%d", pi), pg.Dir, pg.Files, false)
+		clearTreeActions(prRoot.Children)
 		roots = append(roots, prRoot)
 	}
 
@@ -610,6 +692,22 @@ func (cp *ChangesPanel) buildTree() {
 	}
 
 	cp.Tree.SetItems(roots)
+	if revealTreeSelection(cp.Tree, selected) || !selectedWasFile {
+		return
+	}
+	for id, ref := range cp.workFiles {
+		if ref.Dir == selectedFile.Dir && ref.Status.Path == selectedFile.Status.Path {
+			revealTreeSelection(cp.Tree, id)
+			return
+		}
+	}
+}
+
+func clearTreeActions(nodes []*widgets.TreeNode) {
+	for _, node := range nodes {
+		node.Actions = nil
+		clearTreeActions(node.Children)
+	}
 }
 
 func (cp *ChangesPanel) fileNode(dir string, f git.FileStatus, staged bool) *widgets.TreeNode {
@@ -621,8 +719,10 @@ func (cp *ChangesPanel) fileNode(dir string, f git.FileStatus, staged bool) *wid
 		actionIcon = "−"
 		actionCmd = "unstage"
 	}
+	id := fmt.Sprintf("file:%s:%s:%v", dir, f.Path, staged)
+	cp.workFiles[id] = workFileRef{Dir: dir, Status: f, Staged: staged}
 	return &widgets.TreeNode{
-		ID:        fmt.Sprintf("file:%s:%s:%v", dir, f.Path, staged),
+		ID:        id,
 		Label:     f.Path,
 		Icon:      icon,
 		IconStyle: iconStyle,
@@ -679,6 +779,9 @@ func (cp *ChangesPanel) selectedGroupDir() string {
 			return cp.groups[idx].Dir
 		}
 	}
+	if gi := workingFolderGroupIndex(node); gi >= 0 && gi < len(cp.groups) {
+		return cp.groups[gi].Dir
+	}
 	return ""
 }
 
@@ -696,7 +799,18 @@ func (cp *ChangesPanel) selectedInPR() bool {
 		}
 		return false
 	}
-	return strings.HasPrefix(node.ID, "pr:")
+	return strings.HasPrefix(node.ID, "pr:") || strings.HasPrefix(node.ID, "folder:pr:")
+}
+
+func workingFolderGroupIndex(node *widgets.TreeNode) int {
+	if node == nil || !strings.HasPrefix(node.ID, "folder:work:") {
+		return -1
+	}
+	var gi int
+	if _, err := fmt.Sscanf(node.ID, "folder:work:%d:", &gi); err != nil {
+		return -1
+	}
+	return gi
 }
 
 func (cp *ChangesPanel) handleCommand(cmd string, node *widgets.TreeNode) {
@@ -846,6 +960,13 @@ func (cp *ChangesPanel) handleMenu(node *widgets.TreeNode, sx, sy int) {
 			return
 		}
 	}
+	cp.showPanelMenu(sx, sy)
+}
+
+func (cp *ChangesPanel) showPanelMenu(sx, sy int) {
+	if cp.OnPanelMenu != nil {
+		cp.OnPanelMenu(sx, sy)
+	}
 }
 
 func (cp *ChangesPanel) openDiff(dir string, status git.FileStatus, staged bool, extended bool) {
@@ -867,60 +988,11 @@ func (cp *ChangesPanel) parseFileNode(node *widgets.TreeNode) (dir string, statu
 	if node == nil {
 		return
 	}
-	id := node.ID
-	if len(id) < 6 || id[:5] != "file:" {
-		return
+	ref, found := cp.workFiles[node.ID]
+	if !found {
+		return "", git.FileStatus{}, false, false
 	}
-	rest := id[5:]
-	lastColon := -1
-	for i := len(rest) - 1; i >= 0; i-- {
-		if rest[i] == ':' {
-			lastColon = i
-			break
-		}
-	}
-	if lastColon < 0 {
-		return
-	}
-	s := rest[lastColon+1:] == "true"
-	rest = rest[:lastColon]
-
-	secondLastColon := -1
-	for i := len(rest) - 1; i >= 0; i-- {
-		if rest[i] == ':' {
-			secondLastColon = i
-			break
-		}
-	}
-	if secondLastColon < 0 {
-		return
-	}
-	d := rest[:secondLastColon]
-	path := rest[secondLastColon+1:]
-
-	for _, g := range cp.groups {
-		if g.Dir == d {
-			files := g.Unstaged
-			if s {
-				files = g.Staged
-			}
-			for _, f := range files {
-				if f.Path == path {
-					return d, f, s, true
-				}
-			}
-		}
-	}
-	for _, pg := range cp.PRGroups {
-		if pg.Dir == d {
-			for _, f := range pg.Files {
-				if f.Path == path {
-					return d, f, false, true
-				}
-			}
-		}
-	}
-	return
+	return ref.Dir, ref.Status, ref.Staged, true
 }
 
 func (cp *ChangesPanel) groupIndexFromNode(node *widgets.TreeNode) int {

--- a/internal/app/changes_tree.go
+++ b/internal/app/changes_tree.go
@@ -1,0 +1,226 @@
+package app
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/widgets"
+)
+
+const commitFolderPrefix = "folder:history:"
+
+type filePathDir struct {
+	name  string
+	path  string
+	dirs  map[string]*filePathDir
+	files []git.FileStatus
+}
+
+func newFilePathDir(name, path string) *filePathDir {
+	return &filePathDir{name: name, path: path, dirs: make(map[string]*filePathDir)}
+}
+
+// compactFileTree turns Git's slash-separated paths into directory nodes.
+// Consecutive directories with no files or siblings render as one row, which
+// preserves the hierarchy without spending most of a short sidebar on folders.
+func compactFileTree(scope string, files []git.FileStatus, makeLeaf func(git.FileStatus) *widgets.TreeNode, expanded map[string]bool) []*widgets.TreeNode {
+	root := newFilePathDir("", "")
+	for _, file := range files {
+		parts := strings.Split(file.Path, "/")
+		if len(parts) == 1 {
+			root.files = append(root.files, file)
+			continue
+		}
+		dir := root
+		for _, part := range parts[:len(parts)-1] {
+			childPath := part
+			if dir.path != "" {
+				childPath = dir.path + "/" + part
+			}
+			child := dir.dirs[part]
+			if child == nil {
+				child = newFilePathDir(part, childPath)
+				dir.dirs[part] = child
+			}
+			dir = child
+		}
+		dir.files = append(dir.files, file)
+	}
+
+	return compactPathChildren(scope, root, makeLeaf, expanded)
+}
+
+func compactPathChildren(scope string, dir *filePathDir, makeLeaf func(git.FileStatus) *widgets.TreeNode, expanded map[string]bool) []*widgets.TreeNode {
+	dirNames := make([]string, 0, len(dir.dirs))
+	for name := range dir.dirs {
+		dirNames = append(dirNames, name)
+	}
+	slices.Sort(dirNames)
+
+	nodes := make([]*widgets.TreeNode, 0, len(dirNames)+len(dir.files))
+	for _, name := range dirNames {
+		start := dir.dirs[name]
+		current := start
+		labels := []string{current.name}
+		for len(current.files) == 0 && len(current.dirs) == 1 {
+			for _, child := range current.dirs {
+				current = child
+				labels = append(labels, current.name)
+			}
+		}
+
+		id := "folder:" + scope + ":" + start.path
+		isExpanded := true
+		if saved, ok := expanded[id]; ok {
+			isExpanded = saved
+		}
+		nodes = append(nodes, &widgets.TreeNode{
+			ID:         id,
+			Label:      strings.Join(labels, "/"),
+			Expandable: true,
+			Expanded:   isExpanded,
+			Children:   compactPathChildren(scope, current, makeLeaf, expanded),
+		})
+	}
+
+	slices.SortFunc(dir.files, func(a, b git.FileStatus) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	for _, file := range dir.files {
+		leaf := makeLeaf(file)
+		leaf.Label = gitPathBase(file.Path)
+		leaf.TruncateLeft = false
+		nodes = append(nodes, leaf)
+	}
+	return nodes
+}
+
+func gitPathBase(path string) string {
+	if slash := strings.LastIndexByte(path, '/'); slash >= 0 {
+		return path[slash+1:]
+	}
+	return path
+}
+
+func isCommitFolderNode(node *widgets.TreeNode) bool {
+	return node != nil && strings.HasPrefix(node.ID, commitFolderPrefix)
+}
+
+func selectedViewTargetID(tree *widgets.TreeWidget) string {
+	if tree == nil || tree.Selected() == nil {
+		return ""
+	}
+	node := tree.Selected()
+	if strings.HasPrefix(node.ID, "folder:") {
+		if leaf := firstFileDescendant(node.Children); leaf != nil {
+			return leaf.ID
+		}
+	}
+	return node.ID
+}
+
+func firstFileDescendant(nodes []*widgets.TreeNode) *widgets.TreeNode {
+	for _, node := range nodes {
+		if strings.HasPrefix(node.ID, "file:") || strings.HasPrefix(node.ID, "cfile:") {
+			return node
+		}
+		if leaf := firstFileDescendant(node.Children); leaf != nil {
+			return leaf
+		}
+	}
+	return nil
+}
+
+// revealTreeSelection restores by stable identity and opens only the ancestors
+// needed to make that identity visible. It deliberately never falls back to a
+// numeric row, since Tree and List have different visible row counts.
+func revealTreeSelection(tree *widgets.TreeWidget, id string) bool {
+	if tree == nil || id == "" || !expandPathToID(tree.Config.Items, id) {
+		return false
+	}
+	tree.SetItems(tree.Config.Items)
+	tree.SelectByID(id)
+	return tree.Selected() != nil && tree.Selected().ID == id
+}
+
+func expandPathToID(nodes []*widgets.TreeNode, id string) bool {
+	for _, node := range nodes {
+		if node.ID == id {
+			return true
+		}
+		if expandPathToID(node.Children, id) {
+			node.Expanded = true
+			return true
+		}
+	}
+	return false
+}
+
+func (cp *ChangesPanel) FileView() string { return cp.fileView }
+
+func (cp *ChangesPanel) SetFileView(view string) {
+	if view != config.GitFileViewTree {
+		view = config.GitFileViewList
+	}
+	if cp.fileView == view {
+		return
+	}
+
+	workingSelection := selectedViewTargetID(cp.Tree)
+	logSelection := selectedViewTargetID(cp.CommitLog)
+	cp.saveExpanded()
+	cp.saveCommitLogState()
+	cp.fileView = view
+	cp.buildTree()
+	cp.rebuildCommitFileNodes()
+	revealTreeSelection(cp.Tree, workingSelection)
+	revealTreeSelection(cp.CommitLog, logSelection)
+}
+
+func (cp *ChangesPanel) rebuildCommitFileNodes() {
+	cp.logFiles = make(map[string]commitFileRef)
+	for _, node := range cp.CommitLog.Config.Items {
+		commit, ok := cp.logCommits[node.ID]
+		if !ok || len(node.Children) == 0 {
+			continue
+		}
+		files, cached := cp.commitFiles[commit.Dir+"\x00"+commit.Ref]
+		if cached {
+			node.Children = cp.commitFileNodes(commit.Dir, commit.Ref, commit.Short, node.ID, files)
+		}
+	}
+	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
+}
+
+func (cp *ChangesPanel) fileNodes(scope, dir string, files []git.FileStatus, staged bool) []*widgets.TreeNode {
+	makeLeaf := func(file git.FileStatus) *widgets.TreeNode {
+		return cp.fileNode(dir, file, staged)
+	}
+	if cp.fileView == config.GitFileViewList {
+		nodes := make([]*widgets.TreeNode, 0, len(files))
+		for _, file := range files {
+			nodes = append(nodes, makeLeaf(file))
+		}
+		return nodes
+	}
+	nodes := compactFileTree(scope, files, makeLeaf, cp.expanded)
+	if strings.HasPrefix(scope, "work:") {
+		cp.registerWorkingFolders(nodes, "folder:"+scope+":", dir)
+	}
+	return nodes
+}
+
+func (cp *ChangesPanel) registerWorkingFolders(nodes []*widgets.TreeNode, prefix, dir string) {
+	for _, node := range nodes {
+		if strings.HasPrefix(node.ID, prefix) {
+			key := dir + "\x00" + strings.TrimPrefix(node.ID, prefix)
+			cp.workFolderKeys[node.ID] = key
+			if expanded, ok := cp.workFolderExpanded[key]; ok {
+				node.Expanded = expanded
+			}
+		}
+		cp.registerWorkingFolders(node.Children, prefix, dir)
+	}
+}

--- a/internal/app/changes_tree.go
+++ b/internal/app/changes_tree.go
@@ -11,6 +11,26 @@ import (
 
 const commitFolderPrefix = "folder:history:"
 
+type workNodeKind string
+
+const (
+	workNodeRoot     workNodeKind = "root"
+	workNodeSection  workNodeKind = "section"
+	workNodeFolder   workNodeKind = "folder"
+	workNodeFile     workNodeKind = "file"
+	workNodePRRoot   workNodeKind = "pr-root"
+	workNodePRFolder workNodeKind = "pr-folder"
+	workNodePRFile   workNodeKind = "pr-file"
+)
+
+func workingNodeID(kind workNodeKind, dir, path string, staged bool) string {
+	stage := "unstaged"
+	if staged {
+		stage = "staged"
+	}
+	return strings.Join([]string{"working", string(kind), stage, dir, path}, "\x00")
+}
+
 type filePathDir struct {
 	name  string
 	path  string
@@ -26,6 +46,12 @@ func newFilePathDir(name, path string) *filePathDir {
 // Consecutive directories with no files or siblings render as one row, which
 // preserves the hierarchy without spending most of a short sidebar on folders.
 func compactFileTree(scope string, files []git.FileStatus, makeLeaf func(git.FileStatus) *widgets.TreeNode, expanded map[string]bool) []*widgets.TreeNode {
+	return compactFileTreeWithFolderID(files, makeLeaf, func(path string) string {
+		return "folder:" + scope + ":" + path
+	}, expanded)
+}
+
+func compactFileTreeWithFolderID(files []git.FileStatus, makeLeaf func(git.FileStatus) *widgets.TreeNode, folderID func(string) string, expanded map[string]bool) []*widgets.TreeNode {
 	root := newFilePathDir("", "")
 	for _, file := range files {
 		parts := strings.Split(file.Path, "/")
@@ -49,10 +75,10 @@ func compactFileTree(scope string, files []git.FileStatus, makeLeaf func(git.Fil
 		dir.files = append(dir.files, file)
 	}
 
-	return compactPathChildren(scope, root, makeLeaf, expanded)
+	return compactPathChildren(root, makeLeaf, folderID, expanded)
 }
 
-func compactPathChildren(scope string, dir *filePathDir, makeLeaf func(git.FileStatus) *widgets.TreeNode, expanded map[string]bool) []*widgets.TreeNode {
+func compactPathChildren(dir *filePathDir, makeLeaf func(git.FileStatus) *widgets.TreeNode, folderID func(string) string, expanded map[string]bool) []*widgets.TreeNode {
 	dirNames := make([]string, 0, len(dir.dirs))
 	for name := range dir.dirs {
 		dirNames = append(dirNames, name)
@@ -71,7 +97,7 @@ func compactPathChildren(scope string, dir *filePathDir, makeLeaf func(git.FileS
 			}
 		}
 
-		id := "folder:" + scope + ":" + start.path
+		id := folderID(start.path)
 		isExpanded := true
 		if saved, ok := expanded[id]; ok {
 			isExpanded = saved
@@ -81,7 +107,7 @@ func compactPathChildren(scope string, dir *filePathDir, makeLeaf func(git.FileS
 			Label:      strings.Join(labels, "/"),
 			Expandable: true,
 			Expanded:   isExpanded,
-			Children:   compactPathChildren(scope, current, makeLeaf, expanded),
+			Children:   compactPathChildren(current, makeLeaf, folderID, expanded),
 		})
 	}
 
@@ -108,25 +134,29 @@ func isCommitFolderNode(node *widgets.TreeNode) bool {
 	return node != nil && strings.HasPrefix(node.ID, commitFolderPrefix)
 }
 
-func selectedViewTargetID(tree *widgets.TreeWidget) string {
+func (cp *ChangesPanel) selectedViewTargetID(tree *widgets.TreeWidget) string {
 	if tree == nil || tree.Selected() == nil {
 		return ""
 	}
 	node := tree.Selected()
-	if strings.HasPrefix(node.ID, "folder:") {
-		if leaf := firstFileDescendant(node.Children); leaf != nil {
+	ref, working := cp.workNodes[node.ID]
+	if isCommitFolderNode(node) || working && (ref.Kind == workNodeFolder || ref.Kind == workNodePRFolder) {
+		if leaf := cp.firstFileDescendant(node.Children); leaf != nil {
 			return leaf.ID
 		}
 	}
 	return node.ID
 }
 
-func firstFileDescendant(nodes []*widgets.TreeNode) *widgets.TreeNode {
+func (cp *ChangesPanel) firstFileDescendant(nodes []*widgets.TreeNode) *widgets.TreeNode {
 	for _, node := range nodes {
-		if strings.HasPrefix(node.ID, "file:") || strings.HasPrefix(node.ID, "cfile:") {
+		if _, ok := cp.workFiles[node.ID]; ok {
 			return node
 		}
-		if leaf := firstFileDescendant(node.Children); leaf != nil {
+		if _, ok := cp.logFiles[node.ID]; ok {
+			return node
+		}
+		if leaf := cp.firstFileDescendant(node.Children); leaf != nil {
 			return leaf
 		}
 	}
@@ -168,8 +198,8 @@ func (cp *ChangesPanel) SetFileView(view string) {
 		return
 	}
 
-	workingSelection := selectedViewTargetID(cp.Tree)
-	logSelection := selectedViewTargetID(cp.CommitLog)
+	workingSelection := cp.selectedViewTargetID(cp.Tree)
+	logSelection := cp.selectedViewTargetID(cp.CommitLog)
 	cp.saveExpanded()
 	cp.saveCommitLogState()
 	cp.fileView = view
@@ -194,9 +224,15 @@ func (cp *ChangesPanel) rebuildCommitFileNodes() {
 	cp.CommitLog.SetItems(cp.CommitLog.Config.Items)
 }
 
-func (cp *ChangesPanel) fileNodes(scope, dir string, files []git.FileStatus, staged bool) []*widgets.TreeNode {
+func (cp *ChangesPanel) fileNodes(dir string, files []git.FileStatus, staged bool, group int, pr bool) []*widgets.TreeNode {
+	fileKind := workNodeFile
+	folderKind := workNodeFolder
+	if pr {
+		fileKind = workNodePRFile
+		folderKind = workNodePRFolder
+	}
 	makeLeaf := func(file git.FileStatus) *widgets.TreeNode {
-		return cp.fileNode(dir, file, staged)
+		return cp.fileNode(dir, file, staged, fileKind, group, pr)
 	}
 	if cp.fileView == config.GitFileViewList {
 		nodes := make([]*widgets.TreeNode, 0, len(files))
@@ -205,22 +241,9 @@ func (cp *ChangesPanel) fileNodes(scope, dir string, files []git.FileStatus, sta
 		}
 		return nodes
 	}
-	nodes := compactFileTree(scope, files, makeLeaf, cp.expanded)
-	if strings.HasPrefix(scope, "work:") {
-		cp.registerWorkingFolders(nodes, "folder:"+scope+":", dir)
-	}
-	return nodes
-}
-
-func (cp *ChangesPanel) registerWorkingFolders(nodes []*widgets.TreeNode, prefix, dir string) {
-	for _, node := range nodes {
-		if strings.HasPrefix(node.ID, prefix) {
-			key := dir + "\x00" + strings.TrimPrefix(node.ID, prefix)
-			cp.workFolderKeys[node.ID] = key
-			if expanded, ok := cp.workFolderExpanded[key]; ok {
-				node.Expanded = expanded
-			}
-		}
-		cp.registerWorkingFolders(node.Children, prefix, dir)
-	}
+	return compactFileTreeWithFolderID(files, makeLeaf, func(path string) string {
+		id := workingNodeID(folderKind, dir, path, staged)
+		cp.workNodes[id] = workNodeRef{Dir: dir, Path: path, Staged: staged, Kind: folderKind, Group: group, PR: pr}
+		return id
+	}, cp.expanded)
 }

--- a/internal/app/changes_tree_test.go
+++ b/internal/app/changes_tree_test.go
@@ -145,6 +145,63 @@ func TestWorkingTreeSelectionAndFolderStateSurviveStageMove(t *testing.T) {
 	}
 }
 
+func TestWorkingFileSelectionNeverCrossesIntoPRFileOnStageMove(t *testing.T) {
+	for _, view := range []string{config.GitFileViewList, config.GitFileViewTree} {
+		t.Run(view, func(t *testing.T) {
+			cp := NewChangesPanel("/repo")
+			cp.fileView = view
+			file := git.FileStatus{Status: "M", Path: "same/path.go"}
+
+			for i := 0; i < 128; i++ {
+				file.Staged = false
+				cp.PRGroups = nil
+				cp.groups = []changesGroup{{Dir: "/repo", Name: "repo", Unstaged: []git.FileStatus{file}}}
+				cp.buildTree()
+				workingID := workingNodeID(workNodeFile, "/repo", file.Path, false)
+				if !revealTreeSelection(cp.Tree, workingID) {
+					t.Fatalf("iteration %d: working file is not selectable", i)
+				}
+
+				file.Staged = true
+				cp.groups = []changesGroup{{Dir: "/repo", Name: "repo", Staged: []git.FileStatus{file}}}
+				cp.PRGroups = []prGroup{{Dir: "/repo", Name: "pull request", Files: []git.FileStatus{file}}}
+				cp.buildTree()
+				wantID := workingNodeID(workNodeFile, "/repo", file.Path, true)
+				if got := cp.Tree.Selected(); got == nil || got.ID != wantID {
+					t.Fatalf("iteration %d: selection = %+v, want %q", i, got, wantID)
+				}
+				otherView := config.GitFileViewTree
+				if view == config.GitFileViewTree {
+					otherView = config.GitFileViewList
+				}
+				cp.SetFileView(otherView)
+				cp.SetFileView(view)
+				if got := cp.Tree.Selected(); got == nil || got.ID != wantID {
+					t.Fatalf("iteration %d: selection after mode rebuild = %+v, want %q", i, got, wantID)
+				}
+				if cp.selectedInPR() {
+					t.Fatalf("iteration %d: working selection acquired PR context", i)
+				}
+				dir, status, ok := cp.SelectedFile()
+				if !ok || dir != "/repo" || status.Path != file.Path || !status.Staged {
+					t.Fatalf("iteration %d: selected file = dir %q status %+v ok %v", i, dir, status, ok)
+				}
+				group := cp.SelectedGroup()
+				if group == nil || group.IsPR || group.Dir != "/repo" {
+					t.Fatalf("iteration %d: selected group = %+v, want working repo", i, group)
+				}
+				var commitDir string
+				cp.OnCommit = func(dir, _ string) { commitDir = dir }
+				cp.Input.SetText("working commit")
+				cp.commitFocusedGroup()
+				if commitDir != "/repo" {
+					t.Fatalf("iteration %d: commit targeted %q, want /repo", i, commitDir)
+				}
+			}
+		})
+	}
+}
+
 func TestFolderNodesNeverResolveAsFilesOrExecuteFileActions(t *testing.T) {
 	cp := NewChangesPanel("/repo")
 	cp.SetFileView(config.GitFileViewTree)
@@ -189,16 +246,12 @@ func TestWorkingFileIdentitySeparatesColonAmbiguousRoots(t *testing.T) {
 
 	cp := NewChangesPanel(repoA, repoB)
 	cp.Refresh()
+	cp.PRGroups = []prGroup{{Dir: repoA, Name: "pull request", Files: []git.FileStatus{{Status: "M", Path: "b:c"}}}}
+	cp.multiRoot = true
+	cp.buildTree()
 	fileA := nodeWithLabel(cp.Tree.Config.Items, "b:c")
 	if fileA == nil || !revealTreeSelection(cp.Tree, fileA.ID) {
 		t.Fatal("repo A file is not selectable")
-	}
-	var commitDir string
-	cp.OnCommit = func(dir, _ string) { commitDir = dir }
-	cp.Input.SetText("repo A commit")
-	cp.commitFocusedGroup()
-	if commitDir != repoA {
-		t.Fatalf("repo A selection committed to %q", commitDir)
 	}
 
 	cp.ToggleStageSelected()
@@ -207,6 +260,17 @@ func TestWorkingFileIdentitySeparatesColonAmbiguousRoots(t *testing.T) {
 	}
 	if got := runTreeGit(t, repoB, "diff", "--cached", "--name-only", "-z"); got != "" {
 		t.Fatalf("repo B was staged by repo A selection: %q", got)
+	}
+	wantID := workingNodeID(workNodeFile, repoA, "b:c", true)
+	if got := cp.Tree.Selected(); got == nil || got.ID != wantID || cp.selectedInPR() {
+		t.Fatalf("staged working selection = %+v, want %q outside PR context", got, wantID)
+	}
+	var commitDir string
+	cp.OnCommit = func(dir, _ string) { commitDir = dir }
+	cp.Input.SetText("repo A commit")
+	cp.commitFocusedGroup()
+	if commitDir != repoA {
+		t.Fatalf("repo A selection committed to %q", commitDir)
 	}
 }
 

--- a/internal/app/changes_tree_test.go
+++ b/internal/app/changes_tree_test.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/config"
@@ -8,6 +11,16 @@ import (
 	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
 )
+
+func runTreeGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
 
 func findTreeNode(nodes []*widgets.TreeNode, match func(*widgets.TreeNode) bool) *widgets.TreeNode {
 	for _, node := range nodes {
@@ -53,6 +66,27 @@ func TestCompactFileTreeHandlesEmptySingleDeepAndDuplicateBasenames(t *testing.T
 	}
 }
 
+func TestWorkingNodeIdentityIsInjectiveAndStable(t *testing.T) {
+	repoA := "/workspace/a"
+	repoB := "/workspace/a:b"
+	ids := []string{
+		workingNodeID(workNodeFile, repoA, "b:c", false),
+		workingNodeID(workNodeFile, repoB, "c", false),
+		workingNodeID(workNodeFile, repoA, "b:c", true),
+		workingNodeID(workNodeFolder, repoA, "b:c", false),
+	}
+	seen := make(map[string]bool)
+	for _, id := range ids {
+		if seen[id] {
+			t.Fatalf("working identity collision in %q", ids)
+		}
+		seen[id] = true
+	}
+	if got := workingNodeID(workNodeFile, repoA, "b:c", false); got != ids[0] {
+		t.Fatalf("working identity is unstable: %q != %q", got, ids[0])
+	}
+}
+
 func TestGitFileViewSwitchPreservesFileSelection(t *testing.T) {
 	cp := NewChangesPanel("/repo")
 	cp.groups = []changesGroup{{
@@ -61,7 +95,7 @@ func TestGitFileViewSwitchPreservesFileSelection(t *testing.T) {
 		Unstaged: []git.FileStatus{{Status: "M", Path: "deep/nested/file.go"}},
 	}}
 	cp.SetFileView(config.GitFileViewTree)
-	fileID := "file:/repo:deep/nested/file.go:false"
+	fileID := workingNodeID(workNodeFile, "/repo", "deep/nested/file.go", false)
 	if !revealTreeSelection(cp.Tree, fileID) {
 		t.Fatal("tree did not contain nested file")
 	}
@@ -133,6 +167,46 @@ func TestFolderNodesNeverResolveAsFilesOrExecuteFileActions(t *testing.T) {
 	cp.handleCommand("activate", folder)
 	if opened {
 		t.Fatal("folder activation executed a file action")
+	}
+}
+
+func TestWorkingFileIdentitySeparatesColonAmbiguousRoots(t *testing.T) {
+	base := t.TempDir()
+	repoA := filepath.Join(base, "a")
+	repoB := filepath.Join(base, "a:b")
+	for _, dir := range []string{repoA, repoB} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		runTreeGit(t, dir, "init", "-q")
+	}
+	if err := os.WriteFile(filepath.Join(repoA, "b:c"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoB, "c"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cp := NewChangesPanel(repoA, repoB)
+	cp.Refresh()
+	fileA := nodeWithLabel(cp.Tree.Config.Items, "b:c")
+	if fileA == nil || !revealTreeSelection(cp.Tree, fileA.ID) {
+		t.Fatal("repo A file is not selectable")
+	}
+	var commitDir string
+	cp.OnCommit = func(dir, _ string) { commitDir = dir }
+	cp.Input.SetText("repo A commit")
+	cp.commitFocusedGroup()
+	if commitDir != repoA {
+		t.Fatalf("repo A selection committed to %q", commitDir)
+	}
+
+	cp.ToggleStageSelected()
+	if got := runTreeGit(t, repoA, "diff", "--cached", "--name-only", "-z"); got != "b:c\x00" {
+		t.Fatalf("repo A staged paths = %q", got)
+	}
+	if got := runTreeGit(t, repoB, "diff", "--cached", "--name-only", "-z"); got != "" {
+		t.Fatalf("repo B was staged by repo A selection: %q", got)
 	}
 }
 

--- a/internal/app/changes_tree_test.go
+++ b/internal/app/changes_tree_test.go
@@ -1,0 +1,165 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+func findTreeNode(nodes []*widgets.TreeNode, match func(*widgets.TreeNode) bool) *widgets.TreeNode {
+	for _, node := range nodes {
+		if match(node) {
+			return node
+		}
+		if found := findTreeNode(node.Children, match); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func nodeWithLabel(nodes []*widgets.TreeNode, label string) *widgets.TreeNode {
+	return findTreeNode(nodes, func(node *widgets.TreeNode) bool { return node.Label == label })
+}
+
+func nodeWithID(nodes []*widgets.TreeNode, id string) *widgets.TreeNode {
+	return findTreeNode(nodes, func(node *widgets.TreeNode) bool { return node.ID == id })
+}
+
+func TestCompactFileTreeHandlesEmptySingleDeepAndDuplicateBasenames(t *testing.T) {
+	makeLeaf := func(file git.FileStatus) *widgets.TreeNode {
+		return &widgets.TreeNode{ID: file.Path, Label: file.Path}
+	}
+	if nodes := compactFileTree("test", nil, makeLeaf, nil); len(nodes) != 0 {
+		t.Fatalf("empty tree = %+v", nodes)
+	}
+
+	files := []git.FileStatus{
+		{Path: "README.md"},
+		{Path: "one/shared.go"},
+		{Path: "two/deep/nested/shared.go"},
+	}
+	nodes := compactFileTree("test", files, makeLeaf, nil)
+	if nodeWithLabel(nodes, "README.md") == nil || nodeWithLabel(nodes, "two/deep/nested") == nil {
+		t.Fatalf("tree lost root or compact deep path: %+v", nodes)
+	}
+	one := nodeWithID(nodes, "one/shared.go")
+	two := nodeWithID(nodes, "two/deep/nested/shared.go")
+	if one == nil || two == nil || one == two || one.Label != "shared.go" || two.Label != "shared.go" {
+		t.Fatalf("duplicate basenames lost distinct identities: one=%+v two=%+v", one, two)
+	}
+}
+
+func TestGitFileViewSwitchPreservesFileSelection(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.groups = []changesGroup{{
+		Dir:      "/repo",
+		Name:     "repo",
+		Unstaged: []git.FileStatus{{Status: "M", Path: "deep/nested/file.go"}},
+	}}
+	cp.SetFileView(config.GitFileViewTree)
+	fileID := "file:/repo:deep/nested/file.go:false"
+	if !revealTreeSelection(cp.Tree, fileID) {
+		t.Fatal("tree did not contain nested file")
+	}
+
+	cp.SetFileView(config.GitFileViewList)
+	if got := cp.Tree.Selected(); got == nil || got.ID != fileID || got.Label != "deep/nested/file.go" {
+		t.Fatalf("list switch did not preserve file: %+v", got)
+	}
+	cp.SetFileView(config.GitFileViewTree)
+	if got := cp.Tree.Selected(); got == nil || got.ID != fileID || got.Label != "file.go" {
+		t.Fatalf("tree switch did not preserve file: %+v", got)
+	}
+}
+
+func TestWorkingTreeSelectionAndFolderStateSurviveStageMove(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.SetFileView(config.GitFileViewTree)
+	file := git.FileStatus{Status: "M", Path: "src/nested/file.go"}
+	cp.groups = []changesGroup{{Dir: "/repo", Name: "repo", Unstaged: []git.FileStatus{file}}}
+	cp.buildTree()
+	folder := nodeWithLabel(cp.Tree.Config.Items, "src/nested")
+	leaf := nodeWithLabel(cp.Tree.Config.Items, "file.go")
+	if folder == nil || leaf == nil || !revealTreeSelection(cp.Tree, leaf.ID) {
+		t.Fatal("test setup did not build working tree")
+	}
+	file.Staged = true
+	cp.groups = []changesGroup{{Dir: "/repo", Name: "repo", Staged: []git.FileStatus{file}}}
+	cp.buildTree()
+	folder = nodeWithLabel(cp.Tree.Config.Items, "src/nested")
+	if got := cp.Tree.Selected(); got == nil || got.Label != "file.go" {
+		t.Fatalf("file selection did not survive staged-group move: %+v", got)
+	}
+	if folder == nil || !folder.Expanded {
+		t.Fatalf("selected file was not revealed after staged-group move: %+v", folder)
+	}
+
+	folder.Expanded = false
+	cp.Tree.SetItems(cp.Tree.Config.Items)
+	cp.Tree.SelectByID(cp.Tree.Config.Items[0].ID)
+	cp.saveExpanded()
+	file.Staged = false
+	cp.groups = []changesGroup{{Dir: "/repo", Name: "repo", Unstaged: []git.FileStatus{file}}}
+	cp.buildTree()
+	folder = nodeWithLabel(cp.Tree.Config.Items, "src/nested")
+	if folder == nil || folder.Expanded {
+		t.Fatalf("folder state did not survive staged-group move: %+v", folder)
+	}
+}
+
+func TestFolderNodesNeverResolveAsFilesOrExecuteFileActions(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.SetFileView(config.GitFileViewTree)
+	cp.groups = []changesGroup{{Dir: "/repo", Name: "repo", Unstaged: []git.FileStatus{{Status: "R", Path: "src/file:name.go", OldPath: "old/file:name.go"}}}}
+	cp.buildTree()
+	folder := nodeWithLabel(cp.Tree.Config.Items, "src")
+	if folder == nil {
+		t.Fatal("missing folder")
+	}
+	if _, _, _, ok := cp.parseFileNode(folder); ok {
+		t.Fatal("folder resolved as a file")
+	}
+	leaf := nodeWithLabel(cp.Tree.Config.Items, "file:name.go")
+	_, status, _, ok := cp.parseFileNode(leaf)
+	if !ok || status.Path != "src/file:name.go" || status.OldPath != "old/file:name.go" {
+		t.Fatalf("rename/colon path identity was not preserved: status=%+v ok=%v", status, ok)
+	}
+	opened := false
+	cp.OnOpenDiff = func(string, git.FileStatus, bool) { opened = true }
+	cp.handleCommand("activate", folder)
+	if opened {
+		t.Fatal("folder activation executed a file action")
+	}
+}
+
+func TestCommitFileTreeFoldersToggleAndBulkStatePersists(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.SetFileView(config.GitFileViewTree)
+	const ref = "0123456789012345678901234567890123456789"
+	commitID := "commit:" + ref
+	files := []git.FileStatus{{Status: "M", Path: "pkg/history/one.go"}, {Status: "A", Path: "pkg/history/two.go"}}
+	cp.commitFiles["/repo\x00"+ref] = files
+	cp.logCommits[commitID] = commitFileRef{Dir: "/repo", Ref: ref, Short: ref[:7]}
+	commit := &widgets.TreeNode{ID: commitID, Label: "files", Expanded: true, Children: cp.commitFileNodes("/repo", ref, ref[:7], commitID, files)}
+	cp.CommitLog.SetItems([]*widgets.TreeNode{commit})
+	folder := nodeWithLabel(commit.Children, "pkg/history")
+	if folder == nil || !revealTreeSelection(cp.CommitLog, folder.ID) {
+		t.Fatal("missing commit folder")
+	}
+	cp.CommitLog.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if folder.Expanded {
+		t.Fatal("folder label activation did not collapse")
+	}
+	cp.ExpandAll()
+	if !folder.Expanded || !commit.Expanded {
+		t.Fatal("expand all did not open loaded commit folder")
+	}
+	cp.CollapseAll()
+	if folder.Expanded || !commit.Expanded {
+		t.Fatal("collapse all changed commit-row disclosure or left folder open")
+	}
+}

--- a/internal/app/commands_explorer.go
+++ b/internal/app/commands_explorer.go
@@ -122,6 +122,18 @@ func registerExplorerCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "explorer.expandAll", Title: "Explorer: Expand All",
+		Keywords: []string{"view", "file", "tree", "folder", "expand"},
+		Handler:  app.Explorer.ExpandAll,
+	})
+
+	reg.Register(command.Command{
+		ID: "explorer.collapseAll", Title: "Explorer: Collapse All",
+		Keywords: []string{"view", "file", "tree", "folder", "collapse"},
+		Handler:  app.Explorer.CollapseAll,
+	})
+
+	reg.Register(command.Command{
 		ID: "explorer.open", Title: "Explorer: Toggle Node",
 		Keywords: []string{"view", "file"},
 		Handler:  func() { app.Explorer.Tree.ActivateSelected() },

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -263,6 +263,30 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "changes.expandAllWorkingTree", Title: "Git: Expand All Changes Files",
+		Keywords: []string{"git", "changes", "working", "tree", "folder", "expand"},
+		Handler:  app.ExpandAllChangesFiles,
+	})
+
+	reg.Register(command.Command{
+		ID: "changes.collapseAllWorkingTree", Title: "Git: Collapse All Changes Files",
+		Keywords: []string{"git", "changes", "working", "tree", "folder", "collapse"},
+		Handler:  app.CollapseAllChangesFiles,
+	})
+
+	reg.Register(command.Command{
+		ID: "changes.expandAllCommitDetail", Title: "Git: Expand All Commit Detail Files",
+		Keywords: []string{"git", "commit", "detail", "file", "expand"},
+		Handler:  app.ExpandAllCommitDetailFiles,
+	})
+
+	reg.Register(command.Command{
+		ID: "changes.collapseAllCommitDetail", Title: "Git: Collapse All Commit Detail Files",
+		Keywords: []string{"git", "commit", "detail", "file", "collapse"},
+		Handler:  app.CollapseAllCommitDetailFiles,
+	})
+
+	reg.Register(command.Command{
 		ID: "changes.stage", Title: "Git: Stage File",
 		Keywords: []string{"git", "changes", "add"},
 		Handler: func() {

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -251,6 +251,18 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID: "changes.expandAll", Title: "Git: Expand All File Trees",
+		Keywords: []string{"git", "changes", "history", "detail", "tree", "folder", "expand"},
+		Handler:  app.ExpandAllGitFiles,
+	})
+
+	reg.Register(command.Command{
+		ID: "changes.collapseAll", Title: "Git: Collapse All File Trees",
+		Keywords: []string{"git", "changes", "history", "detail", "tree", "folder", "collapse"},
+		Handler:  app.CollapseAllGitFiles,
+	})
+
+	reg.Register(command.Command{
 		ID: "changes.stage", Title: "Git: Stage File",
 		Keywords: []string{"git", "changes", "add"},
 		Handler: func() {

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -83,6 +83,30 @@ func (a *App) CollapseAllGitFiles() {
 	}
 }
 
+func (a *App) ExpandAllChangesFiles() {
+	if a.Changes != nil {
+		a.Changes.ExpandAll()
+	}
+}
+
+func (a *App) CollapseAllChangesFiles() {
+	if a.Changes != nil {
+		a.Changes.CollapseAll()
+	}
+}
+
+func (a *App) ExpandAllCommitDetailFiles() {
+	if detail := a.EditorGroup.ActiveCommitDetailWidget(); detail != nil {
+		detail.ExpandAllFiles()
+	}
+}
+
+func (a *App) CollapseAllCommitDetailFiles() {
+	if detail := a.EditorGroup.ActiveCommitDetailWidget(); detail != nil {
+		detail.CollapseAllFiles()
+	}
+}
+
 func (a *App) ToggleAutoDedent() {
 	enabled := !a.Settings.Editor.IsAutoDedentEnabled()
 	a.Settings.Editor.AutoDedent = &enabled
@@ -340,12 +364,20 @@ func (a *App) BuildDiffViewOptions() []ui.ContextMenuItem {
 }
 
 func (a *App) BuildGitFileOptions() []ui.ContextMenuItem {
+	return a.buildGitFileOptions("changes.expandAll", "changes.collapseAll")
+}
+
+func (a *App) BuildChangesGitFileOptions() []ui.ContextMenuItem {
+	return a.buildGitFileOptions("changes.expandAllWorkingTree", "changes.collapseAllWorkingTree")
+}
+
+func (a *App) buildGitFileOptions(expandCommand, collapseCommand string) []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
 		{Label: "Tree", Command: "options.useGitFileTree", Checked: menuChecked(a.Settings.Git.FileView == config.GitFileViewTree)},
 		{Label: "List", Command: "options.useGitFileList", Checked: menuChecked(a.Settings.Git.FileView != config.GitFileViewTree)},
 		ui.MenuSep(),
-		{Label: "Expand All", Command: "changes.expandAll"},
-		{Label: "Collapse All", Command: "changes.collapseAll"},
+		{Label: "Expand All", Command: expandCommand},
+		{Label: "Collapse All", Command: collapseCommand},
 	}
 }
 

--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -53,6 +53,36 @@ func (a *App) ToggleDiffHighContrast() {
 	a.SaveAndApplySettings()
 }
 
+func (a *App) UseTreeGitFileView() {
+	a.Settings.Git.FileView = config.GitFileViewTree
+	a.SaveAndApplySettings()
+}
+
+func (a *App) UseListGitFileView() {
+	a.Settings.Git.FileView = config.GitFileViewList
+	a.SaveAndApplySettings()
+}
+
+func (a *App) ExpandAllGitFiles() {
+	if detail := a.EditorGroup.ActiveCommitDetailWidget(); detail != nil {
+		detail.ExpandAllFiles()
+		return
+	}
+	if a.Sidebar.ActivePanel == "changes" {
+		a.Changes.ExpandAll()
+	}
+}
+
+func (a *App) CollapseAllGitFiles() {
+	if detail := a.EditorGroup.ActiveCommitDetailWidget(); detail != nil {
+		detail.CollapseAllFiles()
+		return
+	}
+	if a.Sidebar.ActivePanel == "changes" {
+		a.Changes.CollapseAll()
+	}
+}
+
 func (a *App) ToggleAutoDedent() {
 	enabled := !a.Settings.Editor.IsAutoDedentEnabled()
 	a.Settings.Editor.AutoDedent = &enabled
@@ -268,10 +298,8 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
-		{Label: "Diff View Mode", Command: "options.diffViewMode"},
-		{Label: "Diff Context", Command: "options.diffContext"},
-		{Label: "Wrap Diff Lines", Command: "options.toggleDiffWordWrap", Checked: menuChecked(a.Settings.Editor.DiffWordWrap)},
-		{Label: "High Contrast Diffs", Command: "options.toggleDiffHighContrast", Checked: menuChecked(a.Settings.Editor.DiffHighContrast)},
+		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
+		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
 		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
 		{Label: "Auto Dedent", Command: "options.toggleAutoDedent", Checked: autoDedentChecked},
 		{Label: "Syntax Highlight", Command: "options.toggleSyntaxHighlight", Checked: syntaxChecked},
@@ -308,6 +336,16 @@ func (a *App) BuildDiffViewOptions() []ui.ContextMenuItem {
 		ui.MenuSep(),
 		{Label: "Wrap Lines", Command: "options.toggleDiffWordWrap", Checked: menuChecked(a.Settings.Editor.DiffWordWrap)},
 		{Label: "High Contrast", Command: "options.toggleDiffHighContrast", Checked: menuChecked(a.Settings.Editor.DiffHighContrast)},
+	}
+}
+
+func (a *App) BuildGitFileOptions() []ui.ContextMenuItem {
+	return []ui.ContextMenuItem{
+		{Label: "Tree", Command: "options.useGitFileTree", Checked: menuChecked(a.Settings.Git.FileView == config.GitFileViewTree)},
+		{Label: "List", Command: "options.useGitFileList", Checked: menuChecked(a.Settings.Git.FileView != config.GitFileViewTree)},
+		ui.MenuSep(),
+		{Label: "Expand All", Command: "changes.expandAll"},
+		{Label: "Collapse All", Command: "changes.collapseAll"},
 	}
 }
 
@@ -378,6 +416,18 @@ func registerOptionsCommands(app *App) {
 		ID: "options.toggleDiffHighContrast", Title: "Toggle High Contrast Diffs",
 		Keywords: []string{"preferences", "settings", "git", "diff", "contrast", "color", "accessibility"},
 		Handler:  app.ToggleDiffHighContrast,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useGitFileTree", Title: "View Git Files as Tree",
+		Keywords: []string{"preferences", "settings", "git", "changes", "history", "files", "tree"},
+		Handler:  app.UseTreeGitFileView,
+	})
+
+	reg.Register(command.Command{
+		ID: "options.useGitFileList", Title: "View Git Files as List",
+		Keywords: []string{"preferences", "settings", "git", "changes", "history", "files", "flat", "list"},
+		Handler:  app.UseListGitFileView,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_settings.go
+++ b/internal/app/commands_settings.go
@@ -92,6 +92,9 @@ func (a *App) ApplySettings(s config.Settings) {
 		a.Explorer.Settings = s.Explorer
 		a.Explorer.Reload()
 	}
+	if a.Changes != nil {
+		a.Changes.SetFileView(s.Git.FileView)
+	}
 
 	// An empty theme name means the built-in default, and must still be applied —
 	// otherwise switching back to it leaves the previous theme's colors on screen.

--- a/internal/app/commit_history_authored_unix_test.go
+++ b/internal/app/commit_history_authored_unix_test.go
@@ -1,0 +1,39 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadCommitDetailPreservesContentWhenAuthoredDateIsUnavailable(t *testing.T) {
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+case " $* " in
+  *" --format=%B "*) printf 'subject\n' ;;
+  *" --format=%aI "*) printf 'date unavailable\n' >&2; exit 1 ;;
+  *" --name-status "*) exit 0 ;;
+  *) printf 'unexpected git invocation: %s\n' "$*" >&2; exit 2 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	result := readCommitDetail(context.Background(), 1, "/repo", strings.Repeat("a", 40), "aaaaaaa")
+
+	if result.Canceled || result.Err != "" {
+		t.Fatalf("detail failed: canceled=%v err=%q", result.Canceled, result.Err)
+	}
+	if result.Message != "subject" || len(result.Files) != 0 {
+		t.Fatalf("content = message %q, files %#v", result.Message, result.Files)
+	}
+	if !result.AuthoredAt.IsZero() || !result.AuthoredAtUnavailable {
+		t.Fatalf("authored state = %v, unavailable=%v", result.AuthoredAt, result.AuthoredAtUnavailable)
+	}
+}

--- a/internal/app/commit_history_release_review_unix_test.go
+++ b/internal/app/commit_history_release_review_unix_test.go
@@ -57,10 +57,7 @@ func TestClosingCommitDetailCancelsItsGitProcess(t *testing.T) {
 	defer syscall.Kill(pid, syscall.SIGKILL)
 
 	group.ClosePluginTab(tabID)
-	time.Sleep(50 * time.Millisecond)
-	if err := syscall.Kill(pid, 0); err == nil {
-		t.Fatalf("git process %d is still alive after its detail tab closed", pid)
-	}
+	waitReviewProcessExit(t, pid)
 }
 
 func TestSupersededCommitHistoryCancelsItsGitProcess(t *testing.T) {

--- a/internal/app/commit_history_review_nitpicks_test.go
+++ b/internal/app/commit_history_review_nitpicks_test.go
@@ -1,0 +1,173 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestApplyCommitDetailReportsUnavailableAuthoredDate(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("a", 40)
+	detail := ui.NewCommitDetailWidget("/repo", ref, "aaaaaaa", false)
+	group.OpenPluginTab(commitDetailTabID("/repo", ref), "Commit aaaaaaa", detail)
+	app := &App{EditorGroup: group}
+
+	app.ApplyCommitDetail(&CommitDetailResult{
+		Dir: "/repo", Ref: ref, Message: "subject", AuthoredAtUnavailable: true,
+	})
+
+	if detail.Metadata != "Authored date unavailable" {
+		t.Fatalf("metadata = %q", detail.Metadata)
+	}
+}
+
+func TestApplyCommitDetailCancellationDoesNotPublishAuthoredDateFallback(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	ref := strings.Repeat("b", 40)
+	detail := ui.NewCommitDetailWidget("/repo", ref, "bbbbbbb", false)
+	group.OpenPluginTab(commitDetailTabID("/repo", ref), "Commit bbbbbbb", detail)
+	app := &App{EditorGroup: group}
+
+	app.ApplyCommitDetail(&CommitDetailResult{
+		Dir: "/repo", Ref: ref, AuthoredAtUnavailable: true, Canceled: true,
+	})
+
+	if detail.Metadata != "" || !detail.Loading {
+		t.Fatalf("canceled result changed detail: metadata=%q loading=%v", detail.Metadata, detail.Loading)
+	}
+}
+
+func TestApplyCommitLogReleasesCurrentTimeoutOnCompletion(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "success"},
+		{name: "failure", err: errors.New("git failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := NewChangesPanel()
+			cp.logGen = 1
+			cp.lastLogDir = "/repo"
+			ctx, cancel := context.WithCancel(context.Background())
+			cp.logCancel = cancel
+
+			cp.ApplyCommitLog(&CommitLogResult{Gen: 1, Dir: "/repo", Err: tc.err})
+
+			select {
+			case <-ctx.Done():
+			default:
+				t.Fatal("completed history read retained its timeout")
+			}
+			if cp.logCancel != nil {
+				t.Fatal("completed history read retained its cancel function")
+			}
+		})
+	}
+}
+
+func TestStaleCommitLogCompletionDoesNotCancelNewerRead(t *testing.T) {
+	cp := NewChangesPanel()
+	cp.logGen = 2
+	cp.lastLogDir = "/new"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cp.logCancel = cancel
+
+	cp.ApplyCommitLog(&CommitLogResult{Gen: 1, Dir: "/old"})
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("stale history completion canceled the newer read")
+	default:
+	}
+	if cp.logCancel == nil {
+		t.Fatal("stale history completion cleared the newer cancel function")
+	}
+}
+
+func TestRecordCommitFilesReleasesMatchingTimeoutOnCompletion(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "success"},
+		{name: "failure", err: errors.New("git failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := NewChangesPanel()
+			key := "/repo\x00ref"
+			ctx, cancel := context.WithCancel(context.Background())
+			cp.commitFilesPending[key] = commitFilesRequest{ID: 1, Cancel: cancel}
+
+			if !cp.recordCommitFiles(&CommitFilesResult{Request: 1, Dir: "/repo", Ref: "ref", Err: tc.err}) {
+				t.Fatal("matching completion was rejected")
+			}
+			select {
+			case <-ctx.Done():
+			default:
+				t.Fatal("completed commit-file read retained its timeout")
+			}
+			if _, ok := cp.commitFilesPending[key]; ok {
+				t.Fatal("completed commit-file read remained pending")
+			}
+		})
+	}
+}
+
+func TestStaleCommitFilesCompletionDoesNotCancelNewerRead(t *testing.T) {
+	cp := NewChangesPanel()
+	key := "/repo\x00ref"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cp.commitFilesPending[key] = commitFilesRequest{ID: 2, Cancel: cancel}
+
+	if cp.recordCommitFiles(&CommitFilesResult{Request: 1, Dir: "/repo", Ref: "ref"}) {
+		t.Fatal("stale commit-file completion was accepted")
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("stale commit-file completion canceled the newer read")
+	default:
+	}
+	if request := cp.commitFilesPending[key]; request.ID != 2 {
+		t.Fatalf("newer pending request = %#v", request)
+	}
+}
+
+func TestCommitHistoryFileKeysActivateCommitAndFileRows(t *testing.T) {
+	cp := NewChangesPanel()
+	ref := strings.Repeat("c", 40)
+	commit := commitFileRef{Dir: "/repo", Ref: ref, Short: "ccccccc"}
+	commitNode := &widgets.TreeNode{ID: "commit:" + ref}
+	fileNode := &widgets.TreeNode{ID: "cfile:commit:" + ref + ":file.go"}
+	cp.logCommits[commitNode.ID] = commit
+	cp.logFiles[fileNode.ID] = commit
+
+	var calls []commitFileRef
+	cp.OnOpenCommit = func(dir, gotRef, short string) {
+		calls = append(calls, commitFileRef{Dir: dir, Ref: gotRef, Short: short})
+	}
+	for _, node := range []*widgets.TreeNode{commitNode, fileNode} {
+		for _, key := range []rune{'c', 'o', 'v', 'e'} {
+			if !cp.handleCommitLogKey(tcell.NewEventKey(tcell.KeyRune, string(key), tcell.ModNone), node) {
+				t.Fatalf("key %q on %s was not handled", key, node.ID)
+			}
+		}
+	}
+
+	if len(calls) != 8 {
+		t.Fatalf("open calls = %d, want 8", len(calls))
+	}
+	for i, call := range calls {
+		if call != commit {
+			t.Fatalf("open call %d = %#v, want %#v", i, call, commit)
+		}
+	}
+}

--- a/internal/app/explorer.go
+++ b/internal/app/explorer.go
@@ -95,6 +95,16 @@ func (n *NavigationPanel) Reload() {
 	n.Tree.Reload()
 }
 
+func (n *NavigationPanel) ExpandAll() {
+	n.Tree.ExpandAllWhere(func(node *widgets.TreeNode) bool {
+		return !node.Muted
+	})
+}
+
+func (n *NavigationPanel) CollapseAll() {
+	n.Tree.CollapseAll()
+}
+
 func (n *NavigationPanel) SetRoots(paths []string) {
 	expanded := map[string]bool{}
 	n.Tree.CollectExpanded(expanded)

--- a/internal/app/explorer.go
+++ b/internal/app/explorer.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -96,9 +97,43 @@ func (n *NavigationPanel) Reload() {
 }
 
 func (n *NavigationPanel) ExpandAll() {
-	n.Tree.ExpandAllWhere(func(node *widgets.TreeNode) bool {
-		return !node.Muted
-	})
+	selectedID := ""
+	if selected := n.Tree.Selected(); selected != nil {
+		selectedID = selected.ID
+	}
+	var expand func(*widgets.TreeNode, map[string]bool)
+	expand = func(node *widgets.TreeNode, ancestors map[string]bool) {
+		if node == nil || !node.Expandable {
+			return
+		}
+		info, err := os.Lstat(node.ID)
+		if err == nil && (info.Mode()&os.ModeSymlink != 0 || info.IsDir() && filepath.Base(node.ID) == ".git") {
+			return
+		}
+		node.Expanded = true
+		canonical, err := filepath.EvalSymlinks(node.ID)
+		if err != nil {
+			canonical = filepath.Clean(node.ID)
+		}
+		if ancestors[canonical] {
+			return
+		}
+		if len(node.Children) == 0 {
+			n.loadChildren(node)
+		}
+		ancestors[canonical] = true
+		for _, child := range node.Children {
+			expand(child, ancestors)
+		}
+		delete(ancestors, canonical)
+	}
+	for _, root := range n.Tree.Config.Items {
+		expand(root, make(map[string]bool))
+	}
+	n.Tree.SetItems(n.Tree.Config.Items)
+	if selectedID != "" {
+		n.Tree.SelectByID(selectedID)
+	}
 }
 
 func (n *NavigationPanel) CollapseAll() {

--- a/internal/app/explorer_expand_test.go
+++ b/internal/app/explorer_expand_test.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+)
+
+func TestExplorerExpandAllLoadsProgressivelyAndCollapseAllClosesTree(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootPath, "src", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootPath, "src", "nested", "file.go"), []byte("package nested\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	explorer := NewNavigationPanel(config.DefaultExplorerSettings(), rootPath)
+	root := explorer.Tree.Config.Items[0]
+	src := nodeWithLabel(root.Children, "src")
+	if src == nil || len(src.Children) != 0 {
+		t.Fatalf("test setup src = %+v", src)
+	}
+
+	explorer.ExpandAll()
+	nested := nodeWithLabel(src.Children, "nested")
+	if !root.Expanded || !src.Expanded || nested == nil || nested.Expanded {
+		t.Fatalf("first expand should load only represented level: root=%v src=%v nested=%+v", root.Expanded, src.Expanded, nested)
+	}
+	explorer.ExpandAll()
+	if !nested.Expanded || nodeWithLabel(nested.Children, "file.go") == nil {
+		t.Fatal("second expand did not load nested level")
+	}
+	explorer.CollapseAll()
+	if root.Expanded || src.Expanded || nested.Expanded {
+		t.Fatalf("collapse left folders open: root=%v src=%v nested=%v", root.Expanded, src.Expanded, nested.Expanded)
+	}
+}

--- a/internal/app/explorer_expand_test.go
+++ b/internal/app/explorer_expand_test.go
@@ -6,34 +6,114 @@ import (
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/widgets"
 )
 
-func TestExplorerExpandAllLoadsProgressivelyAndCollapseAllClosesTree(t *testing.T) {
+func TestExplorerExpandAllReachesEveryVisibleDescendantAndCollapseAllClosesTree(t *testing.T) {
 	rootPath := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(rootPath, "src", "nested"), 0o755); err != nil {
+	for _, dir := range []string{
+		"deep/one/two",
+		"visible/inner",
+		"visible/.hidden",
+		"visible/.ignored",
+	} {
+		if err := os.MkdirAll(filepath.Join(rootPath, filepath.FromSlash(dir)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(rootPath, ".gitignore"), []byte("visible/.ignored/\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(rootPath, "src", "nested", "file.go"), []byte("package nested\n"), 0o644); err != nil {
-		t.Fatal(err)
+	runTreeGit(t, rootPath, "init", "-q")
+	for _, path := range []string{
+		"deep/one/two/deep.txt",
+		"visible/inner/inner.txt",
+		"visible/.hidden/hidden.txt",
+		"visible/.ignored/ignored.txt",
+	} {
+		if err := os.WriteFile(filepath.Join(rootPath, filepath.FromSlash(path)), []byte(path), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	explorer := NewNavigationPanel(config.DefaultExplorerSettings(), rootPath)
 	root := explorer.Tree.Config.Items[0]
-	src := nodeWithLabel(root.Children, "src")
-	if src == nil || len(src.Children) != 0 {
-		t.Fatalf("test setup src = %+v", src)
-	}
 
 	explorer.ExpandAll()
-	nested := nodeWithLabel(src.Children, "nested")
-	if !root.Expanded || !src.Expanded || nested == nil || nested.Expanded {
-		t.Fatalf("first expand should load only represented level: root=%v src=%v nested=%+v", root.Expanded, src.Expanded, nested)
+	gitMetadata := nodeWithLabel(root.Children, ".git")
+	if gitMetadata == nil || gitMetadata.Expanded || len(gitMetadata.Children) != 0 {
+		t.Fatalf("bulk expansion traversed .git metadata: %+v", gitMetadata)
 	}
-	explorer.ExpandAll()
-	if !nested.Expanded || nodeWithLabel(nested.Children, "file.go") == nil {
-		t.Fatal("second expand did not load nested level")
+	for _, label := range []string{"deep", "one", "two", "deep.txt", "visible", "inner", "inner.txt", ".hidden", "hidden.txt", ".ignored", "ignored.txt"} {
+		node := nodeWithLabel(root.Children, label)
+		if node == nil {
+			t.Errorf("one expand did not materialize %q", label)
+		} else if node.Expandable && !node.Expanded {
+			t.Errorf("one expand left %q collapsed", label)
+		}
 	}
 	explorer.CollapseAll()
-	if root.Expanded || src.Expanded || nested.Expanded {
-		t.Fatalf("collapse left folders open: root=%v src=%v nested=%v", root.Expanded, src.Expanded, nested.Expanded)
+	for _, node := range []*widgets.TreeNode{root, nodeWithLabel(root.Children, "deep"), nodeWithLabel(root.Children, "visible")} {
+		if node != nil && node.Expanded {
+			t.Errorf("collapse left %q open", node.Label)
+		}
+	}
+}
+
+func TestExplorerExpandAllLeavesGitMetadataManual(t *testing.T) {
+	rootPath := t.TempDir()
+	runTreeGit(t, rootPath, "init", "-q")
+	explorer := NewNavigationPanel(config.DefaultExplorerSettings(), rootPath)
+	explorer.ExpandAll()
+	gitMetadata := nodeWithLabel(explorer.Tree.Config.Items, ".git")
+	if gitMetadata == nil || gitMetadata.Expanded || len(gitMetadata.Children) != 0 {
+		t.Fatalf("bulk expansion traversed .git metadata: %+v", gitMetadata)
+	}
+	explorer.Tree.SelectByID(gitMetadata.ID)
+	explorer.Tree.ActivateSelected()
+	if !gitMetadata.Expanded || nodeWithLabel(gitMetadata.Children, "HEAD") == nil {
+		t.Fatalf("manual expansion no longer opens .git metadata: %+v", gitMetadata)
+	}
+}
+
+func TestExplorerExpandAllStopsAtSymlinkCycles(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootPath, "deep", "one"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(rootPath, filepath.Join(rootPath, "deep", "one", "loop")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	explorer := NewNavigationPanel(config.DefaultExplorerSettings(), rootPath)
+	explorer.ExpandAll()
+	loop := nodeWithLabel(explorer.Tree.Config.Items, "loop")
+	if loop == nil || loop.Expanded {
+		t.Fatalf("cycle symlink was bulk-expanded: %+v", loop)
+	}
+	if len(loop.Children) != 0 {
+		t.Fatalf("cycle recursively materialized children: %+v", loop.Children)
+	}
+}
+
+func TestExplorerExpandAllDoesNotTraverseExternalDirectorySymlink(t *testing.T) {
+	rootPath := t.TempDir()
+	externalPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(externalPath, "large", "external", "tree"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(rootPath, "external-link")
+	if err := os.Symlink(externalPath, linkPath); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	explorer := NewNavigationPanel(config.DefaultExplorerSettings(), rootPath)
+	explorer.ExpandAll()
+	link := nodeWithLabel(explorer.Tree.Config.Items, "external-link")
+	if link == nil || link.Expanded || len(link.Children) != 0 {
+		t.Fatalf("bulk expansion traversed external symlink: %+v", link)
+	}
+
+	explorer.Tree.SelectByID(link.ID)
+	explorer.Tree.ActivateSelected()
+	if !link.Expanded || nodeWithLabel(link.Children, "large") == nil {
+		t.Fatalf("manual expansion no longer opens directory symlinks: %+v", link)
 	}
 }

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -111,8 +111,8 @@ var diffContextMenu = []ui.ContextMenuItem{
 var commitDetailContextMenu = []ui.ContextMenuItem{
 	{Label: "Copy", Command: "editor.copy"},
 	ui.MenuSep(),
-	{Label: "Expand All Files", Command: "changes.expandAll"},
-	{Label: "Collapse All Files", Command: "changes.collapseAll"},
+	{Label: "Expand All Files", Command: "changes.expandAllCommitDetail"},
+	{Label: "Collapse All Files", Command: "changes.collapseAllCommitDetail"},
 }
 
 var changesContextMenuStaged = []ui.ContextMenuItem{

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -108,6 +108,13 @@ var diffContextMenu = []ui.ContextMenuItem{
 	{Label: "Find", Command: "search.find"},
 }
 
+var commitDetailContextMenu = []ui.ContextMenuItem{
+	{Label: "Copy", Command: "editor.copy"},
+	ui.MenuSep(),
+	{Label: "Expand All Files", Command: "changes.expandAll"},
+	{Label: "Collapse All Files", Command: "changes.collapseAll"},
+}
+
 var changesContextMenuStaged = []ui.ContextMenuItem{
 	{Label: "Open Compact Diff", Command: "changes.openDiff"},
 	{Label: "Open Extended Diff", Command: "changes.openExtendedDiff"},
@@ -256,7 +263,10 @@ func handleRightClick(app *App, mx, my int) {
 			if my > sidebarR.Y+1 {
 				ev := tcell.NewEventMouse(mx, my, tcell.Button2, 0)
 				if w := app.Sidebar.ActiveWidget(); w != nil {
-					w.HandleEvent(ev)
+					result := w.HandleEvent(ev)
+					if result == ui.EventIgnored && app.Sidebar.ActivePanel == "changes" {
+						app.ShowChangesContextMenu(mx, my)
+					}
 				}
 			}
 			return
@@ -270,7 +280,9 @@ func handleRightClick(app *App, mx, my int) {
 		return
 	}
 
-	if app.EditorGroup.ActiveDiffWidget() != nil {
+	if app.EditorGroup.ActiveCommitDetailWidget() != nil {
+		openContextMenu(app, commitDetailContextMenu, mx, my)
+	} else if app.EditorGroup.ActiveDiffWidget() != nil {
 		openContextMenu(app, diffContextMenu, mx, my)
 	} else {
 		openEditorContextMenu(app, mx, my)

--- a/internal/app/settings_view.go
+++ b/internal/app/settings_view.go
@@ -146,9 +146,6 @@ func settingsCategories() []settingsCategory {
 				GetInt: func(s *config.Settings) int { return s.Autocomplete.Debounce },
 				SetInt: func(s *config.Settings, v int) { s.Autocomplete.Debounce = v }},
 		}},
-		// Git, explorer, terminal, search and plugin settings are a handful of fields
-		// each; separate tabs for them left the strip mostly empty. Labels here
-		// name their area, since the tab title no longer does.
 		{Title: "Advanced", Fields: []settingField{
 			{Label: "Git: file view", Kind: settingEnum, Options: gitFileViewItems,
 				GetString: func(s *config.Settings) string { return s.Git.FileView },

--- a/internal/app/settings_view.go
+++ b/internal/app/settings_view.go
@@ -146,10 +146,13 @@ func settingsCategories() []settingsCategory {
 				GetInt: func(s *config.Settings) int { return s.Autocomplete.Debounce },
 				SetInt: func(s *config.Settings, v int) { s.Autocomplete.Debounce = v }},
 		}},
-		// Explorer, terminal, search and plugin settings are a handful of fields
+		// Git, explorer, terminal, search and plugin settings are a handful of fields
 		// each; separate tabs for them left the strip mostly empty. Labels here
 		// name their area, since the tab title no longer does.
 		{Title: "Advanced", Fields: []settingField{
+			{Label: "Git: file view", Kind: settingEnum, Options: gitFileViewItems,
+				GetString: func(s *config.Settings) string { return s.Git.FileView },
+				SetString: func(s *config.Settings, v string) { s.Git.FileView = v }},
 			{Label: "Explorer: hidden files", Kind: settingBool,
 				GetBool: func(s *config.Settings) bool { return s.Explorer.ShowHidden },
 				SetBool: func(s *config.Settings, v bool) { s.Explorer.ShowHidden = v }},
@@ -172,6 +175,13 @@ func settingsCategories() []settingsCategory {
 				GetBool: func(s *config.Settings) bool { return s.DebugMode },
 				SetBool: func(s *config.Settings, v bool) { s.DebugMode = v }},
 		}},
+	}
+}
+
+func gitFileViewItems() []widgets.SelectItem {
+	return []widgets.SelectItem{
+		{ID: config.GitFileViewTree, Label: "Tree"},
+		{ID: config.GitFileViewList, Label: "List"},
 	}
 }
 

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -266,6 +266,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	search.SetWorkDirs(ws.Paths())
 	search.Debounce.DelayMs = cfg.Settings.Search.Debounce
 	changes := NewChangesPanel(ws.Paths()...)
+	changes.SetFileView(cfg.Settings.Git.FileView)
 	symbols := NewSymbolsPanel()
 
 	explorer := NewNavigationPanel(cfg.Settings.Explorer, ws.Paths()...)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -12,6 +12,7 @@ var (
 	BorderStyles = []string{"default", "theme", "rounded", "sharp", "double", "bold", "ascii", "none"}
 	DiffModes    = []string{"split", "unified"}
 	DiffContexts = []string{"changes", "full"}
+	GitFileViews = []string{"tree", "list"}
 )
 
 const (
@@ -19,6 +20,8 @@ const (
 	DiffModeUnified    = "unified"
 	DiffContextChanges = "changes"
 	DiffContextFull    = "full"
+	GitFileViewTree    = "tree"
+	GitFileViewList    = "list"
 )
 
 type TerminalSettings struct {
@@ -165,6 +168,14 @@ type SidebarSettings struct {
 	PanelOrder []string `json:"panelOrder,omitempty"`
 }
 
+type GitSettings struct {
+	FileView string `json:"fileView"`
+}
+
+func DefaultGitSettings() GitSettings {
+	return GitSettings{FileView: GitFileViewList}
+}
+
 func DefaultExplorerSettings() ExplorerSettings {
 	return ExplorerSettings{
 		ShowHidden:     true,
@@ -201,6 +212,7 @@ type Settings struct {
 	Search       SearchSettings       `json:"search"`
 	Explorer     ExplorerSettings     `json:"explorer"`
 	Sidebar      SidebarSettings      `json:"sidebar,omitzero"`
+	Git          GitSettings          `json:"git"`
 	Terminal     TerminalSettings     `json:"terminal"`
 	LSP          LSPSettings          `json:"lsp"`
 	Autocomplete AutocompleteSettings `json:"autocomplete"`
@@ -220,7 +232,7 @@ type Settings struct {
 // Any other top-level key is preserved via Settings.Extra.
 var knownSettingsKeys = map[string]bool{
 	"version": true, "theme": true, "debugMode": true, "editor": true,
-	"search": true, "explorer": true, "sidebar": true, "terminal": true, "lsp": true,
+	"search": true, "explorer": true, "sidebar": true, "git": true, "terminal": true, "lsp": true,
 	"autocomplete": true, "markdown": true, "plugins": true, "formatters": true,
 }
 
@@ -274,6 +286,7 @@ func DefaultSettings() Settings {
 		Editor:       DefaultEditorSettings(),
 		Search:       DefaultSearchSettings(),
 		Explorer:     DefaultExplorerSettings(),
+		Git:          DefaultGitSettings(),
 		Terminal:     DefaultTerminalSettings(),
 		LSP:          DefaultLSPSettings(),
 		Autocomplete: DefaultAutocompleteSettings(),
@@ -310,6 +323,9 @@ func normalizeSettings(s *Settings) {
 	}
 	if !slices.Contains(DiffContexts, s.Editor.DiffContext) {
 		s.Editor.DiffContext = DiffContextChanges
+	}
+	if !slices.Contains(GitFileViews, s.Git.FileView) {
+		s.Git.FileView = GitFileViewList
 	}
 }
 

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -23,6 +23,7 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s.Editor.TabSize = 7
 	s.Editor.WordWrap = true
 	s.Sidebar.PanelOrder = []string{"changes", "plugin.todo", "explorer"}
+	s.Git.FileView = GitFileViewTree
 	enabled := false
 	s.Editor.SyntaxHighlight = &enabled
 	s.Terminal.Shell = "/bin/zsh"
@@ -40,6 +41,9 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if !slices.Equal(got.Sidebar.PanelOrder, []string{"changes", "plugin.todo", "explorer"}) {
 		t.Errorf("sidebar.panelOrder = %v", got.Sidebar.PanelOrder)
+	}
+	if got.Git.FileView != GitFileViewTree {
+		t.Errorf("git.fileView = %q, want %q", got.Git.FileView, GitFileViewTree)
 	}
 	if got.Editor.IsSyntaxHighlightEnabled() {
 		t.Error("syntaxHighlight=false did not round-trip; tri-state pointer lost")
@@ -97,6 +101,7 @@ func TestNormalizeRejectsUnknownEnumValues(t *testing.T) {
 	s := DefaultSettings()
 	s.Editor.GutterStyle = "bogus"
 	s.Editor.BorderStyle = "bogus"
+	s.Git.FileView = "bogus"
 	normalizeSettings(&s)
 
 	if s.Editor.GutterStyle != "compact" {
@@ -104,6 +109,9 @@ func TestNormalizeRejectsUnknownEnumValues(t *testing.T) {
 	}
 	if s.Editor.BorderStyle != "default" {
 		t.Errorf("borderStyle = %q, want default", s.Editor.BorderStyle)
+	}
+	if s.Git.FileView != GitFileViewList {
+		t.Errorf("git.fileView = %q, want list", s.Git.FileView)
 	}
 
 	for _, v := range GutterStyles {
@@ -118,6 +126,13 @@ func TestNormalizeRejectsUnknownEnumValues(t *testing.T) {
 		normalizeSettings(&s)
 		if s.Editor.BorderStyle != v {
 			t.Errorf("normalize rejected valid border style %q", v)
+		}
+	}
+	for _, v := range GitFileViews {
+		s.Git.FileView = v
+		normalizeSettings(&s)
+		if s.Git.FileView != v {
+			t.Errorf("normalize rejected valid Git file view %q", v)
 		}
 	}
 }

--- a/internal/git/commit_shapes_test.go
+++ b/internal/git/commit_shapes_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 func commitShapeGit(t *testing.T, dir string, args ...string) string {
@@ -103,8 +102,5 @@ func TestCommitLogUnbornAndNonRepo(t *testing.T) {
 	}
 	if _, err := LogWithError(t.TempDir(), 10); err == nil {
 		t.Fatal("non-repository log unexpectedly succeeded")
-	}
-	if got, err := time.Parse(time.RFC3339, "2026-08-22T03:14:15-04:00"); err != nil || got.Second() != 15 {
-		t.Fatal("test timestamp invalid")
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -63,13 +63,17 @@ func parseStatusPorcelainZ(out []byte) []FileStatus {
 		path := string(record[3:])
 
 		var oldPath string
-		if x == 'R' || x == 'C' || y == 'R' || y == 'C' {
+		renameOrCopy := x == 'R' || x == 'C' || y == 'R' || y == 'C'
+		if renameOrCopy {
 			oldEnd := bytes.IndexByte(out, 0)
 			if oldEnd < 0 {
 				break
 			}
 			oldPath = string(out[:oldEnd])
 			out = out[oldEnd+1:]
+		}
+		if path == "" || renameOrCopy && oldPath == "" {
+			continue
 		}
 
 		if x != ' ' && x != '?' {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
@@ -37,24 +38,38 @@ func IsRepoContext(ctx context.Context, dir string) bool {
 }
 
 func StatusFiles(dir string) ([]FileStatus, error) {
-	cmd := exec.Command("git", "-C", dir, "status", "--porcelain", "-u")
+	cmd := exec.Command("git", "-C", dir, "status", "--porcelain=v1", "-z", "--untracked-files=all")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
+	return parseStatusPorcelainZ(out), nil
+}
+
+func parseStatusPorcelainZ(out []byte) []FileStatus {
 	var files []FileStatus
-	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-		if len(line) < 4 {
+	for len(out) > 0 {
+		end := bytes.IndexByte(out, 0)
+		if end < 0 {
+			break
+		}
+		record := out[:end]
+		out = out[end+1:]
+		if len(record) < 3 || record[2] != ' ' {
 			continue
 		}
-		x := line[0] // index (staged) status
-		y := line[1] // worktree (unstaged) status
-		path := strings.TrimSpace(line[3:])
+		x := record[0]
+		y := record[1]
+		path := string(record[3:])
 
 		var oldPath string
-		if parts := strings.SplitN(path, " -> ", 2); len(parts) == 2 {
-			oldPath = parts[0]
-			path = parts[1]
+		if x == 'R' || x == 'C' || y == 'R' || y == 'C' {
+			oldEnd := bytes.IndexByte(out, 0)
+			if oldEnd < 0 {
+				break
+			}
+			oldPath = string(out[:oldEnd])
+			out = out[oldEnd+1:]
 		}
 
 		if x != ' ' && x != '?' {
@@ -68,7 +83,7 @@ func StatusFiles(dir string) ([]FileStatus, error) {
 			files = append(files, FileStatus{Status: st, Path: path, OldPath: oldPath, Staged: false})
 		}
 	}
-	return files, nil
+	return files
 }
 
 // Stage, Unstage and Discard take any number of paths so bulk actions spawn one

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -427,6 +427,30 @@ func TestParseStatusPorcelainZUsesDestinationThenSourceForRenameAndCopy(t *testi
 	}
 }
 
+func TestParseStatusPorcelainZRejectsEmptyPaths(t *testing.T) {
+	valid := "?? valid\n界.txt\x00"
+	tests := []struct {
+		name string
+		tail string
+	}{
+		{name: "ordinary destination", tail: " M \x00"},
+		{name: "rename destination", tail: "R  \x00old.txt\x00"},
+		{name: "rename source", tail: "R  new.txt\x00\x00"},
+		{name: "staged copy destination", tail: "C  \x00old.txt\x00"},
+		{name: "staged copy source", tail: "C  new.txt\x00\x00"},
+		{name: "unstaged copy destination", tail: " C \x00old.txt\x00"},
+		{name: "unstaged copy source", tail: " C new.txt\x00\x00"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := parseStatusPorcelainZ([]byte(valid + tt.tail))
+			if len(files) != 1 || files[0].Path != "valid\n界.txt" || files[0].Status != "?" || files[0].Staged {
+				t.Fatalf("statuses = %+v, want only valid prefix", files)
+			}
+		})
+	}
+}
+
 func TestStatusFilesMultiple(t *testing.T) {
 	dir := setupTestRepo(t)
 	writeFile(t, dir, "tracked.txt", "tracked\n")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -325,7 +325,6 @@ func TestStatusFilesWithSpaces(t *testing.T) {
 	gitRun(t, dir, "commit", "-m", "init")
 
 	// Create a file with spaces in the name.
-	// Git --porcelain wraps such names in double quotes.
 	writeFile(t, dir, "file with spaces.txt", "content\n")
 
 	files, err := StatusFiles(dir)
@@ -335,15 +334,96 @@ func TestStatusFilesWithSpaces(t *testing.T) {
 
 	found := false
 	for _, f := range files {
-		// git status --porcelain quotes paths with spaces:
-		// ?? "file with spaces.txt"
-		// The parser takes line[3:] and trims whitespace, leaving the quoted form.
-		if f.Path == `"file with spaces.txt"` && f.Status == "?" {
+		if f.Path == "file with spaces.txt" && f.Status == "?" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected untracked file with spaces (possibly quoted), got %+v", files)
+		t.Errorf("expected raw untracked file with spaces, got %+v", files)
+	}
+}
+
+func TestStatusFilesReturnsRawPathIdentity(t *testing.T) {
+	dir := setupTestRepo(t)
+	tracked := map[string]string{
+		"ordinary.txt":        "ordinary\n",
+		"界-wide.txt":          "wide\n",
+		"delete-staged.txt":   "delete staged\n",
+		"delete-unstaged.txt": "delete unstaged\n",
+		"rename-old.txt":      "rename\n",
+	}
+	for path, content := range tracked {
+		writeFile(t, dir, path, content)
+	}
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "raw paths")
+
+	writeFile(t, dir, "ordinary.txt", "staged\n")
+	gitRun(t, dir, "add", "--", "ordinary.txt")
+	writeFile(t, dir, "ordinary.txt", "staged and unstaged\n")
+	writeFile(t, dir, "界-wide.txt", "changed\n")
+	if err := os.Remove(filepath.Join(dir, "delete-staged.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, dir, "add", "--", "delete-staged.txt")
+	if err := os.Remove(filepath.Join(dir, "delete-unstaged.txt")); err != nil {
+		t.Fatal(err)
+	}
+	renamePath := "rename -> new\n界.txt"
+	gitRun(t, dir, "mv", "rename-old.txt", renamePath)
+
+	untracked := []string{
+		"quote\"name.txt",
+		"line\nbreak.txt",
+		`back\slash.txt`,
+		"colon:name.txt",
+		"-leading.txt",
+		"新規/深い/同名.go",
+	}
+	for _, path := range untracked {
+		fullPath := filepath.Join(dir, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(path), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := StatusFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStatus := func(path, oldPath, status string, staged bool) {
+		t.Helper()
+		for _, file := range files {
+			if file.Path == path && file.OldPath == oldPath && file.Status == status && file.Staged == staged {
+				return
+			}
+		}
+		t.Errorf("missing raw status path=%q old=%q status=%q staged=%v in %+v", path, oldPath, status, staged, files)
+	}
+	assertStatus("ordinary.txt", "", "M", true)
+	assertStatus("ordinary.txt", "", "M", false)
+	assertStatus("界-wide.txt", "", "M", false)
+	assertStatus("delete-staged.txt", "", "D", true)
+	assertStatus("delete-unstaged.txt", "", "D", false)
+	assertStatus(renamePath, "rename-old.txt", "R", true)
+	for _, path := range untracked {
+		assertStatus(path, "", "?", false)
+	}
+}
+
+func TestParseStatusPorcelainZUsesDestinationThenSourceForRenameAndCopy(t *testing.T) {
+	files := parseStatusPorcelainZ([]byte("R  renamed\n界.txt\x00old:name.txt\x00 C copied\\name.txt\x00source\"name.txt\x00"))
+	if len(files) != 2 {
+		t.Fatalf("rename/copy statuses = %+v", files)
+	}
+	if got := files[0]; got.Status != "R" || !got.Staged || got.Path != "renamed\n界.txt" || got.OldPath != "old:name.txt" {
+		t.Fatalf("rename order = %+v", got)
+	}
+	if got := files[1]; got.Status != "C" || got.Staged || got.Path != `copied\name.txt` || got.OldPath != `source"name.txt` {
+		t.Fatalf("copy order = %+v", got)
 	}
 }
 

--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -25,6 +25,7 @@ type ContentSplitWidget struct {
 	wasPressed                bool
 	capturedChild             Widget
 	pointerCaptureInvalidated func()
+	cancelingPointerCapture   bool
 }
 
 func (cs *ContentSplitWidget) WidgetChildren() []Widget {
@@ -260,12 +261,14 @@ func (cs *ContentSplitWidget) CancelPointerCapture() bool {
 	cs.dragging = false
 	cs.wasPressed = false
 	cs.capturedChild = nil
+	cs.cancelingPointerCapture = true
 	for _, child := range []Widget{cs.Top, cs.Bottom} {
 		if child == nil {
 			continue
 		}
 		canceled = widgets.CancelPointerCapture(child) || canceled
 	}
+	cs.cancelingPointerCapture = false
 	if canceled && cs.pointerCaptureInvalidated != nil {
 		cs.pointerCaptureInvalidated()
 	}
@@ -277,8 +280,10 @@ func (cs *ContentSplitWidget) InvalidatePointerInteraction() bool {
 	cs.dragging = false
 	cs.wasPressed = false
 	cs.capturedChild = nil
+	cs.cancelingPointerCapture = true
 	invalidated = widgets.InvalidatePointerInteraction(cs.Top) || invalidated
 	invalidated = widgets.InvalidatePointerInteraction(cs.Bottom) || invalidated
+	cs.cancelingPointerCapture = false
 	if invalidated && cs.pointerCaptureInvalidated != nil {
 		cs.pointerCaptureInvalidated()
 	}
@@ -290,11 +295,12 @@ func (cs *ContentSplitWidget) SetPointerCaptureInvalidated(invalidated func()) {
 	for _, child := range []Widget{cs.Top, cs.Bottom} {
 		capturedChild := child
 		widgets.SetPointerCaptureInvalidated(child, func() {
-			if cs.capturedChild == capturedChild {
-				cs.capturedChild = nil
+			if cs.capturedChild != capturedChild {
+				return
 			}
+			cs.capturedChild = nil
 			cs.wasPressed = false
-			if cs.pointerCaptureInvalidated != nil {
+			if !cs.cancelingPointerCapture && cs.pointerCaptureInvalidated != nil {
 				cs.pointerCaptureInvalidated()
 			}
 		})

--- a/internal/ui/content_split.go
+++ b/internal/ui/content_split.go
@@ -251,8 +251,8 @@ func (cs *ContentSplitWidget) TopContentHeight() int {
 	if !cs.ShowBottom || cs.Bottom == nil {
 		return r.H
 	}
-	needed := min(cs.BottomH+1, r.H)
-	return max(r.H-needed, 0)
+	bottomH := cs.constrainedBottomHeight(r.H, cs.requestedBottomHeight(r.H))
+	return max(r.H-bottomH-1, 0)
 }
 
 func (cs *ContentSplitWidget) CancelPointerCapture() bool {

--- a/internal/ui/content_split_history_test.go
+++ b/internal/ui/content_split_history_test.go
@@ -27,6 +27,9 @@ func TestContentSplitRatioTracksLayoutUntilDragged(t *testing.T) {
 	if got := bottom.GetRect().H; got != 10 {
 		t.Fatalf("20-row ratio height = %d, want 10", got)
 	}
+	if got := split.TopContentHeight(); got != top.GetRect().H {
+		t.Fatalf("20-row ratio top height = %d, rendered %d", got, top.GetRect().H)
+	}
 	render(30)
 	if got := bottom.GetRect().H; got != 15 {
 		t.Fatalf("30-row ratio height = %d, want 15", got)

--- a/internal/ui/pointer_capture_notification_test.go
+++ b/internal/ui/pointer_capture_notification_test.go
@@ -1,0 +1,112 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+type notificationCaptureProbe struct {
+	BaseWidget
+	active      bool
+	invalidated func()
+}
+
+func (p *notificationCaptureProbe) Height() int    { return 0 }
+func (p *notificationCaptureProbe) Width() int     { return 0 }
+func (p *notificationCaptureProbe) Render(Surface) {}
+func (p *notificationCaptureProbe) HandleEvent(ev tcell.Event) EventResult {
+	mouse, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return EventIgnored
+	}
+	if mouse.Buttons() == tcell.ButtonNone {
+		p.active = false
+		return EventConsumed
+	}
+	if mouse.Buttons()&tcell.Button1 != 0 {
+		p.active = true
+		return EventCaptured
+	}
+	return EventIgnored
+}
+func (p *notificationCaptureProbe) CancelPointerCapture() bool {
+	active := p.active
+	p.active = false
+	if active && p.invalidated != nil {
+		p.invalidated()
+	}
+	return active
+}
+func (p *notificationCaptureProbe) InvalidatePointerInteraction() bool {
+	return p.CancelPointerCapture()
+}
+func (p *notificationCaptureProbe) OwnsPointerCapture() bool { return p.active }
+func (p *notificationCaptureProbe) SetPointerCaptureInvalidated(invalidated func()) {
+	p.invalidated = invalidated
+}
+
+func TestSplitPanelCancellationNotifiesOnce(t *testing.T) {
+	child := &notificationCaptureProbe{}
+	split := NewSplitPanelWidget()
+	split.ShowLeft = false
+	split.Right = child
+	split.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+	invalidations := 0
+	split.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.Button1, 0))
+	if !split.CancelPointerCapture() {
+		t.Fatal("split did not cancel child capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("split cancellation invalidations = %d, want 1", invalidations)
+	}
+
+	invalidations = 0
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.Button1, 0))
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.ButtonNone, 0))
+	if invalidations != 0 {
+		t.Fatalf("split release invalidations = %d, want 0", invalidations)
+	}
+
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.Button1, 0))
+	if !split.InvalidatePointerInteraction() {
+		t.Fatal("split did not invalidate child capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("split invalidation notifications = %d, want 1", invalidations)
+	}
+}
+
+func TestContentSplitCancellationNotifiesOnce(t *testing.T) {
+	child := &notificationCaptureProbe{}
+	split := NewContentSplitWidget()
+	split.Top = child
+	split.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+	invalidations := 0
+	split.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.Button1, 0))
+	if !split.InvalidatePointerInteraction() {
+		t.Fatal("content split did not invalidate child capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("content split invalidation notifications = %d, want 1", invalidations)
+	}
+
+	invalidations = 0
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.Button1, 0))
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.ButtonNone, 0))
+	if invalidations != 0 {
+		t.Fatalf("content split release invalidations = %d, want 0", invalidations)
+	}
+
+	split.HandleEvent(tcell.NewEventMouse(5, 5, tcell.Button1, 0))
+	if !split.CancelPointerCapture() {
+		t.Fatal("content split did not cancel child capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("content split cancellation notifications = %d, want 1", invalidations)
+	}
+}

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -4,14 +4,17 @@ import (
 	"github.com/gdamore/tcell/v3"
 
 	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
 )
 
 type SidebarWidget struct {
 	BaseWidget
 	TabbedPanel
-	Visible       bool
-	Borders       *term.BorderSet
-	capturedChild Widget
+	Visible                   bool
+	Borders                   *term.BorderSet
+	capturedChild             Widget
+	pointerCaptureInvalidated func()
+	cancelingPointerCapture   bool
 }
 
 func NewSidebarWidget() *SidebarWidget {
@@ -31,7 +34,7 @@ func (s *SidebarWidget) Render(surface Surface) {
 
 	tabH := 2
 	if !s.Visible || w <= 0 || h <= tabH {
-		s.Tabs.InvalidatePointerInteraction()
+		s.InvalidatePointerInteraction()
 		return
 	}
 
@@ -48,19 +51,68 @@ func (s *SidebarWidget) Render(surface Surface) {
 }
 
 func (s *SidebarWidget) CancelPointerCapture() bool {
-	return s.Tabs.CancelPointerCapture()
+	captured := s.capturedChild
+	canceled := captured != nil
+	s.capturedChild = nil
+	s.cancelingPointerCapture = true
+	if captured != nil {
+		canceled = widgets.CancelPointerCapture(captured) || canceled
+	}
+	canceled = s.Tabs.CancelPointerCapture() || canceled
+	s.cancelingPointerCapture = false
+	if canceled && s.pointerCaptureInvalidated != nil {
+		s.pointerCaptureInvalidated()
+	}
+	return canceled
 }
 
 func (s *SidebarWidget) OwnsPointerCapture() bool {
+	if s.capturedChild != nil {
+		owner, ok := s.capturedChild.(widgets.PointerCaptureOwner)
+		if !ok || owner.OwnsPointerCapture() {
+			return true
+		}
+		s.capturedChild = nil
+	}
 	return s.Tabs.OwnsPointerCapture()
 }
 
 func (s *SidebarWidget) InvalidatePointerInteraction() bool {
-	return s.Tabs.InvalidatePointerInteraction()
+	captured := s.capturedChild
+	invalidated := captured != nil
+	s.capturedChild = nil
+	s.cancelingPointerCapture = true
+	if captured != nil {
+		invalidated = widgets.InvalidatePointerInteraction(captured) || invalidated
+	}
+	invalidated = s.Tabs.InvalidatePointerInteraction() || invalidated
+	s.cancelingPointerCapture = false
+	if invalidated && s.pointerCaptureInvalidated != nil {
+		s.pointerCaptureInvalidated()
+	}
+	return invalidated
 }
 
 func (s *SidebarWidget) SetPointerCaptureInvalidated(invalidated func()) {
-	s.Tabs.SetPointerCaptureInvalidated(invalidated)
+	s.pointerCaptureInvalidated = invalidated
+	s.Tabs.SetPointerCaptureInvalidated(func() {
+		if !s.cancelingPointerCapture && s.pointerCaptureInvalidated != nil {
+			s.pointerCaptureInvalidated()
+		}
+	})
+}
+
+func (s *SidebarWidget) captureChild(child Widget) {
+	s.capturedChild = child
+	widgets.SetPointerCaptureInvalidated(child, func() {
+		if s.capturedChild != child {
+			return
+		}
+		s.capturedChild = nil
+		if !s.cancelingPointerCapture && s.pointerCaptureInvalidated != nil {
+			s.pointerCaptureInvalidated()
+		}
+	})
 }
 
 func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
@@ -82,7 +134,7 @@ func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
 	if active != nil {
 		result := active.HandleEvent(ev)
 		if result == EventCaptured {
-			s.capturedChild = active
+			s.captureChild(active)
 		}
 		return result
 	}

--- a/internal/ui/sidebar_widget_capture_test.go
+++ b/internal/ui/sidebar_widget_capture_test.go
@@ -21,7 +21,7 @@ func TestSidebarCancelStopsTreeScrollbarDrag(t *testing.T) {
 		items[i] = &widgets.TreeNode{ID: string(rune('a' + i)), Label: "item"}
 	}
 	tree := widgets.NewTreeWidget(widgets.TreeConfig{Items: items})
-	adapter := NewWidgetAdapter(tree)
+	adapter := NewWidgetAdapter(&widgets.BoxWidget{Child: tree})
 	sidebar := NewSidebarWidget()
 	sidebar.AddPanel("tree", "Tree", adapter)
 	split := NewSplitPanelWidget()

--- a/internal/ui/sidebar_widget_capture_test.go
+++ b/internal/ui/sidebar_widget_capture_test.go
@@ -1,0 +1,146 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+type sidebarCaptureProbe struct {
+	BaseWidget
+	capturing       bool
+	cancelCount     int
+	invalidateCount int
+	releaseCount    int
+}
+
+func TestSidebarCancelStopsTreeScrollbarDrag(t *testing.T) {
+	items := make([]*widgets.TreeNode, 20)
+	for i := range items {
+		items[i] = &widgets.TreeNode{ID: string(rune('a' + i)), Label: "item"}
+	}
+	tree := widgets.NewTreeWidget(widgets.TreeConfig{Items: items})
+	adapter := NewWidgetAdapter(tree)
+	sidebar := NewSidebarWidget()
+	sidebar.AddPanel("tree", "Tree", adapter)
+	split := NewSplitPanelWidget()
+	split.Left = sidebar
+	split.Right = &mockWidget{}
+	split.DividerPos = 20
+	split.ShowLeft = true
+	root := NewRoot(widgets.NewVStackWidget(split))
+	root.SetSize(50, 10)
+	root.Render(makeGrid(50, 10))
+	outerInvalidated := sidebar.pointerCaptureInvalidated
+	invalidations := 0
+	sidebar.SetPointerCaptureInvalidated(func() {
+		invalidations++
+		outerInvalidated()
+	})
+
+	scrollbarX := sidebar.GetRect().X + sidebar.GetRect().W - 1
+	scrollbarY := sidebar.GetRect().Y + 2
+	if got := root.HandleEvent(tcell.NewEventMouse(scrollbarX, scrollbarY, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("scrollbar press result = %v, want root-consumed capture", got)
+	}
+	if !root.PointerCaptureActive() || split.capturedChild != sidebar {
+		t.Fatal("scrollbar press did not establish the outer capture chain")
+	}
+	if !sidebar.CancelPointerCapture() {
+		t.Fatal("sidebar did not cancel tree scrollbar capture")
+	}
+	if root.PointerCaptureActive() || split.capturedChild != nil || tree.OwnsPointerCapture() || adapter.OwnsPointerCapture() || sidebar.OwnsPointerCapture() {
+		t.Fatal("tree scrollbar capture survived sidebar cancellation")
+	}
+	if invalidations != 1 {
+		t.Fatalf("nested capture invalidations = %d, want 1", invalidations)
+	}
+	if got := sidebar.HandleEvent(tcell.NewEventMouse(30, 30, tcell.Button1, 0)); got != EventIgnored {
+		t.Fatalf("post-cancel out-of-bounds drag result = %v, want ignored", got)
+	}
+}
+
+func (p *sidebarCaptureProbe) Height() int    { return 0 }
+func (p *sidebarCaptureProbe) Width() int     { return 0 }
+func (p *sidebarCaptureProbe) Render(Surface) {}
+func (p *sidebarCaptureProbe) HandleEvent(ev tcell.Event) EventResult {
+	mouse, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return EventIgnored
+	}
+	if mouse.Buttons() == tcell.ButtonNone {
+		p.capturing = false
+		p.releaseCount++
+		return EventConsumed
+	}
+	if mouse.Buttons()&tcell.Button1 != 0 {
+		p.capturing = true
+		return EventCaptured
+	}
+	return EventIgnored
+}
+func (p *sidebarCaptureProbe) CancelPointerCapture() bool {
+	wasCapturing := p.capturing
+	p.capturing = false
+	p.cancelCount++
+	return wasCapturing
+}
+func (p *sidebarCaptureProbe) InvalidatePointerInteraction() bool {
+	wasCapturing := p.capturing
+	p.capturing = false
+	p.invalidateCount++
+	return wasCapturing
+}
+func (p *sidebarCaptureProbe) OwnsPointerCapture() bool { return p.capturing }
+
+func TestSidebarTracksAndCancelsCapturedPanel(t *testing.T) {
+	panel := &sidebarCaptureProbe{}
+	sidebar := NewSidebarWidget()
+	sidebar.AddPanel("panel", "Panel", panel)
+	sidebar.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+	invalidations := 0
+	sidebar.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	if got := sidebar.HandleEvent(tcell.NewEventMouse(2, 3, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("press result = %v, want captured", got)
+	}
+	if !sidebar.OwnsPointerCapture() {
+		t.Fatal("sidebar did not report its captured panel")
+	}
+	if !sidebar.CancelPointerCapture() {
+		t.Fatal("sidebar did not report canceled panel capture")
+	}
+	if sidebar.capturedChild != nil || sidebar.OwnsPointerCapture() {
+		t.Fatal("sidebar retained canceled panel capture")
+	}
+	if panel.cancelCount != 1 {
+		t.Fatalf("panel cancellation count = %d, want 1", panel.cancelCount)
+	}
+	if invalidations != 1 {
+		t.Fatalf("capture invalidations = %d, want 1", invalidations)
+	}
+}
+
+func TestSidebarInvalidatesCapturedPanelAndPreservesNormalRelease(t *testing.T) {
+	panel := &sidebarCaptureProbe{}
+	sidebar := NewSidebarWidget()
+	sidebar.AddPanel("panel", "Panel", panel)
+	sidebar.SetRect(Rect{X: 0, Y: 0, W: 20, H: 10})
+
+	sidebar.HandleEvent(tcell.NewEventMouse(2, 3, tcell.Button1, 0))
+	if !sidebar.InvalidatePointerInteraction() {
+		t.Fatal("sidebar did not report invalidated panel capture")
+	}
+	if panel.invalidateCount != 1 || sidebar.capturedChild != nil {
+		t.Fatalf("invalidated panel = %d, captured child = %v", panel.invalidateCount, sidebar.capturedChild)
+	}
+
+	sidebar.HandleEvent(tcell.NewEventMouse(2, 3, tcell.Button1, 0))
+	if got := sidebar.HandleEvent(tcell.NewEventMouse(30, 30, tcell.ButtonNone, 0)); got != EventConsumed {
+		t.Fatalf("release result = %v, want consumed", got)
+	}
+	if panel.releaseCount != 1 || sidebar.capturedChild != nil {
+		t.Fatalf("release count = %d, captured child = %v", panel.releaseCount, sidebar.capturedChild)
+	}
+}

--- a/internal/ui/split_panel.go
+++ b/internal/ui/split_panel.go
@@ -30,6 +30,7 @@ type SplitPanelWidget struct {
 	wasPressed                bool
 	capturedChild             Widget
 	pointerCaptureInvalidated func()
+	cancelingPointerCapture   bool
 }
 
 func NewSplitPanelWidget() *SplitPanelWidget {
@@ -303,12 +304,14 @@ func (s *SplitPanelWidget) CancelPointerCapture() bool {
 	s.dragging = false
 	s.wasPressed = false
 	s.capturedChild = nil
+	s.cancelingPointerCapture = true
 	for _, child := range []Widget{s.Left, s.Right} {
 		if child == nil {
 			continue
 		}
 		canceled = widgets.CancelPointerCapture(child) || canceled
 	}
+	s.cancelingPointerCapture = false
 	if canceled && s.pointerCaptureInvalidated != nil {
 		s.pointerCaptureInvalidated()
 	}
@@ -320,8 +323,10 @@ func (s *SplitPanelWidget) InvalidatePointerInteraction() bool {
 	s.dragging = false
 	s.wasPressed = false
 	s.capturedChild = nil
+	s.cancelingPointerCapture = true
 	invalidated = widgets.InvalidatePointerInteraction(s.Left) || invalidated
 	invalidated = widgets.InvalidatePointerInteraction(s.Right) || invalidated
+	s.cancelingPointerCapture = false
 	if invalidated && s.pointerCaptureInvalidated != nil {
 		s.pointerCaptureInvalidated()
 	}
@@ -333,11 +338,12 @@ func (s *SplitPanelWidget) SetPointerCaptureInvalidated(invalidated func()) {
 	for _, child := range []Widget{s.Left, s.Right} {
 		capturedChild := child
 		widgets.SetPointerCaptureInvalidated(child, func() {
-			if s.capturedChild == capturedChild {
-				s.capturedChild = nil
+			if s.capturedChild != capturedChild {
+				return
 			}
+			s.capturedChild = nil
 			s.wasPressed = false
-			if s.pointerCaptureInvalidated != nil {
+			if !s.cancelingPointerCapture && s.pointerCaptureInvalidated != nil {
 				s.pointerCaptureInvalidated()
 			}
 		})

--- a/internal/ui/tree_widget_adapter.go
+++ b/internal/ui/tree_widget_adapter.go
@@ -10,7 +10,7 @@ type WidgetAdapter struct {
 	W                         widgets.Widget
 	focus                     *widgets.FocusManager
 	popups                    []widgets.PopupRenderer
-	rootCaptured              bool
+	capturedWidget            widgets.Widget
 	pointerCaptureInvalidated func()
 	cancelingPointerCapture   bool
 }
@@ -153,10 +153,10 @@ func (a *WidgetAdapter) CursorPosition() (int, int, bool) {
 }
 
 func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
-	if tev, ok := ev.(*tcell.EventMouse); ok && a.rootCaptured {
-		result := a.W.HandleEvent(ev)
+	if tev, ok := ev.(*tcell.EventMouse); ok && a.capturedWidget != nil {
+		result := a.capturedWidget.HandleEvent(ev)
 		if tev.Buttons() == tcell.ButtonNone {
-			a.rootCaptured = false
+			a.capturedWidget = nil
 		}
 		return result
 	}
@@ -164,27 +164,50 @@ func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
 	// they cover before those rows get a chance at them.
 	if tev, ok := ev.(*tcell.EventMouse); ok {
 		if w := a.popupAt(tev.Position()); w != nil {
-			return w.HandleEvent(ev)
+			result := w.HandleEvent(ev)
+			if result == EventCaptured {
+				a.captureWidget(w)
+			}
+			return result
 		}
 	}
 	if result := a.focus.HandleEvent(ev); result != EventIgnored {
 		if result == EventCaptured {
-			a.rootCaptured = true
+			a.captureWidget(a.focus.LastEventTarget())
 		}
 		return result
 	}
 	result := a.W.HandleEvent(ev)
 	if result == EventCaptured {
-		a.rootCaptured = true
+		a.captureWidget(a.W)
 	}
 	return result
 }
 
+func (a *WidgetAdapter) captureWidget(owner widgets.Widget) {
+	if owner == nil {
+		return
+	}
+	a.capturedWidget = owner
+	widgets.SetPointerCaptureInvalidated(owner, func() {
+		if a.capturedWidget != owner || a.cancelingPointerCapture {
+			return
+		}
+		a.capturedWidget = nil
+		if a.pointerCaptureInvalidated != nil {
+			a.pointerCaptureInvalidated()
+		}
+	})
+}
+
 func (a *WidgetAdapter) CancelPointerCapture() bool {
-	canceled := a.rootCaptured
-	a.rootCaptured = false
+	captured := a.capturedWidget
+	canceled := captured != nil
+	a.capturedWidget = nil
 	a.cancelingPointerCapture = true
-	canceled = widgets.CancelPointerCapture(a.W) || canceled
+	if captured != nil {
+		canceled = widgets.CancelPointerCapture(captured) || canceled
+	}
 	a.cancelingPointerCapture = false
 	if canceled && a.pointerCaptureInvalidated != nil {
 		a.pointerCaptureInvalidated()
@@ -193,18 +216,25 @@ func (a *WidgetAdapter) CancelPointerCapture() bool {
 }
 
 func (a *WidgetAdapter) OwnsPointerCapture() bool {
-	if a.rootCaptured {
+	if a.capturedWidget == nil {
+		return false
+	}
+	owner, ok := a.capturedWidget.(widgets.PointerCaptureOwner)
+	if !ok || owner.OwnsPointerCapture() {
 		return true
 	}
-	owner, ok := a.W.(widgets.PointerCaptureOwner)
-	return ok && owner.OwnsPointerCapture()
+	a.capturedWidget = nil
+	return false
 }
 
 func (a *WidgetAdapter) InvalidatePointerInteraction() bool {
-	invalidated := a.rootCaptured
-	a.rootCaptured = false
+	captured := a.capturedWidget
+	invalidated := captured != nil
+	a.capturedWidget = nil
 	a.cancelingPointerCapture = true
-	invalidated = widgets.InvalidatePointerInteraction(a.W) || invalidated
+	if captured != nil {
+		invalidated = widgets.InvalidatePointerInteraction(captured) || invalidated
+	}
 	a.cancelingPointerCapture = false
 	if invalidated && a.pointerCaptureInvalidated != nil {
 		a.pointerCaptureInvalidated()
@@ -214,13 +244,4 @@ func (a *WidgetAdapter) InvalidatePointerInteraction() bool {
 
 func (a *WidgetAdapter) SetPointerCaptureInvalidated(invalidated func()) {
 	a.pointerCaptureInvalidated = invalidated
-	widgets.SetPointerCaptureInvalidated(a.W, func() {
-		if !a.rootCaptured || a.cancelingPointerCapture {
-			return
-		}
-		a.rootCaptured = false
-		if a.pointerCaptureInvalidated != nil {
-			a.pointerCaptureInvalidated()
-		}
-	})
 }

--- a/internal/ui/tree_widget_adapter.go
+++ b/internal/ui/tree_widget_adapter.go
@@ -7,10 +7,12 @@ import (
 
 type WidgetAdapter struct {
 	BaseWidget
-	W            widgets.Widget
-	focus        *widgets.FocusManager
-	popups       []widgets.PopupRenderer
-	rootCaptured bool
+	W                         widgets.Widget
+	focus                     *widgets.FocusManager
+	popups                    []widgets.PopupRenderer
+	rootCaptured              bool
+	pointerCaptureInvalidated func()
+	cancelingPointerCapture   bool
 }
 
 func NewWidgetAdapter(w widgets.Widget) *WidgetAdapter {
@@ -166,6 +168,9 @@ func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
 		}
 	}
 	if result := a.focus.HandleEvent(ev); result != EventIgnored {
+		if result == EventCaptured {
+			a.rootCaptured = true
+		}
 		return result
 	}
 	result := a.W.HandleEvent(ev)
@@ -173,4 +178,49 @@ func (a *WidgetAdapter) HandleEvent(ev tcell.Event) EventResult {
 		a.rootCaptured = true
 	}
 	return result
+}
+
+func (a *WidgetAdapter) CancelPointerCapture() bool {
+	canceled := a.rootCaptured
+	a.rootCaptured = false
+	a.cancelingPointerCapture = true
+	canceled = widgets.CancelPointerCapture(a.W) || canceled
+	a.cancelingPointerCapture = false
+	if canceled && a.pointerCaptureInvalidated != nil {
+		a.pointerCaptureInvalidated()
+	}
+	return canceled
+}
+
+func (a *WidgetAdapter) OwnsPointerCapture() bool {
+	if a.rootCaptured {
+		return true
+	}
+	owner, ok := a.W.(widgets.PointerCaptureOwner)
+	return ok && owner.OwnsPointerCapture()
+}
+
+func (a *WidgetAdapter) InvalidatePointerInteraction() bool {
+	invalidated := a.rootCaptured
+	a.rootCaptured = false
+	a.cancelingPointerCapture = true
+	invalidated = widgets.InvalidatePointerInteraction(a.W) || invalidated
+	a.cancelingPointerCapture = false
+	if invalidated && a.pointerCaptureInvalidated != nil {
+		a.pointerCaptureInvalidated()
+	}
+	return invalidated
+}
+
+func (a *WidgetAdapter) SetPointerCaptureInvalidated(invalidated func()) {
+	a.pointerCaptureInvalidated = invalidated
+	widgets.SetPointerCaptureInvalidated(a.W, func() {
+		if !a.rootCaptured || a.cancelingPointerCapture {
+			return
+		}
+		a.rootCaptured = false
+		if a.pointerCaptureInvalidated != nil {
+			a.pointerCaptureInvalidated()
+		}
+	})
 }

--- a/internal/ui/tree_widget_adapter_capture_test.go
+++ b/internal/ui/tree_widget_adapter_capture_test.go
@@ -226,3 +226,29 @@ func TestWidgetAdapterTargetsFocusableChildInsideScrollView(t *testing.T) {
 	}
 	adapter.HandleEvent(tcell.NewEventMouse(9, 0, tcell.ButtonNone, 0))
 }
+
+func TestWidgetAdapterLetsScrollViewHandleWheelOverMeasuredTree(t *testing.T) {
+	items := make([]*widgets.TreeNode, 12)
+	for i := range items {
+		items[i] = &widgets.TreeNode{ID: string(rune('a' + i)), Label: "item"}
+	}
+	tree := widgets.NewTreeWidget(widgets.TreeConfig{Items: items})
+	stack := widgets.NewVStackWidget(tree)
+	stack.MeasureGrow = true
+	scroll := widgets.NewScrollViewWidget(stack)
+	adapter := NewWidgetAdapter(scroll)
+	adapter.SetRect(Rect{X: 0, Y: 0, W: 10, H: 4})
+	render := func() {
+		adapter.Render(NewRenderSurface(makeGrid(10, 4), Rect{X: 0, Y: 0, W: 10, H: 4}))
+	}
+	render()
+	beforeY := tree.GetRect().Y
+
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 1, tcell.WheelDown, 0)); got != EventConsumed {
+		t.Fatalf("wheel result = %v, want consumed", got)
+	}
+	render()
+	if got := tree.GetRect().Y; got != beforeY-3 {
+		t.Fatalf("tree Y after outer wheel = %d, want %d", got, beforeY-3)
+	}
+}

--- a/internal/ui/tree_widget_adapter_capture_test.go
+++ b/internal/ui/tree_widget_adapter_capture_test.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
+)
+
+type adapterCaptureProbe struct {
+	widgets.BaseWidget
+	height     int
+	focused    bool
+	capturing  bool
+	heldEvents int
+}
+
+func (p *adapterCaptureProbe) Height() int             { return p.height }
+func (p *adapterCaptureProbe) Width() int              { return 0 }
+func (p *adapterCaptureProbe) Render(widgets.Surface)  {}
+func (p *adapterCaptureProbe) Focusable() bool         { return true }
+func (p *adapterCaptureProbe) SetFocused(focused bool) { p.focused = focused }
+func (p *adapterCaptureProbe) IsFocused() bool         { return p.focused }
+func (p *adapterCaptureProbe) HandleEvent(ev tcell.Event) widgets.EventResult {
+	mouse, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return widgets.EventIgnored
+	}
+	if mouse.Buttons() == tcell.ButtonNone {
+		p.capturing = false
+		return widgets.EventConsumed
+	}
+	if mouse.Buttons()&tcell.Button1 != 0 {
+		if p.capturing {
+			p.heldEvents++
+		}
+		p.capturing = true
+		return widgets.EventCaptured
+	}
+	return widgets.EventIgnored
+}
+
+func TestWidgetAdapterRetainsFocusRoutedCaptureAcrossChildren(t *testing.T) {
+	first := &adapterCaptureProbe{height: 2}
+	second := &adapterCaptureProbe{height: 2}
+	stack := widgets.NewVStackWidget(first, second)
+	adapter := NewWidgetAdapter(stack)
+	adapter.SetRect(Rect{X: 0, Y: 0, W: 10, H: 4})
+	adapter.Render(NewRenderSurface(makeGrid(10, 4), Rect{X: 0, Y: 0, W: 10, H: 4}))
+	invalidations := 0
+	adapter.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("press result = %v, want captured", got)
+	}
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("cross-child drag result = %v, want captured", got)
+	}
+	if first.heldEvents != 1 || second.capturing {
+		t.Fatalf("capture moved between children: first held=%d second capturing=%v", first.heldEvents, second.capturing)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.ButtonNone, 0))
+	if adapter.rootCaptured || first.capturing {
+		t.Fatal("release retained adapter capture")
+	}
+	if invalidations != 0 {
+		t.Fatalf("normal release invalidations = %d, want 0", invalidations)
+	}
+
+	adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.Button1, 0))
+	if !adapter.CancelPointerCapture() {
+		t.Fatal("adapter did not cancel capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("capture invalidations = %d, want 1", invalidations)
+	}
+}

--- a/internal/ui/tree_widget_adapter_capture_test.go
+++ b/internal/ui/tree_widget_adapter_capture_test.go
@@ -15,6 +15,49 @@ type adapterCaptureProbe struct {
 	heldEvents int
 }
 
+type adapterPopupCaptureProbe struct {
+	adapterCaptureProbe
+	popup Rect
+}
+
+type adapterRootCaptureProbe struct {
+	widgets.BaseWidget
+	capturing  bool
+	heldEvents int
+}
+
+func (p *adapterRootCaptureProbe) Height() int            { return 0 }
+func (p *adapterRootCaptureProbe) Width() int             { return 0 }
+func (p *adapterRootCaptureProbe) Render(widgets.Surface) {}
+func (p *adapterRootCaptureProbe) HandleEvent(ev tcell.Event) widgets.EventResult {
+	mouse, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return widgets.EventIgnored
+	}
+	if mouse.Buttons() == tcell.ButtonNone {
+		p.capturing = false
+		return widgets.EventConsumed
+	}
+	if mouse.Buttons()&tcell.Button1 != 0 {
+		if p.capturing {
+			p.heldEvents++
+		}
+		p.capturing = true
+		return widgets.EventCaptured
+	}
+	return widgets.EventIgnored
+}
+func (p *adapterRootCaptureProbe) CancelPointerCapture() bool {
+	active := p.capturing
+	p.capturing = false
+	return active
+}
+func (p *adapterRootCaptureProbe) OwnsPointerCapture() bool { return p.capturing }
+
+func (p *adapterPopupCaptureProbe) HasPopup() bool      { return true }
+func (p *adapterPopupCaptureProbe) PopupRect() Rect     { return p.popup }
+func (p *adapterPopupCaptureProbe) RenderPopup(Surface) {}
+
 func (p *adapterCaptureProbe) Height() int             { return p.height }
 func (p *adapterCaptureProbe) Width() int              { return 0 }
 func (p *adapterCaptureProbe) Render(widgets.Surface)  {}
@@ -40,6 +83,18 @@ func (p *adapterCaptureProbe) HandleEvent(ev tcell.Event) widgets.EventResult {
 	return widgets.EventIgnored
 }
 
+func (p *adapterCaptureProbe) CancelPointerCapture() bool {
+	active := p.capturing
+	p.capturing = false
+	return active
+}
+
+func (p *adapterCaptureProbe) OwnsPointerCapture() bool { return p.capturing }
+
+func (p *adapterCaptureProbe) InvalidatePointerInteraction() bool {
+	return p.CancelPointerCapture()
+}
+
 func TestWidgetAdapterRetainsFocusRoutedCaptureAcrossChildren(t *testing.T) {
 	first := &adapterCaptureProbe{height: 2}
 	second := &adapterCaptureProbe{height: 2}
@@ -50,28 +105,79 @@ func TestWidgetAdapterRetainsFocusRoutedCaptureAcrossChildren(t *testing.T) {
 	invalidations := 0
 	adapter.SetPointerCaptureInvalidated(func() { invalidations++ })
 
-	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.Button1, 0)); got != EventCaptured {
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.Button1, 0)); got != EventCaptured {
 		t.Fatalf("press result = %v, want captured", got)
 	}
-	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.Button1, 0)); got != EventCaptured {
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.Button1, 0)); got != EventCaptured {
 		t.Fatalf("cross-child drag result = %v, want captured", got)
 	}
-	if first.heldEvents != 1 || second.capturing {
-		t.Fatalf("capture moved between children: first held=%d second capturing=%v", first.heldEvents, second.capturing)
+	if second.heldEvents != 1 || first.capturing {
+		t.Fatalf("capture moved between children: second held=%d first capturing=%v", second.heldEvents, first.capturing)
 	}
-	adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.ButtonNone, 0))
-	if adapter.rootCaptured || first.capturing {
+	adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.ButtonNone, 0))
+	if adapter.capturedWidget != nil || second.capturing {
 		t.Fatal("release retained adapter capture")
 	}
 	if invalidations != 0 {
 		t.Fatalf("normal release invalidations = %d, want 0", invalidations)
 	}
 
-	adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.Button1, 0))
+	adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.Button1, 0))
 	if !adapter.CancelPointerCapture() {
 		t.Fatal("adapter did not cancel capture")
 	}
 	if invalidations != 1 {
 		t.Fatalf("capture invalidations = %d, want 1", invalidations)
+	}
+
+	adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.Button1, 0))
+	if !adapter.InvalidatePointerInteraction() || second.capturing {
+		t.Fatal("adapter did not invalidate exact capture owner")
+	}
+	if invalidations != 2 {
+		t.Fatalf("capture invalidations = %d, want 2", invalidations)
+	}
+}
+
+func TestWidgetAdapterRetainsPopupCaptureOutsidePopup(t *testing.T) {
+	popup := &adapterPopupCaptureProbe{
+		adapterCaptureProbe: adapterCaptureProbe{height: 2},
+		popup:               Rect{X: 0, Y: 2, W: 10, H: 2},
+	}
+	other := &adapterCaptureProbe{height: 2}
+	stack := widgets.NewVStackWidget(other, popup)
+	adapter := NewWidgetAdapter(stack)
+	adapter.SetRect(Rect{X: 0, Y: 0, W: 10, H: 4})
+	adapter.Render(NewRenderSurface(makeGrid(10, 4), Rect{X: 0, Y: 0, W: 10, H: 4}))
+
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 3, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("popup press result = %v, want captured", got)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.Button1, 0))
+	if popup.heldEvents != 1 || other.capturing {
+		t.Fatalf("popup capture moved to underlying child: popup held=%d other capturing=%v", popup.heldEvents, other.capturing)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(1, 0, tcell.ButtonNone, 0))
+	if popup.capturing {
+		t.Fatal("popup owner did not receive release")
+	}
+}
+
+func TestWidgetAdapterPreservesDirectRootCapture(t *testing.T) {
+	root := &adapterRootCaptureProbe{}
+	adapter := NewWidgetAdapter(root)
+	adapter.SetRect(Rect{X: 0, Y: 0, W: 10, H: 4})
+	adapter.Render(NewRenderSurface(makeGrid(10, 4), Rect{X: 0, Y: 0, W: 10, H: 4}))
+
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 1, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("root press result = %v, want captured", got)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(20, 20, tcell.Button1, 0))
+	if root.heldEvents != 1 {
+		t.Fatalf("root held events = %d, want 1", root.heldEvents)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(20, 20, tcell.ButtonNone, 0))
+	if root.capturing || adapter.capturedWidget != nil {
+		t.Fatal("root release retained capture")
 	}
 }

--- a/internal/ui/tree_widget_adapter_capture_test.go
+++ b/internal/ui/tree_widget_adapter_capture_test.go
@@ -26,6 +26,16 @@ type adapterRootCaptureProbe struct {
 	heldEvents int
 }
 
+type adapterScrollableCaptureProbe struct {
+	adapterCaptureProbe
+	contentW int
+	contentH int
+}
+
+func (p *adapterScrollableCaptureProbe) ScrollSize() (int, int) {
+	return p.contentW, p.contentH
+}
+
 func (p *adapterRootCaptureProbe) Height() int            { return 0 }
 func (p *adapterRootCaptureProbe) Width() int             { return 0 }
 func (p *adapterRootCaptureProbe) Render(widgets.Surface) {}
@@ -180,4 +190,39 @@ func TestWidgetAdapterPreservesDirectRootCapture(t *testing.T) {
 	if root.capturing || adapter.capturedWidget != nil {
 		t.Fatal("root release retained capture")
 	}
+}
+
+func TestWidgetAdapterTargetsFocusableChildInsideScrollView(t *testing.T) {
+	child := &adapterScrollableCaptureProbe{
+		adapterCaptureProbe: adapterCaptureProbe{},
+		contentW:            9,
+		contentH:            12,
+	}
+	scroll := widgets.NewScrollViewWidget(child)
+	adapter := NewWidgetAdapter(scroll)
+	adapter.SetRect(Rect{X: 0, Y: 0, W: 10, H: 4})
+	adapter.Render(NewRenderSurface(makeGrid(10, 4), Rect{X: 0, Y: 0, W: 10, H: 4}))
+
+	if got := adapter.HandleEvent(tcell.NewEventMouse(1, 1, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("child press result = %v, want captured", got)
+	}
+	if adapter.capturedWidget != child {
+		t.Fatalf("captured owner = %T, want focusable child", adapter.capturedWidget)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(9, 3, tcell.Button1, 0))
+	if child.heldEvents != 1 {
+		t.Fatalf("child held events = %d, want 1", child.heldEvents)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(9, 3, tcell.ButtonNone, 0))
+	if child.capturing || adapter.capturedWidget != nil {
+		t.Fatal("child release retained capture")
+	}
+
+	if got := adapter.HandleEvent(tcell.NewEventMouse(9, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("outer scrollbar press result = %v, want captured", got)
+	}
+	if adapter.capturedWidget != scroll {
+		t.Fatalf("scrollbar captured owner = %T, want ScrollViewWidget", adapter.capturedWidget)
+	}
+	adapter.HandleEvent(tcell.NewEventMouse(9, 0, tcell.ButtonNone, 0))
 }

--- a/internal/widgets/box.go
+++ b/internal/widgets/box.go
@@ -94,6 +94,8 @@ func (b *BoxWidget) Render(surface Surface) {
 		}
 		b.Child.SetRect(Rect{X: r.X + ox, Y: r.Y + oy, W: iw, H: ih})
 		b.Child.Render(inner)
+	} else if b.Child != nil {
+		InvalidatePointerInteraction(b.Child)
 	}
 }
 
@@ -102,4 +104,21 @@ func (b *BoxWidget) HandleEvent(ev tcell.Event) EventResult {
 		return b.Child.HandleEvent(ev)
 	}
 	return EventIgnored
+}
+
+func (b *BoxWidget) CancelPointerCapture() bool {
+	return CancelPointerCapture(b.Child)
+}
+
+func (b *BoxWidget) OwnsPointerCapture() bool {
+	owner, ok := b.Child.(PointerCaptureOwner)
+	return ok && owner.OwnsPointerCapture()
+}
+
+func (b *BoxWidget) InvalidatePointerInteraction() bool {
+	return InvalidatePointerInteraction(b.Child)
+}
+
+func (b *BoxWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	SetPointerCaptureInvalidated(b.Child, invalidated)
 }

--- a/internal/widgets/box_pointer_capture_test.go
+++ b/internal/widgets/box_pointer_capture_test.go
@@ -1,0 +1,41 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestBoxForwardsTreeScrollbarCaptureLifecycle(t *testing.T) {
+	items := make([]*TreeNode, 10)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('a' + i)), Label: "item"}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	box := &BoxWidget{Child: tree}
+	box.SetRect(Rect{X: 0, Y: 0, W: 5, H: 3})
+	box.Render(newVirtualSurface(5, 3))
+	invalidations := 0
+	box.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	if got := box.HandleEvent(tcell.NewEventMouse(4, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("boxed scrollbar press result = %v, want captured", got)
+	}
+	if !box.OwnsPointerCapture() || !box.CancelPointerCapture() {
+		t.Fatal("box did not forward tree scrollbar capture and cancellation")
+	}
+	if tree.OwnsPointerCapture() || box.OwnsPointerCapture() {
+		t.Fatal("boxed tree retained canceled scrollbar capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("capture invalidations = %d, want 1", invalidations)
+	}
+
+	box.HandleEvent(tcell.NewEventMouse(4, 0, tcell.Button1, 0))
+	if !box.InvalidatePointerInteraction() || tree.OwnsPointerCapture() {
+		t.Fatal("box did not forward tree scrollbar invalidation")
+	}
+	if invalidations != 2 {
+		t.Fatalf("capture invalidations = %d, want 2", invalidations)
+	}
+}

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -190,6 +190,16 @@ func (fm *FocusManager) innermostVisibleHit(mx, my int) int {
 	return hit
 }
 
+func (fm *FocusManager) firstVisibleHit(mx, my int) int {
+	for i, fw := range fm.items {
+		r := VisibleRect(fm.root, fw)
+		if mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H {
+			return i
+		}
+	}
+	return -1
+}
+
 func (fm *FocusManager) setFocus(idx int) {
 	if fm.focused >= 0 && fm.focused < len(fm.items) {
 		fm.items[fm.focused].SetFocused(false)
@@ -320,9 +330,14 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 		}
 	case *tcell.EventMouse:
 		mx, my := tev.Position()
-		hit := fm.innermostVisibleHit(mx, my)
-		if tev.Buttons()&tcell.Button1 != 0 && hit >= 0 {
-			fm.setFocus(hit)
+		hit := -1
+		if tev.Buttons()&tcell.Button1 != 0 {
+			hit = fm.innermostVisibleHit(mx, my)
+			if hit >= 0 {
+				fm.setFocus(hit)
+			}
+		} else {
+			hit = fm.firstVisibleHit(mx, my)
 		}
 		if hit >= 0 {
 			fm.lastEventTarget = fm.items[hit]

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -5,10 +5,11 @@ import (
 )
 
 type FocusManager struct {
-	items   []FocusableWidget
-	focused int
-	active  bool
-	root    Widget
+	items           []FocusableWidget
+	focused         int
+	active          bool
+	root            Widget
+	lastEventTarget Widget
 	// OnFocusChange is called after focus moves (e.g. to scroll the widget into view).
 	OnFocusChange func(w FocusableWidget)
 }
@@ -291,7 +292,10 @@ func (fm *FocusManager) Focused() Widget {
 	return nil
 }
 
+func (fm *FocusManager) LastEventTarget() Widget { return fm.lastEventTarget }
+
 func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
+	fm.lastEventTarget = nil
 	if len(fm.items) == 0 {
 		return EventIgnored
 	}
@@ -307,6 +311,7 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 		}
 		fm.ensureFocusedRendered()
 		if fw := fm.Focused(); fw != nil {
+			fm.lastEventTarget = fw
 			return fw.HandleEvent(ev)
 		}
 	case *tcell.EventMouse:
@@ -317,10 +322,12 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 		for _, fw := range fm.items {
 			r := VisibleRect(fm.root, fw)
 			if mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H {
+				fm.lastEventTarget = fw
 				return fw.HandleEvent(ev)
 			}
 		}
 		if fw := fm.Focused(); fw != nil {
+			fm.lastEventTarget = fw
 			return fw.HandleEvent(ev)
 		}
 	}

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -174,6 +174,12 @@ func (fm *FocusManager) ensureFocusedRendered() {
 // scroll view, say) matches the container before the control the user aimed at.
 // The last match is the innermost one.
 func (fm *FocusManager) FocusByClick(mx, my int) {
+	if hit := fm.innermostVisibleHit(mx, my); hit >= 0 {
+		fm.setFocus(hit)
+	}
+}
+
+func (fm *FocusManager) innermostVisibleHit(mx, my int) int {
 	hit := -1
 	for i, fw := range fm.items {
 		r := VisibleRect(fm.root, fw)
@@ -181,9 +187,7 @@ func (fm *FocusManager) FocusByClick(mx, my int) {
 			hit = i
 		}
 	}
-	if hit >= 0 {
-		fm.setFocus(hit)
-	}
+	return hit
 }
 
 func (fm *FocusManager) setFocus(idx int) {
@@ -315,16 +319,14 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 			return fw.HandleEvent(ev)
 		}
 	case *tcell.EventMouse:
-		if tev.Buttons()&tcell.Button1 != 0 {
-			fm.FocusByClick(tev.Position())
-		}
 		mx, my := tev.Position()
-		for _, fw := range fm.items {
-			r := VisibleRect(fm.root, fw)
-			if mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H {
-				fm.lastEventTarget = fw
-				return fw.HandleEvent(ev)
-			}
+		hit := fm.innermostVisibleHit(mx, my)
+		if tev.Buttons()&tcell.Button1 != 0 && hit >= 0 {
+			fm.setFocus(hit)
+		}
+		if hit >= 0 {
+			fm.lastEventTarget = fm.items[hit]
+			return fm.items[hit].HandleEvent(ev)
 		}
 		if fw := fm.Focused(); fw != nil {
 			fm.lastEventTarget = fw

--- a/internal/widgets/scrollview.go
+++ b/internal/widgets/scrollview.go
@@ -9,12 +9,14 @@ type ScrollViewWidget struct {
 	BaseWidget
 	Child ScrollableWidget
 
-	scrollX      int
-	scrollY      int
-	vbar         scrollbar
-	focused      bool
-	lastContentH int
-	lastViewH    int
+	scrollX                   int
+	scrollY                   int
+	vbar                      scrollbar
+	focused                   bool
+	lastContentH              int
+	lastViewH                 int
+	pointerCaptureInvalidated func()
+	cancelingPointerCapture   bool
 }
 
 func (s *ScrollViewWidget) WidgetChildren() []Widget {
@@ -96,6 +98,7 @@ func (sv *ScrollViewWidget) Render(surface Surface) {
 	surface = sv.RenderBox(surface)
 	w, h := surface.Size()
 	if w <= 0 || h <= 0 || sv.Child == nil {
+		sv.InvalidatePointerInteraction()
 		return
 	}
 
@@ -231,6 +234,53 @@ func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
 		return sv.Child.HandleEvent(ev)
 	}
 	return EventIgnored
+}
+
+func (sv *ScrollViewWidget) CancelPointerCapture() bool {
+	canceled := sv.vbar.isDragging()
+	sv.vbar.dragging = false
+	sv.cancelingPointerCapture = true
+	if sv.Child != nil {
+		canceled = CancelPointerCapture(sv.Child) || canceled
+	}
+	sv.cancelingPointerCapture = false
+	if canceled && sv.pointerCaptureInvalidated != nil {
+		sv.pointerCaptureInvalidated()
+	}
+	return canceled
+}
+
+func (sv *ScrollViewWidget) OwnsPointerCapture() bool {
+	if sv.vbar.isDragging() {
+		return true
+	}
+	owner, ok := sv.Child.(PointerCaptureOwner)
+	return ok && owner.OwnsPointerCapture()
+}
+
+func (sv *ScrollViewWidget) InvalidatePointerInteraction() bool {
+	invalidated := sv.vbar.isDragging()
+	sv.vbar.dragging = false
+	sv.cancelingPointerCapture = true
+	if sv.Child != nil {
+		invalidated = InvalidatePointerInteraction(sv.Child) || invalidated
+	}
+	sv.cancelingPointerCapture = false
+	if invalidated && sv.pointerCaptureInvalidated != nil {
+		sv.pointerCaptureInvalidated()
+	}
+	return invalidated
+}
+
+func (sv *ScrollViewWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	sv.pointerCaptureInvalidated = invalidated
+	if sv.Child != nil {
+		SetPointerCaptureInvalidated(sv.Child, func() {
+			if !sv.cancelingPointerCapture && sv.pointerCaptureInvalidated != nil {
+				sv.pointerCaptureInvalidated()
+			}
+		})
+	}
 }
 
 func (sv *ScrollViewWidget) viewportContains(mx, my int) bool {

--- a/internal/widgets/scrollview_test.go
+++ b/internal/widgets/scrollview_test.go
@@ -82,6 +82,40 @@ func TestScrollViewContentTallerThanViewport(t *testing.T) {
 	}
 }
 
+func TestScrollViewScrollbarCaptureLifecycle(t *testing.T) {
+	sv := NewScrollViewWidget(newScrollTestChild(15, 30))
+	renderWidget(sv, 0, 0, 20, 10)
+	invalidations := 0
+	sv.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	if got := sv.HandleEvent(tcell.NewEventMouse(19, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("scrollbar press result = %v, want captured", got)
+	}
+	if !sv.OwnsPointerCapture() {
+		t.Fatal("scroll view did not report scrollbar capture")
+	}
+	sv.HandleEvent(tcell.NewEventMouse(30, 30, tcell.ButtonNone, 0))
+	if sv.OwnsPointerCapture() || invalidations != 0 {
+		t.Fatalf("normal release retained capture or notified: invalidations=%d", invalidations)
+	}
+
+	sv.HandleEvent(tcell.NewEventMouse(19, 0, tcell.Button1, 0))
+	if !sv.CancelPointerCapture() || sv.OwnsPointerCapture() {
+		t.Fatal("scroll view did not cancel scrollbar capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("capture invalidations = %d, want 1", invalidations)
+	}
+
+	sv.HandleEvent(tcell.NewEventMouse(19, 0, tcell.Button1, 0))
+	if !sv.InvalidatePointerInteraction() || sv.OwnsPointerCapture() {
+		t.Fatal("scroll view did not invalidate scrollbar capture")
+	}
+	if invalidations != 2 {
+		t.Fatalf("capture invalidations = %d, want 2", invalidations)
+	}
+}
+
 func TestScrollViewWheelDown(t *testing.T) {
 	child := newScrollTestChild(15, 30)
 	sv := NewScrollViewWidget(child)

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -137,6 +137,78 @@ func (t *TreeWidget) SetActiveID(id string) {
 	t.Config.ActiveID = id
 }
 
+// CollapseAll closes every materialized branch while preserving the selected
+// node when it remains visible. A selection hidden inside a collapsed branch
+// falls back to the first visible row instead of drifting by numeric index.
+func (t *TreeWidget) CollapseAll() {
+	selectedID := t.selectedID()
+	setTreeExpanded(t.Config.Items, false)
+	t.flatten()
+	t.restoreVisibleSelection(selectedID)
+}
+
+// ExpandAll opens every branch currently represented in the model. Lazy trees
+// load one newly revealed level without recursively walking newly loaded nodes.
+func (t *TreeWidget) ExpandAll() {
+	t.ExpandAllWhere(func(*TreeNode) bool { return true })
+}
+
+func (t *TreeWidget) ExpandAllWhere(include func(*TreeNode) bool) {
+	selectedID := t.selectedID()
+	nodes := materializedTreeNodes(t.Config.Items)
+	for _, node := range nodes {
+		if !node.isExpandable() || !include(node) {
+			continue
+		}
+		node.Expanded = true
+		if len(node.Children) == 0 && t.Config.OnExpand != nil {
+			t.Config.OnExpand(node)
+		}
+	}
+	t.flatten()
+	t.restoreVisibleSelection(selectedID)
+}
+
+func (t *TreeWidget) selectedID() string {
+	if node := t.Selected(); node != nil {
+		return node.ID
+	}
+	return ""
+}
+
+func (t *TreeWidget) restoreVisibleSelection(id string) {
+	t.selected = 0
+	if id == "" {
+		t.clampSelected()
+		return
+	}
+	for i, node := range t.flatList {
+		if node.ID == id {
+			t.selected = i
+			return
+		}
+	}
+	t.clampSelected()
+}
+
+func setTreeExpanded(nodes []*TreeNode, expanded bool) {
+	for _, node := range nodes {
+		if node.isExpandable() {
+			node.Expanded = expanded
+		}
+		setTreeExpanded(node.Children, expanded)
+	}
+}
+
+func materializedTreeNodes(nodes []*TreeNode) []*TreeNode {
+	var result []*TreeNode
+	for _, node := range nodes {
+		result = append(result, node)
+		result = append(result, materializedTreeNodes(node.Children)...)
+	}
+	return result
+}
+
 func (t *TreeWidget) Reload() {
 	expanded := map[string]bool{}
 	t.CollectExpanded(expanded)

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -69,10 +69,11 @@ type TreeWidget struct {
 	lastSel   int
 	focused   bool
 
-	scrollbar scrollbar
-	contentX  int
-	contentY  int
-	contentW  int
+	scrollbar                 scrollbar
+	contentX                  int
+	contentY                  int
+	contentW                  int
+	pointerCaptureInvalidated func()
 }
 
 func NewTreeWidget(cfg TreeConfig) *TreeWidget {
@@ -481,6 +482,27 @@ func (t *TreeWidget) HandleEvent(ev tcell.Event) EventResult {
 		t.Config.OnSelect(t.Selected())
 	}
 	return result
+}
+
+func (t *TreeWidget) CancelPointerCapture() bool {
+	canceled := t.scrollbar.isDragging()
+	t.scrollbar.dragging = false
+	if canceled && t.pointerCaptureInvalidated != nil {
+		t.pointerCaptureInvalidated()
+	}
+	return canceled
+}
+
+func (t *TreeWidget) OwnsPointerCapture() bool {
+	return t.scrollbar.isDragging()
+}
+
+func (t *TreeWidget) InvalidatePointerInteraction() bool {
+	return t.CancelPointerCapture()
+}
+
+func (t *TreeWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	t.pointerCaptureInvalidated = invalidated
 }
 
 func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {

--- a/internal/widgets/tree_pointer_capture_test.go
+++ b/internal/widgets/tree_pointer_capture_test.go
@@ -1,0 +1,38 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestTreeScrollbarCaptureCanBeCanceled(t *testing.T) {
+	items := make([]*TreeNode, 10)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('a' + i)), Label: "item"}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	tree.SetRect(Rect{X: 0, Y: 0, W: 5, H: 3})
+	tree.Render(newVirtualSurface(5, 3))
+	invalidations := 0
+	tree.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	if got := tree.HandleEvent(tcell.NewEventMouse(4, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("scrollbar press result = %v, want captured", got)
+	}
+	if !tree.OwnsPointerCapture() || !tree.CancelPointerCapture() {
+		t.Fatal("tree did not own and cancel its scrollbar capture")
+	}
+	if tree.OwnsPointerCapture() {
+		t.Fatal("tree retained canceled scrollbar capture")
+	}
+	if invalidations != 1 {
+		t.Fatalf("capture invalidations = %d, want 1", invalidations)
+	}
+	if tree.CancelPointerCapture() || invalidations != 1 {
+		t.Fatalf("idle cancellation changed state: invalidated=%d", invalidations)
+	}
+	if got := tree.HandleEvent(tcell.NewEventMouse(9, 9, tcell.Button1, 0)); got != EventIgnored {
+		t.Fatalf("post-cancel out-of-bounds drag result = %v, want ignored", got)
+	}
+}

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -1224,6 +1224,36 @@ func TestTreeCollectRestoreExpanded(t *testing.T) {
 	}
 }
 
+func TestTreeExpandAndCollapseAllPreserveIdentity(t *testing.T) {
+	root := &TreeNode{ID: "root", Label: "Root", Expandable: true, Expanded: true, Children: []*TreeNode{{
+		ID: "child", Label: "Child", Expandable: true, Children: []*TreeNode{{ID: "leaf", Label: "Leaf"}},
+	}}}
+	tree := NewTreeWidget(TreeConfig{Items: []*TreeNode{root}})
+	tree.SelectByID("root")
+	tree.ExpandAll()
+	if !root.Expanded || !root.Children[0].Expanded || tree.Selected().ID != "root" {
+		t.Fatalf("expand all lost state or selection: root=%+v selected=%+v", root, tree.Selected())
+	}
+	tree.SelectByID("leaf")
+	tree.CollapseAll()
+	if root.Expanded || root.Children[0].Expanded || tree.Selected().ID != "root" {
+		t.Fatalf("collapse all drifted hidden selection: root=%+v selected=%+v", root, tree.Selected())
+	}
+}
+
+func TestTreeExpandAllLoadsOnlyOneLazyLevel(t *testing.T) {
+	root := &TreeNode{ID: "root", Label: "Root", Expandable: true}
+	loaded := []string{}
+	tree := NewTreeWidget(TreeConfig{Items: []*TreeNode{root}, OnExpand: func(node *TreeNode) {
+		loaded = append(loaded, node.ID)
+		node.Children = []*TreeNode{{ID: node.ID + "/child", Label: "Child", Expandable: true}}
+	}})
+	tree.ExpandAll()
+	if !root.Expanded || len(root.Children) != 1 || root.Children[0].Expanded || len(loaded) != 1 {
+		t.Fatalf("lazy expand traversed beyond represented level: root=%+v loaded=%v", root, loaded)
+	}
+}
+
 // --- Shortcut key tests ---
 
 func TestTreeShortcutKey(t *testing.T) {

--- a/internal/widgets/tree_test.go
+++ b/internal/widgets/tree_test.go
@@ -1254,6 +1254,28 @@ func TestTreeExpandAllLoadsOnlyOneLazyLevel(t *testing.T) {
 	}
 }
 
+func TestTreeExpandAllWhereFiltersBranchesAndLazyLoads(t *testing.T) {
+	included := &TreeNode{ID: "included", Label: "Included", Expandable: true}
+	excluded := &TreeNode{ID: "excluded", Label: "Excluded", Expandable: true}
+	loaded := []string{}
+	tree := NewTreeWidget(TreeConfig{Items: []*TreeNode{included, excluded}, OnExpand: func(node *TreeNode) {
+		loaded = append(loaded, node.ID)
+		node.Children = []*TreeNode{{ID: node.ID + "/child", Label: "Child"}}
+	}})
+
+	tree.ExpandAllWhere(func(node *TreeNode) bool { return node.ID == included.ID })
+
+	if !included.Expanded || len(included.Children) != 1 {
+		t.Fatalf("included branch was not expanded and loaded: %+v", included)
+	}
+	if excluded.Expanded || len(excluded.Children) != 0 {
+		t.Fatalf("excluded branch changed: %+v", excluded)
+	}
+	if len(loaded) != 1 || loaded[0] != included.ID {
+		t.Fatalf("lazy loads = %v, want only %q", loaded, included.ID)
+	}
+}
+
 // --- Shortcut key tests ---
 
 func TestTreeShortcutKey(t *testing.T) {

--- a/tests/e2e/options_menu_test.go
+++ b/tests/e2e/options_menu_test.go
@@ -77,7 +77,7 @@ func TestOptionsMenuToggleWordWrap(t *testing.T) {
 	}
 }
 
-func TestOptionsOwnDiffDefaultsAndChangesKeepsContextualAccess(t *testing.T) {
+func TestOptionsAndChangesShareCheckedPresentationSubmenus(t *testing.T) {
 	h := newTestHarness(t, 80, 24)
 	defer h.stop()
 	h.app.EditorGroup.OpenDiff("existing.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
@@ -87,19 +87,23 @@ func TestOptionsOwnDiffDefaultsAndChangesKeepsContextualAccess(t *testing.T) {
 	}
 
 	options := h.app.BuildOptionsMenu()
-	for _, command := range []string{"options.diffViewMode", "options.diffContext", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast"} {
+	for _, command := range []string{"options.useSplitDiff", "options.useUnifiedDiff", "options.useChangesOnlyDiff", "options.useFullFileDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast", "options.useGitFileTree", "options.useGitFileList", "changes.expandAll", "changes.collapseAll"} {
 		if _, ok := findMenuCommand(options, command); !ok {
 			t.Errorf("Options menu missing %s", command)
 		}
 	}
-	if _, ok := findMenuCommand(options, "options.useSplitDiff"); ok {
-		t.Fatal("Options should use the consolidated Diff View Mode picker")
-	}
 	changes := h.app.BuildChangesPanelMenu()
-	for _, command := range []string{"options.useSplitDiff", "options.useUnifiedDiff", "options.useChangesOnlyDiff", "options.useFullFileDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast"} {
+	for _, command := range []string{"options.useSplitDiff", "options.useUnifiedDiff", "options.useChangesOnlyDiff", "options.useFullFileDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast", "options.useGitFileTree", "options.useGitFileList", "changes.expandAll", "changes.collapseAll"} {
 		if _, ok := findMenuCommand(changes, command); !ok {
 			t.Errorf("Changes menu missing contextual command %s", command)
 		}
+	}
+	if item, ok := findMenuCommand(options, "options.useGitFileList"); !ok || item.Checked != ui.MenuChecked {
+		t.Fatalf("List should be the checked default: item=%+v found=%v", item, ok)
+	}
+	h.exec("options.useGitFileTree")
+	if item, ok := findMenuCommand(h.app.BuildChangesContextMenu(), "options.useGitFileTree"); !ok || item.Checked != ui.MenuChecked {
+		t.Fatalf("Changes context did not share checked Tree state: item=%+v found=%v", item, ok)
 	}
 
 	h.exec("options.useUnifiedDiff")

--- a/tests/e2e/options_menu_test.go
+++ b/tests/e2e/options_menu_test.go
@@ -93,7 +93,7 @@ func TestOptionsAndChangesShareCheckedPresentationSubmenus(t *testing.T) {
 		}
 	}
 	changes := h.app.BuildChangesPanelMenu()
-	for _, command := range []string{"options.useSplitDiff", "options.useUnifiedDiff", "options.useChangesOnlyDiff", "options.useFullFileDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast", "options.useGitFileTree", "options.useGitFileList", "changes.expandAll", "changes.collapseAll"} {
+	for _, command := range []string{"options.useSplitDiff", "options.useUnifiedDiff", "options.useChangesOnlyDiff", "options.useFullFileDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast", "options.useGitFileTree", "options.useGitFileList", "changes.expandAllWorkingTree", "changes.collapseAllWorkingTree"} {
 		if _, ok := findMenuCommand(changes, command); !ok {
 			t.Errorf("Changes menu missing contextual command %s", command)
 		}

--- a/tests/e2e/settings_view_test.go
+++ b/tests/e2e/settings_view_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -156,6 +157,23 @@ func TestSettingsEnumSelectOpensPopup(t *testing.T) {
 	h.exec("settings.apply")
 	if h.app.Settings.Theme != "default-dark" {
 		t.Errorf("theme = %q, want default-dark", h.app.Settings.Theme)
+	}
+}
+
+func TestSettingsGitFileViewLiveAppliesOnlyAfterApply(t *testing.T) {
+	h := openSettings(t)
+	clickRowControl(t, h, "Advanced", "Advanced")
+	if !rowHas(h, "Git: file view", "List") {
+		t.Fatalf("Git file view should default to List:\n%s", h.screenText())
+	}
+	clickRowControl(t, h, "Git: file view", "List")
+	clickRowControl(t, h, "Tree", "Tree")
+	if h.app.Settings.Git.FileView != config.GitFileViewList || h.app.Changes.FileView() != config.GitFileViewList {
+		t.Fatal("Git file view applied before Apply")
+	}
+	h.exec("settings.apply")
+	if h.app.Settings.Git.FileView != config.GitFileViewTree || h.app.Changes.FileView() != config.GitFileViewTree {
+		t.Fatalf("Git file view did not live-apply: settings=%q panel=%q", h.app.Settings.Git.FileView, h.app.Changes.FileView())
 	}
 }
 

--- a/tests/e2e/tree_actions_menu_test.go
+++ b/tests/e2e/tree_actions_menu_test.go
@@ -1,11 +1,38 @@
 package e2e
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
 )
+
+func treeNodeWithLabel(nodes []*widgets.TreeNode, label string) *widgets.TreeNode {
+	for _, node := range nodes {
+		if node.Label == label {
+			return node
+		}
+		if found := treeNodeWithLabel(node.Children, label); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func menuCommandWithLabel(items []ui.ContextMenuItem, label string) string {
+	for _, item := range items {
+		if item.Label == label {
+			return item.Command
+		}
+		if command := menuCommandWithLabel(item.Submenu, label); command != "" {
+			return command
+		}
+	}
+	return ""
+}
 
 func TestChangesAndExplorerThreeDotMenusExposeBulkActions(t *testing.T) {
 	h := newTestHarness(t, 100, 28)
@@ -33,7 +60,7 @@ func TestChangesRightClickAndThreeDotMenusHaveGitFileParity(t *testing.T) {
 	defer h.stop()
 	panel := h.app.BuildChangesPanelMenu()
 	context := h.app.BuildChangesContextMenu()
-	for _, command := range []string{"options.useGitFileTree", "options.useGitFileList", "changes.expandAll", "changes.collapseAll"} {
+	for _, command := range []string{"options.useGitFileTree", "options.useGitFileList", "changes.expandAllWorkingTree", "changes.collapseAllWorkingTree"} {
 		panelItem, panelOK := findMenuCommand(panel, command)
 		contextItem, contextOK := findMenuCommand(context, command)
 		if !panelOK || !contextOK || panelItem.Checked != contextItem.Checked {
@@ -48,4 +75,44 @@ func TestChangesRightClickAndThreeDotMenusHaveGitFileParity(t *testing.T) {
 		t.Fatalf("right-click menu focus = %T", h.app.Root.Focused)
 	}
 	h.assertContains("Git Files")
+}
+
+func TestChangesMenusExpandChangesWithoutExpandingActiveCommitDetail(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+	runHistoryGit(t, h.dir, "init", "-q", "-b", "main")
+	if err := os.MkdirAll(filepath.Join(h.dir, "deep", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(h.dir, "deep", "nested", "file.go"), []byte("package nested\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	previousScreen := h.app.Changes.Screen
+	h.app.Changes.Screen = nil
+	h.app.Changes.Refresh()
+	h.app.Changes.Screen = previousScreen
+	h.app.Changes.SetFileView("tree")
+	h.exec("sidebar.changes")
+	detail := ui.NewCommitDetailWidget(h.dir, "ref", "ref", false)
+	detail.SetDetail("detail", []ui.CommitDetailFile{{Path: "detail.txt", Error: "DETAIL SENTINEL"}}, "")
+	detail.CollapseAllFiles()
+	h.app.EditorGroup.OpenPluginTab("routing-detail", "Commit detail", detail)
+
+	menus := [][]ui.ContextMenuItem{h.app.BuildChangesPanelMenu(), h.app.BuildChangesContextMenu()}
+	for index, menu := range menus {
+		h.app.Changes.CollapseAll()
+		detail.CollapseAllFiles()
+		command := menuCommandWithLabel(menu, "Expand All")
+		if command == "" {
+			t.Fatalf("menu %d has no Expand All command", index)
+		}
+		h.exec(command)
+		changes := h.app.Changes.Tree.Config.Items[0]
+		folder := treeNodeWithLabel(changes.Children, "deep/nested")
+		if !changes.Expanded || folder == nil || !folder.Expanded {
+			t.Fatalf("menu %d did not expand Changes: changes=%v folder=%+v", index, changes.Expanded, folder)
+		}
+		h.assertNotContains("DETAIL SENTINEL")
+	}
 }

--- a/tests/e2e/tree_actions_menu_test.go
+++ b/tests/e2e/tree_actions_menu_test.go
@@ -1,0 +1,51 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestChangesAndExplorerThreeDotMenusExposeBulkActions(t *testing.T) {
+	h := newTestHarness(t, 100, 28)
+	defer h.stop()
+
+	h.exec("sidebar.changes")
+	h.app.ShowSidebarMoreMenu(4, 3)
+	h.redraw()
+	h.assertContains("Git Files")
+	h.pressKey(tcell.KeyDown, tcell.ModNone)
+	h.pressKey(tcell.KeyRight, tcell.ModNone)
+	h.assertContains("Expand All")
+	h.assertContains("Collapse All")
+	h.pressKey(tcell.KeyEscape, tcell.ModNone)
+
+	h.exec("sidebar.explorer")
+	h.app.ShowSidebarMoreMenu(4, 3)
+	h.redraw()
+	h.assertContains("Expand All")
+	h.assertContains("Collapse All")
+}
+
+func TestChangesRightClickAndThreeDotMenusHaveGitFileParity(t *testing.T) {
+	h := newTestHarness(t, 100, 28)
+	defer h.stop()
+	panel := h.app.BuildChangesPanelMenu()
+	context := h.app.BuildChangesContextMenu()
+	for _, command := range []string{"options.useGitFileTree", "options.useGitFileList", "changes.expandAll", "changes.collapseAll"} {
+		panelItem, panelOK := findMenuCommand(panel, command)
+		contextItem, contextOK := findMenuCommand(context, command)
+		if !panelOK || !contextOK || panelItem.Checked != contextItem.Checked {
+			t.Errorf("menu parity for %s: panel=%+v/%v context=%+v/%v", command, panelItem, panelOK, contextItem, contextOK)
+		}
+	}
+
+	h.exec("sidebar.changes")
+	h.app.ShowChangesContextMenu(5, 5)
+	h.redraw()
+	if _, ok := h.app.Root.Focused.(*ui.ContextMenuWidget); !ok {
+		t.Fatalf("right-click menu focus = %T", h.app.Root.Focused)
+	}
+	h.assertContains("Git Files")
+}

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -39,4 +39,34 @@ describe("commit history detail", () => {
     expect(snapshots[detail]).toContain("second-detail.txt");
     expect(snapshots[detail]).toContain("second old");
   });
+
+  it("uses shared Git bulk commands for commit-detail file groupings", () => {
+    dir = createGitRepo(createTempDir());
+    createTempFile(dir, "bulk-detail.txt", "visible detail line\n");
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "bulk detail");
+
+    tui.start(dir);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(500);
+    tui.press("tab");
+    tui.press("tab");
+    tui.press("down");
+    tui.press("enter");
+    tui.waitStable(900);
+    const expanded = tui.snapshot();
+    tui.exec("Git: Collapse All File Trees");
+    const collapsed = tui.snapshot();
+    tui.exec("Git: Expand All File Trees");
+    const restored = tui.snapshot();
+    tui.rclick(40, 12);
+    const context = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[expanded]).toContain("visible detail line");
+    expect(snapshots[collapsed]).not.toContain("visible detail line");
+    expect(snapshots[restored]).toContain("visible detail line");
+    expect(snapshots[context]).toContain("Expand All Files");
+    expect(snapshots[context]).toContain("Collapse All Files");
+  });
 });

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -79,15 +79,24 @@ describe("diff reading preferences", () => {
     tui.exec("Menu: Options");
     tui.waitStable();
     const options = tui.snapshot();
+    tui.press("down");
+    tui.press("down");
+    tui.press("right");
+    const diffViews = tui.snapshot();
+    tui.press("escape");
     enableUnifiedWrappedDefaults();
     tui.exec("Show Full File Diff by Default");
     tui.exec("Toggle High Contrast Diffs");
 
     const { snapshots } = tui.run();
-    expect(snapshots[options]).toContain("Diff View Mode");
-    expect(snapshots[options]).toContain("Diff Context");
-    expect(snapshots[options]).toContain("Wrap Diff Lines");
-    expect(snapshots[options]).toContain("High Contrast Diffs");
+    expect(snapshots[options]).toContain("Diff Views");
+    expect(snapshots[options]).toContain("Git Files");
+    expect(snapshots[diffViews]).toContain("Split");
+    expect(snapshots[diffViews]).toContain("Unified");
+    expect(snapshots[diffViews]).toContain("Changes Only");
+    expect(snapshots[diffViews]).toContain("Full File");
+    expect(snapshots[diffViews]).toContain("Wrap Lines");
+    expect(snapshots[diffViews]).toContain("High Contrast");
 
     const saved = savedSettings(fixture.configDir);
     expect(saved.editor.diffMode).toBe("unified");

--- a/tests/functional/git-changes.test.js
+++ b/tests/functional/git-changes.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as tui from "./tui.js";
-import { createTempDir, cleanupDir, createGitRepo, gitStatus, gitLog, readFile } from "./helpers.js";
+import { createTempDir, cleanupDir, createGitRepo, git, gitStatus, gitLog, readFile } from "./helpers.js";
 
 let dir;
 
@@ -20,6 +20,32 @@ function openChanges() {
 }
 
 describe("git changes panel", () => {
+  it("renders raw Unicode Git paths and stages the selected nested basename exactly", () => {
+    dir = createTempDir();
+    createGitRepo(dir);
+    writeFileSync(join(dir, "界-wide.txt"), "wide\n", "utf8");
+    git(dir, "add", "--", "界-wide.txt");
+    git(dir, "commit", "-qm", "wide path");
+    writeFileSync(join(dir, "界-wide.txt"), "changed\n", "utf8");
+    mkdirSync(join(dir, "新規", "深い"), { recursive: true });
+    writeFileSync(join(dir, "新規", "深い", "同名.go"), "package exact\n", "utf8");
+
+    tui.start(dir);
+    openChanges();
+    tui.exec("View Git Files as Tree");
+    const rendered = tui.snapshot();
+    tui.press("down");
+    tui.press("down");
+    tui.exec("Git: Stage File");
+    tui.waitStable();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[rendered]).toContain("界-wide.txt");
+    expect(snapshots[rendered]).toContain("新規/深い");
+    expect(snapshots[rendered]).toContain("同名.go");
+    expect(git(dir, "diff", "--cached", "--name-only", "-z")).toBe("新規/深い/同名.go\0");
+  });
+
   it("should stage every file in one action", () => {
     dir = createTempDir();
     createGitRepo(dir);

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createGitRepo, createTempDir, createTempFile, git } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+function nestedRepo() {
+  const repo = createGitRepo(createTempDir());
+  mkdirSync(join(repo, "pkg", "history"), { recursive: true });
+  createTempFile(repo, "pkg/history/committed.go", "package history\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-qm", "nested history");
+  mkdirSync(join(repo, "src", "work"), { recursive: true });
+  createTempFile(repo, "src/work/changed.go", "package work\n");
+  return repo;
+}
+
+describe("git file tree", () => {
+  it("defaults to lists and preserves working and history files across tree bulk controls", () => {
+    dir = nestedRepo();
+    tui.start(dir);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(500);
+    tui.press("tab");
+    tui.press("tab");
+    tui.press("down");
+    tui.press("right");
+    tui.waitStable(500);
+    const list = tui.snapshot();
+
+    tui.exec("View Git Files as Tree");
+    tui.waitStable();
+    const tree = tui.snapshot();
+    tui.exec("Git: Collapse All File Trees");
+    const collapsed = tui.snapshot();
+    tui.exec("Git: Expand All File Trees");
+    const expanded = tui.snapshot();
+
+    tui.rclick(5, 5);
+    tui.waitStable();
+    tui.press("down");
+    tui.press("right");
+    const context = tui.snapshot();
+    tui.press("escape");
+    tui.click(29, 2);
+    tui.waitStable();
+    tui.press("down");
+    tui.press("right");
+    const threeDot = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[list]).toContain("src/work/changed.go");
+    expect(snapshots[list]).toContain("pkg/history/committed.go");
+    expect(snapshots[tree]).toContain("src/work");
+    expect(snapshots[tree]).toContain("changed.go");
+    expect(snapshots[tree]).toContain("pkg/history");
+    expect(snapshots[tree]).not.toContain("src/work/changed.go");
+    expect(snapshots[collapsed]).not.toContain("changed.go");
+    expect(snapshots[expanded]).toContain("changed.go");
+    for (const menu of [snapshots[context], snapshots[threeDot]]) {
+      expect(menu).toContain("Git Files");
+      expect(menu).toContain("Tree");
+      expect(menu).toContain("List");
+      expect(menu).toContain("Expand All");
+      expect(menu).toContain("Collapse All");
+    }
+  });
+});

--- a/tests/functional/tree-actions.test.js
+++ b/tests/functional/tree-actions.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as tui from "./tui.js";
 import { cleanupDir, createGitRepo, createTempDir, createTempFile } from "./helpers.js";
@@ -12,24 +12,34 @@ afterEach(() => {
 });
 
 describe("tree actions", () => {
-  it("expands represented Explorer folders progressively and collapses them together", () => {
+  it("expands every visible Explorer descendant once and collapses them together", () => {
     dir = createGitRepo(createTempDir());
-    mkdirSync(join(dir, "src", "nested"), { recursive: true });
-    createTempFile(dir, "src/nested/file.txt", "hello\n");
+    for (const path of ["deep/one/two", "visible/inner", "visible/.hidden", "visible/.ignored"]) {
+      mkdirSync(join(dir, path), { recursive: true });
+    }
+    createTempFile(dir, "deep/one/two/deep.txt", "deep\n");
+    createTempFile(dir, "visible/inner/inner.txt", "inner\n");
+    createTempFile(dir, "visible/.hidden/hidden.txt", "hidden\n");
+    createTempFile(dir, "visible/.ignored/ignored.txt", "ignored\n");
+    writeFileSync(join(dir, ".gitignore"), "visible/.ignored/\n", "utf8");
 
     tui.start(dir);
+    tui.setSize(100, 50);
     tui.pressChord("ctrl+k", "e");
     tui.waitStable();
     tui.exec("Explorer: Collapse All");
     const collapsed = tui.snapshot();
     tui.exec("Explorer: Expand All");
-    const rootExpanded = tui.snapshot();
-    tui.exec("Explorer: Expand All");
-    const nestedExpanded = tui.snapshot();
+    const expanded = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(snapshots[collapsed]).not.toContain("src");
-    expect(snapshots[rootExpanded]).toContain("src");
-    expect(snapshots[nestedExpanded]).toContain("nested");
+    expect(snapshots[collapsed]).not.toContain("deep");
+    for (const label of ["one", "two", "deep.txt", "inner", "inner.txt", ".hidden", "hidden.txt", ".ignored", "ignored.txt"]) {
+      expect(snapshots[expanded]).toContain(label);
+    }
+    expect(snapshots[expanded]).toContain(".git");
+    expect(snapshots[expanded]).not.toContain("COMMIT_EDITMSG");
+    expect(snapshots[expanded]).not.toContain("objects");
+    expect(snapshots[expanded]).not.toContain("hooks");
   });
 });

--- a/tests/functional/tree-actions.test.js
+++ b/tests/functional/tree-actions.test.js
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createGitRepo, createTempDir, createTempFile } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("tree actions", () => {
+  it("expands represented Explorer folders progressively and collapses them together", () => {
+    dir = createGitRepo(createTempDir());
+    mkdirSync(join(dir, "src", "nested"), { recursive: true });
+    createTempFile(dir, "src/nested/file.txt", "hello\n");
+
+    tui.start(dir);
+    tui.pressChord("ctrl+k", "e");
+    tui.waitStable();
+    tui.exec("Explorer: Collapse All");
+    const collapsed = tui.snapshot();
+    tui.exec("Explorer: Expand All");
+    const rootExpanded = tui.snapshot();
+    tui.exec("Explorer: Expand All");
+    const nestedExpanded = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[collapsed]).not.toContain("src");
+    expect(snapshots[rootExpanded]).toContain("src");
+    expect(snapshots[nestedExpanded]).toContain("nested");
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> #486 is merged. This branch is rebased onto current `main` and is the active review layer. It also carries the independently verified post-merge CodeRabbit corrections from #486 before the focused Git-tree/menu commits. Later drafts remain cumulative and will narrow in dependency order.

## Summary

- organize staged, unstaged, and expanded historical files as collapsible directory trees while keeping the backward-compatible full-path List view as the default
- persist the Git file-view preference independently from sidebar panel order and other settings
- add Expand All and Collapse All to Changes, commit detail, and Explorer, with the same actions available from contextual right-click menus where appropriate
- group Git Files and Diff View choices into focused submenus in Options and the Changes-panel three-dot menu
- preserve typed Git file identities, selection, stage boundaries, hostile path text, and directory/file collisions instead of inferring identity from display labels or the host filesystem
- make bulk actions operate only on the intended tree and retain focus, expansion, and current-file behavior across rebuilds

This is the focused Git-tree, menu-consolidation, and bulk-control extraction from #474. Repository watching and Current Changes remain in later PRs.

## Verification

- make build
- focused config, app, UI, widget, E2E, and functional tree/menu coverage
- List-default and settings round-trip compatibility
- hostile Git paths, directory/file collisions, typed selection, staged/unstaged boundaries, and rebuilt-tree selection
- keyboard, mouse, right-click, submenu, and bulk expand/collapse interaction coverage
- full Go and functional suites on the final rebased head
- independent adversarial review and semantic range comparison
- gofmt and git diff --check

## Demo

<table>
  <tr>
    <td width="50%"><strong>Changed-file trees</strong><br><img alt="Staged and unstaged files organized as collapsible trees" src="https://github.com/user-attachments/assets/54245cab-2b96-4d7c-ad67-e643112bb063" /></td>
    <td width="50%"><strong>Grouped Changes controls</strong><br><img alt="Changes panel menu with grouped Git Files and Diff View submenus" src="https://github.com/user-attachments/assets/d95edd13-f88a-4428-bfcb-9fbdb8b50596" /></td>
  </tr>
  <tr>
    <td width="50%"><strong>Explorer bulk controls</strong><br><img alt="Explorer panel menu with expand all and collapse all" src="https://github.com/user-attachments/assets/2a639b77-8ff0-42e8-aeb3-b6908d31fbd6" /></td>
    <td width="50%"><strong>Changed-file context menu</strong><br><img alt="Changed-file right-click menu with file, bulk tree, and presentation actions" src="https://github.com/user-attachments/assets/f56c644f-3e66-43e4-bd73-4798eaf9a153" /></td>
  </tr>
</table>

Part of #474.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git files can now be displayed in List or Tree view, with the preference saved in settings.
  * Added Expand All and Collapse All actions for Explorer and Git file trees.
  * Added Git Files and Diff Views submenus to relevant menus and context menus.
* **Bug Fixes**
  * Improved handling of filenames with spaces, Unicode, renames, and nested paths.
  * Improved pointer interaction cancellation for trees, sidebars, scrolling, and popups.
  * Commit details remain usable when authored dates are unavailable.
* **Documentation**
  * Updated Git and settings documentation with the new controls and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->