### PR TITLE
fix(menu): separate Git presentation options

### DIFF
--- a/internal/app/commands_options.go
+++ b/internal/app/commands_options.go
@@ -322,8 +322,6 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 	items := []ui.ContextMenuItem{
 		{Label: "Line Numbers", Command: "options.toggleLineNumbers", Checked: lineNumbersChecked},
 		{Label: "Word Wrap", Command: "options.toggleWordWrap", Checked: wordWrapChecked},
-		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
-		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
 		{Label: "Auto Indent", Command: "options.toggleAutoIndent", Checked: autoIndentChecked},
 		{Label: "Auto Dedent", Command: "options.toggleAutoDedent", Checked: autoDedentChecked},
 		{Label: "Syntax Highlight", Command: "options.toggleSyntaxHighlight", Checked: syntaxChecked},
@@ -331,6 +329,9 @@ func (a *App) BuildOptionsMenu() []ui.ContextMenuItem {
 		{Label: "LSP Code Assist", Command: "options.toggleLSP", Checked: lspChecked},
 		{Label: "Git Gutter", Command: "options.toggleGitGutter", Checked: gitGutterChecked},
 		{Label: "Menu Bar", Command: menuBarToggleCommand, Checked: menuBarChecked},
+		ui.MenuSep(),
+		{Label: "Diff Views", Submenu: a.BuildDiffViewOptions()},
+		{Label: "Git Files", Submenu: a.BuildGitFileOptions()},
 		ui.MenuSep(),
 		{Label: "Gutter Style", Command: "options.gutterStyle"},
 		{Label: "Border Style", Command: "options.borderStyle"},

--- a/internal/app/menubar_test.go
+++ b/internal/app/menubar_test.go
@@ -53,6 +53,35 @@ func TestMenuBarVisibleByDefault(t *testing.T) {
 	}
 }
 
+func TestOptionsMenuSeparatesPresentationSubmenusFromCheckboxes(t *testing.T) {
+	items := buildTestApp(t, config.DefaultSettings()).BuildOptionsMenu()
+	firstSeparator := -1
+	for i, item := range items {
+		if item.IsSep {
+			firstSeparator = i
+			break
+		}
+		if item.Checked == 0 {
+			t.Fatalf("checkbox group item %q has no checked indicator", item.Label)
+		}
+	}
+	if firstSeparator < 0 || firstSeparator+3 >= len(items) {
+		t.Fatalf("options menu has no presentation section: %+v", items)
+	}
+	if items[firstSeparator+1].Label != "Diff Views" || len(items[firstSeparator+1].Submenu) == 0 {
+		t.Fatalf("first presentation item = %+v", items[firstSeparator+1])
+	}
+	if items[firstSeparator+2].Label != "Git Files" || len(items[firstSeparator+2].Submenu) == 0 {
+		t.Fatalf("second presentation item = %+v", items[firstSeparator+2])
+	}
+	if !items[firstSeparator+3].IsSep {
+		t.Fatalf("presentation section is not followed by a separator: %+v", items[firstSeparator+3])
+	}
+	if items[firstSeparator+1].Checked != 0 || items[firstSeparator+2].Checked != 0 {
+		t.Fatal("presentation submenus should not reserve checkbox indicators")
+	}
+}
+
 // Anything remaining focused after being dropped from the tree would swallow
 // key events with nothing on screen to explain it.
 func TestHidingMenuBarMovesFocusAway(t *testing.T) {

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -79,8 +79,7 @@ describe("diff reading preferences", () => {
     tui.exec("Menu: Options");
     tui.waitStable();
     const options = tui.snapshot();
-    tui.press("down");
-    tui.press("down");
+    for (let i = 0; i < 9; i++) tui.press("down");
     tui.press("right");
     const diffViews = tui.snapshot();
     tui.press("escape");


### PR DESCRIPTION
## Summary

- keep all checkbox-backed Options entries in one contiguous group
- place Diff Views and Git Files together between dedicated dividers
- preserve both presentation submenus and their checked-state behavior
- cover the grouping contract and update real-binary submenu navigation

## Verification

- `make build`
- `go test -count=1 ./internal/app`
- focused Options/menu E2E tests
- `pnpm exec vitest run diff-preferences.test.js`
- front-to-back termctrl PTY verification of visible grouping, both submenus, and persisted Tree selection

Closes #497.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reorganized the Options menu to separate editor settings from the **Diff Views** and **Git Files** presentation submenus.
  * Added clearer visual separation between checkbox settings and submenu entries.
  * Improved menu navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->