### PR TITLE
fix(palette): keep width stable across modes

### DIFF
--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -140,7 +140,7 @@ func calculatePaletteWidth(screenWidth int) int {
 	width := screenWidth * 6 / 10
 	width = max(width, paletteMinWidth)
 	width = min(width, paletteMaxWidth)
-	return min(width, screenWidth-4)
+	return min(width, max(screenWidth-4, 1))
 }
 
 func (p *SelectDialogWidget) calculateLayout(sw, sh int) selectDialogLayout {

--- a/internal/ui/selectdialog_widget.go
+++ b/internal/ui/selectdialog_widget.go
@@ -24,7 +24,10 @@ const (
 	paletteHelpMode
 )
 
-const ordinaryPaletteMaxWidth = 60
+const (
+	paletteMinWidth = 40
+	paletteMaxWidth = 90
+)
 
 type selectDialogLayout struct {
 	boxX         int
@@ -133,17 +136,15 @@ func (p *SelectDialogWidget) CursorPosition() (int, int, bool) {
 	return p.Input.CursorX(p.inputX), p.inputY, true
 }
 
+func calculatePaletteWidth(screenWidth int) int {
+	width := screenWidth * 6 / 10
+	width = max(width, paletteMinWidth)
+	width = min(width, paletteMaxWidth)
+	return min(width, screenWidth-4)
+}
+
 func (p *SelectDialogWidget) calculateLayout(sw, sh int) selectDialogLayout {
-	boxW := sw * 6 / 10 // 60% of terminal width
-	if p.mode != paletteHelpMode && boxW > ordinaryPaletteMaxWidth {
-		boxW = ordinaryPaletteMaxWidth
-	}
-	if boxW < 40 {
-		boxW = 40
-	}
-	if boxW > sw-4 {
-		boxW = sw - 4
-	}
+	boxW := calculatePaletteWidth(sw)
 	var boxH int
 	if p.mode == paletteGoToLineMode {
 		boxH = 3

--- a/internal/ui/selectdialog_widget_test.go
+++ b/internal/ui/selectdialog_widget_test.go
@@ -385,26 +385,46 @@ func renderPaletteAt(p *SelectDialogWidget, width, height int) [][]term.Cell {
 	return cells
 }
 
-func TestPaletteWideGeometryTransitionsAndReopen(t *testing.T) {
+func TestCalculatePaletteWidth(t *testing.T) {
+	tests := []struct {
+		name        string
+		screenWidth int
+		want        int
+	}{
+		{name: "narrow safety bound", screenWidth: 30, want: 26},
+		{name: "typical responsive width", screenWidth: 80, want: 48},
+		{name: "wide maximum", screenWidth: 200, want: 90},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculatePaletteWidth(tt.screenWidth); got != tt.want {
+				t.Fatalf("calculatePaletteWidth(%d) = %d, want %d", tt.screenWidth, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPaletteSharedWidthAcrossModeTransitionsAndReopen(t *testing.T) {
 	p := NewSelectDialogWidget(helpTestCommands())
 	p.files = []paletteFile{{Rel: "alpha.txt", Abs: "/workspace/alpha.txt"}}
 
 	commandCells := renderPaletteAt(p, 200, 50)
-	if p.boxX != 70 || p.boxW != 60 {
-		t.Fatalf("command geometry = x:%d width:%d, want x:70 width:60", p.boxX, p.boxW)
+	if p.boxX != 55 || p.boxW != 90 {
+		t.Fatalf("command geometry = x:%d width:%d, want x:55 width:90", p.boxX, p.boxW)
 	}
-	if commandCells[p.boxY][70].Ch != '╔' || commandCells[p.boxY][129].Ch != '╗' {
-		t.Fatal("command border does not match its 60-column layout")
+	if commandCells[p.boxY][55].Ch != '╔' || commandCells[p.boxY][144].Ch != '╗' {
+		t.Fatal("command border does not match its shared layout")
 	}
 
 	p.Input.SetText("?")
 	p.Selected = 2
 	helpCells := renderPaletteAt(p, 200, 50)
-	if p.boxX != 40 || p.boxW != 120 {
-		t.Fatalf("help geometry = x:%d width:%d, want x:40 width:120", p.boxX, p.boxW)
+	if p.boxX != 55 || p.boxW != 90 {
+		t.Fatalf("help geometry = x:%d width:%d, want x:55 width:90", p.boxX, p.boxW)
 	}
-	if helpCells[p.boxY][40].Ch != '╔' || helpCells[p.boxY][159].Ch != '╗' {
-		t.Fatal("help border does not match its responsive layout")
+	if helpCells[p.boxY][55].Ch != '╔' || helpCells[p.boxY][144].Ch != '╗' {
+		t.Fatal("help border does not match its shared layout")
 	}
 
 	p.Input.SetText(">")
@@ -412,27 +432,38 @@ func TestPaletteWideGeometryTransitionsAndReopen(t *testing.T) {
 	if p.Selected != 0 || p.scrollOffset != 0 {
 		t.Fatalf("command transition retained selection state: selected=%d scroll=%d", p.Selected, p.scrollOffset)
 	}
-	if p.boxX != 70 || p.boxW != 60 {
-		t.Fatalf("command transition geometry = x:%d width:%d, want x:70 width:60", p.boxX, p.boxW)
+	if p.boxX != 55 || p.boxW != 90 {
+		t.Fatalf("command transition geometry = x:%d width:%d, want x:55 width:90", p.boxX, p.boxW)
 	}
-	if commandCells[p.boxY][40].Ch != '.' {
-		t.Fatal("command render retained the old help border")
+	if commandCells[p.boxY][55].Ch != '╔' || commandCells[p.boxY][144].Ch != '╗' {
+		t.Fatal("command transition border does not match its shared layout")
 	}
 
 	p.Input.Clear()
 	fileCells := renderPaletteAt(p, 200, 50)
-	if p.boxX != 70 || p.boxW != 60 {
-		t.Fatalf("file geometry = x:%d width:%d, want x:70 width:60", p.boxX, p.boxW)
+	if p.boxX != 55 || p.boxW != 90 {
+		t.Fatalf("file geometry = x:%d width:%d, want x:55 width:90", p.boxX, p.boxW)
 	}
-	if fileCells[p.boxY][70].Ch != '╔' || fileCells[p.boxY][129].Ch != '╗' {
-		t.Fatal("file border does not match its 60-column layout")
+	if fileCells[p.boxY][55].Ch != '╔' || fileCells[p.boxY][144].Ch != '╗' {
+		t.Fatal("file border does not match its shared layout")
 	}
 
+	p.Input.SetText(":")
+	goToLineCells := renderPaletteAt(p, 200, 50)
+	if p.boxX != 55 || p.boxW != 90 || p.boxH != 3 {
+		t.Fatalf("go-to-line geometry = x:%d width:%d height:%d, want x:55 width:90 height:3", p.boxX, p.boxW, p.boxH)
+	}
+	if goToLineCells[p.boxY][55].Ch != '╔' || goToLineCells[p.boxY][144].Ch != '╗' {
+		t.Fatal("go-to-line border does not match its shared layout")
+	}
+
+	p.Input.Clear()
+	renderPaletteAt(p, 200, 50)
 	dismissed := false
 	p.OnDismiss = func() { dismissed = true }
-	p.HandleEvent(tcell.NewEventMouse(50, p.inputY, tcell.Button1, tcell.ModNone))
+	p.HandleEvent(tcell.NewEventMouse(p.boxX-1, p.inputY, tcell.Button1, tcell.ModNone))
 	if !dismissed {
-		t.Fatal("file mode retained the wider help hit target")
+		t.Fatal("outside click did not dismiss file mode")
 	}
 
 	opened := ""
@@ -444,7 +475,7 @@ func TestPaletteWideGeometryTransitionsAndReopen(t *testing.T) {
 
 	reopened := NewSelectDialogWidget(helpTestCommands())
 	renderPaletteAt(reopened, 200, 50)
-	if reopened.Input.Text != ">" || reopened.boxX != 70 || reopened.boxW != 60 {
+	if reopened.Input.Text != ">" || reopened.boxX != 55 || reopened.boxW != 90 {
 		t.Fatalf("reopened command palette = input:%q x:%d width:%d", reopened.Input.Text, reopened.boxX, reopened.boxW)
 	}
 }

--- a/internal/ui/selectdialog_widget_test.go
+++ b/internal/ui/selectdialog_widget_test.go
@@ -391,6 +391,12 @@ func TestCalculatePaletteWidth(t *testing.T) {
 		screenWidth int
 		want        int
 	}{
+		{name: "zero", screenWidth: 0, want: 1},
+		{name: "one", screenWidth: 1, want: 1},
+		{name: "two", screenWidth: 2, want: 1},
+		{name: "three", screenWidth: 3, want: 1},
+		{name: "four", screenWidth: 4, want: 1},
+		{name: "smallest safety bound", screenWidth: 5, want: 1},
 		{name: "narrow safety bound", screenWidth: 30, want: 26},
 		{name: "typical responsive width", screenWidth: 80, want: 48},
 		{name: "wide maximum", screenWidth: 200, want: 90},
@@ -400,6 +406,16 @@ func TestCalculatePaletteWidth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := calculatePaletteWidth(tt.screenWidth); got != tt.want {
 				t.Fatalf("calculatePaletteWidth(%d) = %d, want %d", tt.screenWidth, got, tt.want)
+			}
+
+			p := NewSelectDialogWidget(helpTestCommands())
+			layout := p.calculateLayout(tt.screenWidth, 24)
+			if layout.boxW != tt.want {
+				t.Fatalf("calculateLayout(%d, 24) width = %d, want %d", tt.screenWidth, layout.boxW, tt.want)
+			}
+			renderPaletteAt(p, tt.screenWidth, 24)
+			if p.boxW != tt.want {
+				t.Fatalf("rendered width at %d columns = %d, want %d", tt.screenWidth, p.boxW, tt.want)
 			}
 		})
 	}

--- a/tests/e2e/editor_test.go
+++ b/tests/e2e/editor_test.go
@@ -94,7 +94,32 @@ func paletteBorderWidth(row string) int {
 	return 0
 }
 
-func TestCommandPaletteWideGeometryBindingsAndTransitions(t *testing.T) {
+func TestCommandPaletteResponsiveWidths(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+		want   int
+	}{
+		{name: "narrow", width: 30, height: 24, want: 26},
+		{name: "typical", width: 80, height: 24, want: 48},
+		{name: "wide", width: 200, height: 50, want: 90},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHarness(t, tt.width, tt.height)
+			defer h.stop()
+
+			h.pressCtrl(tcell.KeyCtrlP)
+			if got := paletteBorderWidth(h.screenRow(2)); got != tt.want {
+				t.Fatalf("command palette width=%d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandPaletteSharedWidthBindingsAndTransitions(t *testing.T) {
 	h := newTestHarness(t, 200, 50)
 	defer h.stop()
 
@@ -106,20 +131,20 @@ func TestCommandPaletteWideGeometryBindingsAndTransitions(t *testing.T) {
 	if palette.Input.Text != ">" || len(palette.Items) != len(h.reg.List()) {
 		t.Fatalf("Ctrl+P input=%q items=%d, want > and complete registry of %d", palette.Input.Text, len(palette.Items), len(h.reg.List()))
 	}
-	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
-		t.Fatalf("Ctrl+P command palette width=%d, want 60; row=%q", got, h.screenRow(2))
+	if got := paletteBorderWidth(h.screenRow(2)); got != 90 {
+		t.Fatalf("Ctrl+P command palette width=%d, want 90; row=%q", got, h.screenRow(2))
 	}
 
 	h.pressRune('?')
-	if got := paletteBorderWidth(h.screenRow(2)); got != 120 {
-		t.Fatalf("help palette width=%d, want responsive width 120", got)
+	if got := paletteBorderWidth(h.screenRow(2)); got != 90 {
+		t.Fatalf("help palette width=%d, want shared width 90", got)
 	}
 	palette.Selected = 3
 
 	h.pressKey(tcell.KeyBackspace2, tcell.ModNone)
 	h.pressRune('>')
-	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
-		t.Fatalf("help-to-command palette width=%d, want 60", got)
+	if got := paletteBorderWidth(h.screenRow(2)); got != 90 {
+		t.Fatalf("help-to-command palette width=%d, want 90", got)
 	}
 	if palette.Selected != 0 {
 		t.Fatalf("help-to-command selected=%d, want 0", palette.Selected)
@@ -129,19 +154,28 @@ func TestCommandPaletteWideGeometryBindingsAndTransitions(t *testing.T) {
 	if palette.Input.Text != "" {
 		t.Fatalf("file-mode input=%q, want empty", palette.Input.Text)
 	}
-	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
-		t.Fatalf("file palette width=%d, want 60", got)
+	if got := paletteBorderWidth(h.screenRow(2)); got != 90 {
+		t.Fatalf("file palette width=%d, want 90", got)
 	}
 	h.assertContains("alpha.txt")
 
-	h.click(50, 3)
+	h.pressRune(':')
+	if palette.Input.Text != ":" {
+		t.Fatalf("go-to-line input=%q, want colon prefix", palette.Input.Text)
+	}
+	if got := paletteBorderWidth(h.screenRow(2)); got != 90 {
+		t.Fatalf("go-to-line palette width=%d, want 90", got)
+	}
+
+	h.pressKey(tcell.KeyBackspace2, tcell.ModNone)
+	h.click(54, 3)
 	if h.app.Root.HasOverlay() {
-		t.Fatal("file palette retained the wider help hit target")
+		t.Fatal("outside click did not dismiss file palette")
 	}
 
 	h.pressCtrl(tcell.KeyCtrlP)
-	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
-		t.Fatalf("reopened command palette width=%d, want 60", got)
+	if got := paletteBorderWidth(h.screenRow(2)); got != 90 {
+		t.Fatalf("reopened command palette width=%d, want 90", got)
 	}
 	h.pressKey(tcell.KeyEscape, tcell.ModNone)
 
@@ -154,8 +188,8 @@ func TestCommandPaletteWideGeometryBindingsAndTransitions(t *testing.T) {
 	if palette.Input.Text != "" {
 		t.Fatalf("Ctrl+K P input=%q, want empty file search", palette.Input.Text)
 	}
-	if got := paletteBorderWidth(h.screenRow(2)); got != 60 {
-		t.Fatalf("Ctrl+K P file palette width=%d, want 60", got)
+	if got := paletteBorderWidth(h.screenRow(2)); got != 90 {
+		t.Fatalf("Ctrl+K P file palette width=%d, want 90", got)
 	}
 }
 

--- a/tests/functional/command-palette.test.js
+++ b/tests/functional/command-palette.test.js
@@ -64,7 +64,25 @@ describe("command palette", () => {
     expect(snapshots[s0]).toContain("Dismiss test");
   });
 
-  it("should keep ordinary modes narrow while help responds and transitions cleanly", () => {
+  it.each([
+    { name: "narrow", width: 30, height: 24, expected: 26 },
+    { name: "typical", width: 80, height: 24, expected: 48 },
+    { name: "wide", width: 200, height: 50, expected: 90 },
+  ])("should use the responsive width at $name terminal sizes", ({ width, height, expected }) => {
+    dir = createTempDir();
+    createTempFile(dir, "responsive.txt", "Responsive palette test");
+
+    tui.start(dir);
+    tui.setSize(width, height);
+    tui.waitFor("responsive.txt");
+    tui.press("ctrl+p");
+    const palette = tui.snapshot();
+
+    const { snapshots } = tui.run();
+    expect(paletteWidth(snapshots[palette])).toBe(expected);
+  });
+
+  it("should keep one responsive width across modes and transitions", () => {
     dir = createTempDir();
     createTempFile(dir, "wide.txt", "Wide palette test");
 
@@ -84,7 +102,11 @@ describe("command palette", () => {
     tui.press("backspace");
     const files = tui.snapshot();
 
-    tui.click(50, 3);
+    tui.type(":");
+    const goToLine = tui.snapshot();
+
+    tui.press("backspace");
+    tui.click(54, 3);
     const dismissed = tui.snapshot();
 
     tui.press("ctrl+p");
@@ -94,13 +116,14 @@ describe("command palette", () => {
     const fileBinding = tui.snapshot();
 
     const { snapshots } = tui.run();
-    expect(paletteWidth(snapshots[command])).toBe(60);
-    expect(paletteWidth(snapshots[help])).toBe(120);
-    expect(paletteWidth(snapshots[commandAgain])).toBe(60);
-    expect(paletteWidth(snapshots[files])).toBe(60);
+    expect(paletteWidth(snapshots[command])).toBe(90);
+    expect(paletteWidth(snapshots[help])).toBe(90);
+    expect(paletteWidth(snapshots[commandAgain])).toBe(90);
+    expect(paletteWidth(snapshots[files])).toBe(90);
+    expect(paletteWidth(snapshots[goToLine])).toBe(90);
     expect(paletteWidth(snapshots[dismissed])).toBe(0);
-    expect(paletteWidth(snapshots[reopened])).toBe(60);
-    expect(paletteWidth(snapshots[fileBinding])).toBe(60);
+    expect(paletteWidth(snapshots[reopened])).toBe(90);
+    expect(paletteWidth(snapshots[fileBinding])).toBe(90);
     expect(snapshots[command]).toContain(">");
     expect(snapshots[files]).toContain("wide.txt");
     expect(snapshots[fileBinding]).toContain("wide.txt");


### PR DESCRIPTION
## Summary

Switching between command, file, help, and go-to-line modes should not make the palette jump horizontally. This change gives every mode one responsive outer-width calculation: 60% of the terminal, clamped to 40-90 columns and then bounded by `sw-4`. Mode-specific heights and behavior are unchanged.

Tests now cover narrow (30), typical (80), and wide (200) terminals, plus live `>` / empty / `?` / `:` transitions and reopen/binding paths.

## Verification

- `go test ./internal/ui -run 'Test(CalculatePaletteWidth|PaletteSharedWidthAcrossModeTransitionsAndReopen)$' -count=1`\n- `go test ./tests/e2e -run 'TestCommandPalette(ResponsiveWidths|SharedWidthBindingsAndTransitions)$' -count=1`\n- `make build`\n- `pnpm exec vitest run command-palette.test.js` (10 passed)\n- `go test ./... -count=1 -skip '^TestTerminalWidget_(ForwardsSGRMouseClickAndRelease|ForwardsSGRWheel|CtrlClickStaysLocalEvenWithMouseReporting|TrackingWithoutSGRStaysLocal)$'`\n- `git diff --check`\n\nAn unfiltered `go test ./...` run reproduced timeouts in those four existing PTY mouse tests; they also time out when rerun alone. All remaining Go packages pass fresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved command palette sizing across narrow, typical, and wide terminal layouts.
  - Wide palettes now use a consistent layout across command, help, file-search, go-to-line, and keybinding modes.
  - Palette width remains constrained to preserve screen boundaries and usability.
  - Reopening and dismissing palettes continue to behave correctly across layout transitions.

- **Tests**
  - Added coverage for responsive widths, mode transitions, borders, and outside-click dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->