### PR TITLE
feat(git): react to repository state changes

### DIFF
--- a/docs-web/src/content/docs/guides/git.md
+++ b/docs-web/src/content/docs/guides/git.md
@@ -5,6 +5,8 @@ description: Source control features built into TTT.
 
 The changes panel in the sidebar (**Ctrl+K C**) provides a full staging workflow.
 
+TTT refreshes repository status after editor and source-control mutations. While the Changes panel is visible, it also polls the working tree and `HEAD`, so changes made by external tools appear without a manual refresh. Status-only polls reload commit history when `HEAD` changes; a manual refresh forces both.
+
 ## Staging & Unstaging
 
 - **Spacebar** toggles stage/unstage on the selected file

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,6 +72,7 @@ type App struct {
 	Explorer               *NavigationPanel
 	ExplorerContextNode    *widgets.TreeNode
 	Changes                *ChangesPanel
+	Repository             *RepositoryState
 	Symbols                *SymbolsPanel
 	Reg                    *command.Registry
 	Running                *bool
@@ -151,6 +152,7 @@ func (a *App) ShowSidebar() {
 		a.SplitPanel.DividerPos = ui.DefaultSidebarWidth
 	}
 	a.applySearchHighlights()
+	a.syncRepositoryObservation()
 }
 
 func (a *App) HideSidebar() {
@@ -158,6 +160,7 @@ func (a *App) HideSidebar() {
 	a.Sidebar.Visible = false
 	a.SplitPanel.ShowLeft = false
 	a.EditorGroup.ClearSearch()
+	a.syncRepositoryObservation()
 }
 
 func (a *App) applySearchHighlights() {
@@ -334,7 +337,11 @@ func (a *App) refreshWorkspaceWidgets() {
 	a.Explorer.SetRoots(paths)
 
 	a.Search.SetWorkDirs(paths)
-	a.Changes.SetDirs(paths)
+	if a.Repository != nil {
+		a.Repository.SetDirs(paths)
+	} else {
+		a.Changes.SetDirs(paths)
+	}
 }
 
 func (a *App) refreshProblems() {
@@ -444,7 +451,11 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		a.Changes.OnRefreshed = func() {
 			a.Sidebar.SetPanelDirty("changes", a.Changes.TotalChanges() > 0)
 		}
-		a.Changes.Refresh()
+	}
+	if a.Repository != nil {
+		a.Repository.SetPoster(screen)
+		a.Repository.Start()
+		a.syncRepositoryObservation()
 	}
 
 	a.EditorGroup.OnError = func(msg string) {

--- a/internal/app/app_lsp.go
+++ b/internal/app/app_lsp.go
@@ -534,11 +534,9 @@ func (a *App) ApplyWorkspaceEdit(edit *lsp.WorkspaceEdit) {
 		a.ApplyTextEdits(edits)
 
 		if a.Settings.LSP.SaveOnRename {
-			a.EditorGroup.Save()
-			if a.EditorGroup.Editor != nil && a.EditorGroup.Editor.Highlighter != nil {
-				lang := a.EditorGroup.Editor.Highlighter.Language()
-				text := strings.Join(a.EditorGroup.Editor.Buf.Lines, "\n")
-				a.NotifyLSPSave(path, lang, text)
+			if a.EditorGroup.Save() {
+				_, lang := a.editorPathLang()
+				a.afterFileSave(path, lang)
 			}
 		}
 	}

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -203,6 +203,7 @@ func (a *App) ApplySearchReplace(filePath string, matches []ui.SearchMatch, repl
 		a.StatusWarn("Cannot write file: " + err.Error())
 		return
 	}
+	a.invalidateRepositoryPath(filePath, RepositoryWorktree)
 	a.EditorGroup.ReloadFile(filePath)
 	a.Search.Refresh()
 	a.StatusNotify(fmt.Sprintf("Replaced %d matches in %s", len(matches), filepath.Base(filePath)))
@@ -232,6 +233,7 @@ func (a *App) ApplySearchReplaceAll(allMatches map[string][]ui.SearchMatch, repl
 				if err := os.WriteFile(filePath, []byte(strings.Join(newLines, "\n")+"\n"), 0644); err != nil {
 					continue
 				}
+				a.invalidateRepositoryPath(filePath, RepositoryWorktree)
 				a.EditorGroup.ReloadFile(filePath)
 			}
 			a.Search.Refresh()
@@ -487,9 +489,7 @@ func registerWidgetCallbacks(app *App) {
 		} else {
 			app.EditorGroup.ClearSearch()
 		}
-		if id == "changes" {
-			app.Changes.Refresh()
-		}
+		app.syncRepositoryObservation()
 		if id == "outline" {
 			app.RefreshSymbols()
 		}
@@ -637,6 +637,21 @@ func registerWidgetCallbacks(app *App) {
 	app.Changes.OnCommit = app.CommitChanges
 	app.Changes.OnConfirmDiscard = app.ConfirmDiscard
 	app.Changes.OnError = app.StatusError
+	app.Changes.OnRefresh = func() {
+		if app.Repository != nil {
+			app.Repository.RefreshNow(RepositoryWorktree | RepositoryHistory)
+		} else {
+			app.Changes.Refresh()
+		}
+	}
+	app.Changes.OnStatusChanged = func() {
+		app.invalidateAllRepositories(RepositoryWorktree)
+	}
+	app.Changes.OnHistoryResult = func(err error) {
+		if app.Repository != nil {
+			app.Repository.HandleHistory(err)
+		}
+	}
 
 	app.ContentSplit.OnResize = func(height int) {
 		if height <= 0 {

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -47,13 +47,12 @@ type commitDetailRequest struct {
 
 // CommitLogResult carries a finished read of one repository's recent commits.
 type CommitLogResult struct {
-	Gen         int
-	Dir         string
-	Branch      string
-	Entries     []git.LogEntry
-	Err         error
-	Unavailable bool
-	Canceled    bool
+	Gen      int
+	Dir      string
+	Branch   string
+	Entries  []git.LogEntry
+	Err      error
+	Canceled bool
 }
 
 // CommitFilesResult carries the file list of a single commit back to the node
@@ -119,12 +118,6 @@ func readChangesGroups(dirs []string) []changesGroup {
 }
 
 func readCommitLog(ctx context.Context, dir string, gen int) *CommitLogResult {
-	if !git.IsRepoContext(ctx, dir) {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return &CommitLogResult{Gen: gen, Dir: dir, Err: ctxErr, Canceled: errors.Is(ctxErr, context.Canceled)}
-		}
-		return &CommitLogResult{Gen: gen, Dir: dir, Unavailable: true}
-	}
 	entries, err := git.LogWithErrorContext(ctx, dir, commitLogLimit)
 	if errors.Is(err, context.Canceled) {
 		return &CommitLogResult{Gen: gen, Dir: dir, Canceled: true}

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -47,12 +47,13 @@ type commitDetailRequest struct {
 
 // CommitLogResult carries a finished read of one repository's recent commits.
 type CommitLogResult struct {
-	Gen      int
-	Dir      string
-	Branch   string
-	Entries  []git.LogEntry
-	Err      error
-	Canceled bool
+	Gen         int
+	Dir         string
+	Branch      string
+	Entries     []git.LogEntry
+	Err         error
+	Unavailable bool
+	Canceled    bool
 }
 
 // CommitFilesResult carries the file list of a single commit back to the node
@@ -118,6 +119,12 @@ func readChangesGroups(dirs []string) []changesGroup {
 }
 
 func readCommitLog(ctx context.Context, dir string, gen int) *CommitLogResult {
+	if !git.IsRepoContext(ctx, dir) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return &CommitLogResult{Gen: gen, Dir: dir, Err: ctxErr, Canceled: errors.Is(ctxErr, context.Canceled)}
+		}
+		return &CommitLogResult{Gen: gen, Dir: dir, Unavailable: true}
+	}
 	entries, err := git.LogWithErrorContext(ctx, dir, commitLogLimit)
 	if errors.Is(err, context.Canceled) {
 		return &CommitLogResult{Gen: gen, Dir: dir, Canceled: true}

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -132,9 +132,12 @@ func readCommitLog(ctx context.Context, dir string, gen int) *CommitLogResult {
 	if err != nil {
 		return &CommitLogResult{Gen: gen, Dir: dir, Err: err}
 	}
-	branch := git.BranchNameContext(ctx, dir)
+	branch, branchErr := git.BranchNameContext(ctx, dir)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return &CommitLogResult{Gen: gen, Dir: dir, Err: ctxErr, Canceled: errors.Is(ctxErr, context.Canceled)}
+	}
+	if branchErr != nil {
+		return &CommitLogResult{Gen: gen, Dir: dir, Err: branchErr}
 	}
 	return &CommitLogResult{
 		Gen:     gen,
@@ -163,6 +166,9 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 		cp.logCommits = make(map[string]commitFileRef)
 		cp.logFiles = make(map[string]commitFileRef)
 		cp.CommitLog.SetItems(nil)
+		if cp.OnHistoryResult != nil {
+			cp.OnHistoryResult(nil)
+		}
 		return
 	}
 	if r.Err != nil {
@@ -172,6 +178,9 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 		}
 		if cp.OnError != nil {
 			cp.OnError("Could not refresh commit history: " + r.Err.Error())
+		}
+		if cp.OnHistoryResult != nil {
+			cp.OnHistoryResult(r.Err)
 		}
 		return
 	}
@@ -225,6 +234,9 @@ func (cp *ChangesPanel) ApplyCommitLog(r *CommitLogResult) {
 		nodes = append(nodes, &widgets.TreeNode{ID: "history:empty", Label: "No commits", Muted: true})
 	}
 	cp.CommitLog.SetItems(nodes)
+	if cp.OnHistoryResult != nil {
+		cp.OnHistoryResult(nil)
+	}
 
 	// Restore by identity, never by the index SetItems happened to preserve.
 	// Committing prepends rows, and rewriting history can remove them entirely;

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -78,6 +78,9 @@ type ChangesPanel struct {
 	OnConfirmDiscard func(message string, onConfirm func())
 	OnError          func(message string)
 	OnRefreshed      func()
+	OnRefresh        func()
+	OnStatusChanged  func()
+	OnHistoryResult  func(error)
 
 	PRGroups []prGroup
 }
@@ -269,7 +272,11 @@ func (cp *ChangesPanel) applied(err error) {
 	if err != nil && cp.OnError != nil {
 		cp.OnError(err.Error())
 	}
-	cp.Refresh()
+	if cp.OnStatusChanged != nil {
+		cp.OnStatusChanged()
+	} else {
+		cp.Refresh()
+	}
 }
 
 // paths splits a file list into the untracked ones, which are deleted outright,
@@ -296,12 +303,16 @@ func filePaths(files []git.FileStatus) []string {
 func (cp *ChangesPanel) Refresh() {
 	cp.cancelHistoryReads()
 	dirs := append([]string(nil), cp.Dirs...)
-	cp.saveExpanded()
-	cp.groups = readChangesGroups(dirs)
-	cp.multiRoot = len(cp.groups)+len(cp.PRGroups) > 1
-	cp.buildTree()
+	cp.applyWorkingTree(readChangesGroups(dirs))
 	cp.lastLogDir = ""
 	cp.refreshCommitLog()
+}
+
+func (cp *ChangesPanel) applyWorkingTree(groups []changesGroup) {
+	cp.saveExpanded()
+	cp.groups = groups
+	cp.multiRoot = len(cp.groups)+len(cp.PRGroups) > 1
+	cp.buildTree()
 	if cp.OnRefreshed != nil {
 		cp.OnRefreshed()
 	}
@@ -372,6 +383,16 @@ func (cp *ChangesPanel) cancelCommitFileReads() {
 func (cp *ChangesPanel) cancelHistoryReads() {
 	cp.cancelLogRead()
 	cp.cancelCommitFileReads()
+}
+
+func (cp *ChangesPanel) RefreshHistory() {
+	cp.lastLogDir = ""
+	cp.refreshCommitLog()
+}
+
+func (cp *ChangesPanel) CancelHistoryRead() {
+	cp.cancelHistoryReads()
+	cp.logGen++
 }
 
 func (cp *ChangesPanel) Shutdown() {
@@ -550,7 +571,11 @@ func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.Tre
 	}
 	switch term.KeyRune(ev) {
 	case 'r', 'R':
-		cp.Refresh()
+		if cp.OnRefresh != nil {
+			cp.OnRefresh()
+		} else {
+			cp.Refresh()
+		}
 		return true
 	case 'c', 'o', 'v':
 		cp.openCommitLogNode(node)
@@ -853,6 +878,8 @@ func (cp *ChangesPanel) handleKey(ev *tcell.EventKey) bool {
 	case 'r', 'R':
 		if inPR {
 			cp.refreshSelectedPR()
+		} else if cp.OnRefresh != nil {
+			cp.OnRefresh()
 		} else {
 			cp.Refresh()
 		}

--- a/internal/app/commands_debug.go
+++ b/internal/app/commands_debug.go
@@ -167,30 +167,41 @@ func (a *App) debugRunPlugin() {
 
 func (a *App) debugScreenshot() {
 	a.DismissDialog()
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		path := "screenshot.txt"
-		if err := a.DumpScreenshot(path); err != nil {
-			a.Status.SetNotification("Screenshot error: "+err.Error(), view.NotifyError, 3*time.Second)
-		} else {
-			a.Status.SetNotification("Screenshot saved: "+path, view.NotifyInfo, 3*time.Second)
-		}
-		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	}()
+	time.AfterFunc(50*time.Millisecond, func() {
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&DebugWriteRequest{Kind: "screenshot", Path: "screenshot.txt"}))
+	})
 }
 
 func (a *App) debugDumpState() {
 	a.DismissDialog()
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		path := "debug-state.json"
-		if err := a.DumpDebugState(path); err != nil {
+	time.AfterFunc(50*time.Millisecond, func() {
+		a.Screen.PostEvent(tcell.NewEventInterrupt(&DebugWriteRequest{Kind: "state", Path: "debug-state.json"}))
+	})
+}
+
+type DebugWriteRequest struct {
+	Kind string
+	Path string
+}
+
+func (a *App) HandleDebugWriteRequest(request *DebugWriteRequest) {
+	if request == nil {
+		return
+	}
+	switch request.Kind {
+	case "screenshot":
+		if err := a.DumpScreenshot(request.Path); err != nil {
+			a.Status.SetNotification("Screenshot error: "+err.Error(), view.NotifyError, 3*time.Second)
+		} else {
+			a.Status.SetNotification("Screenshot saved: "+request.Path, view.NotifyInfo, 3*time.Second)
+		}
+	case "state":
+		if err := a.DumpDebugState(request.Path); err != nil {
 			a.Status.SetNotification("Dump error: "+err.Error(), view.NotifyError, 3*time.Second)
 		} else {
-			a.Status.SetNotification("State saved: "+path, view.NotifyInfo, 3*time.Second)
+			a.Status.SetNotification("State saved: "+request.Path, view.NotifyInfo, 3*time.Second)
 		}
-		a.Screen.PostEvent(tcell.NewEventInterrupt(nil))
-	}()
+	}
 }
 
 func (a *App) debugKeyboardTester() {

--- a/internal/app/commands_editor.go
+++ b/internal/app/commands_editor.go
@@ -153,8 +153,9 @@ func (a *App) SaveFileAs() {
 		initial = current
 	}
 	a.ShowInputDialog("Save As", "Filename", initial, func(path string) {
-		if path != "" {
-			a.EditorGroup.SaveAs(path)
+		if path != "" && a.EditorGroup.SaveAs(path) {
+			path, lang := a.editorPathLang()
+			a.afterFileSave(path, lang)
 		}
 	})
 }
@@ -191,6 +192,10 @@ func (a *App) doSaveFile() {
 		return
 	}
 	path, lang = a.editorPathLang()
+	a.afterFileSave(path, lang)
+}
+
+func (a *App) afterFileSave(path, lang string) {
 	if lang != "" {
 		text := strings.Join(a.EditorGroup.Editor.Buf.Lines, "\n")
 		a.NotifyLSPSave(path, lang, text)
@@ -200,6 +205,7 @@ func (a *App) doSaveFile() {
 	if a.PluginManager != nil && path != "" {
 		a.PluginManager.DispatchEvent("file.save", path)
 	}
+	a.invalidateRepositoryPath(path, RepositoryWorktree)
 }
 
 func (a *App) forceQuit() {

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -131,6 +131,7 @@ func (a *App) SaveWorkspace() {
 			a.StatusError("Error: " + err.Error())
 		} else {
 			a.Workspace.FilePath = abs
+			a.invalidateRepositoryPath(abs, RepositoryWorktree)
 			a.StatusNotify("Workspace saved: " + abs)
 		}
 	})
@@ -246,7 +247,11 @@ func registerGitCommands(app *App) {
 		ID: "changes.refresh", Title: "Git: Refresh Changes",
 		Keywords: []string{"git", "changes", "reload"},
 		Handler: func() {
-			app.Changes.Refresh()
+			if app.Repository != nil {
+				app.Repository.RefreshNow(RepositoryWorktree | RepositoryHistory)
+			} else {
+				app.Changes.Refresh()
+			}
 		},
 	})
 

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -483,7 +483,17 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 		fsRoots = append(fsRoots, p.Dir)
 	}
 	p.Filesystem = NewPluginFilesystemAPI(fsRoots...)
+	if fs, ok := p.Filesystem.(*PluginFilesystemAPI); ok {
+		fs.onWrite = func(path string) {
+			a.postRepositoryInvalidation(path, RepositoryWorktree)
+		}
+	}
 	p.System = NewPluginSystemAPI()
+	if system, ok := p.System.(*PluginSystemAPI); ok {
+		system.onExec = func() {
+			a.postRepositoryInvalidation("", RepositoryWorktree|RepositoryHistory)
+		}
+	}
 	p.Network = NewPluginNetworkAPI()
 	a.wirePluginLog(p)
 	p.Markdown = a.Settings.Markdown

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -314,7 +314,6 @@ func registerViewCommands(app *App) {
 		ID: "sidebar.changes", Title: "Show Changes",
 		Keywords: []string{"view", "git", "diff", "source control"},
 		Handler: func() {
-			app.Changes.Refresh()
 			app.ShowPanel("changes", app.Changes.Adapter)
 		},
 	})

--- a/internal/app/commit_history_layer_test.go
+++ b/internal/app/commit_history_layer_test.go
@@ -20,6 +20,14 @@ func TestReadCommitLogAllowsOnlyVerifiedUnbornEmptyHistory(t *testing.T) {
 	}
 }
 
+func TestReadCommitLogMarksNonRepositoryUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	result := readCommitLog(context.Background(), dir, 7)
+	if result.Gen != 7 || result.Dir != dir || !result.Unavailable || result.Err != nil || result.Canceled {
+		t.Fatalf("non-repository history result = %+v, want unavailable", result)
+	}
+}
+
 func TestCommitLogRestoresSelectionByFullHashAfterAsyncRebuild(t *testing.T) {
 	cp := NewChangesPanel()
 	dir := "/repo"

--- a/internal/app/commit_history_layer_test.go
+++ b/internal/app/commit_history_layer_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -9,6 +10,15 @@ import (
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/ui"
 )
+
+func TestReadCommitLogAllowsOnlyVerifiedUnbornEmptyHistory(t *testing.T) {
+	dir := t.TempDir()
+	testAppGit(t, dir, "init", "-q", "-b", "main")
+	result := readCommitLog(context.Background(), dir, 1)
+	if result.Err != nil || result.Canceled || result.Branch != "main" || len(result.Entries) != 0 {
+		t.Fatalf("unborn history result = %+v, want empty successful main history", result)
+	}
+}
 
 func TestCommitLogRestoresSelectionByFullHashAfterAsyncRebuild(t *testing.T) {
 	cp := NewChangesPanel()

--- a/internal/app/debug_dump.go
+++ b/internal/app/debug_dump.go
@@ -472,9 +472,17 @@ func (a *App) DumpDebugState(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return err
+	}
+	a.postRepositoryInvalidation(path, RepositoryWorktree)
+	return nil
 }
 
 func (a *App) DumpScreenshot(path string) error {
-	return os.WriteFile(path, []byte(a.Screenshot()), 0644)
+	if err := os.WriteFile(path, []byte(a.Screenshot()), 0644); err != nil {
+		return err
+	}
+	a.postRepositoryInvalidation(path, RepositoryWorktree)
+	return nil
 }

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -33,6 +33,9 @@ func RunEventLoop(
 	if app.Watcher != nil {
 		defer app.Watcher.Close()
 	}
+	if app.Repository != nil {
+		defer app.Repository.Close()
+	}
 
 	lastBlameLine := -1
 	lastBlameFile := ""
@@ -378,6 +381,16 @@ func RunEventLoop(
 				app.SyncLanguageSegment()
 			case *RepoOpResult:
 				app.HandleRepoOpResult(v)
+			case *RepositoryStatusResult:
+				app.Repository.HandleStatus(v)
+			case *RepositoryInvalidationRequest:
+				app.handleRepositoryInvalidation(v)
+			case *DebugWriteRequest:
+				app.HandleDebugWriteRequest(v)
+			case *repositoryDebounceTick:
+				app.Repository.HandleDebounce(v)
+			case *repositoryPollTick:
+				app.Repository.HandlePoll(v)
 			case *CommitLogResult:
 				app.Changes.ApplyCommitLog(v)
 			case *CommitFilesResult:

--- a/internal/app/fileops.go
+++ b/internal/app/fileops.go
@@ -32,6 +32,7 @@ func (a *App) FileOpNewFile(path string, reload func()) {
 			a.StatusError("Error: " + err.Error())
 			return
 		}
+		a.invalidateRepositoryPath(newPath, RepositoryWorktree)
 		reload()
 		a.EditorGroup.OpenFile(newPath)
 		a.FocusEditor()
@@ -77,6 +78,8 @@ func (a *App) FileOpRename(path string, reload func()) {
 			a.StatusError("Error: " + err.Error())
 			return
 		}
+		a.invalidateRepositoryPath(path, RepositoryWorktree)
+		a.invalidateRepositoryPath(newPath, RepositoryWorktree)
 		a.EditorGroup.RenamePath(path, newPath)
 		reload()
 	})
@@ -97,6 +100,7 @@ func (a *App) FileOpDelete(path string, reload func()) {
 					a.StatusError("Error: " + err.Error())
 					return
 				}
+				a.invalidateRepositoryPath(path, RepositoryWorktree)
 				reload()
 			},
 		},

--- a/internal/app/plugin_api.go
+++ b/internal/app/plugin_api.go
@@ -318,6 +318,7 @@ func (e *PluginEditorAPI) ClearSearch() {
 // PluginFilesystemAPI implements plugin.FilesystemAPI with path restrictions.
 type PluginFilesystemAPI struct {
 	allowedRoots []string
+	onWrite      func(path string)
 }
 
 func NewPluginFilesystemAPI(allowedRoots ...string) *PluginFilesystemAPI {
@@ -364,7 +365,13 @@ func (f *PluginFilesystemAPI) WriteFile(path, content string) error {
 	if err := f.validatePath(path); err != nil {
 		return err
 	}
-	return os.WriteFile(path, []byte(content), 0644)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return err
+	}
+	if f.onWrite != nil {
+		f.onWrite(path)
+	}
+	return nil
 }
 
 func (f *PluginFilesystemAPI) FileExists(path string) bool {
@@ -391,7 +398,9 @@ func (f *PluginFilesystemAPI) ListDir(path string) ([]plugin.FileEntry, error) {
 }
 
 // PluginSystemAPI implements plugin.SystemAPI.
-type PluginSystemAPI struct{}
+type PluginSystemAPI struct {
+	onExec func()
+}
 
 func NewPluginSystemAPI() *PluginSystemAPI {
 	return &PluginSystemAPI{}
@@ -437,6 +446,9 @@ func (s *PluginSystemAPI) Exec(binary string, args []string, stdin string) (stri
 		cmd.Stdin = strings.NewReader(stdin)
 	}
 	err := cmd.Run()
+	if s.onExec != nil {
+		s.onExec()
+	}
 	exitCode := 0
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/internal/app/plugin_api_test.go
+++ b/internal/app/plugin_api_test.go
@@ -6,8 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/gdamore/tcell/v3"
 )
 
 func TestContextMenuItemFromWidgetEntryPreservesMenuContract(t *testing.T) {
@@ -320,6 +322,8 @@ func TestPluginSystemAPI_ExecStdin(t *testing.T) {
 		t.Skip("cat not available")
 	}
 	api := NewPluginSystemAPI()
+	execCount := 0
+	api.onExec = func() { execCount++ }
 
 	stdout, _, code, err := api.Exec("cat", nil, "hello from stdin\n")
 	if err != nil || code != 0 {
@@ -337,5 +341,52 @@ func TestPluginSystemAPI_ExecStdin(t *testing.T) {
 	}
 	if stdout != "" {
 		t.Errorf("expected empty stdout, got %q", stdout)
+	}
+	if execCount != 2 {
+		t.Fatalf("system command completions invalidated repository %d times, want 2", execCount)
+	}
+}
+
+func TestPluginSystemExecCompletionPostsMainThreadRepositoryRequest(t *testing.T) {
+	if _, err := exec.LookPath("true"); err != nil {
+		t.Skip("true not available")
+	}
+	sim := term.NewSimScreen()
+	if err := sim.Init(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sim.Fini)
+	screen := term.NewTcellScreenFrom(sim)
+	repository := NewRepositoryState(nil, []string{"/repo"})
+	repository.poster = newTestEventPoster()
+	a := &App{Screen: screen, Repository: repository}
+	api := NewPluginSystemAPI()
+	api.onExec = func() {
+		a.postRepositoryInvalidation("", RepositoryWorktree|RepositoryHistory)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, _, err := api.Exec("true", nil, "")
+		done <- err
+	}()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if repository.dirty != 0 {
+		t.Fatal("system.exec completion mutated coordinator state off the event loop")
+	}
+	event := screen.PollEvent()
+	interrupt, ok := event.(*tcell.EventInterrupt)
+	if !ok {
+		t.Fatalf("completion event = %T, want interrupt", event)
+	}
+	request, ok := interrupt.Data().(*RepositoryInvalidationRequest)
+	if !ok {
+		t.Fatalf("interrupt data = %T, want repository invalidation", interrupt.Data())
+	}
+	a.handleRepositoryInvalidation(request)
+	if repository.dirty != RepositoryWorktree|RepositoryHistory {
+		t.Fatalf("main-thread invalidation resources = %b", repository.dirty)
 	}
 }

--- a/internal/app/repo_ops.go
+++ b/internal/app/repo_ops.go
@@ -79,6 +79,7 @@ func (a *App) RunRepoTask(task RepoTask) {
 func (a *App) HandleRepoOpResult(r *RepoOpResult) {
 	a.runningRepoOp = ""
 	a.setRepoOpSegment("")
+	a.invalidateAllRepositories(repositoryResourcesForTask(r.Task))
 
 	if r.Err != nil {
 		a.StatusError(fmt.Sprintf("%s failed: %v", r.Task.Progress, r.Err))
@@ -88,7 +89,16 @@ func (a *App) HandleRepoOpResult(r *RepoOpResult) {
 		r.Task.OnDone()
 	}
 	a.StatusNotify(r.Task.Done)
-	a.Changes.Refresh()
+}
+
+func repositoryResourcesForTask(task RepoTask) RepositoryResource {
+	resources := RepositoryWorktree
+	for _, op := range task.Ops {
+		if op.Name == "commit" || op.Name == "pull" {
+			resources |= RepositoryHistory
+		}
+	}
+	return resources
 }
 
 func (a *App) setRepoOpSegment(text string) {

--- a/internal/app/repo_ops_test.go
+++ b/internal/app/repo_ops_test.go
@@ -1,0 +1,23 @@
+package app
+
+import "testing"
+
+func TestRepositoryResourcesForRepoTask(t *testing.T) {
+	tests := []struct {
+		name string
+		ops  []RepoOp
+		want RepositoryResource
+	}{
+		{name: "push", ops: []RepoOp{OpPush}, want: RepositoryWorktree},
+		{name: "commit", ops: []RepoOp{OpCommit("message")}, want: RepositoryWorktree | RepositoryHistory},
+		{name: "pull", ops: []RepoOp{OpPull}, want: RepositoryWorktree | RepositoryHistory},
+		{name: "sync", ops: []RepoOp{OpPull, OpPush}, want: RepositoryWorktree | RepositoryHistory},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := repositoryResourcesForTask(RepoTask{Ops: test.ops}); got != test.want {
+				t.Fatalf("resources = %b, want %b", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -1,0 +1,509 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/gdamore/tcell/v3"
+)
+
+type RepositoryResource uint8
+
+const (
+	RepositoryWorktree RepositoryResource = 1 << iota
+	RepositoryHistory
+
+	RepositoryStatus = RepositoryWorktree
+
+	repositoryRefreshDebounce = 150 * time.Millisecond
+	repositoryPollInterval    = 2 * time.Second
+	repositoryStatusTimeout   = 10 * time.Second
+)
+
+type repositoryStatusEntry struct {
+	Group       changesGroup
+	Revision    string
+	StatusErr   error
+	RevisionErr error
+}
+
+type RepositoryStatusResult struct {
+	Seq     uint64
+	Entries []repositoryStatusEntry
+}
+
+type RepositoryInvalidationRequest struct {
+	Path      string
+	Resources RepositoryResource
+}
+
+type repositoryDebounceTick struct{ Gen uint64 }
+type repositoryPollTick struct{ Gen uint64 }
+
+type repositoryTimer interface {
+	Stop() bool
+}
+
+type repositoryScheduler interface {
+	AfterFunc(time.Duration, func()) repositoryTimer
+}
+
+type realRepositoryScheduler struct{}
+
+func (realRepositoryScheduler) AfterFunc(d time.Duration, f func()) repositoryTimer {
+	return time.AfterFunc(d, f)
+}
+
+type RepositoryState struct {
+	changes *ChangesPanel
+	dirs    []string
+	poster  eventPoster
+
+	scheduler    repositoryScheduler
+	readStatus   func(context.Context, []string, uint64) *RepositoryStatusResult
+	debounceWait time.Duration
+	pollWait     time.Duration
+	statusWait   time.Duration
+
+	started bool
+	closed  bool
+	visible bool
+	dirty   RepositoryResource
+
+	requested    uint64
+	inFlight     bool
+	refreshAgain bool
+	statusCancel context.CancelFunc
+
+	debounceTimer repositoryTimer
+	debounceGen   uint64
+	pollTimer     repositoryTimer
+	pollGen       uint64
+
+	lastGroups    map[string]changesGroup
+	lastRevisions map[string]string
+}
+
+func NewRepositoryState(changes *ChangesPanel, dirs []string) *RepositoryState {
+	return &RepositoryState{
+		changes:       changes,
+		dirs:          append([]string(nil), dirs...),
+		scheduler:     realRepositoryScheduler{},
+		readStatus:    readRepositoryStatus,
+		debounceWait:  repositoryRefreshDebounce,
+		pollWait:      repositoryPollInterval,
+		statusWait:    repositoryStatusTimeout,
+		lastGroups:    make(map[string]changesGroup),
+		lastRevisions: make(map[string]string),
+	}
+}
+
+func (s *RepositoryState) SetPoster(poster eventPoster) {
+	if s == nil || s.closed {
+		return
+	}
+	s.poster = poster
+}
+
+func (s *RepositoryState) Start() {
+	if s == nil || s.started || s.closed {
+		return
+	}
+	s.started = true
+	s.dirty |= RepositoryHistory
+	s.RefreshNow(RepositoryWorktree)
+}
+
+func (s *RepositoryState) SetDirs(dirs []string) {
+	if s == nil || s.closed {
+		return
+	}
+	s.dirs = append([]string(nil), dirs...)
+	if s.changes != nil {
+		s.changes.Dirs = append([]string(nil), dirs...)
+		s.changes.multiRoot = len(dirs) > 1
+		s.changes.CancelHistoryRead()
+		s.changes.applyWorkingTree(nil)
+		s.changes.RefreshHistory()
+	}
+	s.lastGroups = make(map[string]changesGroup)
+	s.lastRevisions = make(map[string]string)
+	s.dirty |= RepositoryWorktree | RepositoryHistory
+	s.stopDebounce()
+	s.stopPoll()
+	s.requested++
+	if s.inFlight {
+		s.refreshAgain = true
+		if s.statusCancel != nil {
+			s.statusCancel()
+		}
+	} else if s.started {
+		s.startStatus()
+	}
+}
+
+func (s *RepositoryState) SetVisible(visible bool) {
+	if s == nil || s.closed || s.visible == visible {
+		return
+	}
+	s.visible = visible
+	if !visible {
+		s.stopPoll()
+		return
+	}
+	if s.dirty&RepositoryHistory != 0 {
+		s.refreshHistory()
+	}
+	if s.dirty&RepositoryWorktree != 0 {
+		s.RefreshNow(RepositoryWorktree)
+		return
+	}
+	s.armPoll()
+}
+
+func (s *RepositoryState) InvalidateAll(resources RepositoryResource) {
+	if s == nil || s.closed || resources == 0 {
+		return
+	}
+	s.dirty |= resources
+	if resources&RepositoryHistory != 0 && s.visible {
+		s.refreshHistory()
+	}
+	if resources&RepositoryWorktree == 0 {
+		return
+	}
+	s.requested++
+	if s.inFlight {
+		s.refreshAgain = true
+	}
+	if s.poster == nil {
+		if !s.inFlight {
+			s.startStatus()
+		}
+		return
+	}
+	s.scheduleDebounce()
+}
+
+func (s *RepositoryState) InvalidatePath(path string, resources RepositoryResource) {
+	if s == nil || s.closed || path == "" || resources == 0 {
+		return
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return
+	}
+	abs = filepath.Clean(abs)
+	for _, dir := range s.dirs {
+		root, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(filepath.Clean(root), abs)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			s.InvalidateAll(resources)
+			return
+		}
+	}
+}
+
+func (s *RepositoryState) RefreshNow(resources RepositoryResource) {
+	if s == nil || s.closed || resources == 0 {
+		return
+	}
+	s.dirty |= resources
+	if resources&RepositoryHistory != 0 && s.visible {
+		s.refreshHistory()
+	}
+	if resources&RepositoryWorktree == 0 {
+		return
+	}
+	s.requested++
+	s.stopDebounce()
+	if s.inFlight {
+		s.refreshAgain = true
+		return
+	}
+	s.startStatus()
+}
+
+func (s *RepositoryState) startStatus() {
+	if s.closed || s.inFlight {
+		return
+	}
+	s.inFlight = true
+	s.refreshAgain = false
+	seq := s.requested
+	dirs := append([]string(nil), s.dirs...)
+	read := s.readStatus
+	ctx, cancel := context.WithTimeout(context.Background(), s.statusWait)
+	s.statusCancel = cancel
+	if s.poster == nil {
+		result := read(ctx, dirs, seq)
+		cancel()
+		s.HandleStatus(result)
+		return
+	}
+	poster := s.poster
+	go func() {
+		result := read(ctx, dirs, seq)
+		cancel()
+		_ = poster.PostEvent(tcell.NewEventInterrupt(result))
+	}()
+}
+
+func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
+	if s == nil || result == nil || s.closed {
+		return
+	}
+	s.inFlight = false
+	s.statusCancel = nil
+	if result.Seq != s.requested {
+		s.stopDebounce()
+		if s.refreshAgain && s.dirty&RepositoryWorktree != 0 {
+			s.startStatus()
+		}
+		return
+	}
+
+	selectedDir := ""
+	if s.changes != nil {
+		selectedDir = s.changes.selectedGroupDir()
+		if selectedDir == "" && len(result.Entries) > 0 {
+			selectedDir = result.Entries[0].Group.Dir
+		}
+	}
+
+	groups := make([]changesGroup, 0, len(result.Entries))
+	nextGroups := make(map[string]changesGroup, len(result.Entries))
+	nextRevisions := make(map[string]string, len(result.Entries))
+	revisionChanged := false
+	hadError := false
+	for _, entry := range result.Entries {
+		group := entry.Group
+		if entry.StatusErr != nil {
+			hadError = true
+			if previous, ok := s.lastGroups[group.Dir]; ok {
+				group = previous
+			}
+		}
+		groups = append(groups, group)
+		nextGroups[group.Dir] = group
+
+		revision := entry.Revision
+		if entry.RevisionErr != nil {
+			hadError = true
+			revision = s.lastRevisions[group.Dir]
+		}
+		if previous, ok := s.lastRevisions[group.Dir]; ok && group.Dir == selectedDir && previous != revision {
+			revisionChanged = true
+		}
+		nextRevisions[group.Dir] = revision
+	}
+	s.lastGroups = nextGroups
+	s.lastRevisions = nextRevisions
+
+	if s.changes != nil {
+		s.changes.applyWorkingTree(groups)
+	}
+	if !hadError {
+		s.dirty &^= RepositoryWorktree
+	}
+	if revisionChanged {
+		s.dirty |= RepositoryHistory
+	}
+	if s.visible {
+		if s.dirty&RepositoryHistory != 0 {
+			s.refreshHistory()
+		} else if s.changes != nil {
+			s.changes.refreshCommitLog()
+		}
+		s.armPoll()
+	}
+}
+
+func (s *RepositoryState) refreshHistory() {
+	if s.changes != nil {
+		s.changes.RefreshHistory()
+	}
+}
+
+func (s *RepositoryState) HandleHistory(err error) {
+	if s == nil || s.closed {
+		return
+	}
+	if err != nil {
+		s.dirty |= RepositoryHistory
+		return
+	}
+	s.dirty &^= RepositoryHistory
+}
+
+func (s *RepositoryState) scheduleDebounce() {
+	if s.poster == nil || s.closed {
+		return
+	}
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+	}
+	s.debounceGen++
+	gen := s.debounceGen
+	poster := s.poster
+	s.debounceTimer = s.scheduler.AfterFunc(s.debounceWait, func() {
+		_ = poster.PostEvent(tcell.NewEventInterrupt(&repositoryDebounceTick{Gen: gen}))
+	})
+}
+
+func (s *RepositoryState) HandleDebounce(tick *repositoryDebounceTick) {
+	if s == nil || tick == nil || s.closed || tick.Gen != s.debounceGen {
+		return
+	}
+	s.debounceTimer = nil
+	if !s.inFlight && s.dirty&RepositoryWorktree != 0 {
+		s.startStatus()
+	}
+}
+
+func (s *RepositoryState) armPoll() {
+	if s.poster == nil || s.closed || !s.visible || s.pollTimer != nil {
+		return
+	}
+	s.pollGen++
+	gen := s.pollGen
+	poster := s.poster
+	s.pollTimer = s.scheduler.AfterFunc(s.pollWait, func() {
+		_ = poster.PostEvent(tcell.NewEventInterrupt(&repositoryPollTick{Gen: gen}))
+	})
+}
+
+func (s *RepositoryState) HandlePoll(tick *repositoryPollTick) {
+	if s == nil || tick == nil || s.closed || tick.Gen != s.pollGen || !s.visible {
+		return
+	}
+	s.pollTimer = nil
+	s.RefreshNow(RepositoryWorktree)
+}
+
+func (s *RepositoryState) stopDebounce() {
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+		s.debounceTimer = nil
+	}
+	s.debounceGen++
+}
+
+func (s *RepositoryState) stopPoll() {
+	if s.pollTimer != nil {
+		s.pollTimer.Stop()
+		s.pollTimer = nil
+	}
+	s.pollGen++
+}
+
+func (s *RepositoryState) Close() {
+	if s == nil || s.closed {
+		return
+	}
+	s.closed = true
+	s.stopDebounce()
+	s.stopPoll()
+	s.requested++
+	if s.statusCancel != nil {
+		s.statusCancel()
+		s.statusCancel = nil
+	}
+	if s.changes != nil {
+		s.changes.CancelHistoryRead()
+	}
+}
+
+func readRepositoryStatus(ctx context.Context, dirs []string, seq uint64) *RepositoryStatusResult {
+	return &RepositoryStatusResult{Seq: seq, Entries: scanRepositoryStatus(ctx, dirs)}
+}
+
+func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatusEntry {
+	entries := make([]repositoryStatusEntry, 0, len(dirs))
+	seen := make(map[string]bool)
+	for _, dir := range dirs {
+		if root := git.RepoRootContext(ctx, dir); root != "" {
+			dir = root
+		}
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		files, statusErr := git.StatusFilesContext(ctx, dir)
+		var staged, unstaged []git.FileStatus
+		if statusErr == nil {
+			for _, file := range files {
+				if file.Staged {
+					staged = append(staged, file)
+				} else {
+					unstaged = append(unstaged, file)
+				}
+			}
+		}
+		revision, revisionErr := git.RevisionIdentityContext(ctx, dir)
+		entries = append(entries, repositoryStatusEntry{
+			Group: changesGroup{
+				Dir:      dir,
+				Name:     filepath.Base(dir),
+				Staged:   staged,
+				Unstaged: unstaged,
+			},
+			Revision:    revision,
+			StatusErr:   statusErr,
+			RevisionErr: revisionErr,
+		})
+	}
+	return entries
+}
+
+func (a *App) syncRepositoryObservation() {
+	if a == nil || a.Repository == nil || a.Sidebar == nil || a.SplitPanel == nil {
+		return
+	}
+	visible := a.Sidebar.Visible && a.SplitPanel.ShowLeft && a.Sidebar.ActivePanel == "changes"
+	a.Repository.SetVisible(visible)
+}
+
+func (a *App) invalidateRepositoryPath(path string, resources RepositoryResource) {
+	if a != nil && a.Repository != nil {
+		a.Repository.InvalidatePath(path, resources)
+	}
+}
+
+func (a *App) invalidateAllRepositories(resources RepositoryResource) {
+	if a != nil && a.Repository != nil {
+		a.Repository.InvalidateAll(resources)
+	}
+}
+
+func (a *App) postRepositoryInvalidation(path string, resources RepositoryResource) {
+	if a == nil || resources == 0 {
+		return
+	}
+	if a.Screen == nil {
+		if path == "" {
+			a.invalidateAllRepositories(resources)
+		} else {
+			a.invalidateRepositoryPath(path, resources)
+		}
+		return
+	}
+	a.Screen.PostEvent(tcell.NewEventInterrupt(&RepositoryInvalidationRequest{Path: path, Resources: resources}))
+}
+
+func (a *App) handleRepositoryInvalidation(request *RepositoryInvalidationRequest) {
+	if request == nil {
+		return
+	}
+	if request.Path == "" {
+		a.invalidateAllRepositories(request.Resources)
+		return
+	}
+	a.invalidateRepositoryPath(request.Path, request.Resources)
+}

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -68,6 +68,7 @@ type RepositoryState struct {
 
 	scheduler    repositoryScheduler
 	readStatus   func(context.Context, []string, uint64) *RepositoryStatusResult
+	pathIdentity func(string) (string, error)
 	debounceWait time.Duration
 	pollWait     time.Duration
 	statusWait   time.Duration
@@ -199,7 +200,7 @@ func (s *RepositoryState) InvalidatePath(path string, resources RepositoryResour
 	if s == nil || s.closed || path == "" || resources == 0 {
 		return
 	}
-	identity, err := resolveRepositoryPathIdentity(path)
+	identity, err := s.resolvePathIdentity(path)
 	if err != nil {
 		return
 	}
@@ -508,7 +509,7 @@ func (s *RepositoryState) repositoryIdentityRoots() []string {
 	roots := make([]string, 0, len(s.lastGroups)+len(s.dirs))
 	seen := make(map[string]bool)
 	add := func(path string) {
-		identity, err := resolveRepositoryPathIdentity(path)
+		identity, err := s.resolvePathIdentity(path)
 		if err != nil || identity == "" || seen[identity] {
 			return
 		}
@@ -527,67 +528,59 @@ func (s *RepositoryState) repositoryIdentityRoots() []string {
 	return roots
 }
 
+func (s *RepositoryState) resolvePathIdentity(path string) (string, error) {
+	if s.pathIdentity != nil {
+		return s.pathIdentity(path)
+	}
+	return resolveRepositoryPathIdentity(path)
+}
+
 func resolveRepositoryPathIdentity(path string) (string, error) {
+	return resolveRepositoryPathIdentityWith(path, os.Lstat, filepath.EvalSymlinks)
+}
+
+func resolveRepositoryPathIdentityWith(
+	path string,
+	lstat func(string) (os.FileInfo, error),
+	evalSymlinks func(string) (string, error),
+) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
 	abs = filepath.Clean(abs)
-	resolved, resolveErr := stableSymlinkIdentity(abs)
+	resolved, resolveErr := stableSymlinkIdentityWith(abs, evalSymlinks)
 	if resolveErr == nil {
 		return resolved, nil
 	}
-	if _, lstatErr := os.Lstat(abs); lstatErr == nil {
+	if _, lstatErr := lstat(abs); lstatErr == nil {
 		return "", resolveErr
-	} else if errors.Is(lstatErr, os.ErrPermission) {
-		return resolveRepositoryPathFromAccessibleAncestor(abs)
-	} else if !errors.Is(lstatErr, os.ErrNotExist) {
-		return "", resolveErr
-	}
-	parent := filepath.Dir(abs)
-	resolvedParent, parentErr := stableSymlinkIdentity(parent)
-	if parentErr != nil {
-		return "", resolveErr
-	}
-	if _, lstatErr := os.Lstat(abs); lstatErr == nil {
-		return stableSymlinkIdentity(abs)
 	} else if !errors.Is(lstatErr, os.ErrNotExist) {
 		return "", lstatErr
 	}
-	confirmedParent, err := stableSymlinkIdentity(parent)
+	parent := filepath.Dir(abs)
+	resolvedParent, parentErr := stableSymlinkIdentityWith(parent, evalSymlinks)
+	if parentErr != nil {
+		return "", resolveErr
+	}
+	if _, lstatErr := lstat(abs); lstatErr == nil {
+		return stableSymlinkIdentityWith(abs, evalSymlinks)
+	} else if !errors.Is(lstatErr, os.ErrNotExist) {
+		return "", lstatErr
+	}
+	confirmedParent, err := stableSymlinkIdentityWith(parent, evalSymlinks)
 	if err != nil || confirmedParent != resolvedParent {
 		return "", errors.New("repository path parent changed while resolving")
 	}
 	return filepath.Join(resolvedParent, filepath.Base(abs)), nil
 }
 
-func resolveRepositoryPathFromAccessibleAncestor(path string) (string, error) {
-	current := path
-	remaining := make([]string, 0, 4)
-	for {
-		parent := filepath.Dir(current)
-		if parent == current {
-			return "", os.ErrPermission
-		}
-		remaining = append(remaining, filepath.Base(current))
-		current = parent
-		resolved, err := stableSymlinkIdentity(current)
-		if err != nil {
-			continue
-		}
-		for i := len(remaining) - 1; i >= 0; i-- {
-			resolved = filepath.Join(resolved, remaining[i])
-		}
-		return filepath.Clean(resolved), nil
-	}
-}
-
-func stableSymlinkIdentity(path string) (string, error) {
-	first, err := filepath.EvalSymlinks(path)
+func stableSymlinkIdentityWith(path string, evalSymlinks func(string) (string, error)) (string, error) {
+	first, err := evalSymlinks(path)
 	if err != nil {
 		return "", err
 	}
-	second, err := filepath.EvalSymlinks(path)
+	second, err := evalSymlinks(path)
 	if err != nil {
 		return "", err
 	}

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -279,6 +281,7 @@ func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
 	groups := make([]changesGroup, 0, len(result.Entries))
 	nextGroups := make(map[string]changesGroup, len(result.Entries))
 	nextRevisions := make(map[string]string, len(result.Entries))
+	seenGroups := make(map[string]bool, len(result.Entries))
 	revisionChanged := false
 	hadError := false
 	for _, entry := range result.Entries {
@@ -303,14 +306,18 @@ func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
 				group = previous
 			}
 		}
-		groups = append(groups, group)
-		nextGroups[group.Dir] = group
 
 		revision := entry.Revision
 		if entry.RevisionErr != nil {
 			hadError = true
 			revision = s.lastRevisions[group.Dir]
 		}
+		if seenGroups[group.Dir] {
+			continue
+		}
+		seenGroups[group.Dir] = true
+		groups = append(groups, group)
+		nextGroups[group.Dir] = group
 		if previous, ok := s.lastRevisions[group.Dir]; ok && group.Dir == selectedDir && previous != revision {
 			revisionChanged = true
 		}
@@ -525,23 +532,71 @@ func resolveRepositoryPathIdentity(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	current := filepath.Clean(abs)
+	abs = filepath.Clean(abs)
+	resolved, resolveErr := stableSymlinkIdentity(abs)
+	if resolveErr == nil {
+		return resolved, nil
+	}
+	if _, lstatErr := os.Lstat(abs); lstatErr == nil {
+		return "", resolveErr
+	} else if errors.Is(lstatErr, os.ErrPermission) {
+		return resolveRepositoryPathFromAccessibleAncestor(abs)
+	} else if !errors.Is(lstatErr, os.ErrNotExist) {
+		return "", resolveErr
+	}
+	parent := filepath.Dir(abs)
+	resolvedParent, parentErr := stableSymlinkIdentity(parent)
+	if parentErr != nil {
+		return "", resolveErr
+	}
+	if _, lstatErr := os.Lstat(abs); lstatErr == nil {
+		return stableSymlinkIdentity(abs)
+	} else if !errors.Is(lstatErr, os.ErrNotExist) {
+		return "", lstatErr
+	}
+	confirmedParent, err := stableSymlinkIdentity(parent)
+	if err != nil || confirmedParent != resolvedParent {
+		return "", errors.New("repository path parent changed while resolving")
+	}
+	return filepath.Join(resolvedParent, filepath.Base(abs)), nil
+}
+
+func resolveRepositoryPathFromAccessibleAncestor(path string) (string, error) {
+	current := path
 	remaining := make([]string, 0, 4)
 	for {
-		resolved, resolveErr := filepath.EvalSymlinks(current)
-		if resolveErr == nil {
-			for i := len(remaining) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, remaining[i])
-			}
-			return filepath.Clean(resolved), nil
-		}
 		parent := filepath.Dir(current)
 		if parent == current {
-			return "", resolveErr
+			return "", os.ErrPermission
 		}
 		remaining = append(remaining, filepath.Base(current))
 		current = parent
+		resolved, err := stableSymlinkIdentity(current)
+		if err != nil {
+			continue
+		}
+		for i := len(remaining) - 1; i >= 0; i-- {
+			resolved = filepath.Join(resolved, remaining[i])
+		}
+		return filepath.Clean(resolved), nil
 	}
+}
+
+func stableSymlinkIdentity(path string) (string, error) {
+	first, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	second, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	first = filepath.Clean(first)
+	second = filepath.Clean(second)
+	if first != second {
+		return "", errors.New("repository path changed while resolving")
+	}
+	return first, nil
 }
 
 func cleanAbsolutePath(path string) string {

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -24,8 +24,10 @@ const (
 )
 
 type repositoryStatusEntry struct {
+	SourceDir   string
 	Group       changesGroup
 	Revision    string
+	RootErr     error
 	StatusErr   error
 	RevisionErr error
 }
@@ -85,6 +87,7 @@ type RepositoryState struct {
 
 	lastGroups    map[string]changesGroup
 	lastRevisions map[string]string
+	lastRoots     map[string]string
 }
 
 func NewRepositoryState(changes *ChangesPanel, dirs []string) *RepositoryState {
@@ -98,6 +101,7 @@ func NewRepositoryState(changes *ChangesPanel, dirs []string) *RepositoryState {
 		statusWait:    repositoryStatusTimeout,
 		lastGroups:    make(map[string]changesGroup),
 		lastRevisions: make(map[string]string),
+		lastRoots:     make(map[string]string),
 	}
 }
 
@@ -131,6 +135,7 @@ func (s *RepositoryState) SetDirs(dirs []string) {
 	}
 	s.lastGroups = make(map[string]changesGroup)
 	s.lastRevisions = make(map[string]string)
+	s.lastRoots = make(map[string]string)
 	s.dirty |= RepositoryWorktree | RepositoryHistory
 	s.stopDebounce()
 	s.stopPoll()
@@ -192,18 +197,12 @@ func (s *RepositoryState) InvalidatePath(path string, resources RepositoryResour
 	if s == nil || s.closed || path == "" || resources == 0 {
 		return
 	}
-	abs, err := filepath.Abs(path)
+	identity, err := resolveRepositoryPathIdentity(path)
 	if err != nil {
 		return
 	}
-	abs = filepath.Clean(abs)
-	for _, dir := range s.dirs {
-		root, err := filepath.Abs(dir)
-		if err != nil {
-			continue
-		}
-		rel, err := filepath.Rel(filepath.Clean(root), abs)
-		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	for _, root := range s.repositoryIdentityRoots() {
+		if pathWithin(root, identity) {
 			s.InvalidateAll(resources)
 			return
 		}
@@ -284,6 +283,20 @@ func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
 	hadError := false
 	for _, entry := range result.Entries {
 		group := entry.Group
+		sourceDir := cleanAbsolutePath(entry.SourceDir)
+		if sourceDir == "" {
+			sourceDir = cleanAbsolutePath(group.Dir)
+		}
+		if entry.RootErr != nil {
+			hadError = true
+			if previousRoot := s.previousRootForSource(sourceDir); previousRoot != "" {
+				group.Dir = previousRoot
+				group.Name = filepath.Base(previousRoot)
+			}
+		}
+		if sourceDir != "" && entry.RootErr == nil {
+			s.lastRoots[sourceDir] = group.Dir
+		}
 		if entry.StatusErr != nil {
 			hadError = true
 			if previous, ok := s.lastGroups[group.Dir]; ok {
@@ -428,9 +441,12 @@ func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatus
 	entries := make([]repositoryStatusEntry, 0, len(dirs))
 	seen := make(map[string]bool)
 	for _, dir := range dirs {
-		if root := git.RepoRootContext(ctx, dir); root != "" {
+		sourceDir := cleanAbsolutePath(dir)
+		root, rootErr := git.RepoRootWithErrorContext(ctx, dir)
+		if rootErr == nil && root != "" {
 			dir = root
 		}
+		dir = cleanAbsolutePath(dir)
 		if seen[dir] {
 			continue
 		}
@@ -448,6 +464,7 @@ func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatus
 		}
 		revision, revisionErr := git.RevisionIdentityContext(ctx, dir)
 		entries = append(entries, repositoryStatusEntry{
+			SourceDir: sourceDir,
 			Group: changesGroup{
 				Dir:      dir,
 				Name:     filepath.Base(dir),
@@ -455,11 +472,97 @@ func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatus
 				Unstaged: unstaged,
 			},
 			Revision:    revision,
+			RootErr:     rootErr,
 			StatusErr:   statusErr,
 			RevisionErr: revisionErr,
 		})
 	}
 	return entries
+}
+
+func (s *RepositoryState) previousRootForSource(source string) string {
+	if root := s.lastRoots[source]; root != "" {
+		return root
+	}
+	resolved, err := resolveRepositoryPathIdentity(source)
+	if err != nil {
+		resolved = source
+	}
+	best := ""
+	for root := range s.lastGroups {
+		if pathWithin(root, resolved) && len(root) > len(best) {
+			best = root
+		}
+	}
+	return best
+}
+
+func (s *RepositoryState) repositoryIdentityRoots() []string {
+	roots := make([]string, 0, len(s.lastGroups)+len(s.dirs))
+	seen := make(map[string]bool)
+	add := func(path string) {
+		identity, err := resolveRepositoryPathIdentity(path)
+		if err != nil || identity == "" || seen[identity] {
+			return
+		}
+		seen[identity] = true
+		roots = append(roots, identity)
+	}
+	for root := range s.lastGroups {
+		add(root)
+	}
+	for _, root := range s.lastRoots {
+		add(root)
+	}
+	for _, dir := range s.dirs {
+		add(dir)
+	}
+	return roots
+}
+
+func resolveRepositoryPathIdentity(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	current := filepath.Clean(abs)
+	remaining := make([]string, 0, 4)
+	for {
+		resolved, resolveErr := filepath.EvalSymlinks(current)
+		if resolveErr == nil {
+			for i := len(remaining) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, remaining[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", resolveErr
+		}
+		remaining = append(remaining, filepath.Base(current))
+		current = parent
+	}
+}
+
+func cleanAbsolutePath(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	return filepath.Clean(abs)
+}
+
+func pathWithin(root, path string) bool {
+	root = cleanAbsolutePath(root)
+	path = cleanAbsolutePath(path)
+	if root == "" || path == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (a *App) syncRepositoryObservation() {

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -257,6 +257,209 @@ func TestRepositoryStatusFailurePreservesLastGoodAndRetries(t *testing.T) {
 	}
 }
 
+func TestRepositoryRootFailurePreservesCanonicalMultiRootOrderAndRecovers(t *testing.T) {
+	rootA := filepath.Join(t.TempDir(), "repo-a")
+	rootB := filepath.Join(t.TempDir(), "repo-b")
+	sourceA := filepath.Join(rootA, "workspace")
+	sourceB := filepath.Join(rootB, "workspace")
+	goodA := changesGroup{Dir: rootA, Name: "repo-a", Unstaged: []git.FileStatus{{Status: "M", Path: "kept-a.txt"}}}
+	goodB := changesGroup{Dir: rootB, Name: "repo-b", Unstaged: []git.FileStatus{{Status: "M", Path: "kept-b.txt"}}}
+	cp := NewChangesPanel(sourceB, sourceA)
+	s := NewRepositoryState(cp, []string{sourceB, sourceA})
+
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	s.HandleStatus(&RepositoryStatusResult{Seq: 1, Entries: []repositoryStatusEntry{
+		{SourceDir: sourceB, Group: goodB, Revision: "head-b"},
+		{SourceDir: sourceA, Group: goodA, Revision: "head-a"},
+	}})
+
+	s.requested = 2
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	s.HandleStatus(&RepositoryStatusResult{Seq: 2, Entries: []repositoryStatusEntry{
+		{SourceDir: sourceB, Group: changesGroup{Dir: sourceB, Name: "workspace"}, RootErr: errors.New("temporary root failure"), StatusErr: errors.New("temporary status failure"), RevisionErr: errors.New("temporary revision failure")},
+		{SourceDir: sourceA, Group: changesGroup{Dir: sourceA, Name: "workspace"}, RootErr: errors.New("temporary root failure"), StatusErr: errors.New("temporary status failure"), RevisionErr: errors.New("temporary revision failure")},
+	}})
+	if len(cp.groups) != 2 || cp.groups[0].Dir != rootB || cp.groups[1].Dir != rootA {
+		t.Fatalf("root failure changed canonical ordering: %+v", cp.groups)
+	}
+	if cp.groups[0].Unstaged[0].Path != "kept-b.txt" || cp.groups[1].Unstaged[0].Path != "kept-a.txt" {
+		t.Fatalf("root failure replaced last-good groups: %+v", cp.groups)
+	}
+	if s.dirty&RepositoryWorktree == 0 {
+		t.Fatal("root failure was marked fresh")
+	}
+
+	freshA := changesGroup{Dir: rootA, Name: "repo-a", Unstaged: []git.FileStatus{{Status: "M", Path: "fresh-a.txt"}}}
+	freshB := changesGroup{Dir: rootB, Name: "repo-b", Unstaged: []git.FileStatus{{Status: "M", Path: "fresh-b.txt"}}}
+	s.requested = 3
+	s.inFlight = true
+	s.HandleStatus(&RepositoryStatusResult{Seq: 3, Entries: []repositoryStatusEntry{
+		{SourceDir: sourceB, Group: freshB, Revision: "head-b"},
+		{SourceDir: sourceA, Group: freshA, Revision: "head-a"},
+	}})
+	if len(cp.groups) != 2 || cp.groups[0].Dir != rootB || cp.groups[0].Unstaged[0].Path != "fresh-b.txt" || cp.groups[1].Dir != rootA || cp.groups[1].Unstaged[0].Path != "fresh-a.txt" {
+		t.Fatalf("successful retry did not recover canonical groups: %+v", cp.groups)
+	}
+	if s.dirty&RepositoryWorktree != 0 {
+		t.Fatal("successful retry did not mark working tree fresh")
+	}
+}
+
+func TestRepositoryScanCarriesSourceIdentityAndRootFailure(t *testing.T) {
+	bin := t.TempDir()
+	script := "#!/bin/sh\nexit 91\n"
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+":"+os.Getenv("PATH"))
+	source := filepath.Join(t.TempDir(), "repo", "workspace")
+
+	entries := scanRepositoryStatus(context.Background(), []string{source})
+	if len(entries) != 1 {
+		t.Fatalf("scan entries = %d, want 1", len(entries))
+	}
+	entry := entries[0]
+	if entry.SourceDir != source || entry.Group.Dir != source || entry.RootErr == nil || entry.StatusErr == nil || entry.RevisionErr == nil {
+		t.Fatalf("failed root scan lost source/error identity: %+v", entry)
+	}
+}
+
+func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePositives(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	external := t.TempDir()
+	alias := filepath.Join(outside, "repo-alias")
+	if err := os.Symlink(repo, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	existing := filepath.Join(repo, "existing.txt")
+	if err := os.WriteFile(existing, []byte("existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		path func(t *testing.T) string
+		want bool
+	}{
+		{
+			name: "existing target through outside alias",
+			path: func(t *testing.T) string { return filepath.Join(alias, "existing.txt") },
+			want: true,
+		},
+		{
+			name: "new target through outside alias",
+			path: func(t *testing.T) string { return filepath.Join(alias, "new.txt") },
+			want: true,
+		},
+		{
+			name: "newly created target through outside alias",
+			path: func(t *testing.T) string {
+				path := filepath.Join(alias, "created.txt")
+				if err := os.WriteFile(path, []byte("created\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			want: true,
+		},
+		{
+			name: "chain of symlinked parents",
+			path: func(t *testing.T) string {
+				chain := filepath.Join(outside, "chain")
+				if err := os.Symlink(alias, chain); err != nil {
+					t.Fatal(err)
+				}
+				return filepath.Join(chain, "new.txt")
+			},
+			want: true,
+		},
+		{
+			name: "permission failure below resolved repository alias",
+			path: func(t *testing.T) string {
+				restricted := filepath.Join(repo, "restricted")
+				if err := os.Mkdir(restricted, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(restricted, 0); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(restricted, 0o700) })
+				return filepath.Join(alias, "restricted", "new.txt")
+			},
+			want: true,
+		},
+		{
+			name: "external target through in-repository symlink",
+			path: func(t *testing.T) string {
+				link := filepath.Join(repo, "external")
+				if err := os.Symlink(external, link); err != nil {
+					t.Fatal(err)
+				}
+				return filepath.Join(link, "new.txt")
+			},
+			want: false,
+		},
+		{
+			name: "broken outside symlink",
+			path: func(t *testing.T) string {
+				link := filepath.Join(outside, "broken")
+				if err := os.Symlink(filepath.Join(outside, "missing"), link); err != nil {
+					t.Fatal(err)
+				}
+				return filepath.Join(link, "new.txt")
+			},
+			want: false,
+		},
+		{
+			name: "permission failure outside repository",
+			path: func(t *testing.T) string {
+				denied := filepath.Join(outside, "denied")
+				if err := os.Mkdir(denied, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(repo, filepath.Join(denied, "hidden-alias")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(denied, 0); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(denied, 0o700) })
+				return filepath.Join(denied, "hidden-alias", "new.txt")
+			},
+			want: false,
+		},
+		{
+			name: "outside symlink loop",
+			path: func(t *testing.T) string {
+				first := filepath.Join(outside, "loop-a")
+				second := filepath.Join(outside, "loop-b")
+				if err := os.Symlink(second, first); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(first, second); err != nil {
+					t.Fatal(err)
+				}
+				return filepath.Join(first, "new.txt")
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, _, _ := testRepositoryState(nil, repo)
+			s.InvalidatePath(test.path(t), RepositoryWorktree)
+			if got := s.requested == 1 && s.dirty&RepositoryWorktree != 0; got != test.want {
+				t.Fatalf("invalidated = %v, want %v (requested=%d dirty=%b)", got, test.want, s.requested, s.dirty)
+			}
+		})
+	}
+}
+
 func TestRepositoryUnchangedHeadDoesNotReloadHistoryChangedHeadDoes(t *testing.T) {
 	dir := testAppRepository(t)
 	cp := NewChangesPanel(dir)

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -1,0 +1,501 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/eugenioenko/ttt/internal/widgets"
+	"github.com/eugenioenko/ttt/internal/workspace"
+	"github.com/gdamore/tcell/v3"
+)
+
+type testEventPoster struct {
+	events chan tcell.Event
+}
+
+func newTestEventPoster() *testEventPoster {
+	return &testEventPoster{events: make(chan tcell.Event, 32)}
+}
+
+func (p *testEventPoster) PostEvent(event tcell.Event) error {
+	p.events <- event
+	return nil
+}
+
+func (p *testEventPoster) await(t *testing.T) any {
+	t.Helper()
+	select {
+	case event := <-p.events:
+		interrupt, ok := event.(*tcell.EventInterrupt)
+		if !ok {
+			t.Fatalf("event type = %T, want interrupt", event)
+		}
+		return interrupt.Data()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for repository event")
+		return nil
+	}
+}
+
+type fakeRepositoryTimer struct {
+	fn      func()
+	stopped bool
+}
+
+func (t *fakeRepositoryTimer) Stop() bool {
+	wasActive := !t.stopped
+	t.stopped = true
+	return wasActive
+}
+
+func (t *fakeRepositoryTimer) fire() {
+	if !t.stopped {
+		t.fn()
+	}
+}
+
+func (t *fakeRepositoryTimer) fireLate() { t.fn() }
+
+type fakeRepositoryScheduler struct {
+	timers []*fakeRepositoryTimer
+}
+
+func (s *fakeRepositoryScheduler) AfterFunc(_ time.Duration, fn func()) repositoryTimer {
+	timer := &fakeRepositoryTimer{fn: fn}
+	s.timers = append(s.timers, timer)
+	return timer
+}
+
+func (s *fakeRepositoryScheduler) latest(t *testing.T) *fakeRepositoryTimer {
+	t.Helper()
+	if len(s.timers) == 0 {
+		t.Fatal("no repository timer was scheduled")
+	}
+	return s.timers[len(s.timers)-1]
+}
+
+func repositoryResult(seq uint64, dir, revision string, files ...git.FileStatus) *RepositoryStatusResult {
+	group := changesGroup{Dir: dir, Name: filepath.Base(dir)}
+	for _, file := range files {
+		if file.Staged {
+			group.Staged = append(group.Staged, file)
+		} else {
+			group.Unstaged = append(group.Unstaged, file)
+		}
+	}
+	return &RepositoryStatusResult{Seq: seq, Entries: []repositoryStatusEntry{{Group: group, Revision: revision}}}
+}
+
+func testRepositoryState(changes *ChangesPanel, dir string) (*RepositoryState, *fakeRepositoryScheduler, *testEventPoster) {
+	s := NewRepositoryState(changes, []string{dir})
+	scheduler := &fakeRepositoryScheduler{}
+	poster := newTestEventPoster()
+	s.scheduler = scheduler
+	s.poster = poster
+	s.started = true
+	return s, scheduler, poster
+}
+
+func TestRepositoryInvalidationBurstCoalesces(t *testing.T) {
+	s, scheduler, poster := testRepositoryState(nil, "/repo")
+	var reads atomic.Int32
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		reads.Add(1)
+		return repositoryResult(seq, "/repo", "head")
+	}
+
+	s.InvalidateAll(RepositoryWorktree)
+	s.InvalidateAll(RepositoryWorktree)
+	s.InvalidateAll(RepositoryWorktree)
+	if len(scheduler.timers) != 3 {
+		t.Fatalf("scheduled timers = %d, want 3 trailing-edge generations", len(scheduler.timers))
+	}
+	for _, timer := range scheduler.timers[:2] {
+		if !timer.stopped {
+			t.Fatal("superseded debounce timer remained active")
+		}
+	}
+
+	scheduler.latest(t).fire()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	if got := reads.Load(); got != 1 {
+		t.Fatalf("status reads = %d, want 1", got)
+	}
+}
+
+func TestRepositoryInFlightInvalidationPublishesOnlyOneFollowUp(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	publications := 0
+	cp.OnRefreshed = func() { publications++ }
+	s, scheduler, poster := testRepositoryState(cp, "/repo")
+	started := make(chan uint64, 2)
+	release := make(chan struct{}, 2)
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		started <- seq
+		<-release
+		path := "fresh.txt"
+		if seq == 1 {
+			path = "stale.txt"
+		}
+		return repositoryResult(seq, "/repo", "head", git.FileStatus{Status: "M", Path: path})
+	}
+
+	s.InvalidateAll(RepositoryWorktree)
+	scheduler.latest(t).fire()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	first := <-started
+
+	s.InvalidateAll(RepositoryWorktree)
+	s.InvalidateAll(RepositoryWorktree)
+	scheduler.latest(t).fire()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	select {
+	case seq := <-started:
+		t.Fatalf("overlapping status read %d started while %d was in flight", seq, first)
+	default:
+	}
+
+	release <- struct{}{}
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	if publications != 0 || cp.TotalChanges() != 0 {
+		t.Fatal("stale in-flight result published working-tree state")
+	}
+	second := <-started
+	if second != s.requested || second == first {
+		t.Fatalf("follow-up seq = %d, first = %d, requested = %d", second, first, s.requested)
+	}
+	release <- struct{}{}
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	if publications != 1 || cp.TotalChanges() != 1 || cp.groups[0].Unstaged[0].Path != "fresh.txt" {
+		t.Fatalf("follow-up publish = %d, groups = %+v", publications, cp.groups)
+	}
+}
+
+func TestRepositoryVisibilityPollRearmAndGenerationLifecycle(t *testing.T) {
+	s, scheduler, poster := testRepositoryState(nil, "/repo")
+	s.dirty = RepositoryWorktree
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		return repositoryResult(seq, "/repo", "head")
+	}
+
+	s.SetVisible(true)
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	firstPoll := scheduler.latest(t)
+	if firstPoll.stopped || s.pollTimer == nil {
+		t.Fatal("visible repository did not arm polling")
+	}
+	s.SetVisible(false)
+	if !firstPoll.stopped || s.pollTimer != nil {
+		t.Fatal("hiding Changes did not invalidate its queued poll")
+	}
+	firstPoll.fireLate()
+	s.HandlePoll(poster.await(t).(*repositoryPollTick))
+	if s.inFlight {
+		t.Fatal("late hidden poll started a status read")
+	}
+
+	s.SetVisible(true)
+	secondPoll := scheduler.latest(t)
+	if secondPoll == firstPoll || secondPoll.stopped {
+		t.Fatal("re-entering visible state did not rearm polling")
+	}
+	s.Close()
+	secondPoll.fireLate()
+	s.HandlePoll(poster.await(t).(*repositoryPollTick))
+	if s.inFlight || !secondPoll.stopped {
+		t.Fatal("late poll survived repository close")
+	}
+}
+
+func TestHiddenRepositoryMutationStillRefreshesWorkingTree(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	s, scheduler, poster := testRepositoryState(cp, "/repo")
+	s.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		return repositoryResult(seq, "/repo", "head", git.FileStatus{Status: "M", Path: "hidden.txt"})
+	}
+
+	s.InvalidateAll(RepositoryWorktree)
+	scheduler.latest(t).fire()
+	s.HandleDebounce(poster.await(t).(*repositoryDebounceTick))
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	if s.visible || s.pollTimer != nil {
+		t.Fatal("hidden invalidation enabled visible polling")
+	}
+	if cp.TotalChanges() != 1 || cp.groups[0].Unstaged[0].Path != "hidden.txt" {
+		t.Fatalf("hidden mutation was not observed: %+v", cp.groups)
+	}
+}
+
+func TestRepositoryStatusFailurePreservesLastGoodAndRetries(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	previous := changesGroup{Dir: "/repo", Name: "repo", Unstaged: []git.FileStatus{{Status: "M", Path: "kept.txt"}}}
+	s, _, _ := testRepositoryState(cp, "/repo")
+	s.lastGroups["/repo"] = previous
+	s.lastRevisions["/repo"] = "head"
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+
+	s.HandleStatus(&RepositoryStatusResult{Seq: 1, Entries: []repositoryStatusEntry{{
+		Group: changesGroup{Dir: "/repo", Name: "repo"}, Revision: "head", StatusErr: errors.New("index locked"),
+	}}})
+	if cp.TotalChanges() != 1 || cp.groups[0].Unstaged[0].Path != "kept.txt" {
+		t.Fatalf("failed status replaced last good snapshot: %+v", cp.groups)
+	}
+	if s.dirty&RepositoryWorktree == 0 {
+		t.Fatal("failed status was marked fresh")
+	}
+}
+
+func TestRepositoryUnchangedHeadDoesNotReloadHistoryChangedHeadDoes(t *testing.T) {
+	dir := testAppRepository(t)
+	cp := NewChangesPanel(dir)
+	cp.groups = []changesGroup{{Dir: dir, Name: filepath.Base(dir)}}
+	cp.buildTree()
+	cp.lastLogDir = dir
+	cp.logDir = dir
+	poster := newTestEventPoster()
+	cp.Screen = poster
+	s, _, _ := testRepositoryState(cp, dir)
+	s.visible = true
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	oldHead := git.RevisionIdentity(dir)
+	s.lastGroups[dir] = cp.groups[0]
+	s.lastRevisions[dir] = oldHead
+	before := cp.logGen
+
+	s.HandleStatus(repositoryResult(1, dir, oldHead))
+	if cp.logGen != before {
+		t.Fatalf("unchanged HEAD reloaded history: %d -> %d", before, cp.logGen)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "next.txt"), []byte("next\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "next.txt")
+	testAppGit(t, dir, "commit", "-m", "next")
+	s.requested = 2
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	s.HandleStatus(repositoryResult(2, dir, git.RevisionIdentity(dir)))
+	if cp.logGen != before+1 || s.dirty&RepositoryHistory == 0 {
+		t.Fatalf("changed HEAD history gen = %d, dirty = %b", cp.logGen, s.dirty)
+	}
+	cp.CancelHistoryRead()
+}
+
+func TestRepositoryRootReplacementCancelsAndSupersedesOldResult(t *testing.T) {
+	cp := NewChangesPanel("/old")
+	s, _, poster := testRepositoryState(cp, "/old")
+	firstCanceled := make(chan struct{})
+	secondStarted := make(chan struct{})
+	s.statusWait = time.Hour
+	s.readStatus = func(ctx context.Context, dirs []string, seq uint64) *RepositoryStatusResult {
+		if dirs[0] == "/old" {
+			<-ctx.Done()
+			close(firstCanceled)
+			return repositoryResult(seq, "/old", "old", git.FileStatus{Status: "M", Path: "old.txt"})
+		}
+		close(secondStarted)
+		return repositoryResult(seq, "/new", "new", git.FileStatus{Status: "M", Path: "new.txt"})
+	}
+
+	s.RefreshNow(RepositoryWorktree)
+	s.SetDirs([]string{"/new"})
+	select {
+	case <-firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("root replacement did not cancel the old status context")
+	}
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("replacement root status did not start")
+	}
+	s.HandleStatus(poster.await(t).(*RepositoryStatusResult))
+	if len(cp.groups) != 1 || cp.groups[0].Dir != "/new" || cp.groups[0].Unstaged[0].Path != "new.txt" {
+		t.Fatalf("old root result survived replacement: %+v", cp.groups)
+	}
+}
+
+func TestRepositoryCloseCancelsStatusAndLateDebounce(t *testing.T) {
+	s, _, _ := testRepositoryState(nil, "/repo")
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	s.statusWait = time.Hour
+	s.readStatus = func(ctx context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		return repositoryResult(seq, "/repo", "")
+	}
+	s.RefreshNow(RepositoryWorktree)
+	<-started
+	s.Close()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel the in-flight status read")
+	}
+
+	s2, scheduler2, poster2 := testRepositoryState(nil, "/repo")
+	var reads atomic.Int32
+	s2.readStatus = func(_ context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		reads.Add(1)
+		return repositoryResult(seq, "/repo", "head")
+	}
+	s2.InvalidateAll(RepositoryWorktree)
+	debounce := scheduler2.latest(t)
+	s2.Close()
+	debounce.fireLate()
+	s2.HandleDebounce(poster2.await(t).(*repositoryDebounceTick))
+	if reads.Load() != 0 || !debounce.stopped {
+		t.Fatal("late debounce survived repository close")
+	}
+}
+
+func TestCommitHistoryRefreshKeyRoutesThroughCoordinator(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	called := 0
+	cp.OnRefresh = func() { called++ }
+	if !cp.handleCommitLogKey(tcell.NewEventKey(tcell.KeyRune, "r", tcell.ModNone), nil) {
+		t.Fatal("commit-history refresh key was not handled")
+	}
+	if called != 1 {
+		t.Fatalf("coordinator refresh callback calls = %d, want 1", called)
+	}
+}
+
+func TestManualRepositoryRefreshForcesWorktreeAndSelectedHistory(t *testing.T) {
+	dir := testAppRepository(t)
+	cp := NewChangesPanel(dir)
+	cp.groups = []changesGroup{{Dir: dir, Name: filepath.Base(dir)}}
+	cp.buildTree()
+	cp.lastLogDir = dir
+	cp.logDir = dir
+	cp.Screen = newTestEventPoster()
+	s, _, _ := testRepositoryState(cp, dir)
+	s.visible = true
+	s.readStatus = func(ctx context.Context, _ []string, seq uint64) *RepositoryStatusResult {
+		<-ctx.Done()
+		return repositoryResult(seq, dir, "")
+	}
+	before := cp.logGen
+	s.RefreshNow(RepositoryWorktree | RepositoryHistory)
+	if !s.inFlight || s.requested != 1 {
+		t.Fatalf("manual refresh status inFlight=%v requested=%d", s.inFlight, s.requested)
+	}
+	if cp.logGen != before+1 {
+		t.Fatalf("manual refresh history gen = %d, want %d", cp.logGen, before+1)
+	}
+	s.Close()
+}
+
+func TestCommitLogFailurePreservesLastGoodAndRemainsRetryable(t *testing.T) {
+	cp := NewChangesPanel("/repo")
+	cp.lastLogDir = "/repo"
+	cp.logDir = "/repo"
+	cp.logGen = 4
+	good := &widgets.TreeNode{ID: "commit:good", Label: "last good commit"}
+	cp.CommitLog.SetItems([]*widgets.TreeNode{good})
+	s := NewRepositoryState(cp, []string{"/repo"})
+	var callbackErr error
+	cp.OnHistoryResult = func(err error) {
+		callbackErr = err
+		s.HandleHistory(err)
+	}
+
+	cp.ApplyCommitLog(&CommitLogResult{Gen: 4, Dir: "/repo", Err: errors.New("temporary log failure")})
+	if len(cp.CommitLog.Config.Items) != 1 || cp.CommitLog.Config.Items[0] != good {
+		t.Fatalf("history failure replaced last good items: %+v", cp.CommitLog.Config.Items)
+	}
+	if cp.lastLogDir != "" || callbackErr == nil {
+		t.Fatalf("failed history retry guard = %q, callback err = %v", cp.lastLogDir, callbackErr)
+	}
+	if s.dirty&RepositoryHistory == 0 {
+		t.Fatal("failed history read was marked fresh")
+	}
+}
+
+func TestDebugScreenshotAndStateDumpEachInvalidateTheirPathOnce(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.AppConfig{
+		Keybindings: config.DefaultKeybindings(),
+		Settings:    config.DefaultSettings(),
+		Theme:       config.DefaultTheme(),
+	}
+	borders := BuildBorderSet(cfg.Theme.Borders)
+	a := BuildAppFromConfig(&cfg, &borders, workspace.New([]string{dir}), nil)
+	sim := term.NewSimScreen()
+	if err := sim.Init(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sim.Fini)
+	sim.SetSize(80, 24)
+	a.Screen = term.NewTcellScreenFrom(sim)
+	a.Root.SetSize(80, 24)
+	a.Repository.poster = newTestEventPoster()
+	a.Repository.scheduler = &fakeRepositoryScheduler{}
+
+	paths := []string{filepath.Join(dir, "screen.txt"), filepath.Join(dir, "state.json")}
+	if err := a.DumpScreenshot(paths[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.DumpDebugState(paths[1]); err != nil {
+		t.Fatal(err)
+	}
+	if a.Repository.requested != 0 {
+		t.Fatal("debug writer mutated repository coordinator off the event loop")
+	}
+	for _, path := range paths {
+		var interrupt *tcell.EventInterrupt
+		for interrupt == nil {
+			interrupt, _ = a.Screen.PollEvent().(*tcell.EventInterrupt)
+		}
+		request, ok := interrupt.Data().(*RepositoryInvalidationRequest)
+		if !ok || request.Path != path || request.Resources != RepositoryWorktree {
+			t.Fatalf("debug invalidation = %#v, want path %q worktree", interrupt.Data(), path)
+		}
+		a.handleRepositoryInvalidation(request)
+	}
+	if a.Repository.requested != 2 {
+		t.Fatalf("debug write invalidations = %d, want exactly 2", a.Repository.requested)
+	}
+	a.Repository.Close()
+}
+
+func testAppRepository(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	testAppGit(t, dir, "init", "-q", "-b", "main")
+	testAppGit(t, dir, "config", "user.email", "test@test.com")
+	testAppGit(t, dir, "config", "user.name", "Test User")
+	testAppGit(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "initial.txt"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "initial.txt")
+	testAppGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func testAppGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -308,6 +308,99 @@ func TestRepositoryRootFailurePreservesCanonicalMultiRootOrderAndRecovers(t *tes
 	}
 }
 
+func TestRepositoryRootFailureDeduplicatesCanonicalRepositoryAndRecovers(t *testing.T) {
+	repo := t.TempDir()
+	sourceA := filepath.Join(repo, "workspace-a")
+	sourceB := filepath.Join(repo, "workspace-b")
+	for _, source := range []string{sourceA, sourceB} {
+		if err := os.Mkdir(source, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	previous := changesGroup{Dir: repo, Name: filepath.Base(repo), Unstaged: []git.FileStatus{{Status: "M", Path: "kept.txt"}}}
+	cp := NewChangesPanel(sourceA, sourceB)
+	s := NewRepositoryState(cp, []string{sourceA, sourceB})
+
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	s.HandleStatus(&RepositoryStatusResult{Seq: 1, Entries: []repositoryStatusEntry{{SourceDir: sourceA, Group: previous, Revision: "old"}}})
+
+	failure := func(source string) repositoryStatusEntry {
+		return repositoryStatusEntry{
+			SourceDir: source,
+			Group:     changesGroup{Dir: source, Name: filepath.Base(source)},
+			RootErr:   errors.New("root unavailable"), StatusErr: errors.New("status unavailable"), RevisionErr: errors.New("revision unavailable"),
+		}
+	}
+	assertLastGood := func(stage string) {
+		t.Helper()
+		if len(cp.groups) != 1 || cp.groups[0].Dir != repo || len(cp.groups[0].Unstaged) != 1 || cp.groups[0].Unstaged[0].Path != "kept.txt" {
+			t.Fatalf("%s groups = %+v, want one canonical last-good group", stage, cp.groups)
+		}
+		if s.dirty&RepositoryWorktree == 0 {
+			t.Fatalf("%s failure was marked fresh", stage)
+		}
+	}
+
+	s.requested = 2
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	s.HandleStatus(&RepositoryStatusResult{Seq: 2, Entries: []repositoryStatusEntry{
+		{SourceDir: sourceA, Group: previous, Revision: "old"},
+		failure(sourceB),
+	}})
+	assertLastGood("partial")
+
+	s.requested = 3
+	s.inFlight = true
+	s.HandleStatus(&RepositoryStatusResult{Seq: 3, Entries: []repositoryStatusEntry{failure(sourceB), failure(sourceA)}})
+	assertLastGood("all-sources")
+
+	fresh := changesGroup{Dir: repo, Name: filepath.Base(repo), Unstaged: []git.FileStatus{{Status: "M", Path: "fresh.txt"}}}
+	s.requested = 4
+	s.inFlight = true
+	s.HandleStatus(&RepositoryStatusResult{Seq: 4, Entries: []repositoryStatusEntry{{SourceDir: sourceB, Group: fresh, Revision: "new"}}})
+	if len(cp.groups) != 1 || cp.groups[0].Dir != repo || cp.groups[0].Unstaged[0].Path != "fresh.txt" {
+		t.Fatalf("recovery groups = %+v, want one fresh canonical group", cp.groups)
+	}
+	if s.dirty&RepositoryWorktree != 0 {
+		t.Fatal("successful recovery did not mark working tree fresh")
+	}
+}
+
+func TestRepositoryRootFailureKeepsDistinctNestedRepositories(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "nested")
+	outerSource := filepath.Join(outer, "outer-work")
+	innerSource := filepath.Join(inner, "inner-work")
+	for _, dir := range []string{inner, outerSource, innerSource} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cp := NewChangesPanel(outerSource, innerSource)
+	s := NewRepositoryState(cp, []string{outerSource, innerSource})
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	s.HandleStatus(&RepositoryStatusResult{Seq: 1, Entries: []repositoryStatusEntry{
+		{SourceDir: outerSource, Group: changesGroup{Dir: outer, Name: filepath.Base(outer)}, Revision: "outer"},
+		{SourceDir: innerSource, Group: changesGroup{Dir: inner, Name: filepath.Base(inner)}, Revision: "inner"},
+	}})
+
+	s.requested = 2
+	s.inFlight = true
+	s.dirty = RepositoryWorktree
+	s.HandleStatus(&RepositoryStatusResult{Seq: 2, Entries: []repositoryStatusEntry{
+		{SourceDir: outerSource, Group: changesGroup{Dir: outerSource}, RootErr: errors.New("root"), StatusErr: errors.New("status"), RevisionErr: errors.New("revision")},
+		{SourceDir: innerSource, Group: changesGroup{Dir: innerSource}, RootErr: errors.New("root"), StatusErr: errors.New("status"), RevisionErr: errors.New("revision")},
+	}})
+	if len(cp.groups) != 2 || cp.groups[0].Dir != outer || cp.groups[1].Dir != inner {
+		t.Fatalf("nested groups merged or reordered: %+v", cp.groups)
+	}
+}
+
 func TestRepositoryScanCarriesSourceIdentityAndRootFailure(t *testing.T) {
 	bin := t.TempDir()
 	script := "#!/bin/sh\nexit 91\n"
@@ -345,6 +438,11 @@ func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePosit
 		path func(t *testing.T) string
 		want bool
 	}{
+		{
+			name: "missing internal target",
+			path: func(t *testing.T) string { return filepath.Join(repo, "missing.txt") },
+			want: true,
+		},
 		{
 			name: "existing target through outside alias",
 			path: func(t *testing.T) string { return filepath.Join(alias, "existing.txt") },
@@ -391,6 +489,32 @@ func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePosit
 				return filepath.Join(alias, "restricted", "new.txt")
 			},
 			want: true,
+		},
+		{
+			name: "broken in-repository symlink",
+			path: func(t *testing.T) string {
+				link := filepath.Join(repo, "broken-internal")
+				if err := os.Symlink(filepath.Join(external, "missing"), link); err != nil {
+					t.Fatal(err)
+				}
+				return filepath.Join(link, "new.txt")
+			},
+			want: false,
+		},
+		{
+			name: "in-repository symlink loop",
+			path: func(t *testing.T) string {
+				first := filepath.Join(repo, "loop-a")
+				second := filepath.Join(repo, "loop-b")
+				if err := os.Symlink(second, first); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(first, second); err != nil {
+					t.Fatal(err)
+				}
+				return filepath.Join(first, "new.txt")
+			},
+			want: false,
 		},
 		{
 			name: "external target through in-repository symlink",
@@ -457,6 +581,33 @@ func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePosit
 				t.Fatalf("invalidated = %v, want %v (requested=%d dirty=%b)", got, test.want, s.requested, s.dirty)
 			}
 		})
+	}
+}
+
+func TestRepositoryInvalidationUsesCurrentSymlinkTargetAfterRetarget(t *testing.T) {
+	repo := t.TempDir()
+	external := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "retargeted")
+	if err := os.Symlink(repo, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	internal, _, _ := testRepositoryState(nil, repo)
+	internal.InvalidatePath(filepath.Join(alias, "new.txt"), RepositoryWorktree)
+	if internal.requested != 1 || internal.dirty&RepositoryWorktree == 0 {
+		t.Fatalf("internal alias did not invalidate: requested=%d dirty=%b", internal.requested, internal.dirty)
+	}
+
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, alias); err != nil {
+		t.Fatal(err)
+	}
+	externalState, _, _ := testRepositoryState(nil, repo)
+	externalState.InvalidatePath(filepath.Join(alias, "new.txt"), RepositoryWorktree)
+	if externalState.requested != 0 || externalState.dirty != 0 {
+		t.Fatalf("retargeted external alias invalidated: requested=%d dirty=%b", externalState.requested, externalState.dirty)
 	}
 }
 

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -476,21 +476,6 @@ func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePosit
 			want: true,
 		},
 		{
-			name: "permission failure below resolved repository alias",
-			path: func(t *testing.T) string {
-				restricted := filepath.Join(repo, "restricted")
-				if err := os.Mkdir(restricted, 0o700); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.Chmod(restricted, 0); err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() { _ = os.Chmod(restricted, 0o700) })
-				return filepath.Join(alias, "restricted", "new.txt")
-			},
-			want: true,
-		},
-		{
 			name: "broken in-repository symlink",
 			path: func(t *testing.T) string {
 				link := filepath.Join(repo, "broken-internal")
@@ -539,24 +524,6 @@ func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePosit
 			want: false,
 		},
 		{
-			name: "permission failure outside repository",
-			path: func(t *testing.T) string {
-				denied := filepath.Join(outside, "denied")
-				if err := os.Mkdir(denied, 0o700); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.Symlink(repo, filepath.Join(denied, "hidden-alias")); err != nil {
-					t.Fatal(err)
-				}
-				if err := os.Chmod(denied, 0); err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() { _ = os.Chmod(denied, 0o700) })
-				return filepath.Join(denied, "hidden-alias", "new.txt")
-			},
-			want: false,
-		},
-		{
 			name: "outside symlink loop",
 			path: func(t *testing.T) string {
 				first := filepath.Join(outside, "loop-a")
@@ -581,6 +548,85 @@ func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePosit
 				t.Fatalf("invalidated = %v, want %v (requested=%d dirty=%b)", got, test.want, s.requested, s.dirty)
 			}
 		})
+	}
+}
+
+func TestRepositoryInvalidationRejectsUnprovablePermissionAncestors(t *testing.T) {
+	repo := t.TempDir()
+	external := t.TempDir()
+	restricted := filepath.Join(repo, "restricted")
+	plain := filepath.Join(repo, "plain")
+	for _, dir := range []string{restricted, plain} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(external, filepath.Join(restricted, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(filepath.Join(restricted, "escape")); err != nil || resolved != external {
+		t.Fatalf("external symlink parent identity=%q err=%v, want %q", resolved, err, external)
+	}
+	for _, dir := range []string{restricted, plain} {
+		if err := os.Chmod(dir, 0); err != nil {
+			t.Fatal(err)
+		}
+		dir := dir
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	}
+
+	tests := []struct {
+		name   string
+		denied string
+		path   string
+	}{
+		{
+			name:   "permission-hidden external symlink",
+			denied: restricted,
+			path:   filepath.Join(restricted, "escape", "missing.txt"),
+		},
+		{
+			name:   "plain permission-denied internal directory",
+			denied: plain,
+			path:   filepath.Join(plain, "missing.txt"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, _, _ := testRepositoryState(nil, repo)
+			s.pathIdentity = permissionDeniedRepositoryPathResolver(test.denied)
+			if resolved, err := s.resolvePathIdentity(test.path); resolved != "" || !errors.Is(err, os.ErrPermission) {
+				t.Fatalf("permission seam resolved=%q err=%v, want os.ErrPermission", resolved, err)
+			}
+			s.InvalidatePath(test.path, RepositoryWorktree)
+			if s.requested != 0 || s.dirty != 0 {
+				t.Fatalf("unprovable path invalidated: requested=%d dirty=%b", s.requested, s.dirty)
+			}
+		})
+	}
+}
+
+func permissionDeniedRepositoryPathResolver(denied string) func(string) (string, error) {
+	permissionError := func(op, path string) error {
+		return &os.PathError{Op: op, Path: path, Err: os.ErrPermission}
+	}
+	deniedDescendant := func(path string) bool {
+		return filepath.Clean(path) != filepath.Clean(denied) && pathWithin(denied, path)
+	}
+	lstat := func(path string) (os.FileInfo, error) {
+		if deniedDescendant(path) {
+			return nil, permissionError("lstat", path)
+		}
+		return os.Lstat(path)
+	}
+	evalSymlinks := func(path string) (string, error) {
+		if deniedDescendant(path) {
+			return "", permissionError("evalsymlinks", path)
+		}
+		return filepath.EvalSymlinks(path)
+	}
+	return func(path string) (string, error) {
+		return resolveRepositoryPathIdentityWith(path, lstat, evalSymlinks)
 	}
 }
 

--- a/internal/app/watch.go
+++ b/internal/app/watch.go
@@ -46,6 +46,7 @@ func (a *App) SyncWatched() {
 // warned. The recorded disk state of a dirty buffer is deliberately not
 // updated, so the save-time conflict check keeps working.
 func (a *App) HandleFileChanged(path string) {
+	a.invalidateRepositoryPath(path, RepositoryWorktree)
 	buf := a.EditorGroup.BufferForPath(path)
 	if buf == nil {
 		return

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -330,6 +330,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		LspNotified:         make(map[string]bool),
 		pluginDetailWidgets: make(map[string]*pluginDetailState),
 	}
+	app.Repository = NewRepositoryState(changes, ws.Paths())
 	app.applyMenuBarVisibility(cfg.Settings.Editor.IsMenuBarVisible())
 	// Rebuild the Diagnostics panel whenever any source (LSP or a plugin)
 	// changes its diagnostics.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -23,12 +24,26 @@ func RepoRoot(dir string) string {
 }
 
 func RepoRootContext(ctx context.Context, dir string) string {
+	root, _ := RepoRootWithErrorContext(ctx, dir)
+	return root
+}
+
+// RepoRootWithErrorContext preserves discovery failures for callers that must
+// retain a previously verified repository identity and retry.
+func RepoRootWithErrorContext(ctx context.Context, dir string) (string, error) {
 	cmd := gitCommandContext(ctx, "-C", dir, "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		return "", err
 	}
-	return strings.TrimSpace(string(out))
+	root := strings.TrimSpace(string(out))
+	if root == "" {
+		return "", fmt.Errorf("git returned an empty repository root")
+	}
+	return root, nil
 }
 
 func IsRepo(dir string) bool {
@@ -188,7 +203,17 @@ func BranchNameContext(ctx context.Context, dir string) (string, error) {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
-		return "", err
+		revision, revisionErr := RevisionIdentityContext(ctx, dir)
+		if revisionErr != nil || revision != "" {
+			return "", err
+		}
+		out, err = gitCommandContext(ctx, "-C", dir, "symbolic-ref", "--short", "-q", "HEAD").Output()
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", ctx.Err()
+			}
+			return "", err
+		}
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -210,14 +235,12 @@ func LogWithError(dir string, n int) ([]LogEntry, error) {
 }
 
 func LogWithErrorContext(ctx context.Context, dir string, n int) ([]LogEntry, error) {
-	if err := gitCommandContext(ctx, "-C", dir, "rev-parse", "--verify", "HEAD").Run(); err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		if IsRepoContext(ctx, dir) {
-			return nil, nil
-		}
+	revision, err := RevisionIdentityContext(ctx, dir)
+	if err != nil {
 		return nil, err
+	}
+	if revision == "" {
+		return nil, nil
 	}
 	cmd := gitCommandContext(ctx, "-C", dir, "log", fmt.Sprintf("-%d", n), "--pretty=format:%H %h %s")
 	out, err := cmd.Output()
@@ -423,6 +446,8 @@ func RevisionIdentity(dir string) string {
 	return identity
 }
 
+// RevisionIdentityContext returns empty success only when Git verifies that
+// HEAD names an unborn branch whose ref does not yet exist.
 func RevisionIdentityContext(ctx context.Context, dir string) (string, error) {
 	out, err := gitCommandContext(ctx, "-C", dir, "rev-parse", "--verify", "HEAD").Output()
 	if err == nil {
@@ -431,10 +456,39 @@ func RevisionIdentityContext(ctx context.Context, dir string) (string, error) {
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}
-	if IsRepoContext(ctx, dir) {
+	unborn, verifyErr := verifyUnbornHEADContext(ctx, dir)
+	if verifyErr != nil {
+		return "", errors.Join(err, fmt.Errorf("verify unborn HEAD: %w", verifyErr))
+	}
+	if unborn {
 		return "", nil
 	}
 	return "", err
+}
+
+func verifyUnbornHEADContext(ctx context.Context, dir string) (bool, error) {
+	out, err := gitCommandContext(ctx, "-C", dir, "symbolic-ref", "-q", "HEAD").Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		return false, err
+	}
+	ref := strings.TrimSpace(string(out))
+	if ref == "" {
+		return false, fmt.Errorf("symbolic HEAD has no ref")
+	}
+	err = gitCommandContext(ctx, "-C", dir, "show-ref", "--verify", "--quiet", ref).Run()
+	if err == nil {
+		return false, nil
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return true, nil
+	}
+	return false, err
 }
 
 func RemoteURL(dir string) string {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -19,7 +19,11 @@ type FileStatus struct {
 }
 
 func RepoRoot(dir string) string {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
+	return RepoRootContext(context.Background(), dir)
+}
+
+func RepoRootContext(ctx context.Context, dir string) string {
+	cmd := gitCommandContext(ctx, "-C", dir, "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -38,7 +42,11 @@ func IsRepoContext(ctx context.Context, dir string) bool {
 }
 
 func StatusFiles(dir string) ([]FileStatus, error) {
-	cmd := exec.Command("git", "-C", dir, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	return StatusFilesContext(context.Background(), dir)
+}
+
+func StatusFilesContext(ctx context.Context, dir string) ([]FileStatus, error) {
+	cmd := gitCommandContext(ctx, "-C", dir, "status", "--porcelain=v1", "-z", "--untracked-files=all")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -169,16 +177,20 @@ func Push(dir string) error {
 }
 
 func BranchName(dir string) string {
-	return BranchNameContext(context.Background(), dir)
+	name, _ := BranchNameContext(context.Background(), dir)
+	return name
 }
 
-func BranchNameContext(ctx context.Context, dir string) string {
+func BranchNameContext(ctx context.Context, dir string) (string, error) {
 	cmd := gitCommandContext(ctx, "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
-		return ""
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		return "", err
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(string(out)), nil
 }
 
 type LogEntry struct {
@@ -404,6 +416,25 @@ func HeadSHA(dir string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func RevisionIdentity(dir string) string {
+	identity, _ := RevisionIdentityContext(context.Background(), dir)
+	return identity
+}
+
+func RevisionIdentityContext(ctx context.Context, dir string) (string, error) {
+	out, err := gitCommandContext(ctx, "-C", dir, "rev-parse", "--verify", "HEAD").Output()
+	if err == nil {
+		return strings.TrimSpace(string(out)), nil
+	}
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	if IsRepoContext(ctx, dir) {
+		return "", nil
+	}
+	return "", err
 }
 
 func RemoteURL(dir string) string {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -137,6 +138,38 @@ func TestStatusFilesEmpty(t *testing.T) {
 	}
 	if len(files) != 0 {
 		t.Errorf("expected no files, got %d: %+v", len(files), files)
+	}
+}
+
+func TestStatusFilesContextHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := StatusFilesContext(ctx, setupTestRepo(t)); err == nil {
+		t.Fatal("canceled status context returned success")
+	}
+}
+
+func TestRevisionIdentityTracksHead(t *testing.T) {
+	dir := setupTestRepo(t)
+	writeFile(t, dir, "initial.txt", "hello\n")
+	gitRun(t, dir, "add", "initial.txt")
+	gitRun(t, dir, "commit", "-m", "init")
+	initial := RevisionIdentity(dir)
+	if initial == "" {
+		t.Fatal("committed repository has an empty revision identity")
+	}
+	writeFile(t, dir, "next.txt", "next\n")
+	gitRun(t, dir, "add", "next.txt")
+	gitRun(t, dir, "commit", "-m", "next")
+	if next := RevisionIdentity(dir); next == initial || next == "" {
+		t.Fatalf("revision identity after commit = %q, initial = %q", next, initial)
+	}
+}
+
+func TestRevisionIdentityAllowsUnbornRepository(t *testing.T) {
+	identity, err := RevisionIdentityContext(context.Background(), setupTestRepo(t))
+	if err != nil || identity != "" {
+		t.Fatalf("unborn repository identity = (%q, %v), want empty success", identity, err)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -167,9 +167,36 @@ func TestRevisionIdentityTracksHead(t *testing.T) {
 }
 
 func TestRevisionIdentityAllowsUnbornRepository(t *testing.T) {
-	identity, err := RevisionIdentityContext(context.Background(), setupTestRepo(t))
+	dir := setupTestRepo(t)
+	identity, err := RevisionIdentityContext(context.Background(), dir)
 	if err != nil || identity != "" {
 		t.Fatalf("unborn repository identity = (%q, %v), want empty success", identity, err)
+	}
+	if branch, err := BranchNameContext(context.Background(), dir); err != nil || branch == "" {
+		t.Fatalf("unborn repository branch = (%q, %v), want symbolic branch", branch, err)
+	}
+}
+
+func TestRevisionIdentityRequiresVerifiedUnbornHead(t *testing.T) {
+	bin := t.TempDir()
+	script := `#!/bin/sh
+case "$*" in
+  *"rev-parse --verify HEAD"*) exit 73 ;;
+  *"symbolic-ref -q HEAD"*) printf 'refs/heads/main\n'; exit 0 ;;
+  *"show-ref --verify --quiet refs/heads/main"*) exit 0 ;;
+esac
+exit 99
+`
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+":"+os.Getenv("PATH"))
+
+	if identity, err := RevisionIdentityContext(context.Background(), "/repo"); err == nil {
+		t.Fatalf("failed HEAD read returned empty success: identity=%q", identity)
+	}
+	if entries, err := LogWithErrorContext(context.Background(), "/repo", 10); err == nil {
+		t.Fatalf("failed HEAD read returned successful empty log: entries=%v", entries)
 	}
 }
 

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -949,15 +949,15 @@ func (g *EditorGroupWidget) Save() bool {
 	return true
 }
 
-func (g *EditorGroupWidget) SaveAs(path string) {
+func (g *EditorGroupWidget) SaveAs(path string) bool {
 	t := g.activeTab()
 	if t == nil || t.Content != nil {
-		return
+		return false
 	}
 	g.applySaveCleanups(t)
 	if err := t.Buf.SaveFile(path); err != nil {
 		g.reportError(fmt.Sprintf("Failed to save %s: %v", path, err))
-		return
+		return false
 	}
 	if t.Undo != nil {
 		t.Undo.MarkSaved()
@@ -970,6 +970,7 @@ func (g *EditorGroupWidget) SaveAs(path string) {
 		t.Highlighter = nil
 	}
 	g.syncTabs()
+	return true
 }
 
 // RenamePath repoints open tabs after a path is renamed on disk. oldPath may be

--- a/tests/e2e/changes_reactivity_test.go
+++ b/tests/e2e/changes_reactivity_test.go
@@ -1,0 +1,92 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/app"
+	"github.com/gdamore/tcell/v3"
+)
+
+func initializeHarnessRepository(t *testing.T, dir string) {
+	t.Helper()
+	commands := [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test User"},
+		{"config", "commit.gpgsign", "false"},
+		{"add", "-A"},
+		{"commit", "-qm", "initial commit"},
+	}
+	for _, args := range commands {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+}
+
+func showCleanChanges(t *testing.T, h *testHarness) {
+	t.Helper()
+	h.app.Repository.RefreshNow(app.RepositoryWorktree | app.RepositoryHistory)
+	h.exec("sidebar.changes")
+	h.assertContains("No changes")
+}
+
+func TestSavedFileAppearsInVisibleChangesWithoutManualRefresh(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+	initializeHarnessRepository(t, h.dir)
+	showCleanChanges(t, h)
+
+	path := filepath.Join(h.dir, "alpha.txt")
+	h.app.EditorGroup.OpenFile(path)
+	h.exec("editor.focus")
+	h.pressKey(tcell.KeyEnd, tcell.ModNone)
+	h.pressRune('X')
+	h.exec("file.save")
+
+	h.assertContains("Changes (1)")
+	h.assertContains("alpha.txt")
+}
+
+func TestSaveAsAppearsInVisibleChangesWithoutManualRefresh(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+	initializeHarnessRepository(t, h.dir)
+	showCleanChanges(t, h)
+
+	h.exec("file.new")
+	h.pressRune('n')
+	h.exec("file.save")
+	path := filepath.Join(h.dir, "saved-as.txt")
+	h.app.PasteText(path)
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Save As did not write %s: %v", path, err)
+	}
+	h.assertContains("Changes (1)")
+	h.assertContains("saved-as.txt")
+}
+
+func TestWatcherReconciliationInvalidatesVisibleChanges(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+	initializeHarnessRepository(t, h.dir)
+	showCleanChanges(t, h)
+
+	path := filepath.Join(h.dir, "beta.txt")
+	h.app.EditorGroup.OpenFile(path)
+	if err := os.WriteFile(path, []byte("external\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.HandleFileChanged(path)
+	h.redraw()
+
+	h.assertContains("Changes (1)")
+	h.assertContains("beta.txt")
+}

--- a/tests/functional/git-changes-reactive.test.js
+++ b/tests/functional/git-changes-reactive.test.js
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createGitRepo, createTempDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("reactive git changes", () => {
+  it("shows a saved editor change without a manual refresh", () => {
+    dir = createGitRepo(createTempDir());
+    const tracked = join(dir, "tracked.txt");
+
+    tui.start(dir, tracked);
+    tui.waitFor("Explore");
+    tui.exec("Show Changes");
+    tui.waitStable(300);
+    const clean = tui.snapshot();
+
+    tui.exec("View: Focus Editor");
+    tui.press("end");
+    tui.type("changed");
+    tui.exec("Save File");
+    tui.waitStable(600);
+    const updated = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[clean]).toContain("No changes");
+    expect(snapshots[updated]).toContain("Changes (1)");
+    expect(snapshots[updated]).toContain("tracked.txt");
+  });
+});

--- a/tests/integration/git-changes-reactive.test.js
+++ b/tests/integration/git-changes-reactive.test.js
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createTempDir } from "./helpers.js";
+
+let dir;
+
+function git(...args) {
+  return execFileSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+}
+
+function createRepository() {
+  dir = createTempDir();
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "test@test.com");
+  git("config", "user.name", "Test User");
+  git("config", "commit.gpgsign", "false");
+  writeFileSync(join(dir, "tracked.txt"), "original\n", "utf8");
+  git("add", "tracked.txt");
+  git("commit", "-qm", "initial commit");
+}
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("reactive git polling", () => {
+  it("detects an external change to an unopened file while Changes is visible", () => {
+    createRepository();
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+    tui.exec("Show Changes");
+    tui.waitFor("No changes");
+
+    writeFileSync(join(dir, "tracked.txt"), "external\n", "utf8");
+    tui.waitFor("tracked.txt");
+
+    const screen = tui.snapshot();
+    expect(screen).toContain("Changes (1)");
+    expect(screen).toContain("tracked.txt");
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> #487 is merged. This branch is rebased onto current `main` and is the active review layer. Later drafts remain cumulative and will narrow in dependency order.

## Summary

- keep the Changes panel and commit history synchronized with external working-tree, index, HEAD, and repository-identity changes without requiring manual refresh
- coalesce filesystem and Git invalidations through a repository-state coordinator, polling only when the relevant surface is visible and applying widget mutations on the main event loop
- preserve the last known-good status and history across transient Git failures, retry the same revision after failure, and prevent stale reads from marking freshness
- cancel in-flight status/history commands on shutdown or supersession so stuck helpers cannot suppress later invalidations
- validate repository roots and mutation paths conservatively across multi-root workspaces, symlinks, missing paths, nested repositories, and unprovable identities
- route mutation-capable plugin/system commands and scripted workflows through typed invalidation boundaries

This is the focused repository-reactivity extraction from #474. The all-files Current Changes review document remains in the next PR.

## Verification

- make build
- focused app, watcher, Git, E2E, functional, and live-PTY repository-change coverage
- race coverage for coalescing, supersession, shutdown, visibility changes, and main-thread result application
- transient-failure, same-revision retry, stale-result, root replacement, symlink, nested-repository, and multi-root probes
- full Go, functional, and integration suites on the final rebased head
- independent adversarial event-sequence review with fail-before/pass-after coverage
- gofmt and git diff --check

## Demo

Changed-file views update as files and Git state change outside the editor; the Tree/List controls shown here are supplied by the preceding focused PR.

https://github.com/user-attachments/assets/1b0aa1a2-b463-46d1-94fc-cef5f51c3165

Part of #474.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git Changes now refresh automatically while the Changes panel is visible.
  * External file changes, saved files, and Save As operations appear without manual refresh.
  * Repository history updates when commits or other history-affecting operations occur.
  * Manual refresh remains available for worktree and history data.
* **Bug Fixes**
  * Improved handling of repository errors while preserving the last known valid state.
  * File saves and workspace edits now trigger follow-up updates only after successful completion.
* **Documentation**
  * Added guidance on automatic repository status refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->