### PR TITLE
feat(git): add live Current Changes review

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -63,6 +64,8 @@ type App struct {
 	AutocompleteTimer      *time.Timer
 	HoverTimer             *time.Timer
 	HoverGen               uint64
+	diffOpenGen            int
+	diffOpenCancel         context.CancelFunc
 	LastHoverLine          int
 	LastHoverCol           int
 	Problems               *ui.ProblemsWidget

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -94,12 +94,13 @@ type App struct {
 	PluginsPanel       *PluginsPanel
 	Output             *ui.OutputWidget
 	// runningRepoOp is the progress label of the in-flight task, empty when idle.
-	runningRepoOp        string
-	pluginDetailWidgets  map[string]*pluginDetailState
-	pluginDrawer         ui.Widget
-	commandLine          *ui.CommandLineWidget
-	commandLinePrevFocus ui.Widget
-	settingsView         *settingsView
+	runningRepoOp             string
+	pluginDetailWidgets       map[string]*pluginDetailState
+	pluginDrawer              ui.Widget
+	commandLine               *ui.CommandLineWidget
+	commandLinePrevFocus      ui.Widget
+	settingsView              *settingsView
+	pendingCurrentChangesOpen bool
 	// appliedSettings is the last value ApplySettings acted on. Callers routinely
 	// mutate a.Settings before calling it, so a.Settings cannot serve as "before".
 	appliedSettings    config.Settings
@@ -450,6 +451,10 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 		a.Changes.Screen = screen
 		a.Changes.OnRefreshed = func() {
 			a.Sidebar.SetPanelDirty("changes", a.Changes.TotalChanges() > 0)
+			if a.pendingCurrentChangesOpen && a.selectedChangesDir() != "" {
+				a.pendingCurrentChangesOpen = false
+				a.OpenCurrentChanges()
+			}
 		}
 	}
 	if a.Repository != nil {

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -82,6 +82,8 @@ func (a *App) ShowSidebarMoreMenu(sx, sy int) {
 
 func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
+		{Label: "Open Current Changes", Command: "changes.viewAll"},
+		ui.MenuSep(),
 		{Label: "Refresh", Command: "changes.refresh"},
 		{Label: "Git Files", Submenu: a.BuildChangesGitFileOptions()},
 		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
@@ -98,6 +100,8 @@ func (a *App) BuildChangesPanelMenu() []ui.ContextMenuItem {
 
 func (a *App) BuildChangesContextMenu() []ui.ContextMenuItem {
 	return []ui.ContextMenuItem{
+		{Label: "Open Current Changes", Command: "changes.viewAll"},
+		ui.MenuSep(),
 		{Label: "Refresh", Command: "changes.refresh"},
 		{Label: "Git Files", Submenu: a.BuildChangesGitFileOptions()},
 		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -224,6 +226,7 @@ func (a *App) ApplySearchReplaceAll(allMatches map[string][]ui.SearchMatch, repl
 		func() { a.DismissDialog() },
 		func() {
 			a.DismissDialog()
+			invalidatePath := ""
 			for filePath, matches := range allMatches {
 				data, err := os.ReadFile(filePath)
 				if err != nil {
@@ -237,34 +240,19 @@ func (a *App) ApplySearchReplaceAll(allMatches map[string][]ui.SearchMatch, repl
 				if err := os.WriteFile(filePath, []byte(strings.Join(newLines, "\n")+"\n"), 0644); err != nil {
 					continue
 				}
-				a.invalidateRepositoryPath(filePath, RepositoryWorktree)
+				if invalidatePath == "" {
+					invalidatePath = filePath
+				}
 				a.EditorGroup.ReloadFile(filePath)
 			}
+			a.invalidateRepositoryPath(invalidatePath, RepositoryWorktree)
 			a.Search.Refresh()
 			a.StatusNotify(fmt.Sprintf("Replaced %d matches across %d files", totalMatches, totalFiles))
 		},
 	})
 }
 
-func (a *App) openSelectedDiff(extended bool) {
-	g := a.Changes.SelectedGroup()
-	if g != nil {
-	} else {
-	}
-	if g != nil && g.IsPR {
-		_, status, ok := a.Changes.SelectedFile()
-		if ok && a.Changes.OnOpenPRDiff != nil {
-			a.Changes.OnOpenPRDiff(g, status, extended)
-		} else {
-		}
-	} else {
-		dir, status, ok := a.Changes.SelectedFile()
-		if ok && a.Changes.OnOpenDiff != nil {
-			a.Changes.OnOpenDiff(dir, status, extended)
-		} else {
-		}
-	}
-}
+func (a *App) openSelectedDiff(extended bool) { a.Changes.OpenSelectedDiff(extended) }
 
 func (a *App) OpenChangeDiff(dir string, status git.FileStatus, extended bool) {
 	fullPath := filepath.Join(dir, status.Path)
@@ -308,6 +296,56 @@ func (a *App) OpenChangeDiff(dir string, status git.FileStatus, extended bool) {
 	}
 	a.EditorGroup.OpenDiff(status.Path, parsed, oldLines, newLines, extended)
 	a.FocusEditorIfEnabled()
+}
+
+func (a *App) OpenCommitDiff(dir, ref, short string, status git.FileStatus, extended bool) {
+	a.startDiffOpen(func(ctx context.Context) *DiffOpenResult {
+		return readCommitDiff(ctx, dir, ref, short, status, extended)
+	})
+}
+
+func readCommitDiff(ctx context.Context, dir, ref, short string, status git.FileStatus, extended bool) *DiffOpenResult {
+	diffText, err := git.CommitFileDiffContext(ctx, dir, ref, status)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return &DiffOpenResult{Canceled: true}
+		}
+		return &DiffOpenResult{Warn: fmt.Sprintf("Could not read %s at %s", status.Path, short)}
+	}
+	parsed := diff.Parse(diffText)
+	if len(parsed.Hunks) == 0 {
+		return &DiffOpenResult{Warn: fmt.Sprintf("No line changes for %s in %s", status.Path, short)}
+	}
+	oldPath := status.Path
+	if status.OldPath != "" {
+		oldPath = status.OldPath
+	}
+	oldLines := gitFileLines(ctx, dir, oldPath, ref+"^")
+	newLines := gitFileLines(ctx, dir, status.Path, ref)
+	if ctx.Err() != nil {
+		return &DiffOpenResult{Canceled: true}
+	}
+	return &DiffOpenResult{
+		TabName:  fmt.Sprintf("%s:%s (diff)", ref, status.Path),
+		Title:    fmt.Sprintf("%s @ %s", filepath.Base(status.Path), short),
+		Path:     status.Path,
+		Diff:     parsed,
+		OldLines: oldLines,
+		NewLines: newLines,
+		Extended: extended,
+	}
+}
+
+func gitFileLines(ctx context.Context, dir, path, ref string) []string {
+	content, err := git.ShowFileContext(ctx, dir, path, ref)
+	if err != nil {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
 }
 
 func (a *App) OpenPRDiff(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
@@ -631,6 +669,7 @@ func registerWidgetCallbacks(app *App) {
 	app.Changes.OnOpenDiff = func(dir string, status git.FileStatus, extended bool) {
 		app.OpenChangeDiff(dir, status, extended)
 	}
+	app.Changes.OnOpenCommitDiff = app.OpenCommitDiff
 	app.Changes.OnOpenCommit = app.OpenCommitDetail
 	app.Changes.OnOpenPRDiff = func(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
 		app.OpenPRDiff(group, status, extended)
@@ -641,13 +680,7 @@ func registerWidgetCallbacks(app *App) {
 	app.Changes.OnCommit = app.CommitChanges
 	app.Changes.OnConfirmDiscard = app.ConfirmDiscard
 	app.Changes.OnError = app.StatusError
-	app.Changes.OnRefresh = func() {
-		if app.Repository != nil {
-			app.Repository.RefreshNow(RepositoryWorktree | RepositoryHistory)
-		} else {
-			app.Changes.Refresh()
-		}
-	}
+	app.Changes.OnRefresh = app.RefreshChanges
 	app.Changes.OnStatusChanged = func() {
 		app.invalidateAllRepositories(RepositoryWorktree)
 	}

--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/view"
 	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
 )
@@ -32,6 +33,7 @@ const (
 	commitHistoryTimeout = 15 * time.Second
 	commitFilesTimeout   = 15 * time.Second
 	commitDetailTimeout  = 30 * time.Second
+	diffOpenTimeout      = 15 * time.Second
 )
 
 type commitFilesRequest struct {
@@ -444,6 +446,7 @@ func readCommitDetail(ctx context.Context, incarnation uint64, dir, ref, short s
 // performs every Git read off the event loop. Reopening an immutable commit
 // reuses its full-hash tab and never starts a duplicate read.
 func (a *App) OpenCommitDetail(dir, ref, short string) {
+	a.cancelPendingDiff()
 	tabID := commitDetailTabID(dir, ref)
 	if a.EditorGroup.CommitDetailWidgetByTab(tabID) != nil {
 		a.EditorGroup.SwitchToTabByPath(tabID)
@@ -504,6 +507,7 @@ func (a *App) cancelCommitDetailRequest(tabID string, incarnation uint64) {
 }
 
 func (a *App) ShutdownGitReads() {
+	a.cancelPendingDiff()
 	a.commitDetailMu.Lock()
 	requests := a.commitDetailRequests
 	a.commitDetailRequests = nil
@@ -532,4 +536,75 @@ func (a *App) ApplyCommitDetail(result *CommitDetailResult) {
 		detail.Metadata = "Authored date unavailable"
 	}
 	detail.SetDetail(result.Message, result.Files, result.Err)
+}
+
+type DiffOpenResult struct {
+	Gen      int
+	Origin   string
+	Canceled bool
+	Warn     string
+	TabName  string
+	Title    string
+	Path     string
+	Diff     diff.FileDiff
+	OldLines []string
+	NewLines []string
+	Extended bool
+}
+
+func (a *App) cancelPendingDiff() {
+	a.diffOpenGen++
+	if a.diffOpenCancel != nil {
+		a.diffOpenCancel()
+		a.diffOpenCancel = nil
+	}
+	if a.Status != nil {
+		a.setDiffOpenSegment("")
+	}
+}
+
+func (a *App) startDiffOpen(read func(context.Context) *DiffOpenResult) {
+	a.cancelPendingDiff()
+	gen := a.diffOpenGen
+	origin := a.EditorGroup.ActiveFilePath()
+	ctx, cancel := context.WithTimeout(context.Background(), diffOpenTimeout)
+	a.diffOpenCancel = cancel
+	if a.Screen == nil {
+		result := read(ctx)
+		cancel()
+		result.Gen = gen
+		result.Origin = origin
+		a.ApplyDiffOpen(result)
+		return
+	}
+	a.setDiffOpenSegment("Opening diff…")
+	screen := a.Screen
+	go func() {
+		result := read(ctx)
+		cancel()
+		result.Gen = gen
+		result.Origin = origin
+		screen.PostEvent(tcell.NewEventInterrupt(result))
+	}()
+}
+
+func (a *App) setDiffOpenSegment(text string) {
+	a.Status.SetSegment(view.StatusSegment{ID: "diffopen", Side: "left", Priority: 160, Text: text})
+}
+
+func (a *App) ApplyDiffOpen(result *DiffOpenResult) {
+	if result == nil || result.Gen != a.diffOpenGen {
+		return
+	}
+	a.diffOpenCancel = nil
+	a.setDiffOpenSegment("")
+	if result.Canceled || a.EditorGroup.ActiveFilePath() != result.Origin {
+		return
+	}
+	if result.Warn != "" {
+		a.StatusWarn(result.Warn)
+		return
+	}
+	a.EditorGroup.OpenDiffTab(result.TabName, result.Title, result.Path, result.Diff, result.OldLines, result.NewLines, result.Extended)
+	a.FocusEditorIfEnabled()
 }

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -66,6 +66,7 @@ type ChangesPanel struct {
 	fileView           string
 
 	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
+	OnOpenCommitDiff func(dir, ref, short string, status git.FileStatus, extended bool)
 	OnOpenCommit     func(dir, ref, short string)
 	OnOpenPRDiff     func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
 	OnOpenFile       func(path string)
@@ -132,8 +133,9 @@ type commitFileRef struct {
 	Dir string
 	// Ref is the full hash, which is what git is asked with and what the tab
 	// key is built from. Short is only ever shown to the reader.
-	Ref   string
-	Short string
+	Ref    string
+	Short  string
+	Status git.FileStatus
 }
 
 type prGroup struct {
@@ -520,7 +522,7 @@ func (cp *ChangesPanel) commitFileNodes(dir, ref, short, parentID string, files 
 	}
 	makeLeaf := func(f git.FileStatus) *widgets.TreeNode {
 		id := fmt.Sprintf("cfile:%s:%s", parentID, f.Path)
-		cp.logFiles[id] = commitFileRef{Dir: dir, Ref: ref, Short: short}
+		cp.logFiles[id] = commitFileRef{Dir: dir, Ref: ref, Short: short, Status: f}
 		return &widgets.TreeNode{
 			ID:           id,
 			Label:        f.Path,
@@ -539,17 +541,15 @@ func (cp *ChangesPanel) commitFileNodes(dir, ref, short, parentID string, files 
 	return compactFileTree("history:"+parentID, files, makeLeaf, cp.logFolderExpanded)
 }
 
-func (cp *ChangesPanel) openCommitFile(node *widgets.TreeNode, _ bool) {
-	if node == nil {
+func (cp *ChangesPanel) openCommitFile(node *widgets.TreeNode, extended bool) {
+	if node == nil || cp.OnOpenCommitDiff == nil {
 		return
 	}
 	ref, ok := cp.logFiles[node.ID]
 	if !ok {
 		return
 	}
-	if cp.OnOpenCommit != nil {
-		cp.OnOpenCommit(ref.Dir, ref.Ref, ref.Short)
-	}
+	cp.OnOpenCommitDiff(ref.Dir, ref.Ref, ref.Short, ref.Status, extended)
 }
 
 func (cp *ChangesPanel) openCommitLogNode(node *widgets.TreeNode) {

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -204,6 +204,14 @@ func (a *App) ChangesNextFile() { a.changesNavFile(1) }
 // wrapping around at the start of the list.
 func (a *App) ChangesPrevFile() { a.changesNavFile(-1) }
 
+func (a *App) RefreshChanges() {
+	if a.Repository != nil {
+		a.Repository.RefreshNow(RepositoryWorktree | RepositoryHistory)
+		return
+	}
+	a.Changes.Refresh()
+}
+
 func registerGitCommands(app *App) {
 	reg := app.Reg
 
@@ -253,13 +261,7 @@ func registerGitCommands(app *App) {
 	reg.Register(command.Command{
 		ID: "changes.refresh", Title: "Git: Refresh Changes",
 		Keywords: []string{"git", "changes", "reload"},
-		Handler: func() {
-			if app.Repository != nil {
-				app.Repository.RefreshNow(RepositoryWorktree | RepositoryHistory | RepositoryCurrentChanges)
-			} else {
-				app.Changes.Refresh()
-			}
-		},
+		Handler:  app.RefreshChanges,
 	})
 
 	reg.Register(command.Command{

--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -244,11 +244,18 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
+		ID:       "changes.viewAll",
+		Title:    "Git: Open Current Changes",
+		Keywords: []string{"git", "changes", "diff", "all", "working tree"},
+		Handler:  app.OpenCurrentChanges,
+	})
+
+	reg.Register(command.Command{
 		ID: "changes.refresh", Title: "Git: Refresh Changes",
 		Keywords: []string{"git", "changes", "reload"},
 		Handler: func() {
 			if app.Repository != nil {
-				app.Repository.RefreshNow(RepositoryWorktree | RepositoryHistory)
+				app.Repository.RefreshNow(RepositoryWorktree | RepositoryHistory | RepositoryCurrentChanges)
 			} else {
 				app.Changes.Refresh()
 			}

--- a/internal/app/commit_history_layer_test.go
+++ b/internal/app/commit_history_layer_test.go
@@ -3,13 +3,60 @@ package app
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/eugenioenko/ttt/internal/view"
 )
+
+func TestReadCommitDiffBuildsAnImmutableFileView(t *testing.T) {
+	dir := testAppRepository(t)
+	path := filepath.Join(dir, "tracked.txt")
+	if err := os.WriteFile(path, []byte("new content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "tracked.txt")
+	testAppGit(t, dir, "commit", "-qm", "change tracked")
+	ref := git.HeadSHA(dir)
+	files, err := git.CommitFiles(dir, ref)
+	if err != nil || len(files) != 1 {
+		t.Fatalf("commit files = %+v, err = %v", files, err)
+	}
+
+	result := readCommitDiff(context.Background(), dir, ref, ref[:7], files[0], false)
+	if result.Canceled || result.Warn != "" || len(result.Diff.Hunks) == 0 {
+		t.Fatalf("commit diff result = %+v", result)
+	}
+	if result.Title != "tracked.txt @ "+ref[:7] || result.TabName != ref+":tracked.txt (diff)" {
+		t.Fatalf("commit diff identity = title %q tab %q", result.Title, result.TabName)
+	}
+	if strings.Join(result.NewLines, "\n") != "new content" {
+		t.Fatalf("new lines = %q", result.NewLines)
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if result := readCommitDiff(canceled, dir, ref, ref[:7], files[0], false); !result.Canceled {
+		t.Fatalf("canceled commit diff result = %+v", result)
+	}
+}
+
+func TestApplyDiffOpenDoesNotStealFocusAfterNavigation(t *testing.T) {
+	group := ui.NewEditorGroupWidget(nil, 4, true, "relative")
+	origin := group.ActiveFilePath()
+	group.NewFile()
+	app := &App{EditorGroup: group, Status: view.NewStatusBar(), diffOpenGen: 3}
+
+	app.ApplyDiffOpen(&DiffOpenResult{Gen: 3, Origin: origin, TabName: "late (diff)", Path: "late.txt"})
+	if group.DiffWidgetByTab("late (diff)") != nil {
+		t.Fatal("late diff opened after foreground navigation")
+	}
+}
 
 func TestReadCommitLogAllowsOnlyVerifiedUnbornEmptyHistory(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/app/commit_history_review_nitpicks_test.go
+++ b/internal/app/commit_history_review_nitpicks_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/ui"
 	"github.com/eugenioenko/ttt/internal/widgets"
 	"github.com/gdamore/tcell/v3"
@@ -144,7 +145,8 @@ func TestStaleCommitFilesCompletionDoesNotCancelNewerRead(t *testing.T) {
 func TestCommitHistoryFileKeysActivateCommitAndFileRows(t *testing.T) {
 	cp := NewChangesPanel()
 	ref := strings.Repeat("c", 40)
-	commit := commitFileRef{Dir: "/repo", Ref: ref, Short: "ccccccc"}
+	status := git.FileStatus{Status: "M", Path: "file.go"}
+	commit := commitFileRef{Dir: "/repo", Ref: ref, Short: "ccccccc", Status: status}
 	commitNode := &widgets.TreeNode{ID: "commit:" + ref}
 	fileNode := &widgets.TreeNode{ID: "cfile:commit:" + ref + ":file.go"}
 	cp.logCommits[commitNode.ID] = commit
@@ -154,6 +156,13 @@ func TestCommitHistoryFileKeysActivateCommitAndFileRows(t *testing.T) {
 	cp.OnOpenCommit = func(dir, gotRef, short string) {
 		calls = append(calls, commitFileRef{Dir: dir, Ref: gotRef, Short: short})
 	}
+	var diffCalls []bool
+	cp.OnOpenCommitDiff = func(dir, gotRef, short string, gotStatus git.FileStatus, extended bool) {
+		if dir != commit.Dir || gotRef != commit.Ref || short != commit.Short || gotStatus != status {
+			t.Fatalf("diff call = %q %q %q %#v", dir, gotRef, short, gotStatus)
+		}
+		diffCalls = append(diffCalls, extended)
+	}
 	for _, node := range []*widgets.TreeNode{commitNode, fileNode} {
 		for _, key := range []rune{'c', 'o', 'v', 'e'} {
 			if !cp.handleCommitLogKey(tcell.NewEventKey(tcell.KeyRune, string(key), tcell.ModNone), node) {
@@ -162,12 +171,17 @@ func TestCommitHistoryFileKeysActivateCommitAndFileRows(t *testing.T) {
 		}
 	}
 
-	if len(calls) != 8 {
-		t.Fatalf("open calls = %d, want 8", len(calls))
+	if len(calls) != 4 {
+		t.Fatalf("commit open calls = %d, want 4", len(calls))
 	}
+	commitOnly := commit
+	commitOnly.Status = git.FileStatus{}
 	for i, call := range calls {
-		if call != commit {
-			t.Fatalf("open call %d = %#v, want %#v", i, call, commit)
+		if call != commitOnly {
+			t.Fatalf("open call %d = %#v, want %#v", i, call, commitOnly)
 		}
+	}
+	if len(diffCalls) != 4 || diffCalls[0] || diffCalls[1] || diffCalls[2] || !diffCalls[3] {
+		t.Fatalf("file diff calls = %v, want compact, compact, compact, extended", diffCalls)
 	}
 }

--- a/internal/app/current_changes.go
+++ b/internal/app/current_changes.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
@@ -29,11 +28,10 @@ type CurrentChangesResult struct {
 	Canceled    bool
 }
 
-type currentFileState struct {
-	status   git.FileStatus
-	staged   bool
-	unstaged bool
-	added    bool
+type currentFileEndpoint struct {
+	content []byte
+	exists  bool
+	gitlink bool
 }
 
 func currentChangesTabID(dir string) string {
@@ -109,10 +107,10 @@ func currentChangesErrorText(err error) string {
 
 func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
 	result := &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request}
-	states := mergeCurrentFileStates(statuses)
-	result.Files = make([]ui.CommitDetailFile, 0, len(states))
-	staged, unstaged, mixed := 0, 0, 0
+	result.Files = make([]ui.CommitDetailFile, 0, len(statuses))
+	staged, unstaged := 0, 0
 	additions, deletions := 0, 0
+	paths := make(map[string]struct{}, len(statuses))
 	fingerprint := sha256.New()
 	writeFingerprint := func(value []byte) {
 		var size [8]byte
@@ -123,76 +121,70 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 	writeFingerprint([]byte(dir))
 	writeFingerprint([]byte(revision))
 
-	for _, state := range states {
+	for _, status := range statuses {
 		if err := ctx.Err(); err != nil {
 			result.Err = err
 			result.Canceled = errors.Is(err, context.Canceled)
 			return result
 		}
+		paths[status.Path] = struct{}{}
 		stage := ui.CommitDetailStageUnstaged
-		switch {
-		case state.staged && state.unstaged:
-			stage = ui.CommitDetailStageMixed
-			mixed++
-		case state.staged:
+		boundary := ui.CommitDetailBoundaryIndexToWorktree
+		if status.Staged {
 			stage = ui.CommitDetailStageStaged
+			boundary = ui.CommitDetailBoundaryHeadToIndex
 			staged++
-		default:
+		} else {
 			unstaged++
 		}
-		status := combinedCurrentStatus(state)
-		oldPath := state.status.Path
-		if state.status.OldPath != "" {
-			oldPath = state.status.OldPath
+
+		oldEndpoint, newEndpoint, indexStages, err := readCurrentFileEndpoints(ctx, dir, revision, status)
+		if err != nil {
+			result.Err = fmt.Errorf("read %s boundary for %q: %w", currentBoundaryName(boundary), status.Path, err)
+			result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+			return result
 		}
-		var oldContent []byte
-		oldExists := revision != "" && (!state.added || state.status.OldPath != "")
-		if oldExists {
-			var err error
-			oldContent, err = git.ShowFileBytesContext(ctx, dir, oldPath, revision)
+		oldLines := splitCurrentChangesLines(oldEndpoint.content)
+		newLines := splitCurrentChangesLines(newEndpoint.content)
+		var fileDiff diff.FileDiff
+		var patch string
+		if oldEndpoint.gitlink || newEndpoint.gitlink {
+			patch, err = git.DiffCurrentFileContext(ctx, dir, revision, status)
 			if err != nil {
-				result.Err = fmt.Errorf("read HEAD content for %q: %w", state.status.Path, err)
+				result.Err = fmt.Errorf("read %s gitlink diff for %q: %w", currentBoundaryName(boundary), status.Path, err)
 				result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
 				return result
 			}
+			fileDiff = diff.Parse(patch)
+		} else if !bytes.Equal(oldEndpoint.content, newEndpoint.content) || oldEndpoint.exists != newEndpoint.exists {
+			fileDiff = diff.Parse(diff.Generate(oldLines, newLines, status.Path))
 		}
-		newContent, newExists, err := readWorkingTreeContent(filepath.Join(dir, state.status.Path))
-		if err != nil {
-			result.Err = fmt.Errorf("read working tree content for %q: %w", state.status.Path, err)
-			return result
-		}
-		if !newExists && status != "D" {
-			result.Err = fmt.Errorf("working tree path %q disappeared during refresh", state.status.Path)
-			return result
-		}
+		presentedStatus := currentPresentedStatus(status.Status)
+		presentedOldPath := currentPresentedOldPath(status)
 
-		writeFingerprint([]byte(status))
+		writeFingerprint([]byte(presentedStatus))
 		writeFingerprint([]byte{byte(stage)})
-		writeFingerprint([]byte(state.status.OldPath))
-		writeFingerprint([]byte(state.status.Path))
-		writeFingerprint(oldContent)
-		writeFingerprint(newContent)
+		writeFingerprint([]byte{byte(boundary)})
+		writeFingerprint([]byte(presentedOldPath))
+		writeFingerprint([]byte(status.Path))
+		writeFingerprint(indexStages)
+		writeFingerprint(oldEndpoint.content)
+		writeFingerprint(newEndpoint.content)
+		writeFingerprint([]byte(patch))
 
 		file := ui.CommitDetailFile{
-			Status: status, Path: state.status.Path, OldPath: state.status.OldPath, Stage: stage,
+			Status: presentedStatus, Path: status.Path, OldPath: presentedOldPath, Stage: stage, Boundary: boundary,
+			IndexStages: append([]byte(nil), indexStages...),
 		}
 		switch {
-		case isBinaryContent(oldContent) || isBinaryContent(newContent):
+		case isBinaryContent(oldEndpoint.content) || isBinaryContent(newEndpoint.content):
 			file.ContentKind = ui.CommitDetailContentBinary
 			file.FullFileState = ui.CommitDetailFullFileLoaded
-		case len(oldContent) == 0 && len(newContent) == 0 && (oldExists || newExists):
+		case len(oldEndpoint.content) == 0 && len(newEndpoint.content) == 0 && (oldEndpoint.exists || newEndpoint.exists) && !oldEndpoint.gitlink && !newEndpoint.gitlink:
 			file.ContentKind = ui.CommitDetailContentEmpty
 			file.FullFileState = ui.CommitDetailFullFileLoaded
 		default:
-			oldLines := splitCurrentChangesLines(oldContent)
-			newLines := splitCurrentChangesLines(newContent)
-			patch, err := git.DiffWorkingTreeFileContext(ctx, dir, revision, state.status)
-			if err != nil {
-				result.Err = fmt.Errorf("read diff for %q: %w", state.status.Path, err)
-				result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
-				return result
-			}
-			file.Diff = diff.Parse(patch)
+			file.Diff = fileDiff
 			file = ui.CommitDetailFileWithContent(file, oldLines, newLines)
 			added, deleted := currentDiffStats(file.Diff)
 			additions += added
@@ -201,27 +193,130 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 		result.Files = append(result.Files, file)
 	}
 	result.Fingerprint = fmt.Sprintf("%x", fingerprint.Sum(nil))
-	result.Summary = currentChangesSummary(len(states), additions, deletions, staged, unstaged, mixed)
+	result.Summary = currentChangesSummary(len(paths), additions, deletions, staged, unstaged, 0)
 	return result
 }
 
-func readWorkingTreeContent(path string) ([]byte, bool, error) {
-	info, err := os.Lstat(path)
-	if os.IsNotExist(err) {
-		return nil, false, nil
+func readCurrentFileEndpoints(ctx context.Context, dir, revision string, status git.FileStatus) (currentFileEndpoint, currentFileEndpoint, []byte, error) {
+	indexPath := status.Path
+	if !status.Staged && (status.Status == "R" || status.Status == "C") && status.OldPath != "" {
+		indexPath = status.OldPath
 	}
+	entries, err := git.IndexEntriesContext(ctx, dir, indexPath)
 	if err != nil {
-		return nil, false, err
+		return currentFileEndpoint{}, currentFileEndpoint{}, nil, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		target, err := os.Readlink(path)
-		return []byte(target), true, err
+	indexStages := make([]byte, 0, len(entries))
+	for _, entry := range entries {
+		indexStages = append(indexStages, byte(entry.Stage))
 	}
-	if info.IsDir() {
-		return []byte{0}, true, nil
+
+	if status.Staged {
+		oldEndpoint, err := readTreeEndpoint(ctx, dir, revision, currentOldPath(status))
+		if err != nil {
+			return currentFileEndpoint{}, currentFileEndpoint{}, nil, err
+		}
+		newEndpoint, err := readIndexEndpoint(ctx, dir, indexPath, entries)
+		return oldEndpoint, newEndpoint, indexStages, err
 	}
-	content, err := os.ReadFile(path)
-	return content, true, err
+
+	oldEndpoint := currentFileEndpoint{}
+	if status.Status != "?" {
+		oldEndpoint, err = readIndexEndpoint(ctx, dir, indexPath, entries)
+		if err != nil {
+			return currentFileEndpoint{}, currentFileEndpoint{}, nil, err
+		}
+	}
+	if status.Status == "D" {
+		return oldEndpoint, currentFileEndpoint{}, indexStages, nil
+	}
+	working, err := readWorkingTreeFileContext(ctx, dir, status.Path)
+	if err != nil {
+		var pathErr *workingTreePathError
+		if errors.As(err, &pathErr) && pathErr.Kind == workingTreePathDirectory && (oldEndpoint.gitlink || hasGitlinkEntry(entries)) {
+			return oldEndpoint, currentFileEndpoint{exists: true, gitlink: true}, indexStages, nil
+		}
+		return currentFileEndpoint{}, currentFileEndpoint{}, nil, err
+	}
+	if !working.Exists {
+		return currentFileEndpoint{}, currentFileEndpoint{}, nil, fmt.Errorf("working tree path disappeared")
+	}
+	return oldEndpoint, currentFileEndpoint{content: working.Content, exists: true}, indexStages, nil
+}
+
+func readTreeEndpoint(ctx context.Context, dir, revision, path string) (currentFileEndpoint, error) {
+	if revision == "" || path == "" {
+		return currentFileEndpoint{}, nil
+	}
+	entry, exists, err := git.TreeEntryContext(ctx, dir, revision, path)
+	if err != nil || !exists {
+		return currentFileEndpoint{}, err
+	}
+	if entry.Mode == "160000" {
+		return currentFileEndpoint{content: []byte("Subproject commit " + entry.Object + "\n"), exists: true, gitlink: true}, nil
+	}
+	content, err := git.ShowFileBytesContext(ctx, dir, path, revision)
+	return currentFileEndpoint{content: content, exists: err == nil}, err
+}
+
+func readIndexEndpoint(ctx context.Context, dir, path string, entries []git.IndexEntry) (currentFileEndpoint, error) {
+	if len(entries) == 0 {
+		return currentFileEndpoint{}, nil
+	}
+	entry := entries[0]
+	for _, candidate := range entries {
+		if candidate.Stage == 0 || candidate.Stage == 2 {
+			entry = candidate
+			if candidate.Stage == 0 {
+				break
+			}
+		}
+	}
+	if entry.Mode == "160000" {
+		return currentFileEndpoint{content: []byte("Subproject commit " + entry.Object + "\n"), exists: true, gitlink: true}, nil
+	}
+	content, err := git.ShowIndexFileBytesContext(ctx, dir, path, entry.Stage)
+	return currentFileEndpoint{content: content, exists: err == nil}, err
+}
+
+func hasGitlinkEntry(entries []git.IndexEntry) bool {
+	for _, entry := range entries {
+		if entry.Mode == "160000" {
+			return true
+		}
+	}
+	return false
+}
+
+func currentOldPath(status git.FileStatus) string {
+	if status.OldPath != "" {
+		return status.OldPath
+	}
+	return status.Path
+}
+
+func currentPresentedOldPath(status git.FileStatus) string {
+	if status.Status == "R" || status.Status == "C" {
+		return status.OldPath
+	}
+	return ""
+}
+
+func currentPresentedStatus(status string) string {
+	if status == "?" {
+		return "A"
+	}
+	if status == "" {
+		return "M"
+	}
+	return status
+}
+
+func currentBoundaryName(boundary ui.CommitDetailBoundary) string {
+	if boundary == ui.CommitDetailBoundaryHeadToIndex {
+		return "HEAD-to-index"
+	}
+	return "index-to-worktree"
 }
 
 func isBinaryContent(content []byte) bool {
@@ -237,48 +332,6 @@ func splitCurrentChangesLines(content []byte) []string {
 		lines = lines[:len(lines)-1]
 	}
 	return lines
-}
-
-func mergeCurrentFileStates(statuses []git.FileStatus) []currentFileState {
-	states := make([]currentFileState, 0, len(statuses))
-	index := make(map[string]int, len(statuses))
-	for _, status := range statuses {
-		i, ok := index[status.Path]
-		if !ok {
-			i = len(states)
-			index[status.Path] = i
-			states = append(states, currentFileState{status: status})
-		}
-		state := &states[i]
-		if status.OldPath != "" {
-			state.status.OldPath = status.OldPath
-		}
-		if status.Staged {
-			state.staged = true
-			if status.Status == "A" {
-				state.added = true
-			}
-			if state.status.Status == "M" || state.status.Status == "" {
-				state.status.Status = status.Status
-			}
-		} else {
-			state.unstaged = true
-			if status.Status == "?" {
-				state.added = true
-			}
-			if status.Status == "?" || status.Status == "D" {
-				state.status.Status = status.Status
-			}
-		}
-	}
-	return states
-}
-
-func combinedCurrentStatus(state currentFileState) string {
-	if state.status.Status == "" {
-		return "M"
-	}
-	return state.status.Status
 }
 
 func currentDiffStats(file diff.FileDiff) (added, deleted int) {

--- a/internal/app/current_changes.go
+++ b/internal/app/current_changes.go
@@ -34,6 +34,11 @@ type currentFileEndpoint struct {
 	gitlink bool
 }
 
+type currentChangeStatus struct {
+	status       git.FileStatus
+	conflictCode string
+}
+
 func currentChangesTabID(dir string) string {
 	return "current-changes:\x00" + filepath.Clean(dir)
 }
@@ -108,7 +113,7 @@ func currentChangesErrorText(err error) string {
 func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
 	result := &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request}
 	result.Files = make([]ui.CommitDetailFile, 0, len(statuses))
-	staged, unstaged := 0, 0
+	staged, unstaged, conflicts := 0, 0, 0
 	additions, deletions := 0, 0
 	paths := make(map[string]struct{}, len(statuses))
 	fingerprint := sha256.New()
@@ -121,7 +126,8 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 	writeFingerprint([]byte(dir))
 	writeFingerprint([]byte(revision))
 
-	for _, status := range statuses {
+	for _, change := range normalizeCurrentChangeStatuses(statuses) {
+		status := change.status
 		if err := ctx.Err(); err != nil {
 			result.Err = err
 			result.Canceled = errors.Is(err, context.Canceled)
@@ -130,7 +136,11 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 		paths[status.Path] = struct{}{}
 		stage := ui.CommitDetailStageUnstaged
 		boundary := ui.CommitDetailBoundaryIndexToWorktree
-		if status.Staged {
+		if change.conflictCode != "" {
+			stage = ui.CommitDetailStageConflict
+			boundary = ui.CommitDetailBoundaryConflictToWorktree
+			conflicts++
+		} else if status.Staged {
 			stage = ui.CommitDetailStageStaged
 			boundary = ui.CommitDetailBoundaryHeadToIndex
 			staged++
@@ -138,7 +148,14 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 			unstaged++
 		}
 
-		oldEndpoint, newEndpoint, indexStages, err := readCurrentFileEndpoints(ctx, dir, revision, status)
+		var oldEndpoint, newEndpoint currentFileEndpoint
+		var indexStages []byte
+		var err error
+		if change.conflictCode != "" {
+			oldEndpoint, newEndpoint, indexStages, err = readCurrentConflictEndpoints(ctx, dir, status.Path)
+		} else {
+			oldEndpoint, newEndpoint, indexStages, err = readCurrentFileEndpoints(ctx, dir, revision, status)
+		}
 		if err != nil {
 			result.Err = fmt.Errorf("read %s boundary for %q: %w", currentBoundaryName(boundary), status.Path, err)
 			result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
@@ -148,7 +165,7 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 		newLines := splitCurrentChangesLines(newEndpoint.content)
 		var fileDiff diff.FileDiff
 		var patch string
-		if oldEndpoint.gitlink || newEndpoint.gitlink {
+		if change.conflictCode == "" && (oldEndpoint.gitlink || newEndpoint.gitlink) {
 			patch, err = git.DiffCurrentFileContext(ctx, dir, revision, status)
 			if err != nil {
 				result.Err = fmt.Errorf("read %s gitlink diff for %q: %w", currentBoundaryName(boundary), status.Path, err)
@@ -157,7 +174,14 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 			}
 			fileDiff = diff.Parse(patch)
 		} else if !bytes.Equal(oldEndpoint.content, newEndpoint.content) || oldEndpoint.exists != newEndpoint.exists {
-			fileDiff = diff.Parse(diff.Generate(oldLines, newLines, status.Path))
+			generated, generateErr := diff.GenerateContext(ctx, oldLines, newLines, status.Path)
+			err = generateErr
+			if err != nil {
+				result.Err = fmt.Errorf("generate %s diff for %q: %w", currentBoundaryName(boundary), status.Path, err)
+				result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+				return result
+			}
+			fileDiff = diff.Parse(generated)
 		}
 		presentedStatus := currentPresentedStatus(status.Status)
 		presentedOldPath := currentPresentedOldPath(status)
@@ -168,13 +192,14 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 		writeFingerprint([]byte(presentedOldPath))
 		writeFingerprint([]byte(status.Path))
 		writeFingerprint(indexStages)
+		writeFingerprint([]byte(change.conflictCode))
 		writeFingerprint(oldEndpoint.content)
 		writeFingerprint(newEndpoint.content)
 		writeFingerprint([]byte(patch))
 
 		file := ui.CommitDetailFile{
 			Status: presentedStatus, Path: status.Path, OldPath: presentedOldPath, Stage: stage, Boundary: boundary,
-			IndexStages: append([]byte(nil), indexStages...),
+			IndexStages: append([]byte(nil), indexStages...), ConflictCode: change.conflictCode,
 		}
 		switch {
 		case isBinaryContent(oldEndpoint.content) || isBinaryContent(newEndpoint.content):
@@ -193,8 +218,115 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 		result.Files = append(result.Files, file)
 	}
 	result.Fingerprint = fmt.Sprintf("%x", fingerprint.Sum(nil))
-	result.Summary = currentChangesSummary(len(paths), additions, deletions, staged, unstaged, 0)
+	result.Summary = currentChangesSummary(len(paths), additions, deletions, staged, unstaged, conflicts)
 	return result
+}
+
+func normalizeCurrentChangeStatuses(statuses []git.FileStatus) []currentChangeStatus {
+	type pathStatuses struct {
+		count            int
+		staged, unstaged int
+	}
+	pairs := make(map[string]pathStatuses, len(statuses))
+	for i, status := range statuses {
+		pair := pairs[status.Path]
+		if pair.count == 0 {
+			pair.staged = -1
+			pair.unstaged = -1
+		}
+		pair.count++
+		if status.Staged {
+			pair.staged = i
+		} else {
+			pair.unstaged = i
+		}
+		pairs[status.Path] = pair
+	}
+
+	conflicts := make(map[int]string)
+	skip := make(map[int]struct{})
+	for _, pair := range pairs {
+		if pair.count != 2 || pair.staged < 0 || pair.unstaged < 0 {
+			continue
+		}
+		code, ok := currentConflictCode(statuses[pair.staged].Status, statuses[pair.unstaged].Status)
+		if !ok {
+			continue
+		}
+		first, second := pair.staged, pair.unstaged
+		if second < first {
+			first, second = second, first
+		}
+		conflicts[first] = code
+		skip[second] = struct{}{}
+	}
+
+	normalized := make([]currentChangeStatus, 0, len(statuses)-len(skip))
+	for i, status := range statuses {
+		if _, omitted := skip[i]; omitted {
+			continue
+		}
+		code := conflicts[i]
+		if code != "" {
+			status.Status = "U"
+			status.OldPath = ""
+			status.Staged = false
+		}
+		normalized = append(normalized, currentChangeStatus{status: status, conflictCode: code})
+	}
+	return normalized
+}
+
+func currentConflictCode(staged, unstaged string) (string, bool) {
+	code := staged + unstaged
+	switch code {
+	case "DD", "AU", "UD", "UA", "DU", "AA", "UU":
+		return code, true
+	default:
+		return "", false
+	}
+}
+
+func readCurrentConflictEndpoints(ctx context.Context, dir, path string) (currentFileEndpoint, currentFileEndpoint, []byte, error) {
+	entries, err := git.IndexEntriesContext(ctx, dir, path)
+	if err != nil {
+		return currentFileEndpoint{}, currentFileEndpoint{}, nil, err
+	}
+	indexStages := make([]byte, 0, len(entries))
+	for _, entry := range entries {
+		indexStages = append(indexStages, byte(entry.Stage))
+	}
+	entry, ok := preferredConflictEntry(entries)
+	if !ok {
+		return currentFileEndpoint{}, currentFileEndpoint{}, indexStages, fmt.Errorf("unmerged path has no stage 1, 2, or 3 endpoint")
+	}
+	oldEndpoint, err := readIndexEntryEndpoint(ctx, dir, path, entry)
+	if err != nil {
+		return currentFileEndpoint{}, currentFileEndpoint{}, indexStages, err
+	}
+	working, err := readWorkingTreeFileContext(ctx, dir, path)
+	if err != nil {
+		var pathErr *workingTreePathError
+		if errors.As(err, &pathErr) && pathErr.Kind == workingTreePathDirectory && oldEndpoint.gitlink {
+			return oldEndpoint, currentFileEndpoint{exists: true, gitlink: true}, indexStages, nil
+		}
+		return currentFileEndpoint{}, currentFileEndpoint{}, indexStages, err
+	}
+	if !working.Exists {
+		return oldEndpoint, currentFileEndpoint{}, indexStages, nil
+	}
+	return oldEndpoint, currentFileEndpoint{content: working.Content, exists: true}, indexStages, nil
+}
+
+func preferredConflictEntry(entries []git.IndexEntry) (git.IndexEntry, bool) {
+	for _, stage := range []int{2, 3, 1} {
+		for _, entry := range entries {
+			if entry.Stage == stage {
+				return entry, true
+			}
+		}
+	}
+	return git.IndexEntry{}, false
 }
 
 func readCurrentFileEndpoints(ctx context.Context, dir, revision string, status git.FileStatus) (currentFileEndpoint, currentFileEndpoint, []byte, error) {
@@ -272,6 +404,10 @@ func readIndexEndpoint(ctx context.Context, dir, path string, entries []git.Inde
 			}
 		}
 	}
+	return readIndexEntryEndpoint(ctx, dir, path, entry)
+}
+
+func readIndexEntryEndpoint(ctx context.Context, dir, path string, entry git.IndexEntry) (currentFileEndpoint, error) {
 	if entry.Mode == "160000" {
 		return currentFileEndpoint{content: []byte("Subproject commit " + entry.Object + "\n"), exists: true, gitlink: true}, nil
 	}
@@ -313,10 +449,14 @@ func currentPresentedStatus(status string) string {
 }
 
 func currentBoundaryName(boundary ui.CommitDetailBoundary) string {
-	if boundary == ui.CommitDetailBoundaryHeadToIndex {
+	switch boundary {
+	case ui.CommitDetailBoundaryHeadToIndex:
 		return "HEAD-to-index"
+	case ui.CommitDetailBoundaryConflictToWorktree:
+		return "conflict-to-worktree"
+	default:
+		return "index-to-worktree"
 	}
-	return "index-to-worktree"
 }
 
 func isBinaryContent(content []byte) bool {
@@ -346,7 +486,7 @@ func currentDiffStats(file diff.FileDiff) (added, deleted int) {
 	return added, deleted
 }
 
-func currentChangesSummary(files, additions, deletions, staged, unstaged, mixed int) string {
+func currentChangesSummary(files, additions, deletions, staged, unstaged, conflicts int) string {
 	if files == 0 {
 		return "Working tree clean"
 	}
@@ -361,8 +501,12 @@ func currentChangesSummary(files, additions, deletions, staged, unstaged, mixed 
 	if unstaged > 0 {
 		parts = append(parts, fmt.Sprintf("%d unstaged", unstaged))
 	}
-	if mixed > 0 {
-		parts = append(parts, fmt.Sprintf("%d mixed", mixed))
+	if conflicts > 0 {
+		label := "conflict"
+		if conflicts != 1 {
+			label = "conflicts"
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", conflicts, label))
 	}
 	return strings.Join(parts, " · ")
 }

--- a/internal/app/current_changes.go
+++ b/internal/app/current_changes.go
@@ -39,6 +39,8 @@ type currentChangeStatus struct {
 	conflictCode string
 }
 
+const currentChangesMaxDiffCells = 4_000_000
+
 func currentChangesTabID(dir string) string {
 	return "current-changes:\x00" + filepath.Clean(dir)
 }
@@ -174,8 +176,17 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 			}
 			fileDiff = diff.Parse(patch)
 		} else if !bytes.Equal(oldEndpoint.content, newEndpoint.content) || oldEndpoint.exists != newEndpoint.exists {
-			generated, generateErr := diff.GenerateContext(ctx, oldLines, newLines, status.Path)
-			err = generateErr
+			generated := ""
+			if currentChangesDiffExceedsLimit(len(oldLines), len(newLines)) {
+				if change.conflictCode == "" {
+					generated, err = git.DiffCurrentFileContext(ctx, dir, revision, status)
+				} else {
+					generated, err = generateCurrentChangesReplacement(ctx, oldLines, newLines, status.Path)
+				}
+				patch = generated
+			} else {
+				generated, err = diff.GenerateContext(ctx, oldLines, newLines, status.Path)
+			}
 			if err != nil {
 				result.Err = fmt.Errorf("generate %s diff for %q: %w", currentBoundaryName(boundary), status.Path, err)
 				result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
@@ -220,6 +231,33 @@ func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch,
 	result.Fingerprint = fmt.Sprintf("%x", fingerprint.Sum(nil))
 	result.Summary = currentChangesSummary(len(paths), additions, deletions, staged, unstaged, conflicts)
 	return result
+}
+
+func currentChangesDiffExceedsLimit(oldLines, newLines int) bool {
+	rows, columns := oldLines+1, newLines+1
+	return rows > currentChangesMaxDiffCells/columns
+}
+
+func generateCurrentChangesReplacement(ctx context.Context, oldLines, newLines []string, path string) (string, error) {
+	var generated strings.Builder
+	fmt.Fprintf(&generated, "diff --git a/%s b/%s\n--- a/%s\n+++ b/%s\n@@ -1,%d +1,%d @@\n", path, path, path, path, len(oldLines), len(newLines))
+	for _, line := range oldLines {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		generated.WriteByte('-')
+		generated.WriteString(line)
+		generated.WriteByte('\n')
+	}
+	for _, line := range newLines {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		generated.WriteByte('+')
+		generated.WriteString(line)
+		generated.WriteByte('\n')
+	}
+	return generated.String(), nil
 }
 
 func normalizeCurrentChangeStatuses(statuses []git.FileStatus) []currentChangeStatus {

--- a/internal/app/current_changes.go
+++ b/internal/app/current_changes.go
@@ -1,0 +1,315 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+type CurrentChangesResult struct {
+	Dir         string
+	TabID       string
+	Epoch       uint64
+	Request     uint64
+	Fingerprint string
+	Summary     string
+	Files       []ui.CommitDetailFile
+	Err         error
+	Canceled    bool
+}
+
+type currentFileState struct {
+	status   git.FileStatus
+	staged   bool
+	unstaged bool
+	added    bool
+}
+
+func currentChangesTabID(dir string) string {
+	return "current-changes:\x00" + filepath.Clean(dir)
+}
+
+func currentChangesTitle(dir string, multiRoot bool) string {
+	if multiRoot {
+		return "Changes · " + filepath.Base(dir)
+	}
+	return "Current Changes"
+}
+
+func (a *App) selectedChangesDir() string {
+	if a == nil || a.Changes == nil {
+		return ""
+	}
+	if dir := a.Changes.selectedGroupDir(); dir != "" {
+		return dir
+	}
+	if len(a.Changes.groups) > 0 {
+		return a.Changes.groups[0].Dir
+	}
+	return ""
+}
+
+func (a *App) OpenCurrentChanges() {
+	dir := a.selectedChangesDir()
+	if dir == "" {
+		a.pendingCurrentChangesOpen = true
+		if a.Repository != nil {
+			a.Repository.RefreshNow(RepositoryWorktree)
+		}
+		a.StatusNotify("Loading repository changes…")
+		return
+	}
+	a.pendingCurrentChangesOpen = false
+	tabID := currentChangesTabID(dir)
+	detail := a.EditorGroup.CurrentChangesWidgetByTab(tabID)
+	if detail == nil {
+		detail = ui.NewCurrentChangesWidget(dir, a.EditorGroup.SyntaxHighlight)
+		detail.OnClose = func() {
+			if a.Repository != nil {
+				a.Repository.CloseCurrentChangesTab(tabID)
+			}
+		}
+		a.EditorGroup.ApplyDiffDefaults(detail)
+		a.EditorGroup.OpenPluginTab(tabID, currentChangesTitle(dir, len(a.Changes.groups) > 1), detail)
+	} else {
+		a.EditorGroup.SwitchToTabByPath(tabID)
+	}
+	a.FocusEditorIfEnabled()
+	a.syncRepositoryObservation()
+}
+
+func (a *App) ApplyCurrentChanges(result *CurrentChangesResult) {
+	if result == nil || result.Canceled || a.EditorGroup == nil {
+		return
+	}
+	detail := a.EditorGroup.CurrentChangesWidgetByTab(result.TabID)
+	if detail == nil || detail.Dir != result.Dir || detail.Incarnation != result.Epoch {
+		return
+	}
+	detail.SetCurrentChanges(result.Summary, result.Files, currentChangesErrorText(result.Err))
+}
+
+func currentChangesErrorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return "Could not refresh current changes: " + err.Error()
+}
+
+func readCurrentChanges(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+	result := &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request}
+	states := mergeCurrentFileStates(statuses)
+	result.Files = make([]ui.CommitDetailFile, 0, len(states))
+	staged, unstaged, mixed := 0, 0, 0
+	additions, deletions := 0, 0
+	fingerprint := sha256.New()
+	writeFingerprint := func(value []byte) {
+		var size [8]byte
+		binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+		_, _ = fingerprint.Write(size[:])
+		_, _ = fingerprint.Write(value)
+	}
+	writeFingerprint([]byte(dir))
+	writeFingerprint([]byte(revision))
+
+	for _, state := range states {
+		if err := ctx.Err(); err != nil {
+			result.Err = err
+			result.Canceled = errors.Is(err, context.Canceled)
+			return result
+		}
+		stage := ui.CommitDetailStageUnstaged
+		switch {
+		case state.staged && state.unstaged:
+			stage = ui.CommitDetailStageMixed
+			mixed++
+		case state.staged:
+			stage = ui.CommitDetailStageStaged
+			staged++
+		default:
+			unstaged++
+		}
+		status := combinedCurrentStatus(state)
+		oldPath := state.status.Path
+		if state.status.OldPath != "" {
+			oldPath = state.status.OldPath
+		}
+		var oldContent []byte
+		oldExists := revision != "" && (!state.added || state.status.OldPath != "")
+		if oldExists {
+			var err error
+			oldContent, err = git.ShowFileBytesContext(ctx, dir, oldPath, revision)
+			if err != nil {
+				result.Err = fmt.Errorf("read HEAD content for %q: %w", state.status.Path, err)
+				result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+				return result
+			}
+		}
+		newContent, newExists, err := readWorkingTreeContent(filepath.Join(dir, state.status.Path))
+		if err != nil {
+			result.Err = fmt.Errorf("read working tree content for %q: %w", state.status.Path, err)
+			return result
+		}
+		if !newExists && status != "D" {
+			result.Err = fmt.Errorf("working tree path %q disappeared during refresh", state.status.Path)
+			return result
+		}
+
+		writeFingerprint([]byte(status))
+		writeFingerprint([]byte{byte(stage)})
+		writeFingerprint([]byte(state.status.OldPath))
+		writeFingerprint([]byte(state.status.Path))
+		writeFingerprint(oldContent)
+		writeFingerprint(newContent)
+
+		file := ui.CommitDetailFile{
+			Status: status, Path: state.status.Path, OldPath: state.status.OldPath, Stage: stage,
+		}
+		switch {
+		case isBinaryContent(oldContent) || isBinaryContent(newContent):
+			file.ContentKind = ui.CommitDetailContentBinary
+			file.FullFileState = ui.CommitDetailFullFileLoaded
+		case len(oldContent) == 0 && len(newContent) == 0 && (oldExists || newExists):
+			file.ContentKind = ui.CommitDetailContentEmpty
+			file.FullFileState = ui.CommitDetailFullFileLoaded
+		default:
+			oldLines := splitCurrentChangesLines(oldContent)
+			newLines := splitCurrentChangesLines(newContent)
+			patch, err := git.DiffWorkingTreeFileContext(ctx, dir, revision, state.status)
+			if err != nil {
+				result.Err = fmt.Errorf("read diff for %q: %w", state.status.Path, err)
+				result.Canceled = errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+				return result
+			}
+			file.Diff = diff.Parse(patch)
+			file = ui.CommitDetailFileWithContent(file, oldLines, newLines)
+			added, deleted := currentDiffStats(file.Diff)
+			additions += added
+			deletions += deleted
+		}
+		result.Files = append(result.Files, file)
+	}
+	result.Fingerprint = fmt.Sprintf("%x", fingerprint.Sum(nil))
+	result.Summary = currentChangesSummary(len(states), additions, deletions, staged, unstaged, mixed)
+	return result
+}
+
+func readWorkingTreeContent(path string) ([]byte, bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(path)
+		return []byte(target), true, err
+	}
+	if info.IsDir() {
+		return []byte{0}, true, nil
+	}
+	content, err := os.ReadFile(path)
+	return content, true, err
+}
+
+func isBinaryContent(content []byte) bool {
+	return bytes.IndexByte(content, 0) >= 0 || !utf8.Valid(content)
+}
+
+func splitCurrentChangesLines(content []byte) []string {
+	if len(content) == 0 {
+		return nil
+	}
+	lines := strings.Split(string(content), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func mergeCurrentFileStates(statuses []git.FileStatus) []currentFileState {
+	states := make([]currentFileState, 0, len(statuses))
+	index := make(map[string]int, len(statuses))
+	for _, status := range statuses {
+		i, ok := index[status.Path]
+		if !ok {
+			i = len(states)
+			index[status.Path] = i
+			states = append(states, currentFileState{status: status})
+		}
+		state := &states[i]
+		if status.OldPath != "" {
+			state.status.OldPath = status.OldPath
+		}
+		if status.Staged {
+			state.staged = true
+			if status.Status == "A" {
+				state.added = true
+			}
+			if state.status.Status == "M" || state.status.Status == "" {
+				state.status.Status = status.Status
+			}
+		} else {
+			state.unstaged = true
+			if status.Status == "?" {
+				state.added = true
+			}
+			if status.Status == "?" || status.Status == "D" {
+				state.status.Status = status.Status
+			}
+		}
+	}
+	return states
+}
+
+func combinedCurrentStatus(state currentFileState) string {
+	if state.status.Status == "" {
+		return "M"
+	}
+	return state.status.Status
+}
+
+func currentDiffStats(file diff.FileDiff) (added, deleted int) {
+	for _, line := range file.AllLines() {
+		if line.Left.Kind == diff.Deleted {
+			deleted++
+		}
+		if line.Right.Kind == diff.Added {
+			added++
+		}
+	}
+	return added, deleted
+}
+
+func currentChangesSummary(files, additions, deletions, staged, unstaged, mixed int) string {
+	if files == 0 {
+		return "Working tree clean"
+	}
+	fileLabel := "file"
+	if files != 1 {
+		fileLabel = "files"
+	}
+	parts := []string{fmt.Sprintf("%d %s", files, fileLabel), fmt.Sprintf("+%d −%d", additions, deletions)}
+	if staged > 0 {
+		parts = append(parts, fmt.Sprintf("%d staged", staged))
+	}
+	if unstaged > 0 {
+		parts = append(parts, fmt.Sprintf("%d unstaged", unstaged))
+	}
+	if mixed > 0 {
+		parts = append(parts, fmt.Sprintf("%d mixed", mixed))
+	}
+	return strings.Join(parts, " · ")
+}

--- a/internal/app/current_changes_release_test.go
+++ b/internal/app/current_changes_release_test.go
@@ -133,12 +133,14 @@ func TestReadCurrentChangesPreservesUnmergedIndexStages(t *testing.T) {
 	}
 
 	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
-	if result.Err != nil || len(result.Files) != 2 {
+	if result.Err != nil || len(result.Files) != 1 {
 		t.Fatalf("conflict result=%+v", result)
 	}
-	for _, file := range result.Files {
-		if string(file.IndexStages) != string([]byte{1, 2, 3}) {
-			t.Fatalf("conflict stages for %v = %v", file.Boundary, file.IndexStages)
-		}
+	file := result.Files[0]
+	if file.Status != "U" || file.Stage != ui.CommitDetailStageConflict || file.Boundary != ui.CommitDetailBoundaryConflictToWorktree || file.ConflictCode != "UU" {
+		t.Fatalf("conflict identity=%+v", file)
+	}
+	if string(file.IndexStages) != string([]byte{1, 2, 3}) {
+		t.Fatalf("conflict stages = %v", file.IndexStages)
 	}
 }

--- a/internal/app/current_changes_release_test.go
+++ b/internal/app/current_changes_release_test.go
@@ -1,0 +1,144 @@
+package app
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func TestReleaseContractMixedChangeKeepsIndexBoundary(t *testing.T) {
+	dir := testAppRepository(t)
+	path := filepath.Join(dir, "initial.txt")
+	if err := os.WriteFile(path, []byte("staged snapshot\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "--", "initial.txt")
+	if err := os.WriteFile(path, []byte("unstaged snapshot\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	if len(result.Files) != 2 {
+		t.Fatalf("files = %d, want staged and unstaged boundaries", len(result.Files))
+	}
+	staged, unstaged := result.Files[0], result.Files[1]
+	if staged.Stage != ui.CommitDetailStageStaged || staged.Boundary != ui.CommitDetailBoundaryHeadToIndex ||
+		unstaged.Stage != ui.CommitDetailStageUnstaged || unstaged.Boundary != ui.CommitDetailBoundaryIndexToWorktree {
+		t.Fatalf("boundary identities = %+v", result.Files)
+	}
+	if ui.CommitDetailContextKey(staged) == ui.CommitDetailContextKey(unstaged) {
+		t.Fatal("identical paths collapsed to the same typed key")
+	}
+	seenStaged := false
+	for _, line := range staged.Diff.AllLines() {
+		seenStaged = seenStaged || line.Right.Text == "staged snapshot"
+	}
+	seenIndex, seenFinal := false, false
+	for _, line := range unstaged.Diff.AllLines() {
+		seenIndex = seenIndex || line.Left.Text == "staged snapshot"
+		seenFinal = seenFinal || line.Right.Text == "unstaged snapshot"
+	}
+	if !seenStaged || !seenIndex || !seenFinal {
+		t.Fatalf("mixed boundaries lost an endpoint: staged=%+v unstaged=%+v", staged.Diff.AllLines(), unstaged.Diff.AllLines())
+	}
+	if !strings.Contains(result.Summary, "1 file") || !strings.Contains(result.Summary, "1 staged") || !strings.Contains(result.Summary, "1 unstaged") {
+		t.Fatalf("mixed summary = %q", result.Summary)
+	}
+}
+
+func TestReleaseContractIntentToAddRenders(t *testing.T) {
+	dir := testAppRepository(t)
+	path := filepath.Join(dir, "intent.txt")
+	if err := os.WriteFile(path, []byte("intent content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "-N", "--", "intent.txt")
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil || len(result.Files) != 1 {
+		t.Fatalf("intent-to-add result = %+v", result)
+	}
+	if file := result.Files[0]; file.Status != "A" || file.Stage != ui.CommitDetailStageUnstaged || file.Boundary != ui.CommitDetailBoundaryIndexToWorktree {
+		t.Fatalf("intent-to-add identity = %+v", file)
+	}
+}
+
+func TestReadCurrentChangesCoversUntrackedStagedDeletedRenameCopyAndConflictShapes(t *testing.T) {
+	dir := testAppRepository(t)
+	write := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, path), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("delete.txt", "delete\n")
+	write("rename.txt", "rename\n")
+	testAppGit(t, dir, "add", "-A")
+	testAppGit(t, dir, "commit", "-m", "shapes")
+	write("untracked.txt", "untracked\n")
+	write("staged.txt", "staged\n")
+	testAppGit(t, dir, "add", "staged.txt")
+	if err := os.Remove(filepath.Join(dir, "delete.txt")); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "mv", "rename.txt", "renamed.txt")
+
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	wants := map[string]string{"untracked.txt": "A", "staged.txt": "A", "delete.txt": "D", "renamed.txt": "R"}
+	for path, status := range wants {
+		found := false
+		for _, file := range result.Files {
+			found = found || file.Path == path && file.Status == status
+		}
+		if !found {
+			t.Fatalf("missing %s %s in %+v", status, path, result.Files)
+		}
+	}
+
+	copyPath := filepath.Join(dir, "copy.txt")
+	write("copy.txt", "initial\n")
+	testAppGit(t, dir, "add", "copy.txt")
+	copyResult := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 2, 2,
+		[]git.FileStatus{{Status: "C", OldPath: "initial.txt", Path: "copy.txt", Staged: true}})
+	if copyResult.Err != nil || len(copyResult.Files) != 1 || copyResult.Files[0].OldPath != "initial.txt" {
+		t.Fatalf("copy boundary=%+v path=%s", copyResult, copyPath)
+	}
+}
+
+func TestReadCurrentChangesPreservesUnmergedIndexStages(t *testing.T) {
+	dir := testAppRepository(t)
+	testAppGit(t, dir, "checkout", "-qb", "other")
+	if err := os.WriteFile(filepath.Join(dir, "initial.txt"), []byte("other\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "commit", "-am", "other")
+	testAppGit(t, dir, "checkout", "-q", "main")
+	if err := os.WriteFile(filepath.Join(dir, "initial.txt"), []byte("main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "commit", "-am", "main")
+	if err := exec.Command("git", "-C", dir, "merge", "other").Run(); err == nil {
+		t.Fatal("merge unexpectedly succeeded")
+	}
+
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil || len(result.Files) != 2 {
+		t.Fatalf("conflict result=%+v", result)
+	}
+	for _, file := range result.Files {
+		if string(file.IndexStages) != string([]byte{1, 2, 3}) {
+			t.Fatalf("conflict stages for %v = %v", file.Boundary, file.IndexStages)
+		}
+	}
+}

--- a/internal/app/current_changes_test.go
+++ b/internal/app/current_changes_test.go
@@ -3,7 +3,9 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -198,6 +200,149 @@ func TestReadCurrentChangesFingerprintIncludesStageIdentity(t *testing.T) {
 	}
 	if unstaged.Fingerprint == staged.Fingerprint {
 		t.Fatal("stage-only transition did not change the current changes fingerprint")
+	}
+}
+
+func TestReadCurrentChangesUnmergedModifyDeleteShapesUseOneSection(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		otherDelete bool
+		stages      []byte
+	}{
+		{name: "UD", otherDelete: true, stages: []byte{1, 2}},
+		{name: "DU", otherDelete: false, stages: []byte{1, 3}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := testAppRepository(t)
+			path := filepath.Join(dir, "initial.txt")
+			testAppGit(t, dir, "checkout", "-qb", "other")
+			if tc.otherDelete {
+				testAppGit(t, dir, "rm", "--", "initial.txt")
+				testAppGit(t, dir, "commit", "-m", "other deletes")
+			} else {
+				if err := os.WriteFile(path, []byte("other content\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				testAppGit(t, dir, "commit", "-am", "other modifies")
+			}
+			testAppGit(t, dir, "checkout", "-q", "main")
+			if tc.otherDelete {
+				if err := os.WriteFile(path, []byte("head content\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				testAppGit(t, dir, "commit", "-am", "head modifies")
+			} else {
+				testAppGit(t, dir, "rm", "--", "initial.txt")
+				testAppGit(t, dir, "commit", "-m", "head deletes")
+			}
+			if err := exec.Command("git", "-C", dir, "merge", "other").Run(); err == nil {
+				t.Fatal("merge unexpectedly succeeded")
+			}
+
+			result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+			if result.Err != nil {
+				t.Fatal(result.Err)
+			}
+			if len(result.Files) != 1 {
+				t.Fatalf("%s conflict files = %d, want one stable section: %+v", tc.name, len(result.Files), result.Files)
+			}
+			file := result.Files[0]
+			if file.Status != "U" || file.Stage != ui.CommitDetailStageConflict || file.Boundary != ui.CommitDetailBoundaryConflictToWorktree || file.ConflictCode != tc.name {
+				t.Fatalf("%s conflict identity = %+v", tc.name, file)
+			}
+			if string(file.IndexStages) != string(tc.stages) {
+				t.Fatalf("%s index stages = %v, want %v", tc.name, file.IndexStages, tc.stages)
+			}
+			if lines := file.Diff.AllLines(); len(lines) != 0 {
+				t.Fatalf("%s preferred conflict side differs from the worktree: %+v", tc.name, lines)
+			}
+			if !strings.Contains(result.Summary, "1 conflict") || strings.Contains(result.Summary, "staged") || strings.Contains(result.Summary, "unstaged") {
+				t.Fatalf("%s conflict summary = %q", tc.name, result.Summary)
+			}
+		})
+	}
+}
+
+func TestNormalizeCurrentChangeStatusesMapsEveryPorcelainConflictShape(t *testing.T) {
+	for _, code := range []string{"DD", "AU", "UD", "UA", "DU", "AA", "UU"} {
+		t.Run(code, func(t *testing.T) {
+			statuses := []git.FileStatus{
+				{Status: code[:1], Path: "conflict.txt", Staged: true},
+				{Status: code[1:], Path: "conflict.txt", Staged: false},
+			}
+			normalized := normalizeCurrentChangeStatuses(statuses)
+			if len(normalized) != 1 || normalized[0].conflictCode != code || normalized[0].status.Status != "U" || normalized[0].status.Staged {
+				t.Fatalf("normalize %s = %+v", code, normalized)
+			}
+		})
+	}
+
+	ordinary := normalizeCurrentChangeStatuses([]git.FileStatus{
+		{Status: "M", Path: "mixed.txt", Staged: true},
+		{Status: "M", Path: "mixed.txt", Staged: false},
+	})
+	if len(ordinary) != 2 || ordinary[0].conflictCode != "" || ordinary[1].conflictCode != "" || !ordinary[0].status.Staged || ordinary[1].status.Staged {
+		t.Fatalf("ordinary mixed path was normalized as a conflict: %+v", ordinary)
+	}
+}
+
+func TestPreferredConflictEntryUsesOursThenTheirsThenBase(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stages []int
+		want   int
+	}{
+		{name: "ours", stages: []int{1, 3, 2}, want: 2},
+		{name: "theirs", stages: []int{1, 3}, want: 3},
+		{name: "base", stages: []int{1}, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := make([]git.IndexEntry, len(tc.stages))
+			for i, stage := range tc.stages {
+				entries[i].Stage = stage
+			}
+			entry, ok := preferredConflictEntry(entries)
+			if !ok || entry.Stage != tc.want {
+				t.Fatalf("preferred stage for %v = %d, %v; want %d", tc.stages, entry.Stage, ok, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadCurrentChangesCancelsDuringDiffGeneration(t *testing.T) {
+	dir := testAppRepository(t)
+	const lines = 8000
+	var oldText, newText strings.Builder
+	for i := 0; i < lines; i++ {
+		fmt.Fprintf(&oldText, "old-%05d\n", i)
+		fmt.Fprintf(&newText, "new-%05d\n", i)
+	}
+	path := filepath.Join(dir, "large.txt")
+	if err := os.WriteFile(path, []byte(oldText.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "--", "large.txt")
+	testAppGit(t, dir, "commit", "-m", "large baseline")
+	if err := os.WriteFile(path, []byte(newText.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan *CurrentChangesResult, 1)
+	statuses := currentChangesStatuses(t, dir)
+	revision := git.RevisionIdentity(dir)
+	go func() {
+		resultCh <- readCurrentChanges(ctx, dir, revision, currentChangesTabID(dir), 1, 1, statuses)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	select {
+	case result := <-resultCh:
+		if !result.Canceled || !errors.Is(result.Err, context.Canceled) {
+			t.Fatalf("diff generation cancellation result = %+v", result)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("diff generation did not stop within 500ms of cancellation")
 	}
 }
 

--- a/internal/app/current_changes_test.go
+++ b/internal/app/current_changes_test.go
@@ -1,0 +1,372 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func currentChangesStatuses(t *testing.T, dir string) []git.FileStatus {
+	t.Helper()
+	statuses, err := git.StatusFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return statuses
+}
+
+func TestReadCurrentChangesUsesRawStatusIdentityForWorkingTreeShapes(t *testing.T) {
+	dir := testAppRepository(t)
+	write := func(name string, content []byte) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("delete.txt", []byte("remove me\n"))
+	write("old name.txt", []byte("before rename\n"))
+	write("blob.bin", []byte{0, 1, 2, 3})
+	testAppGit(t, dir, "add", "-A")
+	testAppGit(t, dir, "commit", "-m", "shapes")
+
+	write("initial.txt", []byte("staged version\n"))
+	testAppGit(t, dir, "add", "initial.txt")
+	write("initial.txt", []byte("final working version\n"))
+	if err := os.Remove(filepath.Join(dir, "delete.txt")); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "mv", "old name.txt", "renamed:界.txt")
+	write("renamed:界.txt", []byte("after rename 界\n"))
+	write("blob.bin", []byte{0, 9, 8, 7})
+	write("empty.txt", nil)
+	rawPath := "raw\n\t界.txt"
+	write(rawPath, []byte("path content\n"))
+
+	revision := git.RevisionIdentity(dir)
+	result := readCurrentChanges(context.Background(), dir, revision, currentChangesTabID(dir), 7, 11, currentChangesStatuses(t, dir))
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	files := make(map[string]int)
+	for i := range result.Files {
+		files[result.Files[i].Path] = i
+	}
+	for _, path := range []string{"initial.txt", "delete.txt", "renamed:界.txt", "blob.bin", "empty.txt", rawPath} {
+		if _, ok := files[path]; !ok {
+			t.Fatalf("typed current changes omitted %q: %+v", path, result.Files)
+		}
+	}
+	mixed := result.Files[files["initial.txt"]]
+	if mixed.Stage != ui.CommitDetailStageMixed {
+		t.Fatalf("mixed stage = %v", mixed.Stage)
+	}
+	foundFinal := false
+	for _, line := range mixed.Diff.AllLines() {
+		foundFinal = foundFinal || line.Right.Text == "final working version"
+		if line.Right.Text == "staged version" {
+			t.Fatal("current changes stopped at the staged snapshot")
+		}
+	}
+	if !foundFinal {
+		t.Fatalf("mixed diff omitted final working content: %+v", mixed.Diff.AllLines())
+	}
+	deleted := result.Files[files["delete.txt"]]
+	if deleted.Status != "D" || len(deleted.Diff.Hunks) == 0 {
+		t.Fatalf("deleted file = %+v", deleted)
+	}
+	renamed := result.Files[files["renamed:界.txt"]]
+	if renamed.Status != "R" || renamed.OldPath != "old name.txt" {
+		t.Fatalf("renamed file identity = %+v", renamed)
+	}
+	if result.Files[files["blob.bin"]].ContentKind != ui.CommitDetailContentBinary {
+		t.Fatalf("binary file kind = %v", result.Files[files["blob.bin"]].ContentKind)
+	}
+	if result.Files[files["empty.txt"]].ContentKind != ui.CommitDetailContentEmpty {
+		t.Fatalf("empty file kind = %v", result.Files[files["empty.txt"]].ContentKind)
+	}
+	if !strings.Contains(result.Summary, "mixed") || result.Fingerprint == "" {
+		t.Fatalf("summary=%q fingerprint=%q", result.Summary, result.Fingerprint)
+	}
+}
+
+func TestReadCurrentChangesSupportsTypedCopyIdentity(t *testing.T) {
+	dir := testAppRepository(t)
+	if err := os.WriteFile(filepath.Join(dir, "copy.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1,
+		[]git.FileStatus{{Status: "C", OldPath: "initial.txt", Path: "copy.txt", Staged: true}})
+	if result.Err != nil || len(result.Files) != 1 || result.Files[0].Status != "C" || result.Files[0].OldPath != "initial.txt" {
+		t.Fatalf("copy result=%+v", result)
+	}
+}
+
+func TestReadCurrentChangesHandlesAddedFilesWithFurtherWorkingTreeChanges(t *testing.T) {
+	dir := testAppRepository(t)
+	path := filepath.Join(dir, "added.txt")
+	if err := os.WriteFile(path, []byte("staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "added.txt")
+	if err := os.WriteFile(path, []byte("final\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil || len(result.Files) != 1 {
+		t.Fatalf("added mixed result=%+v", result)
+	}
+	file := result.Files[0]
+	if file.Status != "A" || file.Stage != ui.CommitDetailStageMixed {
+		t.Fatalf("added mixed identity=%+v", file)
+	}
+	foundFinal := false
+	for _, line := range file.Diff.AllLines() {
+		foundFinal = foundFinal || line.Right.Text == "final"
+	}
+	if !foundFinal {
+		t.Fatalf("added mixed diff omitted final content: %+v", file.Diff.AllLines())
+	}
+}
+
+func TestCurrentChangesTabIdentityDoesNotCollideAcrossRoots(t *testing.T) {
+	left := filepath.Join(t.TempDir(), "project")
+	right := filepath.Join(t.TempDir(), "project")
+	if currentChangesTabID(left) == currentChangesTabID(right) {
+		t.Fatalf("multi-root tab IDs collided for %q and %q", left, right)
+	}
+}
+
+func TestReadCurrentChangesFingerprintIncludesStageIdentity(t *testing.T) {
+	dir := testAppRepository(t)
+	path := filepath.Join(dir, "initial.txt")
+	if err := os.WriteFile(path, []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	revision := git.RevisionIdentity(dir)
+	unstaged := readCurrentChanges(context.Background(), dir, revision, currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if unstaged.Err != nil {
+		t.Fatal(unstaged.Err)
+	}
+	testAppGit(t, dir, "add", "initial.txt")
+	staged := readCurrentChanges(context.Background(), dir, revision, currentChangesTabID(dir), 1, 2, currentChangesStatuses(t, dir))
+	if staged.Err != nil {
+		t.Fatal(staged.Err)
+	}
+	if unstaged.Fingerprint == staged.Fingerprint {
+		t.Fatal("stage-only transition did not change the current changes fingerprint")
+	}
+}
+
+func primeCurrentChangesInput(s *RepositoryState, dir, revision string, group changesGroup) {
+	statuses := make([]git.FileStatus, 0, len(group.Staged)+len(group.Unstaged))
+	statuses = append(statuses, group.Staged...)
+	statuses = append(statuses, group.Unstaged...)
+	s.lastGroups[dir] = group
+	s.lastRevisions[dir] = revision
+	s.currentInputs[dir] = newCurrentChangesInput(revision, statuses)
+}
+
+func TestRepositoryCurrentChangesCoalescesDropsStaleAndRetriesErrors(t *testing.T) {
+	dir := "/repo"
+	s, _, poster := testRepositoryState(nil, dir)
+	primeCurrentChangesInput(s, dir, "head", changesGroup{Dir: dir, Unstaged: []git.FileStatus{{Status: "M", Path: "file.txt"}}})
+	started := make(chan uint64, 4)
+	release := make(chan struct{}, 4)
+	s.readCurrentChanges = func(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		started <- request
+		select {
+		case <-release:
+			return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Fingerprint: "fresh", Summary: "fresh"}
+		case <-ctx.Done():
+			return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Err: ctx.Err(), Canceled: true}
+		}
+	}
+	var applied atomic.Int32
+	s.SetCurrentChangesHandler(func(*CurrentChangesResult) { applied.Add(1) })
+	tabID := currentChangesTabID(dir)
+	epoch := s.SetCurrentChangesRoot(dir, tabID)
+	s.EnsureCurrentChanges()
+	first := <-started
+	s.currentInputs[dir] = newCurrentChangesInput("head", []git.FileStatus{{Status: "M", Path: "new-file.txt"}})
+	s.requestCurrentChanges()
+	s.requestCurrentChanges()
+	if s.currentRequest == first {
+		t.Fatal("in-flight invalidations did not supersede the request")
+	}
+	s.HandleCurrentChanges(poster.await(t).(*CurrentChangesResult))
+	second := <-started
+	if second != s.currentRequest {
+		t.Fatalf("coalesced request = %d, want %d", second, s.currentRequest)
+	}
+	release <- struct{}{}
+	if !s.HandleCurrentChanges(poster.await(t).(*CurrentChangesResult)) || applied.Load() != 1 {
+		t.Fatalf("fresh result was not applied once: epoch=%d applied=%d", epoch, applied.Load())
+	}
+
+	s.readCurrentChanges = func(_ context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Err: errors.New("index locked")}
+	}
+	s.requestCurrentChanges()
+	if !s.HandleCurrentChanges(poster.await(t).(*CurrentChangesResult)) || !s.currentDirty || applied.Load() != 2 {
+		t.Fatalf("error was not visible and retryable: dirty=%v applied=%d", s.currentDirty, applied.Load())
+	}
+	s.readCurrentChanges = func(_ context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Fingerprint: "fresh", Summary: "recovered"}
+	}
+	s.currentInputReady = true
+	s.requestCurrentChanges()
+	if !s.HandleCurrentChanges(poster.await(t).(*CurrentChangesResult)) || s.currentDirty || applied.Load() != 3 {
+		t.Fatalf("retry did not recover: dirty=%v applied=%d", s.currentDirty, applied.Load())
+	}
+}
+
+func TestRepositoryCurrentChangesIdenticalPollCoalescesWithoutStarvation(t *testing.T) {
+	dir := "/repo"
+	s, _, poster := testRepositoryState(nil, dir)
+	primeCurrentChangesInput(s, dir, "head", changesGroup{Dir: dir, Unstaged: []git.FileStatus{{Status: "M", Path: "file.txt"}}})
+	started := make(chan uint64, 2)
+	release := make(chan struct{}, 2)
+	s.readCurrentChanges = func(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		started <- request
+		select {
+		case <-release:
+			return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Fingerprint: strings.Repeat("x", int(request))}
+		case <-ctx.Done():
+			return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Err: ctx.Err(), Canceled: true}
+		}
+	}
+	var applied atomic.Int32
+	s.SetCurrentChangesHandler(func(*CurrentChangesResult) { applied.Add(1) })
+	s.SetCurrentChangesRoot(dir, currentChangesTabID(dir))
+	s.EnsureCurrentChanges()
+	first := <-started
+	s.requestCurrentChanges()
+	if s.currentRequest != first {
+		t.Fatalf("identical poll superseded in-flight request: first=%d current=%d", first, s.currentRequest)
+	}
+	release <- struct{}{}
+	if !s.HandleCurrentChanges(poster.await(t).(*CurrentChangesResult)) {
+		t.Fatal("slow identical-input read was not applied")
+	}
+	second := <-started
+	if second == first {
+		t.Fatalf("coalesced follow-up reused request %d", first)
+	}
+	release <- struct{}{}
+	if !s.HandleCurrentChanges(poster.await(t).(*CurrentChangesResult)) || applied.Load() != 2 {
+		t.Fatalf("coalesced follow-up did not apply: applied=%d", applied.Load())
+	}
+}
+
+func TestRepositoryCurrentChangesCancelsOnCloseAndRootSupersession(t *testing.T) {
+	s, _, poster := testRepositoryState(nil, "/old")
+	for _, dir := range []string{"/old", "/new"} {
+		primeCurrentChangesInput(s, dir, "head", changesGroup{Dir: dir})
+	}
+	oldCanceled := make(chan struct{})
+	s.readCurrentChanges = func(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		if dir == "/old" {
+			<-ctx.Done()
+			close(oldCanceled)
+			return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Err: ctx.Err(), Canceled: true}
+		}
+		return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Fingerprint: "new"}
+	}
+	s.SetCurrentChangesRoot("/old", currentChangesTabID("/old"))
+	s.EnsureCurrentChanges()
+	s.SetCurrentChangesRoot("/new", currentChangesTabID("/new"))
+	s.EnsureCurrentChanges()
+	select {
+	case <-oldCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("root supersession did not cancel the old current-changes read")
+	}
+	for range 2 {
+		s.HandleCurrentChanges(poster.await(t).(*CurrentChangesResult))
+	}
+	if s.currentRoot != "/new" || s.currentAppliedFingerprint != "new" {
+		t.Fatalf("superseded root survived: root=%q fingerprint=%q", s.currentRoot, s.currentAppliedFingerprint)
+	}
+
+	canceled := make(chan struct{})
+	s.readCurrentChanges = func(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		<-ctx.Done()
+		close(canceled)
+		return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Err: ctx.Err(), Canceled: true}
+	}
+	s.requestCurrentChanges()
+	s.Close()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("repository close did not cancel current changes")
+	}
+}
+
+func TestRepositoryCurrentChangesCancelsImmediatelyWhenTabCloses(t *testing.T) {
+	dir := "/repo"
+	s, _, _ := testRepositoryState(nil, dir)
+	primeCurrentChangesInput(s, dir, "head", changesGroup{Dir: dir})
+	canceled := make(chan struct{})
+	s.readCurrentChanges = func(ctx context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		<-ctx.Done()
+		close(canceled)
+		return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Err: ctx.Err(), Canceled: true}
+	}
+	tabID := currentChangesTabID(dir)
+	s.SetCurrentChangesRoot(dir, tabID)
+	s.EnsureCurrentChanges()
+	s.CloseCurrentChangesTab(tabID)
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("tab close did not cancel current changes immediately")
+	}
+	if s.currentRoot != "" || s.currentTabID != "" || s.currentInFlight {
+		t.Fatalf("tab close left current changes active: root=%q tab=%q inFlight=%v", s.currentRoot, s.currentTabID, s.currentInFlight)
+	}
+}
+
+func TestRepositoryCurrentChangesWaitsForFreshStatusAfterStatusFailure(t *testing.T) {
+	dir := "/repo"
+	s := NewRepositoryState(nil, []string{dir})
+	group := changesGroup{Dir: dir, Unstaged: []git.FileStatus{{Status: "M", Path: "kept.txt"}}}
+	primeCurrentChangesInput(s, dir, "head", group)
+	s.SetCurrentChangesRoot(dir, currentChangesTabID(dir))
+	s.currentInputReady = false
+	s.requested = 1
+	s.inFlight = true
+	s.dirty = RepositoryWorktree | RepositoryCurrentChanges
+	var reads atomic.Int32
+	var reported atomic.Int32
+	s.readCurrentChanges = func(_ context.Context, dir, revision, tabID string, epoch, request uint64, statuses []git.FileStatus) *CurrentChangesResult {
+		reads.Add(1)
+		return &CurrentChangesResult{Dir: dir, TabID: tabID, Epoch: epoch, Request: request, Fingerprint: "unexpected"}
+	}
+	s.SetCurrentChangesHandler(func(result *CurrentChangesResult) {
+		if result.Err != nil {
+			reported.Add(1)
+		}
+	})
+
+	s.HandleStatus(&RepositoryStatusResult{Seq: 1, Entries: []repositoryStatusEntry{{
+		Group:       changesGroup{Dir: dir},
+		Revision:    "",
+		StatusErr:   errors.New("index locked"),
+		RevisionErr: errors.New("HEAD unavailable"),
+	}}})
+	s.inFlight = true
+	s.EnsureCurrentChanges()
+	if reads.Load() != 0 || reported.Load() != 1 || s.currentInputReady || !s.currentDirty {
+		t.Fatalf("failed status state: reads=%d reported=%d ready=%v dirty=%v", reads.Load(), reported.Load(), s.currentInputReady, s.currentDirty)
+	}
+}

--- a/internal/app/current_changes_test.go
+++ b/internal/app/current_changes_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/git"
 	"github.com/eugenioenko/ttt/internal/ui"
 )
@@ -309,9 +310,23 @@ func TestPreferredConflictEntryUsesOursThenTheirsThenBase(t *testing.T) {
 	}
 }
 
+type cancelAfterErrChecksContext struct {
+	context.Context
+	checks   int
+	cancelAt int
+}
+
+func (c *cancelAfterErrChecksContext) Err() error {
+	c.checks++
+	if c.checks >= c.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
 func TestReadCurrentChangesCancelsDuringDiffGeneration(t *testing.T) {
 	dir := testAppRepository(t)
-	const lines = 8000
+	const lines = 500
 	var oldText, newText strings.Builder
 	for i := 0; i < lines; i++ {
 		fmt.Fprintf(&oldText, "old-%05d\n", i)
@@ -327,22 +342,65 @@ func TestReadCurrentChangesCancelsDuringDiffGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	resultCh := make(chan *CurrentChangesResult, 1)
+	ctx := &cancelAfterErrChecksContext{Context: context.Background(), cancelAt: 50}
 	statuses := currentChangesStatuses(t, dir)
 	revision := git.RevisionIdentity(dir)
-	go func() {
-		resultCh <- readCurrentChanges(ctx, dir, revision, currentChangesTabID(dir), 1, 1, statuses)
-	}()
-	time.Sleep(100 * time.Millisecond)
+	result := readCurrentChanges(ctx, dir, revision, currentChangesTabID(dir), 1, 1, statuses)
+	if !result.Canceled || !errors.Is(result.Err, context.Canceled) {
+		t.Fatalf("diff generation cancellation result = %+v", result)
+	}
+}
+
+func TestCurrentChangesDiffLimitBoundsMatrixAllocation(t *testing.T) {
+	if currentChangesDiffExceedsLimit(1999, 1999) {
+		t.Fatal("diff at the configured matrix limit was rejected")
+	}
+	if !currentChangesDiffExceedsLimit(2000, 2000) {
+		t.Fatal("diff above the configured matrix limit was accepted")
+	}
+}
+
+func TestGenerateCurrentChangesReplacementPreservesEndpointsAndCancellation(t *testing.T) {
+	generated, err := generateCurrentChangesReplacement(context.Background(), []string{"old-a", "old-b"}, []string{"new-a", "new-b"}, "conflict.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	added, deleted := currentDiffStats(diff.Parse(generated))
+	if added != 2 || deleted != 2 {
+		t.Fatalf("replacement stats = +%d -%d", added, deleted)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
-	select {
-	case result := <-resultCh:
-		if !result.Canceled || !errors.Is(result.Err, context.Canceled) {
-			t.Fatalf("diff generation cancellation result = %+v", result)
-		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("diff generation did not stop within 500ms of cancellation")
+	if _, err := generateCurrentChangesReplacement(canceled, []string{"old"}, []string{"new"}, "conflict.txt"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("replacement cancellation error = %v", err)
+	}
+}
+
+func TestReadCurrentChangesFallsBackAboveDiffLimit(t *testing.T) {
+	dir := testAppRepository(t)
+	const lines = 2001
+	var oldText, newText strings.Builder
+	for i := 0; i < lines; i++ {
+		fmt.Fprintf(&oldText, "old-%05d\n", i)
+		fmt.Fprintf(&newText, "new-%05d\n", i)
+	}
+	path := filepath.Join(dir, "large.txt")
+	if err := os.WriteFile(path, []byte(oldText.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "--", "large.txt")
+	testAppGit(t, dir, "commit", "-m", "large baseline")
+	if err := os.WriteFile(path, []byte(newText.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil || len(result.Files) != 1 {
+		t.Fatalf("large fallback result=%+v", result)
+	}
+	added, deleted := currentDiffStats(result.Files[0].Diff)
+	if added != lines || deleted != lines {
+		t.Fatalf("large fallback stats = +%d -%d", added, deleted)
 	}
 }
 

--- a/internal/app/current_changes_test.go
+++ b/internal/app/current_changes_test.go
@@ -56,35 +56,44 @@ func TestReadCurrentChangesUsesRawStatusIdentityForWorkingTreeShapes(t *testing.
 		t.Fatal(result.Err)
 	}
 	files := make(map[string]int)
+	boundaries := make(map[string]map[ui.CommitDetailStage]int)
 	for i := range result.Files {
 		files[result.Files[i].Path] = i
+		if boundaries[result.Files[i].Path] == nil {
+			boundaries[result.Files[i].Path] = make(map[ui.CommitDetailStage]int)
+		}
+		boundaries[result.Files[i].Path][result.Files[i].Stage] = i
 	}
 	for _, path := range []string{"initial.txt", "delete.txt", "renamed:界.txt", "blob.bin", "empty.txt", rawPath} {
 		if _, ok := files[path]; !ok {
 			t.Fatalf("typed current changes omitted %q: %+v", path, result.Files)
 		}
 	}
-	mixed := result.Files[files["initial.txt"]]
-	if mixed.Stage != ui.CommitDetailStageMixed {
-		t.Fatalf("mixed stage = %v", mixed.Stage)
+	stagedFile := result.Files[boundaries["initial.txt"][ui.CommitDetailStageStaged]]
+	unstagedFile := result.Files[boundaries["initial.txt"][ui.CommitDetailStageUnstaged]]
+	if stagedFile.Boundary != ui.CommitDetailBoundaryHeadToIndex || unstagedFile.Boundary != ui.CommitDetailBoundaryIndexToWorktree {
+		t.Fatalf("mixed boundaries = staged:%v unstaged:%v", stagedFile.Boundary, unstagedFile.Boundary)
 	}
-	foundFinal := false
-	for _, line := range mixed.Diff.AllLines() {
+	foundStaged := false
+	for _, line := range stagedFile.Diff.AllLines() {
+		foundStaged = foundStaged || line.Right.Text == "staged version"
+	}
+	foundIndexBoundary, foundFinal := false, false
+	for _, line := range unstagedFile.Diff.AllLines() {
+		foundIndexBoundary = foundIndexBoundary || line.Left.Text == "staged version"
 		foundFinal = foundFinal || line.Right.Text == "final working version"
-		if line.Right.Text == "staged version" {
-			t.Fatal("current changes stopped at the staged snapshot")
-		}
 	}
-	if !foundFinal {
-		t.Fatalf("mixed diff omitted final working content: %+v", mixed.Diff.AllLines())
+	if !foundStaged || !foundIndexBoundary || !foundFinal {
+		t.Fatalf("mixed boundaries omitted content: staged=%+v unstaged=%+v", stagedFile.Diff.AllLines(), unstagedFile.Diff.AllLines())
 	}
 	deleted := result.Files[files["delete.txt"]]
 	if deleted.Status != "D" || len(deleted.Diff.Hunks) == 0 {
 		t.Fatalf("deleted file = %+v", deleted)
 	}
-	renamed := result.Files[files["renamed:界.txt"]]
-	if renamed.Status != "R" || renamed.OldPath != "old name.txt" {
-		t.Fatalf("renamed file identity = %+v", renamed)
+	renamed := result.Files[boundaries["renamed:界.txt"][ui.CommitDetailStageStaged]]
+	renamedWorktree := result.Files[boundaries["renamed:界.txt"][ui.CommitDetailStageUnstaged]]
+	if renamed.Status != "R" || renamed.OldPath != "old name.txt" || renamedWorktree.Status != "M" || renamedWorktree.OldPath != "" {
+		t.Fatalf("renamed boundaries = staged:%+v unstaged:%+v", renamed, renamedWorktree)
 	}
 	if result.Files[files["blob.bin"]].ContentKind != ui.CommitDetailContentBinary {
 		t.Fatalf("binary file kind = %v", result.Files[files["blob.bin"]].ContentKind)
@@ -92,7 +101,7 @@ func TestReadCurrentChangesUsesRawStatusIdentityForWorkingTreeShapes(t *testing.
 	if result.Files[files["empty.txt"]].ContentKind != ui.CommitDetailContentEmpty {
 		t.Fatalf("empty file kind = %v", result.Files[files["empty.txt"]].ContentKind)
 	}
-	if !strings.Contains(result.Summary, "mixed") || result.Fingerprint == "" {
+	if !strings.Contains(result.Summary, "staged") || !strings.Contains(result.Summary, "unstaged") || result.Fingerprint == "" {
 		t.Fatalf("summary=%q fingerprint=%q", result.Summary, result.Fingerprint)
 	}
 }
@@ -121,19 +130,45 @@ func TestReadCurrentChangesHandlesAddedFilesWithFurtherWorkingTreeChanges(t *tes
 	}
 
 	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
-	if result.Err != nil || len(result.Files) != 1 {
+	if result.Err != nil || len(result.Files) != 2 {
 		t.Fatalf("added mixed result=%+v", result)
 	}
-	file := result.Files[0]
-	if file.Status != "A" || file.Stage != ui.CommitDetailStageMixed {
-		t.Fatalf("added mixed identity=%+v", file)
+	stagedFile, unstagedFile := result.Files[0], result.Files[1]
+	if stagedFile.Status != "A" || stagedFile.Stage != ui.CommitDetailStageStaged || unstagedFile.Status != "M" || unstagedFile.Stage != ui.CommitDetailStageUnstaged {
+		t.Fatalf("added mixed identities=%+v", result.Files)
 	}
-	foundFinal := false
-	for _, line := range file.Diff.AllLines() {
+	foundIndex, foundFinal := false, false
+	for _, line := range unstagedFile.Diff.AllLines() {
+		foundIndex = foundIndex || line.Left.Text == "staged"
 		foundFinal = foundFinal || line.Right.Text == "final"
 	}
-	if !foundFinal {
-		t.Fatalf("added mixed diff omitted final content: %+v", file.Diff.AllLines())
+	if !foundIndex || !foundFinal {
+		t.Fatalf("added mixed diff omitted index boundary: %+v", unstagedFile.Diff.AllLines())
+	}
+}
+
+func TestReadCurrentChangesIntentToAddUsesEmptyIndexBoundary(t *testing.T) {
+	dir := testAppRepository(t)
+	path := filepath.Join(dir, "intent.txt")
+	if err := os.WriteFile(path, []byte("intent content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, dir, "add", "-N", "--", "intent.txt")
+
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil || len(result.Files) != 1 {
+		t.Fatalf("intent-to-add result=%+v", result)
+	}
+	file := result.Files[0]
+	if file.Status != "A" || file.Stage != ui.CommitDetailStageUnstaged || file.Boundary != ui.CommitDetailBoundaryIndexToWorktree {
+		t.Fatalf("intent-to-add identity=%+v", file)
+	}
+	found := false
+	for _, line := range file.Diff.AllLines() {
+		found = found || line.Right.Text == "intent content"
+	}
+	if !found {
+		t.Fatalf("intent-to-add content=%+v", file.Diff.AllLines())
 	}
 }
 

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -51,6 +51,7 @@ func RunEventLoop(
 	app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: git.BranchName(lastBranchDir)})
 
 	syncStatus := func() {
+		app.syncRepositoryObservation()
 		line, col := app.EditorGroup.ActiveCursor()
 		filePath := app.EditorGroup.ActiveFilePath()
 		cursorCount := app.EditorGroup.MultiCursorCount()
@@ -383,6 +384,8 @@ func RunEventLoop(
 				app.HandleRepoOpResult(v)
 			case *RepositoryStatusResult:
 				app.Repository.HandleStatus(v)
+			case *CurrentChangesResult:
+				app.Repository.HandleCurrentChanges(v)
 			case *RepositoryInvalidationRequest:
 				app.handleRepositoryInvalidation(v)
 			case *DebugWriteRequest:

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -402,6 +402,8 @@ func RunEventLoop(
 				app.ApplyCommitDetail(v)
 			case *CommitDetailContextResult:
 				app.ApplyCommitDetailContext(v)
+			case *DiffOpenResult:
+				app.ApplyDiffOpen(v)
 			case *FileChangedResult:
 				app.HandleFileChanged(v.Path)
 			case *ui.SearchBatch:

--- a/internal/app/repository_current_changes.go
+++ b/internal/app/repository_current_changes.go
@@ -1,0 +1,241 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/gdamore/tcell/v3"
+)
+
+const currentChangesTimeout = 30 * time.Second
+
+type currentChangesInput struct {
+	revision string
+	statuses []git.FileStatus
+	identity [32]byte
+}
+
+func newCurrentChangesInput(revision string, statuses []git.FileStatus) currentChangesInput {
+	input := currentChangesInput{revision: revision, statuses: append([]git.FileStatus(nil), statuses...)}
+	hash := sha256.New()
+	write := func(value []byte) {
+		var size [8]byte
+		binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+		_, _ = hash.Write(size[:])
+		_, _ = hash.Write(value)
+	}
+	write([]byte(revision))
+	for _, status := range statuses {
+		write([]byte(status.Status))
+		write([]byte(status.OldPath))
+		write([]byte(status.Path))
+		if status.Staged {
+			write([]byte{1})
+		} else {
+			write([]byte{0})
+		}
+	}
+	copy(input.identity[:], hash.Sum(nil))
+	return input
+}
+
+func (s *RepositoryState) SetCurrentChangesHandler(handler func(*CurrentChangesResult)) {
+	if s == nil || s.closed {
+		return
+	}
+	s.currentChangesHandler = handler
+}
+
+func (s *RepositoryState) SetCurrentChangesRoot(dir, tabID string) uint64 {
+	if s == nil || s.closed {
+		return 0
+	}
+	if dir == s.currentRoot && tabID == s.currentTabID {
+		return s.currentEpoch
+	}
+	s.stopCurrentChanges()
+	if dir == "" || tabID == "" {
+		return 0
+	}
+	s.currentRoot = dir
+	s.currentTabID = tabID
+	s.currentEpoch++
+	s.currentDirty = true
+	_, s.currentInputReady = s.currentInputs[dir]
+	s.dirty |= RepositoryCurrentChanges
+	s.currentRequest++
+	return s.currentEpoch
+}
+
+func (s *RepositoryState) EnsureCurrentChanges() {
+	if s == nil || s.closed || s.currentRoot == "" || s.currentInFlight || !s.currentDirty {
+		return
+	}
+	if s.currentInputReady {
+		s.startCurrentChanges()
+		return
+	}
+	s.RefreshNow(RepositoryWorktree)
+}
+
+func (s *RepositoryState) CloseCurrentChangesTab(tabID string) {
+	if s == nil || s.closed || tabID == "" || tabID != s.currentTabID {
+		return
+	}
+	s.stopCurrentChanges()
+}
+
+func (s *RepositoryState) reportCurrentChangesStatusError(err error) {
+	if s == nil || s.closed || err == nil || s.currentRoot == "" {
+		return
+	}
+	if s.currentCancel != nil {
+		s.currentCancel()
+		s.currentCancel = nil
+	}
+	s.currentRequest++
+	s.currentInFlight = false
+	s.currentInFlightRequest = 0
+	s.currentInFlightIdentity = [32]byte{}
+	s.currentRefreshAgain = false
+	s.currentDirty = true
+	s.currentInputReady = false
+	s.currentAppliedFingerprint = ""
+	s.dirty |= RepositoryCurrentChanges
+	if s.currentChangesHandler != nil {
+		s.currentChangesHandler(&CurrentChangesResult{
+			Dir: s.currentRoot, TabID: s.currentTabID, Epoch: s.currentEpoch, Request: s.currentRequest, Err: err,
+		})
+	}
+}
+
+func (s *RepositoryState) stopCurrentChanges() {
+	if s == nil {
+		return
+	}
+	if s.currentCancel != nil {
+		s.currentCancel()
+		s.currentCancel = nil
+	}
+	s.currentRoot = ""
+	s.currentTabID = ""
+	s.currentEpoch++
+	s.currentRequest++
+	s.currentInFlight = false
+	s.currentInFlightRequest = 0
+	s.currentInFlightIdentity = [32]byte{}
+	s.currentRefreshAgain = false
+	s.currentDirty = false
+	s.currentInputReady = false
+	s.currentAppliedFingerprint = ""
+	s.dirty &^= RepositoryCurrentChanges
+}
+
+func (s *RepositoryState) requestCurrentChanges() {
+	if s == nil || s.closed || s.currentRoot == "" || !s.currentInputReady {
+		return
+	}
+	s.currentDirty = true
+	s.dirty |= RepositoryCurrentChanges
+	if s.currentInFlight {
+		s.currentRefreshAgain = true
+		input, ok := s.currentInputs[s.currentRoot]
+		if ok && input.identity != s.currentInFlightIdentity && s.currentRequest == s.currentInFlightRequest {
+			s.currentRequest++
+		}
+		if s.currentRequest != s.currentInFlightRequest && s.currentCancel != nil {
+			s.currentCancel()
+		}
+		return
+	}
+	s.currentRequest++
+	s.startCurrentChanges()
+}
+
+func (s *RepositoryState) startCurrentChanges() {
+	if s.closed || s.currentInFlight || s.currentRoot == "" || !s.currentDirty {
+		return
+	}
+	input, ok := s.currentInputs[s.currentRoot]
+	if !ok {
+		return
+	}
+	statuses := append([]git.FileStatus(nil), input.statuses...)
+	dir, tabID := s.currentRoot, s.currentTabID
+	epoch, request := s.currentEpoch, s.currentRequest
+	read := s.readCurrentChanges
+	ctx, cancel := context.WithTimeout(context.Background(), currentChangesTimeout)
+	s.currentCancel = cancel
+	s.currentInFlight = true
+	s.currentInFlightRequest = request
+	s.currentInFlightIdentity = input.identity
+	s.currentRefreshAgain = false
+	if s.poster == nil {
+		result := read(ctx, dir, input.revision, tabID, epoch, request, statuses)
+		cancel()
+		s.HandleCurrentChanges(result)
+		return
+	}
+	poster := s.poster
+	go func() {
+		result := read(ctx, dir, input.revision, tabID, epoch, request, statuses)
+		cancel()
+		_ = poster.PostEvent(tcell.NewEventInterrupt(result))
+	}()
+}
+
+func (s *RepositoryState) HandleCurrentChanges(result *CurrentChangesResult) bool {
+	if s == nil || result == nil || s.closed {
+		return false
+	}
+	if result.Request == s.currentInFlightRequest {
+		s.currentInFlight = false
+		s.currentInFlightRequest = 0
+		s.currentInFlightIdentity = [32]byte{}
+		s.currentCancel = nil
+	}
+	if result.Epoch != s.currentEpoch || result.Dir != s.currentRoot || result.TabID != s.currentTabID || result.Request != s.currentRequest {
+		if !s.currentInFlight && s.currentRefreshAgain {
+			s.startCurrentChanges()
+		}
+		return false
+	}
+	if result.Canceled || errors.Is(result.Err, context.Canceled) {
+		if s.currentRefreshAgain {
+			s.startCurrentChanges()
+		}
+		return false
+	}
+	followUp := s.currentRefreshAgain
+	s.currentRefreshAgain = false
+	if result.Err != nil {
+		s.currentDirty = true
+		s.currentInputReady = false
+		s.dirty |= RepositoryCurrentChanges
+		s.currentAppliedFingerprint = ""
+		if s.currentChangesHandler != nil {
+			s.currentChangesHandler(result)
+		}
+		return true
+	}
+	s.currentDirty = false
+	s.dirty &^= RepositoryCurrentChanges
+	applied := result.Fingerprint != s.currentAppliedFingerprint
+	if applied {
+		s.currentAppliedFingerprint = result.Fingerprint
+		if s.currentChangesHandler != nil {
+			s.currentChangesHandler(result)
+		}
+	}
+	if followUp && s.currentInputReady {
+		s.currentDirty = true
+		s.dirty |= RepositoryCurrentChanges
+		s.currentRequest++
+		s.startCurrentChanges()
+	}
+	return applied
+}

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -17,6 +17,7 @@ type RepositoryResource uint8
 const (
 	RepositoryWorktree RepositoryResource = 1 << iota
 	RepositoryHistory
+	RepositoryCurrentChanges
 
 	RepositoryStatus = RepositoryWorktree
 
@@ -91,20 +92,38 @@ type RepositoryState struct {
 	lastGroups    map[string]changesGroup
 	lastRevisions map[string]string
 	lastRoots     map[string]string
+
+	currentRoot               string
+	currentTabID              string
+	currentEpoch              uint64
+	currentRequest            uint64
+	currentInFlightRequest    uint64
+	currentInFlightIdentity   [32]byte
+	currentInFlight           bool
+	currentRefreshAgain       bool
+	currentDirty              bool
+	currentCancel             context.CancelFunc
+	currentAppliedFingerprint string
+	currentInputs             map[string]currentChangesInput
+	currentInputReady         bool
+	readCurrentChanges        func(context.Context, string, string, string, uint64, uint64, []git.FileStatus) *CurrentChangesResult
+	currentChangesHandler     func(*CurrentChangesResult)
 }
 
 func NewRepositoryState(changes *ChangesPanel, dirs []string) *RepositoryState {
 	return &RepositoryState{
-		changes:       changes,
-		dirs:          append([]string(nil), dirs...),
-		scheduler:     realRepositoryScheduler{},
-		readStatus:    readRepositoryStatus,
-		debounceWait:  repositoryRefreshDebounce,
-		pollWait:      repositoryPollInterval,
-		statusWait:    repositoryStatusTimeout,
-		lastGroups:    make(map[string]changesGroup),
-		lastRevisions: make(map[string]string),
-		lastRoots:     make(map[string]string),
+		changes:            changes,
+		dirs:               append([]string(nil), dirs...),
+		scheduler:          realRepositoryScheduler{},
+		readStatus:         readRepositoryStatus,
+		debounceWait:       repositoryRefreshDebounce,
+		pollWait:           repositoryPollInterval,
+		statusWait:         repositoryStatusTimeout,
+		lastGroups:         make(map[string]changesGroup),
+		lastRevisions:      make(map[string]string),
+		lastRoots:          make(map[string]string),
+		currentInputs:      make(map[string]currentChangesInput),
+		readCurrentChanges: readCurrentChanges,
 	}
 }
 
@@ -129,6 +148,7 @@ func (s *RepositoryState) SetDirs(dirs []string) {
 		return
 	}
 	s.dirs = append([]string(nil), dirs...)
+	s.stopCurrentChanges()
 	if s.changes != nil {
 		s.changes.Dirs = append([]string(nil), dirs...)
 		s.changes.multiRoot = len(dirs) > 1
@@ -139,7 +159,8 @@ func (s *RepositoryState) SetDirs(dirs []string) {
 	s.lastGroups = make(map[string]changesGroup)
 	s.lastRevisions = make(map[string]string)
 	s.lastRoots = make(map[string]string)
-	s.dirty |= RepositoryWorktree | RepositoryHistory
+	s.currentInputs = make(map[string]currentChangesInput)
+	s.dirty |= RepositoryWorktree | RepositoryHistory | RepositoryCurrentChanges
 	s.stopDebounce()
 	s.stopPoll()
 	s.requested++
@@ -177,6 +198,11 @@ func (s *RepositoryState) InvalidateAll(resources RepositoryResource) {
 		return
 	}
 	s.dirty |= resources
+	if resources&RepositoryWorktree != 0 && s.currentRoot != "" {
+		s.dirty |= RepositoryCurrentChanges
+		s.currentDirty = true
+		s.currentInputReady = false
+	}
 	if resources&RepositoryHistory != 0 && s.visible {
 		s.refreshHistory()
 	}
@@ -217,6 +243,11 @@ func (s *RepositoryState) RefreshNow(resources RepositoryResource) {
 		return
 	}
 	s.dirty |= resources
+	if resources&RepositoryWorktree != 0 && s.currentRoot != "" {
+		s.dirty |= RepositoryCurrentChanges
+		s.currentDirty = true
+		s.currentInputReady = false
+	}
 	if resources&RepositoryHistory != 0 && s.visible {
 		s.refreshHistory()
 	}
@@ -285,6 +316,8 @@ func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
 	seenGroups := make(map[string]bool, len(result.Entries))
 	revisionChanged := false
 	hadError := false
+	currentStatusFresh := false
+	currentStatusErrors := make(map[string]error)
 	for _, entry := range result.Entries {
 		group := entry.Group
 		sourceDir := cleanAbsolutePath(entry.SourceDir)
@@ -323,6 +356,20 @@ func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
 			revisionChanged = true
 		}
 		nextRevisions[group.Dir] = revision
+		entryErr := errors.Join(entry.RootErr, entry.StatusErr, entry.RevisionErr)
+		if entryErr != nil {
+			currentStatusErrors[group.Dir] = entryErr
+		}
+		if group.Dir == s.currentRoot && entryErr == nil {
+			s.currentInputReady = true
+			currentStatusFresh = true
+		}
+		if entryErr == nil {
+			statuses := make([]git.FileStatus, 0, len(group.Staged)+len(group.Unstaged))
+			statuses = append(statuses, group.Staged...)
+			statuses = append(statuses, group.Unstaged...)
+			s.currentInputs[group.Dir] = newCurrentChangesInput(revision, statuses)
+		}
 	}
 	s.lastGroups = nextGroups
 	s.lastRevisions = nextRevisions
@@ -332,6 +379,12 @@ func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
 	}
 	if !hadError {
 		s.dirty &^= RepositoryWorktree
+	}
+	if currentErr := currentStatusErrors[s.currentRoot]; currentErr != nil {
+		s.reportCurrentChangesStatusError(currentErr)
+	}
+	if currentStatusFresh {
+		s.requestCurrentChanges()
 	}
 	if revisionChanged {
 		s.dirty |= RepositoryHistory
@@ -429,6 +482,7 @@ func (s *RepositoryState) Close() {
 		return
 	}
 	s.closed = true
+	s.stopCurrentChanges()
 	s.stopDebounce()
 	s.stopPoll()
 	s.requested++
@@ -618,6 +672,14 @@ func (a *App) syncRepositoryObservation() {
 		return
 	}
 	visible := a.Sidebar.Visible && a.SplitPanel.ShowLeft && a.Sidebar.ActivePanel == "changes"
+	if detail := a.EditorGroup.ActiveCurrentChangesWidget(); detail != nil {
+		tabID := currentChangesTabID(detail.Dir)
+		detail.Incarnation = a.Repository.SetCurrentChangesRoot(detail.Dir, tabID)
+		a.Repository.EnsureCurrentChanges()
+		visible = true
+	} else {
+		a.Repository.SetCurrentChangesRoot("", "")
+	}
 	a.Repository.SetVisible(visible)
 }
 

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -331,6 +331,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 		pluginDetailWidgets: make(map[string]*pluginDetailState),
 	}
 	app.Repository = NewRepositoryState(changes, ws.Paths())
+	app.Repository.SetCurrentChangesHandler(app.ApplyCurrentChanges)
 	app.applyMenuBarVisibility(cfg.Settings.Editor.IsMenuBarVisible())
 	// Rebuild the Diagnostics panel whenever any source (LSP or a plugin)
 	// changes its diagnostics.

--- a/internal/app/working_tree_reader.go
+++ b/internal/app/working_tree_reader.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type workingTreeFileKind uint8
+
+const (
+	workingTreeFileMissing workingTreeFileKind = iota
+	workingTreeFileRegular
+	workingTreeFileSymlink
+)
+
+type workingTreePathKind string
+
+const (
+	workingTreePathSymlinkComponent workingTreePathKind = "symlink component"
+	workingTreePathDirectory        workingTreePathKind = "directory"
+	workingTreePathFIFO             workingTreePathKind = "FIFO"
+	workingTreePathDevice           workingTreePathKind = "device"
+	workingTreePathSocket           workingTreePathKind = "socket"
+	workingTreePathSpecial          workingTreePathKind = "special file"
+	workingTreePathUnverified       workingTreePathKind = "unverified path"
+)
+
+type workingTreePathError struct {
+	Path string
+	Kind workingTreePathKind
+	Err  error
+}
+
+func (e *workingTreePathError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("unsupported working tree %s %q: %v", e.Kind, e.Path, e.Err)
+	}
+	return fmt.Sprintf("unsupported working tree %s %q", e.Kind, e.Path)
+}
+
+func (e *workingTreePathError) Unwrap() error { return e.Err }
+
+type workingTreeFile struct {
+	Content []byte
+	Exists  bool
+	Kind    workingTreeFileKind
+}
+
+func readWorkingTreeFileContext(ctx context.Context, root, path string) (workingTreeFile, error) {
+	if err := ctx.Err(); err != nil {
+		return workingTreeFile{}, err
+	}
+	clean := filepath.Clean(path)
+	if path == "" || clean == "." || filepath.IsAbs(path) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return workingTreeFile{}, &workingTreePathError{Path: path, Kind: workingTreePathUnverified, Err: errors.New("path escapes repository root")}
+	}
+	return readWorkingTreeFilePlatform(ctx, root, clean)
+}
+
+func readWorkingTreeContent(path string) ([]byte, bool, error) {
+	file, err := readWorkingTreeFileContext(context.Background(), filepath.Dir(path), filepath.Base(path))
+	return file.Content, file.Exists, err
+}

--- a/internal/app/working_tree_reader.go
+++ b/internal/app/working_tree_reader.go
@@ -10,6 +10,8 @@ import (
 
 type workingTreeFileKind uint8
 
+const workingTreeReadChunk = 64 * 1024
+
 const (
 	workingTreeFileMissing workingTreeFileKind = iota
 	workingTreeFileRegular

--- a/internal/app/working_tree_reader_fallback.go
+++ b/internal/app/working_tree_reader_fallback.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin && !freebsd
+//go:build !linux && !darwin && !freebsd && !windows
 
 package app
 

--- a/internal/app/working_tree_reader_fallback.go
+++ b/internal/app/working_tree_reader_fallback.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin && !freebsd
+
+package app
+
+import (
+	"context"
+	"path/filepath"
+)
+
+func readWorkingTreeFilePlatform(_ context.Context, root, path string) (workingTreeFile, error) {
+	return workingTreeFile{}, &workingTreePathError{Path: filepath.Join(root, path), Kind: workingTreePathUnverified}
+}

--- a/internal/app/working_tree_reader_unix.go
+++ b/internal/app/working_tree_reader_unix.go
@@ -1,0 +1,191 @@
+//go:build linux || darwin || freebsd
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const workingTreeReadChunk = 64 * 1024
+
+func readWorkingTreeFilePlatform(ctx context.Context, root, path string) (workingTreeFile, error) {
+	dirfd, err := openDirectoryPathNoFollow(ctx, root)
+	if err != nil {
+		return workingTreeFile{}, err
+	}
+	defer func() { _ = unix.Close(dirfd) }()
+
+	parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	for _, part := range parts[:len(parts)-1] {
+		if err := ctx.Err(); err != nil {
+			return workingTreeFile{}, err
+		}
+		next, openErr := unix.Openat(dirfd, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+		if openErr != nil {
+			return workingTreeFile{}, classifyWorkingTreeOpenError(filepath.Join(root, path), workingTreePathSymlinkComponent, openErr)
+		}
+		if closeErr := unix.Close(dirfd); closeErr != nil {
+			unix.Close(next)
+			return workingTreeFile{}, closeErr
+		}
+		dirfd = next
+	}
+
+	return readWorkingTreeFinalAt(ctx, dirfd, parts[len(parts)-1], filepath.Join(root, path))
+}
+
+func openDirectoryPathNoFollow(ctx context.Context, path string) (int, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return -1, &workingTreePathError{Path: path, Kind: workingTreePathUnverified, Err: err}
+	}
+	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return -1, err
+	}
+	for _, part := range strings.Split(strings.TrimPrefix(filepath.Clean(abs), string(filepath.Separator)), string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			unix.Close(fd)
+			return -1, err
+		}
+		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+		if openErr != nil {
+			unix.Close(fd)
+			return -1, classifyWorkingTreeOpenError(path, workingTreePathSymlinkComponent, openErr)
+		}
+		if closeErr := unix.Close(fd); closeErr != nil {
+			unix.Close(next)
+			return -1, closeErr
+		}
+		fd = next
+	}
+	return fd, nil
+}
+
+func readWorkingTreeFinalAt(ctx context.Context, dirfd int, name, path string) (workingTreeFile, error) {
+	for range 4 {
+		if err := ctx.Err(); err != nil {
+			return workingTreeFile{}, err
+		}
+		var stat unix.Stat_t
+		if err := unix.Fstatat(dirfd, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+			if errors.Is(err, unix.ENOENT) {
+				return workingTreeFile{Kind: workingTreeFileMissing}, nil
+			}
+			return workingTreeFile{}, err
+		}
+		switch stat.Mode & unix.S_IFMT {
+		case unix.S_IFLNK:
+			content, err := readlinkAtContext(ctx, dirfd, name)
+			if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOENT) {
+				continue
+			}
+			if err != nil {
+				return workingTreeFile{}, err
+			}
+			return workingTreeFile{Content: content, Exists: true, Kind: workingTreeFileSymlink}, nil
+		case unix.S_IFREG:
+			fd, err := unix.Openat(dirfd, name, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+			if errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENOENT) {
+				continue
+			}
+			if err != nil {
+				return workingTreeFile{}, err
+			}
+			content, readErr := readRegularFileContext(ctx, fd, path)
+			closeErr := unix.Close(fd)
+			if readErr != nil {
+				return workingTreeFile{}, readErr
+			}
+			if closeErr != nil {
+				return workingTreeFile{}, closeErr
+			}
+			return workingTreeFile{Content: content, Exists: true, Kind: workingTreeFileRegular}, nil
+		case unix.S_IFDIR:
+			return workingTreeFile{}, &workingTreePathError{Path: path, Kind: workingTreePathDirectory}
+		case unix.S_IFIFO:
+			return workingTreeFile{}, &workingTreePathError{Path: path, Kind: workingTreePathFIFO}
+		case unix.S_IFSOCK:
+			return workingTreeFile{}, &workingTreePathError{Path: path, Kind: workingTreePathSocket}
+		case unix.S_IFCHR, unix.S_IFBLK:
+			return workingTreeFile{}, &workingTreePathError{Path: path, Kind: workingTreePathDevice}
+		default:
+			return workingTreeFile{}, &workingTreePathError{Path: path, Kind: workingTreePathSpecial}
+		}
+	}
+	return workingTreeFile{}, &workingTreePathError{Path: path, Kind: workingTreePathUnverified, Err: errors.New("path identity changed during read")}
+}
+
+func readRegularFileContext(ctx context.Context, fd int, path string) ([]byte, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return nil, err
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return nil, &workingTreePathError{Path: path, Kind: workingTreePathSpecial, Err: errors.New("opened object is not a regular file")}
+	}
+	var content bytes.Buffer
+	if stat.Size > 0 && stat.Size <= 8<<20 {
+		content.Grow(int(stat.Size))
+	}
+	buf := make([]byte, workingTreeReadChunk)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		n, err := unix.Read(fd, buf)
+		if n > 0 {
+			_, _ = content.Write(buf[:n])
+		}
+		if n == 0 && err == nil {
+			return content.Bytes(), nil
+		}
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if errors.Is(err, unix.EAGAIN) {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			return content.Bytes(), nil
+		}
+		return nil, err
+	}
+}
+
+func readlinkAtContext(ctx context.Context, dirfd int, name string) ([]byte, error) {
+	for size := 256; size <= 64*1024; size *= 2 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		buf := make([]byte, size)
+		n, err := unix.Readlinkat(dirfd, name, buf)
+		if err != nil {
+			return nil, err
+		}
+		if n < len(buf) {
+			return buf[:n], nil
+		}
+	}
+	return nil, &workingTreePathError{Path: name, Kind: workingTreePathUnverified, Err: errors.New("symlink target is too long")}
+}
+
+func classifyWorkingTreeOpenError(path string, kind workingTreePathKind, err error) error {
+	if errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENOTDIR) {
+		return &workingTreePathError{Path: path, Kind: kind, Err: err}
+	}
+	return err
+}

--- a/internal/app/working_tree_reader_unix.go
+++ b/internal/app/working_tree_reader_unix.go
@@ -13,8 +13,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const workingTreeReadChunk = 64 * 1024
-
 func readWorkingTreeFilePlatform(ctx context.Context, root, path string) (workingTreeFile, error) {
 	dirfd, err := openDirectoryPathNoFollow(ctx, root)
 	if err != nil {
@@ -46,6 +44,30 @@ func openDirectoryPathNoFollow(ctx context.Context, path string) (int, error) {
 	if err != nil {
 		return -1, &workingTreePathError{Path: path, Kind: workingTreePathUnverified, Err: err}
 	}
+	if abs == string(filepath.Separator) {
+		return unix.Open(abs, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return -1, &workingTreePathError{Path: path, Kind: workingTreePathUnverified, Err: err}
+	}
+	fd, err := openAbsoluteDirectoryNoFollow(ctx, parent, path)
+	if err != nil {
+		return -1, err
+	}
+	next, openErr := unix.Openat(fd, filepath.Base(abs), unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	closeErr := unix.Close(fd)
+	if openErr != nil {
+		return -1, classifyWorkingTreeOpenError(path, workingTreePathSymlinkComponent, openErr)
+	}
+	if closeErr != nil {
+		unix.Close(next)
+		return -1, closeErr
+	}
+	return next, nil
+}
+
+func openAbsoluteDirectoryNoFollow(ctx context.Context, abs, reportedPath string) (int, error) {
 	fd, err := unix.Open(string(filepath.Separator), unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return -1, err
@@ -61,7 +83,7 @@ func openDirectoryPathNoFollow(ctx context.Context, path string) (int, error) {
 		next, openErr := unix.Openat(fd, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 		if openErr != nil {
 			unix.Close(fd)
-			return -1, classifyWorkingTreeOpenError(path, workingTreePathSymlinkComponent, openErr)
+			return -1, classifyWorkingTreeOpenError(reportedPath, workingTreePathSymlinkComponent, openErr)
 		}
 		if closeErr := unix.Close(fd); closeErr != nil {
 			unix.Close(next)

--- a/internal/app/working_tree_reader_unix_test.go
+++ b/internal/app/working_tree_reader_unix_test.go
@@ -1,0 +1,306 @@
+//go:build linux || darwin || freebsd
+
+package app
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eugenioenko/ttt/internal/git"
+	"golang.org/x/sys/unix"
+)
+
+func TestReleaseContractFIFOIsRejectedWithoutBlocking(t *testing.T) {
+	dir := t.TempDir()
+	if err := unix.Mkfifo(filepath.Join(dir, "pipe"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := readWorkingTreeFileContext(ctx, dir, "pipe")
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		var pathErr *workingTreePathError
+		if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathFIFO {
+			t.Fatalf("FIFO error = %T %v", err, err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("FIFO read blocked")
+	}
+}
+
+func TestReadWorkingTreeFileReturnsTypedSocketDirectoryAndDeviceErrors(t *testing.T) {
+	dir := t.TempDir()
+	listener, err := net.Listen("unix", filepath.Join(dir, "socket"))
+	if err != nil {
+		t.Skipf("unix sockets unavailable: %v", err)
+	}
+	defer listener.Close()
+	_, err = readWorkingTreeFileContext(context.Background(), dir, "socket")
+	var pathErr *workingTreePathError
+	if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathSocket {
+		t.Fatalf("socket error = %T %v", err, err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "directory"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = readWorkingTreeFileContext(context.Background(), dir, "directory")
+	if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathDirectory {
+		t.Fatalf("directory error = %T %v", err, err)
+	}
+	_, err = readWorkingTreeFileContext(context.Background(), string(filepath.Separator), filepath.Join("dev", "null"))
+	if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathDevice {
+		t.Fatalf("device error = %T %v", err, err)
+	}
+}
+
+func TestReadWorkingTreeFileReturnsStableSymlinkMetadata(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(target, []byte("SECRET BYTES"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	file, err := readWorkingTreeFileContext(context.Background(), dir, "link")
+	if err != nil || file.Kind != workingTreeFileSymlink || string(file.Content) != target || strings.Contains(string(file.Content), "SECRET BYTES") {
+		t.Fatalf("symlink metadata=%+v err=%v", file, err)
+	}
+}
+
+func TestReadCurrentChangesStableTrackedAndUntrackedSymlinksRenderMetadata(t *testing.T) {
+	dir := testAppRepository(t)
+	out := t.TempDir()
+	first := filepath.Join(out, "first-target")
+	second := filepath.Join(out, "second-target")
+	if err := os.WriteFile(first, []byte("FIRST SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("SECOND SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tracked := filepath.Join(dir, "tracked-link")
+	if err := os.Symlink(first, tracked); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	testAppGit(t, dir, "add", "tracked-link")
+	testAppGit(t, dir, "commit", "-m", "tracked symlink")
+	if err := os.Remove(tracked); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(second, tracked); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(first, filepath.Join(dir, "untracked-link")); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readCurrentChanges(context.Background(), dir, git.RevisionIdentity(dir), currentChangesTabID(dir), 1, 1, currentChangesStatuses(t, dir))
+	if result.Err != nil || len(result.Files) != 2 {
+		t.Fatalf("symlink result=%+v", result)
+	}
+	for _, file := range result.Files {
+		text := ""
+		for _, line := range file.Diff.AllLines() {
+			text += line.Left.Text + line.Right.Text
+		}
+		if strings.Contains(text, "FIRST SECRET") || strings.Contains(text, "SECOND SECRET") {
+			t.Fatalf("target bytes escaped through %q: %q", file.Path, text)
+		}
+		if !strings.Contains(text, "target") {
+			t.Fatalf("link metadata missing for %q: %q", file.Path, text)
+		}
+	}
+}
+
+func TestReleaseContractSymlinkSwapCannotExposeTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "changing")
+	temp := filepath.Join(dir, "replacement")
+	secret := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte("ordinary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secret, []byte("RACE SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stop atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for !stop.Load() {
+			_ = os.Remove(temp)
+			_ = os.WriteFile(temp, []byte("ordinary"), 0o644)
+			_ = os.Rename(temp, path)
+			_ = os.Remove(temp)
+			_ = os.Symlink(secret, temp)
+			_ = os.Rename(temp, path)
+		}
+	}()
+	defer func() {
+		stop.Store(true)
+		<-done
+	}()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		content, _, _ := readWorkingTreeContent(path)
+		if string(content) == "RACE SECRET" {
+			t.Fatal("symlink target bytes escaped")
+		}
+	}
+}
+
+func TestReadWorkingTreeFileIntermediateSymlinkSwapCannotExposeTarget(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	alias := filepath.Join(root, "alias")
+	temp := filepath.Join(root, "replacement")
+	outside := t.TempDir()
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "file"), []byte("ordinary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "file"), []byte("INTERMEDIATE SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	var stop atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for !stop.Load() {
+			_ = os.Remove(temp)
+			_ = os.Symlink("real", temp)
+			_ = os.Rename(temp, alias)
+			_ = os.Remove(temp)
+			_ = os.Symlink(outside, temp)
+			_ = os.Rename(temp, alias)
+		}
+	}()
+	defer func() {
+		stop.Store(true)
+		<-done
+	}()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		file, _ := readWorkingTreeFileContext(context.Background(), root, filepath.Join("alias", "file"))
+		if string(file.Content) == "INTERMEDIATE SECRET" {
+			t.Fatal("intermediate symlink target bytes escaped")
+		}
+	}
+}
+
+func TestReadWorkingTreeFileRejectsSymlinkedRootAndReadsRegularIntermediateComponents(t *testing.T) {
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real")
+	if err := os.MkdirAll(filepath.Join(realRoot, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "nested", "file"), []byte("ordinary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	file, err := readWorkingTreeFileContext(context.Background(), realRoot, filepath.Join("nested", "file"))
+	if err != nil || string(file.Content) != "ordinary" {
+		t.Fatalf("regular intermediate read=%+v err=%v", file, err)
+	}
+	alias := filepath.Join(parent, "alias")
+	if err := os.Symlink(realRoot, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	_, err = readWorkingTreeFileContext(context.Background(), alias, filepath.Join("nested", "file"))
+	var pathErr *workingTreePathError
+	if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathSymlinkComponent {
+		t.Fatalf("symlinked root error = %T %v", err, err)
+	}
+}
+
+func TestReadWorkingTreeLargeRegularFileHonorsCancellation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "large")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(64 << 20); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := readWorkingTreeFileContext(ctx, dir, "large"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("large canceled read error = %v", err)
+	}
+}
+
+func TestReadWorkingTreeFileClosesDescriptors(t *testing.T) {
+	fdDir := "/proc/self/fd"
+	before, err := os.ReadDir(fdDir)
+	if err != nil {
+		t.Skipf("descriptor inventory unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "file"), []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for range 200 {
+		if _, err := readWorkingTreeFileContext(context.Background(), dir, "file"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runtime.GC()
+	after, err := os.ReadDir(fdDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) > len(before)+2 {
+		t.Fatalf("descriptor count grew from %d to %d", len(before), len(after))
+	}
+}
+
+func TestReadCurrentChangesSubmoduleRendersObjectMetadata(t *testing.T) {
+	child := testAppRepository(t)
+	parent := testAppRepository(t)
+	testAppGit(t, parent, "-c", "protocol.file.allow=always", "submodule", "add", child, "sub")
+	testAppGit(t, parent, "commit", "-m", "add submodule")
+	if err := os.WriteFile(filepath.Join(child, "initial.txt"), []byte("child second\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, child, "commit", "-am", "child second")
+	childHead, err := git.RevisionIdentityContext(context.Background(), child)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, parent, "-C", "sub", "fetch", "origin")
+	testAppGit(t, parent, "-C", "sub", "checkout", "--detach", childHead)
+	result := readCurrentChanges(context.Background(), parent, git.RevisionIdentity(parent), currentChangesTabID(parent), 1, 1, currentChangesStatuses(t, parent))
+	if result.Err != nil || len(result.Files) != 1 {
+		t.Fatalf("submodule result=%+v", result)
+	}
+	found := false
+	for _, line := range result.Files[0].Diff.AllLines() {
+		found = found || strings.Contains(line.Left.Text, "Subproject commit") || strings.Contains(line.Right.Text, "Subproject commit")
+	}
+	if !found {
+		t.Fatalf("submodule object metadata missing: %+v", result.Files[0].Diff.AllLines())
+	}
+}

--- a/internal/app/working_tree_reader_unix_test.go
+++ b/internal/app/working_tree_reader_unix_test.go
@@ -231,6 +231,26 @@ func TestReadWorkingTreeFileRejectsSymlinkedRootAndReadsRegularIntermediateCompo
 	}
 }
 
+func TestReadWorkingTreeFileAllowsSymlinkedAncestorsAboveRoot(t *testing.T) {
+	parent := t.TempDir()
+	realParent := filepath.Join(parent, "real-parent")
+	realRoot := filepath.Join(realParent, "repo")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "file"), []byte("ordinary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasParent := filepath.Join(parent, "alias-parent")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	file, err := readWorkingTreeFileContext(context.Background(), filepath.Join(aliasParent, "repo"), "file")
+	if err != nil || string(file.Content) != "ordinary" {
+		t.Fatalf("symlinked ancestor read=%+v err=%v", file, err)
+	}
+}
+
 func TestReadWorkingTreeLargeRegularFileHonorsCancellation(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "large")

--- a/internal/app/working_tree_reader_windows.go
+++ b/internal/app/working_tree_reader_windows.go
@@ -1,0 +1,170 @@
+//go:build windows
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func readWorkingTreeFilePlatform(ctx context.Context, root, path string) (workingTreeFile, error) {
+	if err := ctx.Err(); err != nil {
+		return workingTreeFile{}, err
+	}
+	rootPath, err := verifiedWindowsRootPath(root)
+	if err != nil {
+		return workingTreeFile{}, err
+	}
+	var handles []windows.Handle
+	defer func() {
+		for i := len(handles) - 1; i >= 0; i-- {
+			_ = windows.CloseHandle(handles[i])
+		}
+	}()
+
+	rootHandle, rootInfo, err := openWindowsWorkingTreePath(rootPath, windows.FILE_READ_ATTRIBUTES)
+	if err != nil {
+		return workingTreeFile{}, err
+	}
+	handles = append(handles, rootHandle)
+	if rootInfo.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return workingTreeFile{}, &workingTreePathError{Path: root, Kind: workingTreePathSymlinkComponent}
+	}
+	if rootInfo.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 {
+		return workingTreeFile{}, &workingTreePathError{Path: root, Kind: workingTreePathDirectory}
+	}
+
+	parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	current := rootPath
+	for _, part := range parts[:len(parts)-1] {
+		if err := ctx.Err(); err != nil {
+			return workingTreeFile{}, err
+		}
+		current = filepath.Join(current, part)
+		handle, info, openErr := openWindowsWorkingTreePath(current, windows.FILE_READ_ATTRIBUTES)
+		if openErr != nil {
+			return workingTreeFile{}, classifyWindowsWorkingTreeOpenError(filepath.Join(root, path), openErr)
+		}
+		handles = append(handles, handle)
+		if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+			return workingTreeFile{}, &workingTreePathError{Path: filepath.Join(root, path), Kind: workingTreePathSymlinkComponent}
+		}
+		if info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY == 0 {
+			return workingTreeFile{}, &workingTreePathError{Path: filepath.Join(root, path), Kind: workingTreePathDirectory}
+		}
+	}
+
+	fullPath := filepath.Join(rootPath, path)
+	handle, info, err := openWindowsWorkingTreePath(fullPath, windows.FILE_READ_ATTRIBUTES)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_FILE_NOT_FOUND) || errors.Is(err, windows.ERROR_PATH_NOT_FOUND) {
+			return workingTreeFile{Kind: workingTreeFileMissing}, nil
+		}
+		return workingTreeFile{}, classifyWindowsWorkingTreeOpenError(filepath.Join(root, path), err)
+	}
+	handles = append(handles, handle)
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		target, readErr := os.Readlink(fullPath)
+		if readErr != nil {
+			return workingTreeFile{}, &workingTreePathError{Path: filepath.Join(root, path), Kind: workingTreePathSymlinkComponent, Err: readErr}
+		}
+		return workingTreeFile{Content: []byte(target), Exists: true, Kind: workingTreeFileSymlink}, nil
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 {
+		return workingTreeFile{}, &workingTreePathError{Path: filepath.Join(root, path), Kind: workingTreePathDirectory}
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_DEVICE != 0 {
+		return workingTreeFile{}, &workingTreePathError{Path: filepath.Join(root, path), Kind: workingTreePathDevice}
+	}
+	fileType, _ := windows.GetFileType(handle)
+	if fileType != windows.FILE_TYPE_DISK {
+		kind := workingTreePathSpecial
+		if fileType == windows.FILE_TYPE_PIPE {
+			kind = workingTreePathFIFO
+		}
+		return workingTreeFile{}, &workingTreePathError{Path: filepath.Join(root, path), Kind: kind}
+	}
+	readHandle, _, err := openWindowsWorkingTreePath(fullPath, windows.FILE_GENERIC_READ)
+	if err != nil {
+		return workingTreeFile{}, err
+	}
+	handles = append(handles, readHandle)
+	content, err := readWindowsRegularFileContext(ctx, readHandle)
+	if err != nil {
+		return workingTreeFile{}, err
+	}
+	return workingTreeFile{Content: content, Exists: true, Kind: workingTreeFileRegular}, nil
+}
+
+func verifiedWindowsRootPath(root string) (string, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return "", &workingTreePathError{Path: root, Kind: workingTreePathUnverified, Err: err}
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return "", &workingTreePathError{Path: root, Kind: workingTreePathUnverified, Err: err}
+	}
+	return filepath.Join(parent, filepath.Base(abs)), nil
+}
+
+func openWindowsWorkingTreePath(path string, access uint32) (windows.Handle, windows.ByHandleFileInformation, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return windows.InvalidHandle, windows.ByHandleFileInformation{}, err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		access,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return windows.InvalidHandle, windows.ByHandleFileInformation{}, err
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		_ = windows.CloseHandle(handle)
+		return windows.InvalidHandle, windows.ByHandleFileInformation{}, err
+	}
+	return handle, info, nil
+}
+
+func classifyWindowsWorkingTreeOpenError(path string, err error) error {
+	kind := workingTreePathUnverified
+	if errors.Is(err, windows.ERROR_CANT_ACCESS_FILE) {
+		kind = workingTreePathSymlinkComponent
+	}
+	return &workingTreePathError{Path: path, Kind: kind, Err: err}
+}
+
+func readWindowsRegularFileContext(ctx context.Context, handle windows.Handle) ([]byte, error) {
+	var content bytes.Buffer
+	buf := make([]byte, workingTreeReadChunk)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var read uint32
+		err := windows.ReadFile(handle, buf, &read, nil)
+		if read > 0 {
+			_, _ = content.Write(buf[:read])
+		}
+		if errors.Is(err, io.EOF) || (err == nil && read == 0) {
+			return content.Bytes(), nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}

--- a/internal/app/working_tree_reader_windows_test.go
+++ b/internal/app/working_tree_reader_windows_test.go
@@ -1,0 +1,88 @@
+//go:build windows
+
+package app
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsWorkingTreeReaderClassifiesRegularMissingAndDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "file"), []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	file, err := readWorkingTreeFileContext(context.Background(), root, "file")
+	if err != nil || !file.Exists || file.Kind != workingTreeFileRegular || string(file.Content) != "content" {
+		t.Fatalf("regular file=%+v err=%v", file, err)
+	}
+	missing, err := readWorkingTreeFileContext(context.Background(), root, "missing")
+	if err != nil || missing.Exists || missing.Kind != workingTreeFileMissing {
+		t.Fatalf("missing file=%+v err=%v", missing, err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "directory"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = readWorkingTreeFileContext(context.Background(), root, "directory")
+	var pathErr *workingTreePathError
+	if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathDirectory {
+		t.Fatalf("directory error=%T %v", err, err)
+	}
+}
+
+func TestWindowsWorkingTreeReaderRejectsIntermediateReparsePoint(t *testing.T) {
+	root := t.TempDir()
+	target := t.TempDir()
+	if err := os.WriteFile(filepath.Join(target, "file"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "alias")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	_, err := readWorkingTreeFileContext(context.Background(), root, filepath.Join("alias", "file"))
+	var pathErr *workingTreePathError
+	if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathSymlinkComponent {
+		t.Fatalf("intermediate reparse error=%T %v", err, err)
+	}
+}
+
+func TestWindowsWorkingTreeReaderRejectsReparseRootAndReturnsLinkMetadata(t *testing.T) {
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real")
+	if err := os.Mkdir(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "file"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(parent, "alias")
+	if err := os.Symlink(realRoot, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	_, err := readWorkingTreeFileContext(context.Background(), alias, "file")
+	var pathErr *workingTreePathError
+	if !errors.As(err, &pathErr) || pathErr.Kind != workingTreePathSymlinkComponent {
+		t.Fatalf("reparse root error=%T %v", err, err)
+	}
+
+	link := filepath.Join(realRoot, "link")
+	if err := os.Symlink("file", link); err != nil {
+		t.Skipf("file symlinks unavailable: %v", err)
+	}
+	file, err := readWorkingTreeFileContext(context.Background(), realRoot, "link")
+	if err != nil || file.Kind != workingTreeFileSymlink || string(file.Content) != "file" {
+		t.Fatalf("link metadata=%+v err=%v", file, err)
+	}
+}
+
+func TestWindowsWorkingTreeReaderHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := readWorkingTreeFileContext(ctx, t.TempDir(), "file")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled read error=%v", err)
+	}
+}

--- a/internal/core/diff/diff.go
+++ b/internal/core/diff/diff.go
@@ -1,9 +1,12 @@
 package diff
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
+
+const cancellationCheckInterval = 1024
 
 type LineKind int
 
@@ -186,13 +189,32 @@ func Parse(unified string) FileDiff {
 }
 
 func Generate(oldLines, newLines []string, fileName string) string {
-	lcs := computeLCS(oldLines, newLines)
+	generated, _ := GenerateContext(context.Background(), oldLines, newLines, fileName)
+	return generated
+}
+
+func GenerateContext(ctx context.Context, oldLines, newLines []string, fileName string) (string, error) {
+	lcs, err := computeLCSContext(ctx, oldLines, newLines)
+	if err != nil {
+		return "", err
+	}
 
 	var hunks []string
 	oi, ni, li := 0, 0, 0
 	contextLines := 3
+	work := 0
+	checkCanceled := func() error {
+		work++
+		if work%cancellationCheckInterval != 0 {
+			return nil
+		}
+		return ctx.Err()
+	}
 
 	for oi < len(oldLines) || ni < len(newLines) {
+		if err := checkCanceled(); err != nil {
+			return "", err
+		}
 		if li < len(lcs) && oi < len(oldLines) && ni < len(newLines) && oldLines[oi] == lcs[li] && newLines[ni] == lcs[li] {
 			oi++
 			ni++
@@ -210,10 +232,16 @@ func Generate(oldLines, newLines []string, fileName string) string {
 
 		var hunkLines []string
 		for i := ctxStart; i < hunkOldStart; i++ {
+			if err := checkCanceled(); err != nil {
+				return "", err
+			}
 			hunkLines = append(hunkLines, " "+oldLines[i])
 		}
 
 		for oi < len(oldLines) || ni < len(newLines) {
+			if err := checkCanceled(); err != nil {
+				return "", err
+			}
 			if li < len(lcs) && oi < len(oldLines) && ni < len(newLines) && oldLines[oi] == lcs[li] && newLines[ni] == lcs[li] {
 				peekEnd := 0
 				for peekEnd < contextLines*2 && oi+peekEnd < len(oldLines) && li+peekEnd < len(lcs) && oldLines[oi+peekEnd] == lcs[li+peekEnd] {
@@ -254,6 +282,9 @@ func Generate(oldLines, newLines []string, fileName string) string {
 		oldCount := 0
 		newCount := 0
 		for _, l := range hunkLines {
+			if err := checkCanceled(); err != nil {
+				return "", err
+			}
 			if len(l) > 0 {
 				switch l[0] {
 				case '-':
@@ -273,26 +304,50 @@ func Generate(oldLines, newLines []string, fileName string) string {
 	}
 
 	if len(hunks) == 0 {
-		return ""
+		return "", ctx.Err()
 	}
 
 	var sb strings.Builder
 	sb.WriteString("--- a/" + fileName + "\n")
 	sb.WriteString("+++ b/" + fileName + "\n")
 	for _, line := range hunks {
+		if err := checkCanceled(); err != nil {
+			return "", err
+		}
 		sb.WriteString(line + "\n")
 	}
-	return sb.String()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
 }
 
 func computeLCS(a, b []string) []string {
+	lcs, _ := computeLCSContext(context.Background(), a, b)
+	return lcs
+}
+
+func computeLCSContext(ctx context.Context, a, b []string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	m, n := len(a), len(b)
 	dp := make([][]int, m+1)
 	for i := range dp {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		dp[i] = make([]int, n+1)
 	}
+	work := 0
 	for i := 1; i <= m; i++ {
 		for j := 1; j <= n; j++ {
+			work++
+			if work%cancellationCheckInterval == 0 {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+			}
 			if a[i-1] == b[j-1] {
 				dp[i][j] = dp[i-1][j-1] + 1
 			} else if dp[i-1][j] > dp[i][j-1] {
@@ -305,7 +360,14 @@ func computeLCS(a, b []string) []string {
 
 	lcs := make([]string, 0, dp[m][n])
 	i, j := m, n
+	work = 0
 	for i > 0 && j > 0 {
+		work++
+		if work%cancellationCheckInterval == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		if a[i-1] == b[j-1] {
 			lcs = append(lcs, a[i-1])
 			i--
@@ -317,9 +379,18 @@ func computeLCS(a, b []string) []string {
 		}
 	}
 	for l, r := 0, len(lcs)-1; l < r; l, r = l+1, r-1 {
+		work++
+		if work%cancellationCheckInterval == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		lcs[l], lcs[r] = lcs[r], lcs[l]
 	}
-	return lcs
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return lcs, nil
 }
 
 func parseHunkHeader(header string) (oldStart, newStart int) {

--- a/internal/core/diff/diff_test.go
+++ b/internal/core/diff/diff_test.go
@@ -1,6 +1,24 @@
 package diff
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type cancelAfterChecksContext struct {
+	context.Context
+	calls    int
+	cancelAt int
+}
+
+func (c *cancelAfterChecksContext) Err() error {
+	c.calls++
+	if c.calls >= c.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
 
 const sampleDiff = `diff --git a/main.go b/main.go
 index abc1234..def5678 100644
@@ -151,6 +169,51 @@ func TestGenerateAddition(t *testing.T) {
 	}
 	if !foundAdd {
 		t.Error("expected added line 'b'")
+	}
+}
+
+func TestGenerateContextPreservesGenerateOutput(t *testing.T) {
+	oldLines := []string{"zero", "old", "two", "three"}
+	newLines := []string{"zero", "new", "two", "three", "four"}
+	got, err := GenerateContext(context.Background(), oldLines, newLines, "test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := Generate(oldLines, newLines, "test.txt"); got != want {
+		t.Fatalf("GenerateContext output differs from compatibility API:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestComputeLCSContextChecksCancellationDuringMatrixAllocation(t *testing.T) {
+	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	_, err := computeLCSContext(ctx, make([]string, 32), make([]string, 32))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("allocation cancellation error = %v", err)
+	}
+}
+
+func TestComputeLCSContextChecksCancellationDuringMatrixComputation(t *testing.T) {
+	const rows = 32
+	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 1 + rows + 1 + 2}
+	_, err := computeLCSContext(ctx, make([]string, rows), make([]string, 4096))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("computation cancellation error = %v", err)
+	}
+}
+
+func TestComputeLCSContextChecksCancellationDuringReconstruction(t *testing.T) {
+	lines := make([]string, cancellationCheckInterval)
+	for i := range lines {
+		lines[i] = string(rune(i + 1))
+	}
+	matrixChecks := len(lines) * len(lines) / cancellationCheckInterval
+	ctx := &cancelAfterChecksContext{
+		Context:  context.Background(),
+		cancelAt: 1 + len(lines) + 1 + matrixChecks + 1,
+	}
+	_, err := computeLCSContext(ctx, lines, lines)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("reconstruction cancellation error = %v after %d checks", err, ctx.calls)
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -557,16 +557,21 @@ func ShowFile(dir, path, ref string) (string, error) {
 }
 
 func ShowFileContext(ctx context.Context, dir, path, ref string) (string, error) {
+	out, err := ShowFileBytesContext(ctx, dir, path, ref)
+	return string(out), err
+}
+
+func ShowFileBytesContext(ctx context.Context, dir, path, ref string) ([]byte, error) {
 	spec := ref + ":" + path
 	cmd := gitCommandContext(ctx, "-C", dir, "show", spec)
 	out, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() != nil {
-			return "", ctx.Err()
+			return nil, ctx.Err()
 		}
-		return "", err
+		return nil, err
 	}
-	return string(out), nil
+	return out, nil
 }
 
 func DiffFile(dir, path string) (string, error) {
@@ -613,4 +618,34 @@ func DiffRename(dir, oldPath, newPath string) (string, error) {
 		}
 	}
 	return string(out), nil
+}
+
+func DiffWorkingTreeFileContext(ctx context.Context, dir, revision string, status FileStatus) (string, error) {
+	path := filepath.Join(dir, status.Path)
+	if revision == "" || status.Status == "?" {
+		return diffFileFromEmptyContext(ctx, dir, path)
+	}
+	paths := []string{status.Path}
+	if status.OldPath != "" && status.OldPath != status.Path {
+		paths = []string{status.OldPath, status.Path}
+	}
+	args := []string{"-C", dir, "--literal-pathspecs", "diff", "--no-ext-diff", "--no-textconv", revision, "--"}
+	args = append(args, paths...)
+	out, err := gitCommandContext(ctx, args...).Output()
+	if err != nil && ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	return string(out), err
+}
+
+func diffFileFromEmptyContext(ctx context.Context, dir, path string) (string, error) {
+	cmd := gitCommandContext(ctx, "-C", dir, "diff", "--no-ext-diff", "--no-textconv", "--no-index", "--", "/dev/null", path)
+	out, err := cmd.Output()
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return string(out), nil
+	}
+	if err != nil && ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	return string(out), err
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -574,6 +574,93 @@ func ShowFileBytesContext(ctx context.Context, dir, path, ref string) ([]byte, e
 	return out, nil
 }
 
+func ShowIndexFileBytesContext(ctx context.Context, dir, path string, stage int) ([]byte, error) {
+	spec := ":" + path
+	if stage > 0 {
+		spec = fmt.Sprintf(":%d:%s", stage, path)
+	}
+	cmd := gitCommandContext(ctx, "-C", dir, "show", spec)
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+type IndexEntry struct {
+	Mode   string
+	Object string
+	Stage  int
+}
+
+func IndexEntriesContext(ctx context.Context, dir, path string) ([]IndexEntry, error) {
+	out, err := gitCommandContext(ctx, "-C", dir, "--literal-pathspecs", "ls-files", "--stage", "-z", "--", path).Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	entries := make([]IndexEntry, 0, 3)
+	for len(out) > 0 {
+		end := bytes.IndexByte(out, 0)
+		if end < 0 {
+			break
+		}
+		record := out[:end]
+		out = out[end+1:]
+		tab := bytes.IndexByte(record, '\t')
+		if tab < 0 || string(record[tab+1:]) != path {
+			continue
+		}
+		fields := strings.Fields(string(record[:tab]))
+		if len(fields) != 3 {
+			continue
+		}
+		stage, parseErr := strconv.Atoi(fields[2])
+		if parseErr != nil {
+			continue
+		}
+		entries = append(entries, IndexEntry{Mode: fields[0], Object: fields[1], Stage: stage})
+	}
+	return entries, nil
+}
+
+type TreeEntry struct {
+	Mode   string
+	Object string
+}
+
+func TreeEntryContext(ctx context.Context, dir, revision, path string) (TreeEntry, bool, error) {
+	if revision == "" {
+		return TreeEntry{}, false, nil
+	}
+	out, err := gitCommandContext(ctx, "-C", dir, "--literal-pathspecs", "ls-tree", "-z", revision, "--", path).Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return TreeEntry{}, false, ctx.Err()
+		}
+		return TreeEntry{}, false, err
+	}
+	end := bytes.IndexByte(out, 0)
+	if end < 0 {
+		end = len(out)
+	}
+	record := out[:end]
+	tab := bytes.IndexByte(record, '\t')
+	if tab < 0 || string(record[tab+1:]) != path {
+		return TreeEntry{}, false, nil
+	}
+	fields := strings.Fields(string(record[:tab]))
+	if len(fields) != 3 {
+		return TreeEntry{}, false, nil
+	}
+	return TreeEntry{Mode: fields[0], Object: fields[2]}, true, nil
+}
+
 func DiffFile(dir, path string) (string, error) {
 	absPath := filepath.Join(dir, path)
 	cmd := exec.Command("git", "-C", dir, "diff", "--", absPath)
@@ -630,6 +717,31 @@ func DiffWorkingTreeFileContext(ctx context.Context, dir, revision string, statu
 		paths = []string{status.OldPath, status.Path}
 	}
 	args := []string{"-C", dir, "--literal-pathspecs", "diff", "--no-ext-diff", "--no-textconv", revision, "--"}
+	args = append(args, paths...)
+	out, err := gitCommandContext(ctx, args...).Output()
+	if err != nil && ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	return string(out), err
+}
+
+func DiffCurrentFileContext(ctx context.Context, dir, revision string, status FileStatus) (string, error) {
+	path := filepath.Join(dir, status.Path)
+	if !status.Staged && status.Status == "?" {
+		return diffFileFromEmptyContext(ctx, dir, path)
+	}
+	paths := []string{status.Path}
+	if status.OldPath != "" && status.OldPath != status.Path {
+		paths = []string{status.OldPath, status.Path}
+	}
+	args := []string{"-C", dir, "--literal-pathspecs", "diff", "--no-ext-diff", "--no-textconv", "--submodule=short"}
+	if status.Staged {
+		args = append(args, "--cached")
+		if revision != "" {
+			args = append(args, revision)
+		}
+	}
+	args = append(args, "--")
 	args = append(args, paths...)
 	out, err := gitCommandContext(ctx, args...).Output()
 	if err != nil && ctx.Err() != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -575,10 +575,7 @@ func ShowFileBytesContext(ctx context.Context, dir, path, ref string) ([]byte, e
 }
 
 func ShowIndexFileBytesContext(ctx context.Context, dir, path string, stage int) ([]byte, error) {
-	spec := ":" + path
-	if stage > 0 {
-		spec = fmt.Sprintf(":%d:%s", stage, path)
-	}
+	spec := fmt.Sprintf(":%d:%s", stage, path)
 	cmd := gitCommandContext(ctx, "-C", dir, "show", spec)
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -111,6 +111,20 @@ func gitRun(t *testing.T, dir string, args ...string) {
 	}
 }
 
+func TestShowIndexFileBytesContextUsesExplicitStageZero(t *testing.T) {
+	dir := setupTestRepo(t)
+	writeFile(t, dir, "2:notes.txt", "stage zero\n")
+	gitRun(t, dir, "add", "--", "2:notes.txt")
+
+	got, err := ShowIndexFileBytesContext(context.Background(), dir, "2:notes.txt", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "stage zero\n" {
+		t.Fatalf("index content = %q", got)
+	}
+}
+
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -952,5 +953,32 @@ func TestStageReportsError(t *testing.T) {
 	dir := setupTestRepo(t)
 	if err := Stage(dir, "does-not-exist.txt"); err == nil {
 		t.Error("expected an error staging a missing path")
+	}
+}
+
+func TestDiffWorkingTreeFileContextUsesExplicitRevisionAndRawPath(t *testing.T) {
+	dir := setupTestRepo(t)
+	rawPath := "raw\n\t界.txt"
+	writeFile(t, dir, rawPath, "original\n")
+	gitRun(t, dir, "add", rawPath)
+	gitRun(t, dir, "commit", "-m", "initial")
+	revision := RevisionIdentity(dir)
+	writeFile(t, dir, rawPath, "staged\n")
+	gitRun(t, dir, "add", rawPath)
+	writeFile(t, dir, rawPath, "final working tree\n")
+
+	patch, err := DiffWorkingTreeFileContext(context.Background(), dir, revision, FileStatus{Status: "M", Path: rawPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(patch, "+final working tree") || strings.Contains(patch, "+staged") {
+		t.Fatalf("explicit-revision diff did not use final raw-path content:\n%s", patch)
+	}
+
+	unborn := setupTestRepo(t)
+	writeFile(t, unborn, rawPath, "untracked\n")
+	patch, err = DiffWorkingTreeFileContext(context.Background(), unborn, "", FileStatus{Status: "?", Path: rawPath})
+	if err != nil || !strings.Contains(patch, "+untracked") {
+		t.Fatalf("unborn raw-path diff err=%v:\n%s", err, patch)
 	}
 }

--- a/internal/ui/changes_helpers.go
+++ b/internal/ui/changes_helpers.go
@@ -23,7 +23,7 @@ func StatusStyle(status string) term.Style {
 	switch status {
 	case "M":
 		return term.StyleWarning
-	case "A", "?", "R":
+	case "A", "?", "R", "C":
 		return term.StyleSuccess
 	case "D":
 		return term.StyleDanger
@@ -42,6 +42,8 @@ func StatusBadge(status string) string {
 		return "D"
 	case "R":
 		return "R"
+	case "C":
+		return "C"
 	case "?":
 		return "U"
 	default:

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -22,6 +22,8 @@ type CommitDetailFile struct {
 	Path        string
 	OldPath     string
 	Stage       CommitDetailStage
+	Boundary    CommitDetailBoundary
+	IndexStages []byte
 	ContentKind CommitDetailContentKind
 	Diff        diff.FileDiff
 	Error       string
@@ -38,6 +40,14 @@ type CommitDetailFile struct {
 	gapByLine    map[int]int
 	pendingGap   int
 }
+
+type CommitDetailBoundary uint8
+
+const (
+	CommitDetailBoundaryNone CommitDetailBoundary = iota
+	CommitDetailBoundaryHeadToIndex
+	CommitDetailBoundaryIndexToWorktree
+)
 
 type CommitDetailStage uint8
 
@@ -96,6 +106,18 @@ type commitDetailVisualRow struct {
 type commitDetailControl struct {
 	rect      Rect
 	fileIndex int
+}
+
+type commitDetailSelectionPoint struct {
+	key       string
+	lineIndex int
+	col       int
+}
+
+type commitDetailPreservedSelection struct {
+	anchor  commitDetailSelectionPoint
+	current commitDetailSelectionPoint
+	right   bool
 }
 
 // CommitDetailWidget renders an entire commit as one virtualized scrollable
@@ -317,7 +339,7 @@ func (d *CommitDetailWidget) ApplyFileContext(fileIndex int, key string, oldLine
 func CommitDetailContextKey(file CommitDetailFile) string { return commitDetailFileKey(file) }
 
 func commitDetailFileKey(file CommitDetailFile) string {
-	return file.OldPath + "\x00" + file.Path
+	return file.OldPath + "\x00" + file.Path + "\x00" + string([]byte{byte(file.Boundary)}) + "\x00" + string(file.IndexStages)
 }
 
 func (d *CommitDetailWidget) IsWrapped() bool { return d.wrapMode == DiffWrapOn }
@@ -430,6 +452,7 @@ func (d *CommitDetailWidget) SetCurrentChanges(message string, files []CommitDet
 		collapsed    bool
 		expandedGaps map[int]bool
 	}
+	preservedSelection, hasPreservedSelection := d.captureCurrentChangesSelection()
 	preserved := make(map[string]preservedFileState, len(d.Files))
 	for i, file := range d.Files {
 		state := preservedFileState{expandedGaps: make(map[int]bool)}
@@ -462,9 +485,52 @@ func (d *CommitDetailWidget) SetCurrentChanges(message string, files []CommitDet
 	}
 	d.hasDetail = true
 	d.TopLine = topLine
-	d.ClearSelection()
 	d.rebuildRows()
+	if !hasPreservedSelection || !d.restoreCurrentChangesSelection(preservedSelection) {
+		d.ClearSelection()
+	}
 	d.clampScroll()
+}
+
+func (d *CommitDetailWidget) captureCurrentChangesSelection() (commitDetailPreservedSelection, bool) {
+	if !d.hasSelection {
+		return commitDetailPreservedSelection{}, false
+	}
+	capture := func(pos diffSelPos) (commitDetailSelectionPoint, bool) {
+		if pos.Line < 0 || pos.Line >= len(d.rows) {
+			return commitDetailSelectionPoint{}, false
+		}
+		row := d.rows[pos.Line]
+		if row.kind != commitDetailDiffRow || row.fileIndex < 0 || row.fileIndex >= len(d.Files) {
+			return commitDetailSelectionPoint{}, false
+		}
+		return commitDetailSelectionPoint{key: commitDetailFileKey(d.Files[row.fileIndex]), lineIndex: row.lineIndex, col: pos.Col}, true
+	}
+	anchor, anchorOK := capture(d.selection.Anchor)
+	current, currentOK := capture(d.selection.Current)
+	return commitDetailPreservedSelection{anchor: anchor, current: current, right: d.selRight}, anchorOK && currentOK
+}
+
+func (d *CommitDetailWidget) restoreCurrentChangesSelection(selection commitDetailPreservedSelection) bool {
+	restore := func(point commitDetailSelectionPoint) (diffSelPos, bool) {
+		for rowIndex, row := range d.rows {
+			if row.kind == commitDetailDiffRow && row.lineIndex == point.lineIndex && row.fileIndex >= 0 && row.fileIndex < len(d.Files) && commitDetailFileKey(d.Files[row.fileIndex]) == point.key {
+				return diffSelPos{Line: rowIndex, Col: point.col}, true
+			}
+		}
+		return diffSelPos{}, false
+	}
+	anchor, anchorOK := restore(selection.anchor)
+	current, currentOK := restore(selection.current)
+	if !anchorOK || !currentOK {
+		return false
+	}
+	d.selection.Anchor = anchor
+	d.selection.Current = current
+	d.selRight = selection.right
+	d.hasSelection = true
+	d.selecting = false
+	return true
 }
 
 func (d *CommitDetailWidget) allFilesCollapsed() bool {

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/core/highlight"
@@ -17,11 +18,13 @@ import (
 // the order Git reports them; a failed or hunk-less diff still gets a heading
 // and an explanatory row so a touched path never silently disappears.
 type CommitDetailFile struct {
-	Status  string
-	Path    string
-	OldPath string
-	Diff    diff.FileDiff
-	Error   string
+	Status      string
+	Path        string
+	OldPath     string
+	Stage       CommitDetailStage
+	ContentKind CommitDetailContentKind
+	Diff        diff.FileDiff
+	Error       string
 
 	FullFileState CommitDetailFullFileState
 	FullFileErr   string
@@ -35,6 +38,23 @@ type CommitDetailFile struct {
 	gapByLine    map[int]int
 	pendingGap   int
 }
+
+type CommitDetailStage uint8
+
+const (
+	CommitDetailStageNone CommitDetailStage = iota
+	CommitDetailStageStaged
+	CommitDetailStageUnstaged
+	CommitDetailStageMixed
+)
+
+type CommitDetailContentKind uint8
+
+const (
+	CommitDetailContentText CommitDetailContentKind = iota
+	CommitDetailContentBinary
+	CommitDetailContentEmpty
+)
 
 type CommitDetailFullFileState uint8
 
@@ -84,12 +104,17 @@ type commitDetailControl struct {
 // full-screen cell grid for every changed line on every redraw.
 type CommitDetailWidget struct {
 	BaseWidget
-	Dir         string
-	Ref         string
-	Short       string
-	Incarnation uint64
-	Loading     bool
-	Error       string
+	Dir            string
+	Ref            string
+	Short          string
+	Incarnation    uint64
+	Loading        bool
+	Error          string
+	Header         string
+	LoadingText    string
+	CurrentChanges bool
+	RefreshError   string
+	hasDetail      bool
 
 	Message  string
 	Metadata string
@@ -151,8 +176,29 @@ func NewCommitDetailWidget(dir, ref, short string, syntaxHighlight bool) *Commit
 		Ref:             ref,
 		Short:           short,
 		Loading:         true,
+		Header:          "Commit message",
+		LoadingText:     fmt.Sprintf("Loading commit %s…", short),
 		SyntaxHighlight: syntaxHighlight,
 	}
+}
+
+func NewCurrentChangesWidget(dir string, syntaxHighlight bool) *CommitDetailWidget {
+	return &CommitDetailWidget{
+		Dir:             dir,
+		Ref:             "working-tree",
+		Loading:         true,
+		Header:          "Current changes",
+		LoadingText:     "Loading current changes…",
+		CurrentChanges:  true,
+		SyntaxHighlight: syntaxHighlight,
+	}
+}
+
+func CommitDetailFileWithContent(file CommitDetailFile, oldLines, newLines []string) CommitDetailFile {
+	file.oldLines = append([]string(nil), oldLines...)
+	file.newLines = append([]string(nil), newLines...)
+	file.FullFileState = CommitDetailFullFileLoaded
+	return file
 }
 
 func (d *CommitDetailWidget) Focusable() bool { return true }
@@ -363,6 +409,64 @@ func (d *CommitDetailWidget) SetDetail(message string, files []CommitDetailFile,
 	}
 }
 
+func (d *CommitDetailWidget) SetCurrentChanges(message string, files []CommitDetailFile, errText string) {
+	if !d.CurrentChanges {
+		return
+	}
+	d.Loading = false
+	if errText != "" {
+		if d.hasDetail {
+			d.Error = ""
+			d.RefreshError = errText
+			d.rebuildRows()
+			return
+		}
+		d.Error = errText
+		d.RefreshError = ""
+		return
+	}
+
+	type preservedFileState struct {
+		collapsed    bool
+		expandedGaps map[int]bool
+	}
+	preserved := make(map[string]preservedFileState, len(d.Files))
+	for i, file := range d.Files {
+		state := preservedFileState{expandedGaps: make(map[int]bool)}
+		if i < len(d.collapsedFiles) {
+			state.collapsed = d.collapsedFiles[i]
+		}
+		for gap, expanded := range file.expandedGaps {
+			state.expandedGaps[gap] = expanded
+		}
+		preserved[commitDetailFileKey(file)] = state
+	}
+	topLine := d.TopLine
+	d.Error = ""
+	d.RefreshError = ""
+	d.Message = message
+	d.Files = files
+	d.collapsedFiles = make([]bool, len(files))
+	for i := range d.Files {
+		d.Files[i].pendingGap = -1
+		state, ok := preserved[commitDetailFileKey(d.Files[i])]
+		if ok {
+			d.collapsedFiles[i] = state.collapsed
+			d.Files[i].expandedGaps = state.expandedGaps
+		} else {
+			d.Files[i].expandedGaps = make(map[int]bool)
+		}
+		if d.SyntaxHighlight && d.Files[i].Path != "" && d.Files[i].ContentKind == CommitDetailContentText {
+			d.Files[i].highlighter = highlight.New(d.Files[i].Path)
+		}
+	}
+	d.hasDetail = true
+	d.TopLine = topLine
+	d.ClearSelection()
+	d.rebuildRows()
+	d.clampScroll()
+}
+
 func (d *CommitDetailWidget) allFilesCollapsed() bool {
 	if len(d.Files) == 0 {
 		return false
@@ -420,18 +524,30 @@ func (d *CommitDetailWidget) rebuildRows() {
 		return
 	}
 
-	d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageHeaderRow, text: "Commit message", bold: true})
+	header := d.Header
+	if header == "" {
+		header = "Commit message"
+	}
+	d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageHeaderRow, text: header, bold: true})
 	if d.Metadata != "" {
 		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMetadataRow, text: d.Metadata})
 		d.recordWidth(d.Metadata)
 	}
 	message := strings.TrimRight(d.Message, "\r\n")
 	if message == "" {
-		message = "(No commit message)"
+		if d.CurrentChanges {
+			message = "Working tree clean"
+		} else {
+			message = "(No commit message)"
+		}
 	}
 	for i, line := range strings.Split(message, "\n") {
 		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMessageRow, text: line, bold: i == 0})
 		d.recordWidth(line)
+	}
+	if d.RefreshError != "" {
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: d.RefreshError, danger: true})
+		d.recordWidth(d.RefreshError)
 	}
 	d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
 
@@ -479,6 +595,20 @@ func (d *CommitDetailWidget) rebuildRows() {
 		case file.Error != "":
 			d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: file.Error, fileIndex: fileIndex})
 			d.recordWidth(file.Error)
+		case file.ContentKind == CommitDetailContentBinary:
+			const binary = "Binary file changed"
+			d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: binary, fileIndex: fileIndex})
+			d.recordWidth(binary)
+		case file.ContentKind == CommitDetailContentEmpty:
+			empty := "Empty file changed"
+			switch file.Status {
+			case "A", "?":
+				empty = "Empty file added"
+			case "D":
+				empty = "Empty file deleted"
+			}
+			d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: empty, fileIndex: fileIndex})
+			d.recordWidth(empty)
 		default:
 			if len(file.lines) == 0 {
 				const noChanges = "No line changes"
@@ -512,7 +642,7 @@ func (d *CommitDetailWidget) rebuildRows() {
 			}
 		}
 	}
-	if len(d.Files) == 0 {
+	if len(d.Files) == 0 && !d.CurrentChanges {
 		const noFiles = "No files"
 		d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: noFiles})
 		d.recordWidth(noFiles)
@@ -530,10 +660,30 @@ func (d *CommitDetailWidget) recordWidth(text string) {
 }
 
 func commitDetailFileHeading(file CommitDetailFile) string {
+	path := displayCommitDetailPath(file.Path)
 	if file.OldPath != "" && file.OldPath != file.Path {
-		return fmt.Sprintf("%s → %s", file.OldPath, file.Path)
+		path = fmt.Sprintf("%s → %s", displayCommitDetailPath(file.OldPath), path)
 	}
-	return file.Path
+	if file.Stage == CommitDetailStageNone {
+		return path
+	}
+	stage := "unstaged"
+	switch file.Stage {
+	case CommitDetailStageStaged:
+		stage = "staged"
+	case CommitDetailStageMixed:
+		stage = "mixed"
+	}
+	return fmt.Sprintf("%s  %s · %s", StatusBadge(file.Status), path, stage)
+}
+
+func displayCommitDetailPath(path string) string {
+	for _, r := range path {
+		if !unicode.IsGraphic(r) {
+			return strconv.QuoteToGraphic(path)
+		}
+	}
+	return path
 }
 
 func (d *CommitDetailWidget) Render(surface Surface) {
@@ -545,7 +695,11 @@ func (d *CommitDetailWidget) Render(surface Surface) {
 	surface.Fill(term.Cell{Ch: ' ', Style: term.StyleDefault})
 
 	if d.Loading {
-		surface.DrawText(0, 0, fmt.Sprintf("Loading commit %s…", d.Short), w, term.StyleMuted)
+		loadingText := d.LoadingText
+		if loadingText == "" {
+			loadingText = fmt.Sprintf("Loading commit %s…", d.Short)
+		}
+		surface.DrawText(0, 0, loadingText, w, term.StyleMuted)
 		return
 	}
 	if d.Error != "" {
@@ -748,7 +902,11 @@ func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) 
 	for column := 0; column < viewW; column++ {
 		surface.SetCell(column, y, term.Cell{Ch: ' ', Style: term.StyleCommitMessage})
 	}
-	d.drawStaticText(surface, 0, y, viewW, "Commit message", term.StyleCommitMessage, term.StyleCommitMessage, true)
+	header := d.Header
+	if header == "" {
+		header = "Commit message"
+	}
+	d.drawStaticText(surface, 0, y, viewW, header, term.StyleCommitMessage, term.StyleCommitMessage, true)
 	if len(d.Files) == 0 {
 		return
 	}
@@ -758,7 +916,7 @@ func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) 
 	}
 	controlW := textwidth.String(label)
 	controlX := viewW - controlW
-	if controlX <= textwidth.String("Commit message") {
+	if controlX <= textwidth.String(header) {
 		return
 	}
 	d.drawStaticText(surface, controlX, y, controlW, label, term.StyleCommitMessage, term.StyleCommitMessage, true)
@@ -767,20 +925,24 @@ func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) 
 }
 
 func (d *CommitDetailWidget) renderHeading(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
+	headingStyle := term.StyleDefault
+	if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && d.Files[row.fileIndex].Stage != CommitDetailStageNone {
+		headingStyle = StatusStyle(d.Files[row.fileIndex].Status)
+	}
 	collapsed := row.fileIndex >= 0 && row.fileIndex < len(d.collapsedFiles) && d.collapsedFiles[row.fileIndex]
 	if !visual.continuation {
 		chevron := '▼'
 		if collapsed {
 			chevron = '▶'
 		}
-		surface.SetCell(1, y, term.Cell{Ch: chevron, Style: term.StyleDefault, Bold: true})
+		surface.SetCell(1, y, term.Cell{Ch: chevron, Style: headingStyle, Bold: true})
 	}
 	r := d.GetRect()
 	d.fileControls = append(d.fileControls, commitDetailControl{
 		rect:      Rect{X: r.X, Y: r.Y + y, W: viewW, H: 1},
 		fileIndex: row.fileIndex,
 	})
-	d.drawTextRow(surface, 3, y, viewW-3, row.text, term.StyleDefault, term.StyleDefault, row.bold, visual.leftStart, rowIndex)
+	d.drawTextRow(surface, 3, y, viewW-3, row.text, headingStyle, term.StyleDefault, row.bold, visual.leftStart, rowIndex)
 }
 
 func (d *CommitDetailWidget) renderDiffRow(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
@@ -1038,10 +1200,14 @@ func (d *CommitDetailWidget) renderStickyHeading(surface Surface, viewW int) {
 	for column := 0; column < viewW; column++ {
 		surface.SetCell(column, 0, term.Cell{Ch: ' ', Style: term.StyleDefault})
 	}
-	surface.SetCell(1, 0, term.Cell{Ch: '▼', Style: term.StyleDefault, Bold: true})
+	headingStyle := term.StyleDefault
+	if d.Files[row.fileIndex].Stage != CommitDetailStageNone {
+		headingStyle = StatusStyle(d.Files[row.fileIndex].Status)
+	}
+	surface.SetCell(1, 0, term.Cell{Ch: '▼', Style: headingStyle, Bold: true})
 	path := truncateCommitDetailPath(commitDetailFileHeading(d.Files[row.fileIndex]), viewW-3)
 	drawTextSegment(surface, 3, 0, viewW-3, path, 0, 0, term.Cell{Ch: ' '}, func(_ int, ch rune) term.Cell {
-		return term.Cell{Ch: ch, Style: term.StyleDefault, Bold: true}
+		return term.Cell{Ch: ch, Style: headingStyle, Bold: true}
 	})
 	r := d.GetRect()
 	d.stickyRect = Rect{X: r.X, Y: r.Y, W: viewW, H: 1}

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -24,9 +24,12 @@ type CommitDetailFile struct {
 	Stage       CommitDetailStage
 	Boundary    CommitDetailBoundary
 	IndexStages []byte
-	ContentKind CommitDetailContentKind
-	Diff        diff.FileDiff
-	Error       string
+	// ConflictCode marks a two-way resolution view between the preferred
+	// available conflict stage and the worktree, not a full three-way merge view.
+	ConflictCode string
+	ContentKind  CommitDetailContentKind
+	Diff         diff.FileDiff
+	Error        string
 
 	FullFileState CommitDetailFullFileState
 	FullFileErr   string
@@ -47,6 +50,7 @@ const (
 	CommitDetailBoundaryNone CommitDetailBoundary = iota
 	CommitDetailBoundaryHeadToIndex
 	CommitDetailBoundaryIndexToWorktree
+	CommitDetailBoundaryConflictToWorktree
 )
 
 type CommitDetailStage uint8
@@ -56,6 +60,7 @@ const (
 	CommitDetailStageStaged
 	CommitDetailStageUnstaged
 	CommitDetailStageMixed
+	CommitDetailStageConflict
 )
 
 type CommitDetailContentKind uint8
@@ -339,7 +344,7 @@ func (d *CommitDetailWidget) ApplyFileContext(fileIndex int, key string, oldLine
 func CommitDetailContextKey(file CommitDetailFile) string { return commitDetailFileKey(file) }
 
 func commitDetailFileKey(file CommitDetailFile) string {
-	return file.OldPath + "\x00" + file.Path + "\x00" + string([]byte{byte(file.Boundary)}) + "\x00" + string(file.IndexStages)
+	return file.OldPath + "\x00" + file.Path + "\x00" + string([]byte{byte(file.Boundary)}) + "\x00" + file.ConflictCode + "\x00" + string(file.IndexStages)
 }
 
 func (d *CommitDetailWidget) IsWrapped() bool { return d.wrapMode == DiffWrapOn }
@@ -732,6 +737,9 @@ func commitDetailFileHeading(file CommitDetailFile) string {
 	}
 	if file.Stage == CommitDetailStageNone {
 		return path
+	}
+	if file.Stage == CommitDetailStageConflict {
+		return fmt.Sprintf("%s  %s - conflict (%s)", StatusBadge(file.Status), path, file.ConflictCode)
 	}
 	stage := "unstaged"
 	switch file.Stage {

--- a/internal/ui/current_changes_widget_test.go
+++ b/internal/ui/current_changes_widget_test.go
@@ -136,3 +136,73 @@ func TestCurrentChangesSamePathBoundariesPreserveIndependentCollapseAndSelection
 		t.Fatalf("selection moved across boundary: row=%+v files=%+v", row, detail.Files)
 	}
 }
+
+func currentChangesConflictTestFile(path, code string, stages []byte, oldLines, newLines []string) CommitDetailFile {
+	file := CommitDetailFile{
+		Status: "U", Path: path, Stage: CommitDetailStageConflict, Boundary: CommitDetailBoundaryConflictToWorktree,
+		ConflictCode: code, IndexStages: append([]byte(nil), stages...), Diff: diff.Parse(diff.Generate(oldLines, newLines, path)),
+	}
+	return CommitDetailFileWithContent(file, oldLines, newLines)
+}
+
+func TestCurrentChangesConflictHeadingContentAndIdentity(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	file := currentChangesConflictTestFile("conflict.txt", "UD", []byte{1, 2}, []string{"ours"}, []string{"ours"})
+	detail.SetCurrentChanges("1 conflict", []CommitDetailFile{file}, "")
+	detail.SetRect(Rect{W: 80, H: 8})
+	cells := makeGrid(80, 8)
+	detail.Render(NewRenderSurface(cells, Rect{W: 80, H: 8}))
+	text := detailTestText(cells)
+	for _, want := range []string{"U  conflict.txt - conflict (UD)", "No line changes"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("conflict view omitted %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "staged") || strings.Contains(text, "index") {
+		t.Fatalf("conflict view claimed an unavailable index boundary:\n%s", text)
+	}
+
+	theirs := file
+	theirs.ConflictCode = "DU"
+	theirs.IndexStages = []byte{1, 3}
+	if CommitDetailContextKey(file) == CommitDetailContextKey(theirs) {
+		t.Fatal("conflict XY and index-stage identity collapsed to one context key")
+	}
+}
+
+func TestCurrentChangesConflictRefreshPreservesCollapseAndSelection(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	collapsed := currentChangesConflictTestFile("collapsed.txt", "UD", []byte{1, 2}, []string{"ours"}, []string{"resolved"})
+	selected := currentChangesConflictTestFile("selected.txt", "DU", []byte{1, 3}, []string{"theirs"}, []string{"working"})
+	detail.SetCurrentChanges("2 conflicts", []CommitDetailFile{collapsed, selected}, "")
+	detail.collapsedFiles[0] = true
+	detail.rebuildRows()
+	selectedRow := -1
+	for i, row := range detail.rows {
+		if row.kind == commitDetailDiffRow && row.fileIndex == 1 {
+			selectedRow = i
+			break
+		}
+	}
+	if selectedRow < 0 {
+		t.Fatal("selected conflict has no diff row")
+	}
+	detail.hasSelection = true
+	detail.selRight = true
+	detail.selection.Anchor = diffSelPos{Line: selectedRow, Col: 0}
+	detail.selection.Current = diffSelPos{Line: selectedRow, Col: 4}
+
+	refreshedCollapsed := currentChangesConflictTestFile("collapsed.txt", "UD", []byte{1, 2}, []string{"ours"}, []string{"resolved latest"})
+	refreshedSelected := currentChangesConflictTestFile("selected.txt", "DU", []byte{1, 3}, []string{"theirs"}, []string{"working latest"})
+	detail.SetCurrentChanges("2 conflicts", []CommitDetailFile{refreshedCollapsed, refreshedSelected}, "")
+	if !detail.collapsedFiles[0] || detail.collapsedFiles[1] {
+		t.Fatalf("conflict collapse state = %v", detail.collapsedFiles)
+	}
+	if !detail.hasSelection {
+		t.Fatal("conflict selection was lost across a same-identity refresh")
+	}
+	row := detail.rows[detail.selection.Anchor.Line]
+	if row.fileIndex != 1 || detail.Files[row.fileIndex].ConflictCode != "DU" {
+		t.Fatalf("conflict selection moved across identity: row=%+v files=%+v", row, detail.Files)
+	}
+}

--- a/internal/ui/current_changes_widget_test.go
+++ b/internal/ui/current_changes_widget_test.go
@@ -94,3 +94,45 @@ func TestCurrentChangesBinaryAndEmptyFilesRemainVisibleInFullFileMode(t *testing
 		}
 	}
 }
+
+func TestCurrentChangesSamePathBoundariesPreserveIndependentCollapseAndSelection(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	staged := currentChangesTestFile("file.txt", CommitDetailStageStaged, []string{"head"}, []string{"index"})
+	staged.Boundary = CommitDetailBoundaryHeadToIndex
+	unstaged := currentChangesTestFile("file.txt", CommitDetailStageUnstaged, []string{"index"}, []string{"worktree"})
+	unstaged.Boundary = CommitDetailBoundaryIndexToWorktree
+	detail.SetCurrentChanges("1 file", []CommitDetailFile{staged, unstaged}, "")
+	detail.collapsedFiles[0] = true
+	detail.rebuildRows()
+	selectedRow := -1
+	for i, row := range detail.rows {
+		if row.kind == commitDetailDiffRow && row.fileIndex == 1 {
+			selectedRow = i
+			break
+		}
+	}
+	if selectedRow < 0 {
+		t.Fatal("unstaged boundary has no selectable diff row")
+	}
+	detail.hasSelection = true
+	detail.selRight = true
+	detail.selection.Anchor = diffSelPos{Line: selectedRow, Col: 0}
+	detail.selection.Current = diffSelPos{Line: selectedRow, Col: 4}
+
+	refreshedStaged := currentChangesTestFile("file.txt", CommitDetailStageStaged, []string{"head"}, []string{"index"})
+	refreshedStaged.Boundary = CommitDetailBoundaryHeadToIndex
+	refreshedUnstaged := currentChangesTestFile("file.txt", CommitDetailStageUnstaged, []string{"index"}, []string{"worktree latest"})
+	refreshedUnstaged.Boundary = CommitDetailBoundaryIndexToWorktree
+	detail.SetCurrentChanges("1 file", []CommitDetailFile{refreshedStaged, refreshedUnstaged}, "")
+
+	if !detail.collapsedFiles[0] || detail.collapsedFiles[1] {
+		t.Fatalf("independent collapse state = %v", detail.collapsedFiles)
+	}
+	if !detail.hasSelection {
+		t.Fatal("unstaged selection was lost when the same-path staged boundary refreshed")
+	}
+	row := detail.rows[detail.selection.Anchor.Line]
+	if row.fileIndex != 1 || detail.Files[row.fileIndex].Boundary != CommitDetailBoundaryIndexToWorktree {
+		t.Fatalf("selection moved across boundary: row=%+v files=%+v", row, detail.Files)
+	}
+}

--- a/internal/ui/current_changes_widget_test.go
+++ b/internal/ui/current_changes_widget_test.go
@@ -1,0 +1,96 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/gdamore/tcell/v3"
+)
+
+func currentChangesTestFile(path string, stage CommitDetailStage, oldLines, newLines []string) CommitDetailFile {
+	file := CommitDetailFile{
+		Status: "M", Path: path, Stage: stage, Diff: diff.Parse(diff.Generate(oldLines, newLines, path)),
+	}
+	return CommitDetailFileWithContent(file, oldLines, newLines)
+}
+
+func TestCurrentChangesUsesTypedHeadingAndClickableSharedFileRows(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	file := currentChangesTestFile("wide/界\nname.go", CommitDetailStageMixed,
+		[]string{"old"}, []string{"new"})
+	detail.SetCurrentChanges("1 file", []CommitDetailFile{file}, "")
+	detail.SetRect(Rect{W: 80, H: 10})
+	cells := makeGrid(80, 10)
+	detail.Render(NewRenderSurface(cells, Rect{W: 80, H: 10}))
+	text := detailTestText(cells)
+	if got := displayCommitDetailPath(file.Path); got != `"wide/界\nname.go"` {
+		t.Fatalf("raw path presentation = %q", got)
+	}
+	if !strings.Contains(text, `\nname.go" · mixed`) || !strings.Contains(text, "M  \"") {
+		t.Fatalf("typed current-change heading was not safely presented:\n%s", text)
+	}
+	if len(detail.fileControls) != 1 {
+		t.Fatalf("file controls = %d, want 1", len(detail.fileControls))
+	}
+	control := detail.fileControls[0]
+	if result := detail.HandleEvent(tcell.NewEventMouse(control.rect.X+4, control.rect.Y, tcell.Button1, tcell.ModNone)); result != EventConsumed {
+		t.Fatalf("heading click result = %v", result)
+	}
+	if !detail.collapsedFiles[0] {
+		t.Fatal("current-change heading click did not collapse the file")
+	}
+}
+
+func TestCurrentChangesRefreshPreservesLastGoodExpansionScrollAndContext(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	oldLines := []string{"zero", "old", "two", "three", "four", "five", "six", "seven"}
+	newLines := []string{"zero", "new", "two", "three", "four", "five", "six", "seven"}
+	file := currentChangesTestFile("file.txt", CommitDetailStageUnstaged, oldLines, newLines)
+	detail.SetCurrentChanges("first", []CommitDetailFile{file}, "")
+	detail.SetRect(Rect{W: 40, H: 4})
+	detail.Render(NewRenderSurface(makeGrid(40, 4), Rect{W: 40, H: 4}))
+	detail.collapsedFiles[0] = true
+	detail.TopLine = 2
+
+	refreshed := currentChangesTestFile("file.txt", CommitDetailStageUnstaged, oldLines,
+		[]string{"zero", "latest", "two", "three", "four", "five", "six", "seven"})
+	detail.SetCurrentChanges("second", []CommitDetailFile{refreshed}, "")
+	if !detail.collapsedFiles[0] {
+		t.Fatal("refresh lost file expansion identity")
+	}
+	if detail.TopLine == 0 {
+		t.Fatal("refresh reset the current document scroll position")
+	}
+	if detail.Files[0].FullFileState != CommitDetailFullFileLoaded {
+		t.Fatalf("refreshed Full File state = %v, want loaded", detail.Files[0].FullFileState)
+	}
+
+	detail.SetCurrentChanges("", nil, "temporary read failure")
+	if detail.Message != "second" || len(detail.Files) != 1 || detail.Error != "" || detail.RefreshError == "" {
+		t.Fatalf("failed refresh replaced last good state: message=%q files=%d error=%q refresh=%q",
+			detail.Message, len(detail.Files), detail.Error, detail.RefreshError)
+	}
+	detail.SetCurrentChanges("recovered", []CommitDetailFile{refreshed}, "")
+	if detail.RefreshError != "" || detail.Message != "recovered" {
+		t.Fatalf("successful retry did not clear failure: message=%q refresh=%q", detail.Message, detail.RefreshError)
+	}
+}
+
+func TestCurrentChangesBinaryAndEmptyFilesRemainVisibleInFullFileMode(t *testing.T) {
+	detail := NewCurrentChangesWidget("/repo", false)
+	detail.SetContextMode(DiffContextFullFile)
+	detail.SetCurrentChanges("two files", []CommitDetailFile{
+		{Status: "M", Path: "blob.bin", Stage: CommitDetailStageUnstaged, ContentKind: CommitDetailContentBinary, FullFileState: CommitDetailFullFileLoaded},
+		{Status: "A", Path: "empty.txt", Stage: CommitDetailStageStaged, ContentKind: CommitDetailContentEmpty, FullFileState: CommitDetailFullFileLoaded},
+	}, "")
+	detail.SetRect(Rect{W: 80, H: 12})
+	cells := makeGrid(80, 12)
+	detail.Render(NewRenderSurface(cells, Rect{W: 80, H: 12}))
+	text := detailTestText(cells)
+	for _, want := range []string{"Binary file changed", "Empty file added", "M  blob.bin · unstaged", "A  empty.txt · staged"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("current changes omitted %q in Full File mode:\n%s", want, text)
+		}
+	}
+}

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -622,6 +622,14 @@ func (g *EditorGroupWidget) ActiveCommitDetailWidget() *CommitDetailWidget {
 	return detail
 }
 
+func (g *EditorGroupWidget) ActiveCurrentChangesWidget() *CommitDetailWidget {
+	detail := g.ActiveCommitDetailWidget()
+	if detail != nil && detail.CurrentChanges {
+		return detail
+	}
+	return nil
+}
+
 func (g *EditorGroupWidget) ActiveDiffModeSurface() DiffModeSurface {
 	t := g.activeTab()
 	if t == nil || t.Content == nil {
@@ -658,6 +666,14 @@ func (g *EditorGroupWidget) CommitDetailWidgetByTab(tabName string) *CommitDetai
 			detail, _ := t.Content.(*CommitDetailWidget)
 			return detail
 		}
+	}
+	return nil
+}
+
+func (g *EditorGroupWidget) CurrentChangesWidgetByTab(tabName string) *CommitDetailWidget {
+	detail := g.CommitDetailWidgetByTab(tabName)
+	if detail != nil && detail.CurrentChanges {
+		return detail
 	}
 	return nil
 }

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -404,7 +404,10 @@ func (g *EditorGroupWidget) nextUntitledName() string {
 }
 
 func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, newLines []string, extended bool) {
-	tabName := path + " (diff)"
+	g.OpenDiffTab(path+" (diff)", "", path, fd, oldLines, newLines, extended)
+}
+
+func (g *EditorGroupWidget) OpenDiffTab(tabName, title, path string, fd diff.FileDiff, oldLines, newLines []string, extended bool) {
 	for i, t := range g.tabs {
 		if t.FilePath == tabName {
 			dw := NewDiffViewWidget(path, fd, oldLines, newLines, extended)
@@ -413,6 +416,7 @@ func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, ne
 				dw.Highlighter = nil
 			}
 			t.Content = dw
+			t.Title = title
 			g.tabs[i] = t
 			g.SwitchTab(i)
 			return
@@ -425,6 +429,7 @@ func (g *EditorGroupWidget) OpenDiff(path string, fd diff.FileDiff, oldLines, ne
 	}
 	g.tabs = append(g.tabs, editorTab{
 		FilePath: tabName,
+		Title:    title,
 		Content:  widget,
 	})
 	g.SwitchTab(len(g.tabs) - 1)

--- a/tests/e2e/current_changes_test.go
+++ b/tests/e2e/current_changes_test.go
@@ -1,0 +1,61 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/app"
+)
+
+func TestOpenCurrentChangesReusesOneLiveSharedDiffDocument(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	initializeHarnessRepository(t, h.dir)
+	path := filepath.Join(h.dir, "alpha.txt")
+	if err := os.WriteFile(path, []byte("first working version\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.Repository.RefreshNow(app.RepositoryWorktree)
+	h.exec("changes.viewAll")
+	first := h.app.EditorGroup.ActiveCurrentChangesWidget()
+	if first == nil {
+		t.Fatal("Open Current Changes did not create the shared document")
+	}
+	for _, want := range []string{"Current changes", "M  alpha.txt · unstaged", "first working version"} {
+		h.assertContains(want)
+	}
+
+	h.exec("changes.viewAll")
+	if h.app.EditorGroup.ActiveCurrentChangesWidget() != first {
+		t.Fatal("reopening Current Changes replaced its stable tab incarnation")
+	}
+	lines := strings.Split(h.screenText(), "\n")
+	headingY := -1
+	for y, line := range lines {
+		if strings.Contains(line, "M  alpha.txt · unstaged") {
+			headingY = y
+			break
+		}
+	}
+	if headingY < 0 {
+		t.Fatal("current changes file heading was not rendered")
+	}
+	headingX := first.GetRect().X + 8
+	h.click(headingX, headingY)
+	if strings.Contains(h.screenText(), "first working version") {
+		t.Fatal("clicking the current-change title row did not collapse its diff")
+	}
+
+	if err := os.WriteFile(path, []byte("second external version\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h.app.Repository.RefreshNow(app.RepositoryWorktree)
+	h.redraw()
+	if strings.Contains(h.screenText(), "second external version") {
+		t.Fatal("live refresh lost the collapsed file state")
+	}
+	h.click(headingX, headingY)
+	h.assertContains("second external version")
+}

--- a/tests/e2e/current_changes_test.go
+++ b/tests/e2e/current_changes_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -58,4 +59,37 @@ func TestOpenCurrentChangesReusesOneLiveSharedDiffDocument(t *testing.T) {
 	}
 	h.click(headingX, headingY)
 	h.assertContains("second external version")
+}
+
+func TestOpenCurrentChangesShowsOneExplicitUDConflictSection(t *testing.T) {
+	h := newTestHarness(t, 100, 24)
+	defer h.stop()
+	initializeHarnessRepository(t, h.dir)
+	path := filepath.Join(h.dir, "alpha.txt")
+	runHistoryGit(t, h.dir, "checkout", "-qb", "other")
+	runHistoryGit(t, h.dir, "rm", "--", "alpha.txt")
+	runHistoryGit(t, h.dir, "commit", "-m", "other deletes")
+	runHistoryGit(t, h.dir, "checkout", "-q", "main")
+	if err := os.WriteFile(path, []byte("main content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runHistoryGit(t, h.dir, "commit", "-am", "main modifies")
+	if err := exec.Command("git", "-C", h.dir, "merge", "other").Run(); err == nil {
+		t.Fatal("merge unexpectedly succeeded")
+	}
+
+	h.app.Repository.RefreshNow(app.RepositoryWorktree)
+	h.exec("changes.viewAll")
+	screen := h.screenText()
+	if strings.Count(screen, "U  alpha.txt - conflict (UD)") != 1 {
+		t.Fatalf("UD conflict did not render as one section:\n%s", screen)
+	}
+	for _, want := range []string{"Current changes", "No line changes"} {
+		if !strings.Contains(screen, want) {
+			t.Fatalf("UD conflict omitted %q:\n%s", want, screen)
+		}
+	}
+	if strings.Contains(screen, "alpha.txt · staged") || strings.Contains(screen, "alpha.txt · unstaged") {
+		t.Fatalf("UD conflict was coerced into staged or unstaged claims:\n%s", screen)
+	}
 }

--- a/tests/e2e/options_menu_test.go
+++ b/tests/e2e/options_menu_test.go
@@ -93,7 +93,7 @@ func TestOptionsAndChangesShareCheckedPresentationSubmenus(t *testing.T) {
 		}
 	}
 	changes := h.app.BuildChangesPanelMenu()
-	for _, command := range []string{"options.useSplitDiff", "options.useUnifiedDiff", "options.useChangesOnlyDiff", "options.useFullFileDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast", "options.useGitFileTree", "options.useGitFileList", "changes.expandAllWorkingTree", "changes.collapseAllWorkingTree"} {
+	for _, command := range []string{"changes.viewAll", "options.useSplitDiff", "options.useUnifiedDiff", "options.useChangesOnlyDiff", "options.useFullFileDiff", "options.toggleDiffWordWrap", "options.toggleDiffHighContrast", "options.useGitFileTree", "options.useGitFileList", "changes.expandAllWorkingTree", "changes.collapseAllWorkingTree"} {
 		if _, ok := findMenuCommand(changes, command); !ok {
 			t.Errorf("Changes menu missing contextual command %s", command)
 		}

--- a/tests/e2e/tree_actions_menu_test.go
+++ b/tests/e2e/tree_actions_menu_test.go
@@ -43,6 +43,7 @@ func TestChangesAndExplorerThreeDotMenusExposeBulkActions(t *testing.T) {
 	h.redraw()
 	h.assertContains("Git Files")
 	h.pressKey(tcell.KeyDown, tcell.ModNone)
+	h.pressKey(tcell.KeyDown, tcell.ModNone)
 	h.pressKey(tcell.KeyRight, tcell.ModNone)
 	h.assertContains("Expand All")
 	h.assertContains("Collapse All")

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -10,6 +10,30 @@ afterEach(() => {
 });
 
 describe("commit history detail", () => {
+  it("opens a selected commit file as its own diff", () => {
+    dir = createGitRepo(createTempDir());
+    createTempFile(dir, "selected-detail.txt", "selected commit content\n");
+    git(dir, "add", "-A");
+    git(dir, "commit", "-qm", "selected detail");
+
+    tui.start(dir);
+    tui.pressChord("ctrl+k", "c");
+    tui.waitStable(500);
+    tui.press("tab");
+    tui.press("tab");
+    tui.press("down");
+    tui.press("right");
+    tui.waitStable(500);
+    tui.press("down");
+    tui.exec("Git: Open Compact Diff");
+    tui.waitFor("selected-detail.txt @");
+    const opened = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(snapshots[opened]).toMatch(/selected-detail\.txt @ [0-9a-f]{7,}/);
+    expect(snapshots[opened]).toContain("selected commit content");
+  });
+
   it("opens one read-only document with metadata and every changed file", () => {
     dir = createGitRepo(createTempDir());
     createTempFile(dir, "first-detail.txt", "first old\n");

--- a/tests/functional/current-changes-view.test.js
+++ b/tests/functional/current-changes-view.test.js
@@ -38,4 +38,30 @@ describe("current changes document", () => {
       expect(screen.match(/Current Changes x/g)).toHaveLength(1);
     }
   });
+
+  it("shows a UD merge conflict as one explicit two-way resolution section", () => {
+    dir = createGitRepo(createTempDir());
+    const tracked = join(dir, "tracked.txt");
+    execFileSync("git", ["-C", dir, "checkout", "-qb", "other"]);
+    execFileSync("git", ["-C", dir, "rm", "--", "tracked.txt"]);
+    execFileSync("git", ["-C", dir, "commit", "-m", "other deletes"]);
+    execFileSync("git", ["-C", dir, "checkout", "-q", "main"]);
+    writeFileSync(tracked, "main content\n", "utf8");
+    execFileSync("git", ["-C", dir, "commit", "-am", "main modifies"]);
+    try {
+      execFileSync("git", ["-C", dir, "merge", "other"], { stdio: "pipe" });
+    } catch {}
+
+    tui.start(dir);
+    tui.exec("Git: Open Current Changes");
+    tui.waitStable(500);
+    const conflict = tui.snapshot();
+    const { snapshots } = tui.run();
+    const screen = snapshots[conflict];
+
+    expect(screen).toContain("U  tracked.txt - conflict (UD)");
+    expect(screen).toContain("No line changes");
+    expect(screen).not.toContain("tracked.txt · staged");
+    expect(screen).not.toContain("tracked.txt · unstaged");
+  });
 });

--- a/tests/functional/current-changes-view.test.js
+++ b/tests/functional/current-changes-view.test.js
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as tui from "./tui.js";
+import { cleanupDir, createGitRepo, createTempDir } from "./helpers.js";
+
+let dir;
+
+afterEach(() => {
+  tui.kill();
+  if (dir) cleanupDir(dir);
+});
+
+describe("current changes document", () => {
+  it("shows the final mixed working tree in one stable shared diff tab", () => {
+    dir = createGitRepo(createTempDir());
+    const tracked = join(dir, "tracked.txt");
+    writeFileSync(tracked, "staged version\n", "utf8");
+    execFileSync("git", ["-C", dir, "add", "tracked.txt"]);
+    writeFileSync(tracked, "final working version 界\n", "utf8");
+
+    tui.start(dir);
+    tui.exec("Git: Open Current Changes");
+    tui.waitStable(500);
+    const first = tui.snapshot();
+    tui.exec("Git: Open Current Changes");
+    tui.waitStable(300);
+    const reopened = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    for (const screen of [snapshots[first], snapshots[reopened]]) {
+      expect(screen).toContain("Current changes");
+      expect(screen).toContain("M  tracked.txt · mixed");
+      expect(screen).toContain("final working version 界");
+      expect(screen).not.toContain("staged version");
+      expect(screen.match(/Current Changes x/g)).toHaveLength(1);
+    }
+  });
+});

--- a/tests/functional/current-changes-view.test.js
+++ b/tests/functional/current-changes-view.test.js
@@ -13,7 +13,7 @@ afterEach(() => {
 });
 
 describe("current changes document", () => {
-  it("shows the final mixed working tree in one stable shared diff tab", () => {
+  it("shows both mixed index boundaries in one stable shared diff tab", () => {
     dir = createGitRepo(createTempDir());
     const tracked = join(dir, "tracked.txt");
     writeFileSync(tracked, "staged version\n", "utf8");
@@ -31,9 +31,10 @@ describe("current changes document", () => {
 
     for (const screen of [snapshots[first], snapshots[reopened]]) {
       expect(screen).toContain("Current changes");
-      expect(screen).toContain("M  tracked.txt · mixed");
+      expect(screen).toContain("M  tracked.txt · staged");
+      expect(screen).toContain("M  tracked.txt · unstaged");
+      expect(screen).toContain("staged version");
       expect(screen).toContain("final working version 界");
-      expect(screen).not.toContain("staged version");
       expect(screen.match(/Current Changes x/g)).toHaveLength(1);
     }
   });

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -46,11 +46,13 @@ describe("git file tree", () => {
     tui.rclick(5, 5);
     tui.waitStable();
     tui.press("down");
+    tui.press("down");
     tui.press("right");
     const context = tui.snapshot();
     tui.press("escape");
     tui.click(29, 2);
     tui.waitStable();
+    tui.press("down");
     tui.press("down");
     tui.press("right");
     const threeDot = tui.snapshot();
@@ -65,6 +67,7 @@ describe("git file tree", () => {
     expect(snapshots[collapsed]).not.toContain("changed.go");
     expect(snapshots[expanded]).toContain("changed.go");
     for (const menu of [snapshots[context], snapshots[threeDot]]) {
+      expect(menu).toContain("Open Current Changes");
       expect(menu).toContain("Git Files");
       expect(menu).toContain("Tree");
       expect(menu).toContain("List");

--- a/tests/integration/git-changes-reactive.test.js
+++ b/tests/integration/git-changes-reactive.test.js
@@ -43,4 +43,29 @@ describe("reactive git polling", () => {
     expect(screen).toContain("Changes (1)");
     expect(screen).toContain("tracked.txt");
   });
+
+  it("keeps Current Changes live across same-status edits and close/reopen", () => {
+    createRepository();
+
+    tui.start(dir);
+    tui.waitFor("Explore");
+    tui.exec("Git: Open Current Changes");
+    tui.waitFor("Working tree clean");
+
+    writeFileSync(join(dir, "tracked.txt"), "external-one\n", "utf8");
+    tui.waitFor("external-one");
+    writeFileSync(join(dir, "tracked.txt"), "external-two\n", "utf8");
+    tui.waitFor("external-two");
+
+    tui.press("ctrl+w");
+    tui.waitFor("untitled");
+    writeFileSync(join(dir, "tracked.txt"), "while-closed\n", "utf8");
+    tui.exec("Git: Open Current Changes");
+    tui.waitFor("while-closed");
+
+    const screen = tui.snapshot();
+    expect(screen).toContain("Current changes");
+    expect(screen).toContain("M  tracked.txt · unstaged");
+    expect(screen).toContain("while-closed");
+  });
 });


### PR DESCRIPTION
> [!NOTE]

> #488 is merged. This branch is rebased onto current `main` and is the active review layer. It also carries the focused post-merge follow-ups: commit-history files open their own diffs, refresh entry points share one named handler, and replace-all coalesces repository invalidation.

## Summary

- open staged and unstaged work as one read-only Current Changes editor document, using the same shared diff reader and presentation controls as individual file diffs
- keep the document live through repository-state generations while preserving the active tab, scroll position, collapse state, and user-selected presentation
- compute staged content against HEAD and unstaged content against the index so mixed and partially staged files retain their true review boundaries
- represent intent-to-add, deletions, binary/type changes, renames, and every porcelain-v1 unmerged XY state explicitly without silently comparing the wrong endpoints
- cancel superseded diff subprocesses and in-process LCS work across launch, read, parse, and compute phases without leaking processes, goroutines, or file descriptors
- read Git descriptors defensively and fail closed when safe bounded descriptor handling is unavailable

This is the focused live Current Changes extraction from #474. It depends on repository reactivity and the shared diff reader; history pagination remains in the final PR.

## Verification

- make build
- focused app, Git, diff, UI, E2E, functional, and live repository-update coverage
- staged/index/working-tree boundary fixtures, including partially staged and intent-to-add files
- all seven porcelain-v1 unmerged XY combinations normalized into one explicit conflict section
- cancellation probes for pre-launch, subprocess, descriptor-read, parse, LCS, close, and supersession phases with leak checks
- full Go, race, functional, and integration suites on the final rebased head
- independent adversarial SHIP review with fail-before/pass-after boundary, cancellation, and conflict-state evidence
- gofmt and git diff --check

## Demo

<img alt="All staged and unstaged work in one scrollable Current Changes document" src="https://github.com/user-attachments/assets/5f458a21-9861-498c-a172-26992769a985" />

Part of #474.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Current Changes** view for staged, unstaged, untracked, renamed, copied, deleted, binary, empty, and conflicted files.
  - Added **Open Current Changes** actions to Changes panel menus and commands.
  - Current Changes preserves expanded sections, selections, and scroll position during refreshes.
  - Commit file diffs now display richer status and metadata.

- **Bug Fixes**
  - Prevented outdated or canceled diffs from opening after navigation.
  - Improved handling of symlinks, special files, merge conflicts, and untracked files.
  - Added copied-file status indicators and more reliable refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->