### PR TITLE
fix(diff): preserve context and reuse hover theme

### DIFF
--- a/docs-web/src/content/docs/guides/themes.md
+++ b/docs-web/src/content/docs/guides/themes.md
@@ -59,7 +59,7 @@ Theme files are stored as `<name>.json` in the `themes/` subdirectory of your co
 
 ## Full Theme Reference
 
-Below is a complete theme file showing every configurable section. All color values are hex strings (`"#rrggbb"`). Optional `"bold"` and `"italic"` flags are supported where noted. Any field left empty (`{}`) inherits from the `default` colors, except `diff.collapsedHover.bg`, which inherits from `editor.activeLine.bg`.
+Below is a complete theme file showing every configurable section. Ordinary color values are hex strings (`"#rrggbb"`); `editor.bracketColors` also accepts the named terminal colors documented below. Optional `"bold"` and `"italic"` flags are supported where noted. Any field left empty (`{}`) inherits from the `default` colors, except `diff.collapsedHover.bg`, which inherits from `editor.activeLine.bg`.
 
 ```json
 {

--- a/docs-web/src/content/docs/guides/themes.md
+++ b/docs-web/src/content/docs/guides/themes.md
@@ -59,7 +59,7 @@ Theme files are stored as `<name>.json` in the `themes/` subdirectory of your co
 
 ## Full Theme Reference
 
-Below is a complete theme file showing every configurable section. All color values are hex strings (`"#rrggbb"`). Optional `"bold"` and `"italic"` flags are supported where noted. Any field left empty (`{}`) inherits from the `default` colors.
+Below is a complete theme file showing every configurable section. All color values are hex strings (`"#rrggbb"`). Optional `"bold"` and `"italic"` flags are supported where noted. Any field left empty (`{}`) inherits from the `default` colors, except `diff.collapsedHover.bg`, which inherits from `editor.activeLine.bg`.
 
 ```json
 {
@@ -242,7 +242,7 @@ Below is a complete theme file showing every configurable section. All color val
 | `dialog` | Command palette and dialog boxes: input field, items, selection, muted text |
 | `editor` | Editor pane: line numbers, active line highlight, selection, search matches, and bracket pair colors. `bracketColors` accepts terminal color names (`yellow`, `magenta`, `cyan`, `red`, `green`, `blue`, `black`, `white`, `brightRed`, `brightGreen`, `brightYellow`, `brightBlue`, `brightMagenta`, `brightCyan`, `brightBlack`, `brightWhite`), syntax style names (`keyword`, `function`, `type`, `comment`, `string`, `number`, `operator`, `builtin`, `variable`, `punctuation`, `tag`, `attribute`), or hex colors (`#rrggbb`). Up to 6 colors cycle by nesting depth. |
 | `menu` | Menu bar dropdown items and active/hovered item |
-| `diff` | Diff presentation styles: `added`, `deleted`, and `modified` backgrounds; `gutterAdded`, `gutterDeleted`, and `gutterModified` semantic foregrounds; and the `collapsedHover` accent. An omitted `collapsedHover` background inherits the editor active-line background. |
+| `diff` | Diff presentation styles: `added`, `deleted`, and `modified` backgrounds; `gutterAdded`, `gutterDeleted`, and `gutterModified` semantic foregrounds; and the `collapsedHover` accent. An omitted `collapsedHover` background inherits the editor active-line background. The legacy `collapsed` field remains accepted, but new themes should use `collapsedHover`. |
 | `scrollbar` | Scrollbar thumb (`fg`) and track (`bg`) colors |
 | `syntax` | Syntax highlighting colors for language tokens |
 | `terminal` | ANSI color palette for the integrated terminal (16 colors) |

--- a/docs-web/src/content/docs/guides/themes.md
+++ b/docs-web/src/content/docs/guides/themes.md
@@ -150,10 +150,8 @@ Below is a complete theme file showing every configurable section. All color val
     "modified": {
       "bg": "#2e2e1a"
     },
-    "collapsed": {
-      "fg": "#1f1f1f",
-      "bg": "#8ab4d8",
-      "bold": true
+    "collapsedHover": {
+      "bg": "#282828"
     }
   },
   "scrollbar": {
@@ -244,7 +242,7 @@ Below is a complete theme file showing every configurable section. All color val
 | `dialog` | Command palette and dialog boxes: input field, items, selection, muted text |
 | `editor` | Editor pane: line numbers, active line highlight, selection, search matches, and bracket pair colors. `bracketColors` accepts terminal color names (`yellow`, `magenta`, `cyan`, `red`, `green`, `blue`, `black`, `white`, `brightRed`, `brightGreen`, `brightYellow`, `brightBlue`, `brightMagenta`, `brightCyan`, `brightBlack`, `brightWhite`), syntax style names (`keyword`, `function`, `type`, `comment`, `string`, `number`, `operator`, `builtin`, `variable`, `punctuation`, `tag`, `attribute`), or hex colors (`#rrggbb`). Up to 6 colors cycle by nesting depth. |
 | `menu` | Menu bar dropdown items and active/hovered item |
-| `diff` | Diff presentation styles: `added`, `deleted`, and `modified` backgrounds; `gutterAdded`, `gutterDeleted`, and `gutterModified` semantic foregrounds; and the `collapsed` hover/focus accent. Omitted `collapsed` values inherit the built-in defaults. |
+| `diff` | Diff presentation styles: `added`, `deleted`, and `modified` backgrounds; `gutterAdded`, `gutterDeleted`, and `gutterModified` semantic foregrounds; and the `collapsedHover` accent. An omitted `collapsedHover` background inherits the editor active-line background. |
 | `scrollbar` | Scrollbar thumb (`fg`) and track (`bg`) colors |
 | `syntax` | Syntax highlighting colors for language tokens |
 | `terminal` | ANSI color palette for the integrated terminal (16 colors) |

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -48,7 +48,11 @@ func BuildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	applyStyleDef(&m, term.StyleDiffAdded, theme.Diff.Added)
 	applyStyleDef(&m, term.StyleDiffDeleted, theme.Diff.Deleted)
 	applyStyleDef(&m, term.StyleDiffModified, theme.Diff.Modified)
-	applyStyleDef(&m, term.StyleDiffCollapsed, theme.Diff.Collapsed)
+	collapsedHover := theme.Diff.CollapsedHover
+	if collapsedHover.Bg == "" {
+		collapsedHover.Bg = theme.Editor.ActiveLine.Bg
+	}
+	applyStyleDef(&m, term.StyleDiffCollapsedHover, collapsedHover)
 	applyStyleDef(&m, term.StyleGutterAdded, theme.Diff.GutterAdded)
 	applyStyleDef(&m, term.StyleGutterDeleted, theme.Diff.GutterDeleted)
 	applyStyleDef(&m, term.StyleGutterModified, theme.Diff.GutterModified)

--- a/internal/app/theme_diff_test.go
+++ b/internal/app/theme_diff_test.go
@@ -8,14 +8,23 @@ import (
 	"github.com/gdamore/tcell/v3"
 )
 
-func TestBuildStyleMapIncludesCollapsedDiffStyle(t *testing.T) {
+func TestBuildStyleMapIncludesCollapsedHoverStyle(t *testing.T) {
 	theme := config.DefaultTheme()
-	theme.Diff.Collapsed = config.StyleDef{Fg: "#123456", Bg: "#654321", Bold: true}
+	theme.Diff.CollapsedHover = config.StyleDef{Fg: "#123456", Bg: "#654321", Bold: true}
 	styles := BuildStyleMap(theme)
-	style := styles[term.StyleDiffCollapsed]
+	style := styles[term.StyleDiffCollapsedHover]
 	fg, bg, attrs := style.GetForeground(), style.GetBackground(), style.GetAttributes()
 	if fg != tcell.GetColor("#123456") || bg != tcell.GetColor("#654321") || attrs&tcell.AttrBold == 0 {
-		t.Fatalf("collapsed diff style = fg %v bg %v attrs %v", fg, bg, attrs)
+		t.Fatalf("collapsed hover style = fg %v bg %v attrs %v", fg, bg, attrs)
+	}
+}
+
+func TestBuildStyleMapDefaultsCollapsedHoverToActiveLine(t *testing.T) {
+	theme := config.DefaultTheme()
+	theme.Editor.ActiveLine.Bg = "#123456"
+	styles := BuildStyleMap(theme)
+	if got := styles[term.StyleDiffCollapsedHover].GetBackground(); got != tcell.GetColor("#123456") {
+		t.Fatalf("collapsed hover background = %v, want active-line background", got)
 	}
 }
 

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -85,6 +85,9 @@ type DiffStyles struct {
 	Deleted        StyleDef `json:"deleted"`
 	Modified       StyleDef `json:"modified"`
 	CollapsedHover StyleDef `json:"collapsedHover,omitempty"`
+	// Collapsed is retained for themes created against the original collapsed-gap contract.
+	// Deprecated: use CollapsedHover.
+	Collapsed      StyleDef `json:"collapsed,omitempty"`
 	GutterAdded    StyleDef `json:"gutterAdded,omitempty"`
 	GutterDeleted  StyleDef `json:"gutterDeleted,omitempty"`
 	GutterModified StyleDef `json:"gutterModified,omitempty"`
@@ -308,6 +311,9 @@ func (t *ThemeConfig) ResolveColors() {
 	fillBg(&t.Diff.Added, "#1e2e1e")
 	fillBg(&t.Diff.Deleted, "#2e1e1e")
 	fillBg(&t.Diff.Modified, "#2e2e1e")
+	if t.Diff.CollapsedHover == (StyleDef{}) && t.Diff.Collapsed != (StyleDef{}) {
+		t.Diff.CollapsedHover = t.Diff.Collapsed
+	}
 	fillBg(&t.Diff.CollapsedHover, t.Editor.ActiveLine.Bg)
 	fillFg(&t.Diff.GutterAdded, "#73c991")
 	fillFg(&t.Diff.GutterDeleted, "#f14c4c")

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -84,7 +84,7 @@ type DiffStyles struct {
 	Added          StyleDef `json:"added"`
 	Deleted        StyleDef `json:"deleted"`
 	Modified       StyleDef `json:"modified"`
-	Collapsed      StyleDef `json:"collapsed,omitempty"`
+	CollapsedHover StyleDef `json:"collapsedHover,omitempty"`
 	GutterAdded    StyleDef `json:"gutterAdded,omitempty"`
 	GutterDeleted  StyleDef `json:"gutterDeleted,omitempty"`
 	GutterModified StyleDef `json:"gutterModified,omitempty"`
@@ -251,9 +251,6 @@ func DefaultTheme() ThemeConfig {
 		},
 
 		Border: StyleDef{Fg: "#555555"},
-		Diff: DiffStyles{
-			Collapsed: StyleDef{Fg: "#1f1f1f", Bg: "#8ab4d8", Bold: true},
-		},
 
 		Editor: EditorStyles{
 			ActiveLine:    StyleDef{Bg: "#282828"},
@@ -311,8 +308,7 @@ func (t *ThemeConfig) ResolveColors() {
 	fillBg(&t.Diff.Added, "#1e2e1e")
 	fillBg(&t.Diff.Deleted, "#2e1e1e")
 	fillBg(&t.Diff.Modified, "#2e2e1e")
-	fillFg(&t.Diff.Collapsed, t.Default.Bg)
-	fillBg(&t.Diff.Collapsed, "#8ab4d8")
+	fillBg(&t.Diff.CollapsedHover, t.Editor.ActiveLine.Bg)
 	fillFg(&t.Diff.GutterAdded, "#73c991")
 	fillFg(&t.Diff.GutterDeleted, "#f14c4c")
 	fillFg(&t.Diff.GutterModified, "#e2c08d")

--- a/internal/config/theme_test.go
+++ b/internal/config/theme_test.go
@@ -97,8 +97,8 @@ func TestBundledThemesLoad(t *testing.T) {
 			if th.Default.Fg == "" {
 				t.Errorf("%s: Default.Fg is empty after resolve", name)
 			}
-			if th.Diff.Collapsed.Fg == "" || th.Diff.Collapsed.Bg == "" {
-				t.Errorf("%s: collapsed diff style did not inherit defaults: %+v", name, th.Diff.Collapsed)
+			if th.Diff.CollapsedHover.Bg != th.Editor.ActiveLine.Bg {
+				t.Errorf("%s: collapsed hover background %q did not inherit active-line background %q", name, th.Diff.CollapsedHover.Bg, th.Editor.ActiveLine.Bg)
 			}
 		})
 	}
@@ -159,8 +159,7 @@ func TestResolveColors(t *testing.T) {
 	th.Diff.Added.Bg = ""
 	th.Diff.Deleted.Bg = ""
 	th.Diff.Modified.Bg = ""
-	th.Diff.Collapsed.Fg = ""
-	th.Diff.Collapsed.Bg = ""
+	th.Diff.CollapsedHover.Bg = ""
 	th.Success.Fg = ""
 	th.Danger.Fg = ""
 	th.Warning.Fg = ""
@@ -179,8 +178,8 @@ func TestResolveColors(t *testing.T) {
 	if th.Diff.Modified.Bg == "" {
 		t.Error("expected Diff.Modified.Bg to be filled by ResolveColors")
 	}
-	if th.Diff.Collapsed.Fg == "" || th.Diff.Collapsed.Bg == "" {
-		t.Errorf("expected Diff.Collapsed colors to be filled by ResolveColors, got %+v", th.Diff.Collapsed)
+	if th.Diff.CollapsedHover.Bg != th.Editor.ActiveLine.Bg {
+		t.Errorf("expected Diff.CollapsedHover background to inherit Editor.ActiveLine, got %+v", th.Diff.CollapsedHover)
 	}
 	if th.Success.Fg == "" {
 		t.Error("expected Success.Fg to be filled by ResolveColors")
@@ -210,7 +209,7 @@ func TestResolveColorsPreservesExisting(t *testing.T) {
 	th.Success.Fg = "#custom"
 	th.Danger.Fg = "#custom2"
 	th.Diff.Added.Bg = "#custom3"
-	th.Diff.Collapsed = StyleDef{Fg: "#custom4", Bg: "#custom5", Bold: true}
+	th.Diff.CollapsedHover = StyleDef{Fg: "#custom4", Bg: "#custom5", Bold: true}
 
 	th.ResolveColors()
 
@@ -223,8 +222,8 @@ func TestResolveColorsPreservesExisting(t *testing.T) {
 	if th.Diff.Added.Bg != "#custom3" {
 		t.Errorf("expected Diff.Added.Bg to remain '#custom3', got %q", th.Diff.Added.Bg)
 	}
-	if th.Diff.Collapsed.Fg != "#custom4" || th.Diff.Collapsed.Bg != "#custom5" || !th.Diff.Collapsed.Bold {
-		t.Errorf("expected explicit Diff.Collapsed to remain unchanged, got %+v", th.Diff.Collapsed)
+	if th.Diff.CollapsedHover.Fg != "#custom4" || th.Diff.CollapsedHover.Bg != "#custom5" || !th.Diff.CollapsedHover.Bold {
+		t.Errorf("expected explicit Diff.CollapsedHover to remain unchanged, got %+v", th.Diff.CollapsedHover)
 	}
 }
 

--- a/internal/config/theme_test.go
+++ b/internal/config/theme_test.go
@@ -91,14 +91,25 @@ func TestBundledThemesLoad(t *testing.T) {
 			if err := json.Unmarshal(data, &th); err != nil {
 				t.Fatalf("failed to parse %s: %v", name, err)
 			}
+			var source ThemeConfig
+			if err := json.Unmarshal(data, &source); err != nil {
+				t.Fatalf("failed to inspect %s: %v", name, err)
+			}
 			th.ResolveColors()
 
 			// After resolving, verify critical fields are non-empty
 			if th.Default.Fg == "" {
 				t.Errorf("%s: Default.Fg is empty after resolve", name)
 			}
-			if th.Diff.CollapsedHover.Bg != th.Editor.ActiveLine.Bg {
-				t.Errorf("%s: collapsed hover background %q did not inherit active-line background %q", name, th.Diff.CollapsedHover.Bg, th.Editor.ActiveLine.Bg)
+			expectedHoverBg := source.Diff.CollapsedHover.Bg
+			if source.Diff.CollapsedHover == (StyleDef{}) && source.Diff.Collapsed != (StyleDef{}) {
+				expectedHoverBg = source.Diff.Collapsed.Bg
+			}
+			if expectedHoverBg == "" {
+				expectedHoverBg = th.Editor.ActiveLine.Bg
+			}
+			if th.Diff.CollapsedHover.Bg != expectedHoverBg {
+				t.Errorf("%s: collapsed hover background = %q, want %q from explicit or inherited source", name, th.Diff.CollapsedHover.Bg, expectedHoverBg)
 			}
 		})
 	}
@@ -224,6 +235,28 @@ func TestResolveColorsPreservesExisting(t *testing.T) {
 	}
 	if th.Diff.CollapsedHover.Fg != "#custom4" || th.Diff.CollapsedHover.Bg != "#custom5" || !th.Diff.CollapsedHover.Bold {
 		t.Errorf("expected explicit Diff.CollapsedHover to remain unchanged, got %+v", th.Diff.CollapsedHover)
+	}
+}
+
+func TestResolveColorsMigratesLegacyCollapsedStyle(t *testing.T) {
+	theme := DefaultTheme()
+	if err := json.Unmarshal([]byte(`{"diff":{"collapsed":{"fg":"#123456","bg":"#654321","bold":true}}}`), &theme); err != nil {
+		t.Fatal(err)
+	}
+	theme.ResolveColors()
+	if got := theme.Diff.CollapsedHover; got != (StyleDef{Fg: "#123456", Bg: "#654321", Bold: true}) {
+		t.Fatalf("migrated collapsed hover style = %+v", got)
+	}
+}
+
+func TestResolveColorsPrefersExplicitCollapsedHover(t *testing.T) {
+	theme := DefaultTheme()
+	if err := json.Unmarshal([]byte(`{"diff":{"collapsed":{"bg":"#legacy"},"collapsedHover":{"bg":"#current"}}}`), &theme); err != nil {
+		t.Fatal(err)
+	}
+	theme.ResolveColors()
+	if got := theme.Diff.CollapsedHover.Bg; got != "#current" {
+		t.Fatalf("collapsed hover background = %q, want explicit current value", got)
 	}
 }
 

--- a/internal/term/screen.go
+++ b/internal/term/screen.go
@@ -21,7 +21,7 @@ const (
 	StyleDiffAdded
 	StyleDiffDeleted
 	StyleDiffModified
-	StyleDiffCollapsed
+	StyleDiffCollapsedHover
 	StyleScrollbar
 	StyleScrollbarThumb
 	StyleActiveLine

--- a/internal/ui/diff_render.go
+++ b/internal/ui/diff_render.go
@@ -198,7 +198,7 @@ func renderDiffText(surface Surface, x, y, width int, text string, baseStyle, fo
 	if foregroundStyle != term.StyleDefault {
 		spans = nil
 	}
-	fullBaseStyle := baseStyle == term.StyleDiffCollapsed
+	fullBaseStyle := baseStyle == term.StyleDiffCollapsedHover
 	blank := term.Cell{Ch: ' '}
 	if fullBaseStyle {
 		blank.Style = baseStyle

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -257,11 +257,14 @@ func (d *DiffViewWidget) FinishLoading() {
 	d.Loading = false
 	d.extendedFetching = false
 	d.contextLoaded = true
-	if d.pendingGap >= 0 {
+	if d.pendingGap >= 0 && d.contextMode != DiffContextFullFile {
 		d.expandedGaps[d.pendingGap] = true
 		d.pendingGap = -1
 		d.extended = false
 		d.contextMode = DiffContextChangesOnly
+	} else if d.contextMode == DiffContextFullFile {
+		d.pendingGap = -1
+		d.extended = true
 	}
 	d.rebuildLines()
 	d.TopLine = d.displayLineForLogicalAnchor(top)
@@ -676,8 +679,8 @@ func (d *DiffViewWidget) Render(surface Surface) {
 		leftStyle := diffKindStyle(dl.Left.Kind)
 		rightStyle := diffKindStyle(dl.Right.Kind)
 		if gap, ok := d.gapByLine[idx]; ok && d.hasHoveredGap && gap == d.hoveredGap {
-			leftStyle = term.StyleDiffCollapsed
-			rightStyle = term.StyleDiffCollapsed
+			leftStyle = term.StyleDiffCollapsedHover
+			rightStyle = term.StyleDiffCollapsedHover
 		}
 
 		if continuation {
@@ -769,7 +772,7 @@ func (d *DiffViewWidget) renderUnifiedRow(surface Surface, y, w, gutterW, conten
 	line := d.unifiedLines[displayIndex]
 	baseStyle := diffKindStyle(line.side.Kind)
 	if gap, ok := d.gapByLine[line.sourceLine]; ok && d.hasHoveredGap && gap == d.hoveredGap {
-		baseStyle = term.StyleDiffCollapsed
+		baseStyle = term.StyleDiffCollapsedHover
 	}
 	if continuation {
 		renderDiffGutter(surface, 0, y, gutterW, diff.SideLine{})

--- a/internal/ui/diff_widget_test.go
+++ b/internal/ui/diff_widget_test.go
@@ -402,8 +402,8 @@ func TestDiffWidgetCollapsedSeparatorIsQuietUntilHovered(t *testing.T) {
 		t.Fatalf("collapsed separator hover result = %v, want EventConsumed for redraw", result)
 	}
 	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
-	if got := grid[separatorRow][dv.layoutLeftStart].Style; got != term.StyleDiffCollapsed {
-		t.Fatalf("hovered separator style = %v, want StyleDiffCollapsed", got)
+	if got := grid[separatorRow][dv.layoutLeftStart].Style; got != term.StyleDiffCollapsedHover {
+		t.Fatalf("hovered separator style = %v, want StyleDiffCollapsedHover", got)
 	}
 	if got := grid[separatorRow][dv.layoutGutterW-1]; got.Ch != '▶' || got.Style != term.StyleLineNumber {
 		t.Fatalf("hovered separator gutter cell = %+v, want stable line-number disclosure triangle", got)
@@ -678,6 +678,41 @@ func TestDiffWidgetLoadingCannotRefetchCollapsedGap(t *testing.T) {
 	}
 	if got := dv.HandleEvent(tcell.NewEventMouse(formerGapX, formerGapY, tcell.Button1, tcell.ModNone)); got != EventIgnored {
 		t.Fatalf("loading mouse event = %v, want ignored", got)
+	}
+}
+
+func TestDiffWidgetFullFileRequestSupersedesInflightGapExpansion(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n first\n@@ -4,1 +4,1 @@\n fourth\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+	fetches := 0
+	dv.SetExtendedFetcher(func(*DiffViewWidget) { fetches++ })
+
+	dv.expandContextGap(0)
+	if fetches != 1 || dv.pendingGap != 0 || !dv.Loading {
+		t.Fatalf("gap fetch state = fetches %d pending %d loading %v", fetches, dv.pendingGap, dv.Loading)
+	}
+	dv.SetContextMode(DiffContextFullFile)
+	dv.SetOldLines([]string{"first", "old-two", "old-three", "fourth"})
+	dv.SetNewLines([]string{"first", "new-two", "new-three", "fourth"})
+	dv.FinishLoading()
+
+	if fetches != 1 || dv.ContextMode() != DiffContextFullFile || !dv.IsExtended() || len(dv.Lines) != 4 {
+		t.Fatalf("full-file completion = fetches %d context %v extended %v lines %d", fetches, dv.ContextMode(), dv.IsExtended(), len(dv.Lines))
+	}
+}
+
+func TestDiffWidgetGapFetchCompletionRemainsChangesOnly(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1,1 +1,1 @@\n first\n@@ -4,1 +4,1 @@\n fourth\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+	dv.SetExtendedFetcher(func(*DiffViewWidget) {})
+
+	dv.expandContextGap(0)
+	dv.SetOldLines([]string{"first", "old-two", "old-three", "fourth"})
+	dv.SetNewLines([]string{"first", "new-two", "new-three", "fourth"})
+	dv.FinishLoading()
+
+	if dv.ContextMode() != DiffContextChangesOnly || dv.IsExtended() || !dv.expandedGaps[0] {
+		t.Fatalf("gap completion = context %v extended %v expanded %v", dv.ContextMode(), dv.IsExtended(), dv.expandedGaps)
 	}
 }
 


### PR DESCRIPTION
## Summary

- rename the hover-only diff theme field from `diff.collapsed` to `diff.collapsedHover`
- preserve the legacy `diff.collapsed` JSON field as a deprecated alias, migrating it only when `collapsedHover` is absent so explicit new values remain authoritative
- inherit the collapsed-gap hover background from `editor.activeLine` instead of introducing a standalone blue that can conflict with bundled and custom themes
- preserve a Full File request made while a collapsed-gap fetch is already in flight, using the complete old/new content returned by that existing fetch
- cover both async outcomes: Full File supersedes the pending gap request, while an ordinary gap fetch remains Changes Only and expands only its selected gap
- update theme documentation and style-map coverage for the clarified contract

This is the focused follow-up to the review feedback on #485, which was approved and merged while this correction was completing its verification pass.

## Verification

- fail-before on exact reviewed head `8686b0b`: the Full File request is lost and completion returns Changes Only with five projected rows
- pass-after on this head: completion remains Full File with four source rows
- companion regression proving ordinary gap completion remains Changes Only
- compatibility coverage for legacy migration, explicit new-field precedence, and explicit bundled-theme backgrounds
- make build
- focused race coverage for config, app, and diff UI paths
- full Go suite with only the four independently reproduced local SGR baseline tests skipped
- full functional suite: 92 files, 309 passes, 27 expected failures
- full integration suite: 7 files, 47 passes
- gofmt and git diff checks

Part of #474.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated theme option for styling collapsed diff sections when hovered.
  - Hovered collapsed sections inherit the editor’s active-line background when no custom background is set.
  - Full-file diff loading now preserves the requested view, while gap expansion remains in changes-only mode.
  - Existing themes using the legacy collapsed-section setting remain compatible.

- **Bug Fixes**
  - Improved styling consistency for hovered collapsed sections in split and unified diff views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->