### PR TITLE
docs: add arimxyer to contributors & acknowledgments secton

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ TTT is better because of the people who took the time to try it, report bugs, re
 
 - [@tenox7](https://github.com/tenox7) — the **Outline** sidebar panel (LSP document symbols with a built-in Go/Markdown fallback) and **markdown syntax highlighting**.
 - [@pirate-boop](https://github.com/pirate-boop) — **NixOS support** end to end: the initial `flake.nix` and ongoing `vendorHash` upkeep.
+- [@arimxyer](https://github.com/arimxyer) — re-envisioned and re-designed the **diff & code review experience** (commit history detail, live current changes, unified presentation controls, hierarchical file trees), plus tab drag reordering, orientation help, checked plugin menu entries, deterministic exec automation, and CLI open-at-line support.
 
 **Packaging**
 


### PR DESCRIPTION
## Summary
- Adds [@arimxyer](https://github.com/arimxyer) to the Contributors & Acknowledgments section in the README for their work re-envisioning the diff & code review experience and numerous other contributions

<!-- @coderabbitai ignore -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)