### PR TITLE
feat(diff): add live controls to detail menus

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -598,7 +598,7 @@ func registerWidgetCallbacks(app *App) {
 			ui.ContextMenuItem{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
 			ui.ContextMenuItem{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
 		)
-		tabContextMenu = app.withActiveDiffViewMenu(tabContextMenu)
+		tabContextMenu = app.withActiveDiffViewSubmenu(tabContextMenu)
 		openContextMenu(app, tabContextMenu, sx, sy)
 	}
 

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -598,13 +598,7 @@ func registerWidgetCallbacks(app *App) {
 			ui.ContextMenuItem{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
 			ui.ContextMenuItem{Label: "Copy Relative Path", Command: "file.copyRelativePath"},
 		)
-		if dv := app.EditorGroup.ActiveDiffWidget(); dv != nil {
-			tabContextMenu = append(tabContextMenu,
-				ui.MenuSep(),
-				ui.ContextMenuItem{Label: "Changes Only", Command: "diff.changesOnlyView", Checked: menuChecked(dv.ContextMode() == ui.DiffContextChangesOnly)},
-				ui.ContextMenuItem{Label: "Full File", Command: "diff.fullFileView", Checked: menuChecked(dv.ContextMode() == ui.DiffContextFullFile)},
-			)
-		}
+		tabContextMenu = app.withActiveDiffViewMenu(tabContextMenu)
 		openContextMenu(app, tabContextMenu, sx, sy)
 	}
 

--- a/internal/app/diff_view_menu_test.go
+++ b/internal/app/diff_view_menu_test.go
@@ -67,3 +67,26 @@ func TestActiveDiffViewMenuTracksFileDiffAndCommitDetailState(t *testing.T) {
 		}
 	}
 }
+
+func TestActiveDiffViewMenuSupportsFlatContentAndCompactTabLayouts(t *testing.T) {
+	a := buildTestApp(t, config.DefaultSettings())
+	detail := ui.NewCommitDetailWidget("/repo", "ref", "abcdef0", false)
+	detail.SetDetail("message", nil, "")
+	a.EditorGroup.ApplyDiffDefaults(detail)
+	a.EditorGroup.OpenPluginTab("commit-detail", "Commit abcdef0", detail)
+
+	base := []ui.ContextMenuItem{{Label: "Base", Command: "base"}}
+	flat := a.withActiveDiffViewMenu(base)
+	if len(flat) < 2 || flat[len(flat)-1].Command != "diff.toggleWrap" {
+		t.Fatalf("flat content menu does not expose direct controls: %+v", flat)
+	}
+	compact := a.withActiveDiffViewSubmenu(base)
+	last := compact[len(compact)-1]
+	if last.Label != "Diff View" || len(last.Submenu) == 0 {
+		t.Fatalf("compact tab menu does not expose Diff View submenu: %+v", compact)
+	}
+	assertActiveDiffViewMenu(t, last.Submenu, "diff.splitView", "diff.changesOnlyView")
+	if len(base) != 1 {
+		t.Fatalf("layout builders mutated their base menu: %+v", base)
+	}
+}

--- a/internal/app/diff_view_menu_test.go
+++ b/internal/app/diff_view_menu_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func assertActiveDiffViewMenu(t *testing.T, items []ui.ContextMenuItem, checkedCommands ...string) {
+	t.Helper()
+	checked := make(map[string]bool, len(checkedCommands))
+	for _, command := range checkedCommands {
+		checked[command] = true
+	}
+	wantCommands := []string{
+		"diff.splitView",
+		"diff.unifiedView",
+		"",
+		"diff.changesOnlyView",
+		"diff.fullFileView",
+		"",
+		"diff.toggleWrap",
+	}
+	if len(items) != len(wantCommands) {
+		t.Fatalf("menu items = %+v, want %d rows", items, len(wantCommands))
+	}
+	for index, wantCommand := range wantCommands {
+		item := items[index]
+		if wantCommand == "" {
+			if !item.IsSep {
+				t.Errorf("row %d = %+v, want separator", index, item)
+			}
+			continue
+		}
+		if item.Command != wantCommand {
+			t.Errorf("row %d command = %q, want %q", index, item.Command, wantCommand)
+		}
+		wantChecked := menuChecked(checked[wantCommand])
+		if item.Checked != wantChecked {
+			t.Errorf("%s checked = %d, want %d", wantCommand, item.Checked, wantChecked)
+		}
+	}
+}
+
+func TestActiveDiffViewMenuTracksFileDiffAndCommitDetailState(t *testing.T) {
+	a := buildTestApp(t, config.DefaultSettings())
+	a.EditorGroup.OpenDiff("file.go", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	fileDiff := a.EditorGroup.ActiveDiffWidget()
+	fileDiff.SetMode(ui.DiffModeUnified)
+	fileDiff.SetContextMode(ui.DiffContextFullFile)
+	fileDiff.SetWrapMode(ui.DiffWrapOn)
+	assertActiveDiffViewMenu(t, a.BuildActiveDiffViewMenu(),
+		"diff.unifiedView", "diff.fullFileView", "diff.toggleWrap")
+
+	detail := ui.NewCommitDetailWidget("/repo", "ref", "abcdef0", false)
+	detail.SetDetail("message", nil, "")
+	a.EditorGroup.ApplyDiffDefaults(detail)
+	a.EditorGroup.OpenPluginTab("commit-detail", "Commit abcdef0", detail)
+	assertActiveDiffViewMenu(t, a.BuildActiveDiffViewMenu(),
+		"diff.splitView", "diff.changesOnlyView")
+
+	for _, item := range a.BuildActiveDiffViewMenu() {
+		if item.Command == "options.toggleDiffHighContrast" {
+			t.Fatal("surface menu exposes global High Contrast preference")
+		}
+	}
+}

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -133,6 +133,45 @@ var changesContextMenuUnstaged = []ui.ContextMenuItem{
 	{Label: "Discard Changes", Command: "changes.discard"},
 }
 
+func (a *App) BuildActiveDiffViewMenu() []ui.ContextMenuItem {
+	var items []ui.ContextMenuItem
+	modeSurface := a.EditorGroup.ActiveDiffModeSurface()
+	contextSurface := a.EditorGroup.ActiveDiffContextSurface()
+	if modeSurface != nil {
+		items = append(items,
+			ui.ContextMenuItem{Label: "Split", Command: "diff.splitView", Checked: menuChecked(modeSurface.Mode() == ui.DiffModeSplit)},
+			ui.ContextMenuItem{Label: "Unified", Command: "diff.unifiedView", Checked: menuChecked(modeSurface.Mode() == ui.DiffModeUnified)},
+		)
+	}
+	if contextSurface != nil {
+		if len(items) > 0 {
+			items = append(items, ui.MenuSep())
+		}
+		items = append(items,
+			ui.ContextMenuItem{Label: "Changes Only", Command: "diff.changesOnlyView", Checked: menuChecked(contextSurface.ContextMode() == ui.DiffContextChangesOnly)},
+			ui.ContextMenuItem{Label: "Full File", Command: "diff.fullFileView", Checked: menuChecked(contextSurface.ContextMode() == ui.DiffContextFullFile)},
+		)
+	}
+	if modeSurface != nil {
+		if len(items) > 0 {
+			items = append(items, ui.MenuSep())
+		}
+		items = append(items, ui.ContextMenuItem{Label: "Wrap Lines", Command: "diff.toggleWrap", Checked: menuChecked(modeSurface.WrapMode() == ui.DiffWrapOn)})
+	}
+	return items
+}
+
+func (a *App) withActiveDiffViewMenu(items []ui.ContextMenuItem) []ui.ContextMenuItem {
+	controls := a.BuildActiveDiffViewMenu()
+	if len(controls) == 0 {
+		return items
+	}
+	combined := make([]ui.ContextMenuItem, 0, len(items)+1+len(controls))
+	combined = append(combined, items...)
+	combined = append(combined, ui.MenuSep())
+	return append(combined, controls...)
+}
+
 func resolveShortcuts(reg *command.Registry, items []ui.ContextMenuItem) []ui.ContextMenuItem {
 	resolved := make([]ui.ContextMenuItem, len(items))
 	for i, item := range items {
@@ -282,9 +321,9 @@ func handleRightClick(app *App, mx, my int) {
 	}
 
 	if app.EditorGroup.ActiveCommitDetailWidget() != nil {
-		openContextMenu(app, commitDetailContextMenu, mx, my)
-	} else if app.EditorGroup.ActiveDiffWidget() != nil {
-		openContextMenu(app, diffContextMenu, mx, my)
+		openContextMenu(app, app.withActiveDiffViewMenu(commitDetailContextMenu), mx, my)
+	} else if app.EditorGroup.ActiveDiffModeSurface() != nil || app.EditorGroup.ActiveDiffContextSurface() != nil {
+		openContextMenu(app, app.withActiveDiffViewMenu(diffContextMenu), mx, my)
 	} else {
 		openEditorContextMenu(app, mx, my)
 	}

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -172,6 +172,17 @@ func (a *App) withActiveDiffViewMenu(items []ui.ContextMenuItem) []ui.ContextMen
 	return append(combined, controls...)
 }
 
+func (a *App) withActiveDiffViewSubmenu(items []ui.ContextMenuItem) []ui.ContextMenuItem {
+	controls := a.BuildActiveDiffViewMenu()
+	if len(controls) == 0 {
+		return items
+	}
+	combined := make([]ui.ContextMenuItem, 0, len(items)+2)
+	combined = append(combined, items...)
+	combined = append(combined, ui.MenuSep(), ui.ContextMenuItem{Label: "Diff View", Submenu: controls})
+	return combined
+}
+
 func resolveShortcuts(reg *command.Registry, items []ui.ContextMenuItem) []ui.ContextMenuItem {
 	resolved := make([]ui.ContextMenuItem, len(items))
 	for i, item := range items {

--- a/tests/e2e/commit_detail_diff_menu_test.go
+++ b/tests/e2e/commit_detail_diff_menu_test.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/diff"
+	"github.com/eugenioenko/ttt/internal/ui"
+)
+
+func focusedContextMenu(t *testing.T, h *testHarness) *ui.ContextMenuWidget {
+	t.Helper()
+	menu, ok := h.app.Root.Focused.(*ui.ContextMenuWidget)
+	if !ok {
+		t.Fatalf("focused widget = %T, want context menu", h.app.Root.Focused)
+	}
+	return menu
+}
+
+func assertSurfaceMenuState(t *testing.T, menu *ui.ContextMenuWidget, checkedCommands ...string) {
+	t.Helper()
+	checked := make(map[string]bool, len(checkedCommands))
+	for _, command := range checkedCommands {
+		checked[command] = true
+	}
+	for _, command := range []string{"diff.splitView", "diff.unifiedView", "diff.changesOnlyView", "diff.fullFileView", "diff.toggleWrap"} {
+		item, ok := findMenuCommand(menu.Items, command)
+		if !ok {
+			t.Errorf("menu missing %s: %+v", command, menu.Items)
+			continue
+		}
+		want := ui.MenuUnchecked
+		if checked[command] {
+			want = ui.MenuChecked
+		}
+		if item.Checked != want {
+			t.Errorf("%s checked = %d, want %d", command, item.Checked, want)
+		}
+	}
+	if _, ok := findMenuCommand(menu.Items, "options.toggleDiffHighContrast"); ok {
+		t.Error("active-surface menu includes global High Contrast command")
+	}
+}
+
+func TestCommitDetailContentAndTabMenusControlOnlyActiveSurface(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+
+	h.app.EditorGroup.OpenDiff("background.txt", diff.FileDiff{}, []string{"old"}, []string{"new"}, true)
+	background := h.app.EditorGroup.ActiveDiffWidget()
+	detail := ui.NewCommitDetailWidget(h.dir, "ref", "abcdef0", false)
+	file := ui.CommitDetailFileWithContent(ui.CommitDetailFile{
+		Path: "detail.txt",
+		Diff: diff.Parse("--- a/detail.txt\n+++ b/detail.txt\n@@ -1 +1 @@\n-old\n+new\n"),
+	}, []string{"old"}, []string{"new"})
+	detail.SetDetail("message", []ui.CommitDetailFile{file}, "")
+	h.app.EditorGroup.ApplyDiffDefaults(detail)
+	h.app.EditorGroup.OpenPluginTab("commit-detail", "Commit abcdef0", detail)
+	h.redraw()
+
+	r := h.app.EditorGroup.GetRect()
+	openContentMenu := func() *ui.ContextMenuWidget {
+		h.rightClick(r.X+r.W/2, r.Y+4)
+		return focusedContextMenu(t, h)
+	}
+	executeContentCommand := func(command string) {
+		menu := openContentMenu()
+		if _, ok := findMenuCommand(menu.Items, command); !ok {
+			t.Fatalf("content menu missing %s", command)
+		}
+		menu.OnExec(command)
+		h.redraw()
+	}
+
+	assertSurfaceMenuState(t, openContentMenu(), "diff.splitView", "diff.changesOnlyView")
+	focusedContextMenu(t, h).OnDismiss()
+	executeContentCommand("diff.unifiedView")
+	executeContentCommand("diff.fullFileView")
+	executeContentCommand("diff.toggleWrap")
+	if detail.Mode() != ui.DiffModeUnified || detail.ContextMode() != ui.DiffContextFullFile || detail.WrapMode() != ui.DiffWrapOn {
+		t.Fatalf("detail state = mode %v context %v wrap %v", detail.Mode(), detail.ContextMode(), detail.WrapMode())
+	}
+	if background.Mode() != ui.DiffModeSplit || background.ContextMode() != ui.DiffContextFullFile || background.WrapMode() != ui.DiffWrapOff {
+		t.Fatalf("inactive diff changed: mode %v context %v wrap %v", background.Mode(), background.ContextMode(), background.WrapMode())
+	}
+	if h.app.Settings.Editor.DiffMode != config.DiffModeSplit || h.app.Settings.Editor.DiffContext != config.DiffContextChanges || h.app.Settings.Editor.DiffWordWrap {
+		t.Fatalf("surface actions persisted defaults: mode %q context %q wrap %v", h.app.Settings.Editor.DiffMode, h.app.Settings.Editor.DiffContext, h.app.Settings.Editor.DiffWordWrap)
+	}
+
+	tabRect := h.app.EditorGroup.TabBar.GetRect()
+	h.app.EditorGroup.TabBar.OnTabRightClick(h.app.EditorGroup.ActiveTabIndex(), tabRect.X+1, tabRect.Y)
+	assertSurfaceMenuState(t, focusedContextMenu(t, h), "diff.unifiedView", "diff.fullFileView", "diff.toggleWrap")
+}

--- a/tests/e2e/commit_detail_diff_menu_test.go
+++ b/tests/e2e/commit_detail_diff_menu_test.go
@@ -1,11 +1,13 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/eugenioenko/ttt/internal/config"
 	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/ui"
+	"github.com/gdamore/tcell/v3"
 )
 
 func focusedContextMenu(t *testing.T, h *testHarness) *ui.ContextMenuWidget {
@@ -90,4 +92,54 @@ func TestCommitDetailContentAndTabMenusControlOnlyActiveSurface(t *testing.T) {
 	tabRect := h.app.EditorGroup.TabBar.GetRect()
 	h.app.EditorGroup.TabBar.OnTabRightClick(h.app.EditorGroup.ActiveTabIndex(), tabRect.X+1, tabRect.Y)
 	assertSurfaceMenuState(t, focusedContextMenu(t, h), "diff.unifiedView", "diff.fullFileView", "diff.toggleWrap")
+}
+
+func TestCommitDetailTabMenuKeepsDiffControlsReachableAt70x16(t *testing.T) {
+	h := newTestHarness(t, 70, 16)
+	defer h.stop()
+
+	detail := ui.NewCommitDetailWidget(h.dir, "ref", "abcdef0", false)
+	detail.SetDetail("message", nil, "")
+	h.app.EditorGroup.ApplyDiffDefaults(detail)
+	h.app.EditorGroup.OpenPluginTab("commit-detail", "Commit abcdef0", detail)
+	h.redraw()
+
+	tabRect := h.app.EditorGroup.TabBar.GetRect()
+	h.app.EditorGroup.TabBar.OnTabRightClick(h.app.EditorGroup.ActiveTabIndex(), tabRect.X+1, tabRect.Y)
+	h.redraw()
+	menu := focusedContextMenu(t, h)
+	if !strings.Contains(h.screenText(), "Diff View") {
+		t.Fatalf("70x16 tab menu has no reachable Diff View entry:\n%s", h.screenText())
+	}
+	diffViewIndex := -1
+	for index, item := range menu.Items {
+		if item.Label == "Diff View" {
+			diffViewIndex = index
+			break
+		}
+	}
+	if diffViewIndex < 0 {
+		t.Fatal("tab menu has no Diff View submenu")
+	}
+	menu.Selected = diffViewIndex
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyRight, "", tcell.ModNone))
+	h.redraw()
+	for _, label := range []string{"Split", "Unified", "Changes Only", "Full File", "Wrap Lines"} {
+		if !strings.Contains(h.screenText(), label) {
+			t.Errorf("70x16 Diff View submenu does not expose %q:\n%s", label, h.screenText())
+		}
+	}
+	if menu.Submenu == nil {
+		t.Fatal("Diff View submenu did not open")
+	}
+	for index, item := range menu.Submenu.Items {
+		if item.Command == "diff.toggleWrap" {
+			menu.Submenu.Selected = index
+			break
+		}
+	}
+	menu.HandleEvent(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if detail.WrapMode() != ui.DiffWrapOn {
+		t.Fatal("Wrap Lines remained unreachable through the 70x16 tab submenu")
+	}
 }

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -122,6 +122,39 @@ describe("commit history detail", () => {
 		expect(snapshots[fullFile]).toContain("unchanged line 15");
 	});
 
+	it("changes the active commit detail from its right-click menus", () => {
+		dir = createGitRepo(createTempDir());
+		createTempFile(dir, "menu-detail.txt", "old detail line\n");
+		git(dir, "add", "-A");
+		git(dir, "commit", "-qm", "menu base");
+		createTempFile(dir, "menu-detail.txt", "new detail line with a long wrapped suffix\n");
+		git(dir, "add", "-A");
+		git(dir, "commit", "-qm", "menu detail");
+
+		tui.start(dir);
+		tui.setSize(100, 30);
+		tui.pressChord("ctrl+k", "c");
+		tui.waitStable(500);
+		tui.press("tab");
+		tui.press("tab");
+		tui.press("down");
+		tui.press("enter");
+		tui.waitStable(900);
+		tui.rclick(60, 12);
+		const contentMenu = tui.snapshot();
+		for (let index = 0; index < 4; index++) tui.press("down");
+		tui.press("enter");
+		tui.rclick(50, 2);
+		const tabMenu = tui.snapshot();
+
+		const { snapshots } = tui.run();
+		for (const label of ["Split", "Unified", "Changes Only", "Full File", "Wrap Lines"]) {
+			expect(snapshots[contentMenu]).toContain(label);
+			expect(snapshots[tabMenu]).toContain(label);
+		}
+		expect(snapshots[tabMenu]).toContain("✓ Unified");
+	});
+
   it("uses shared Git bulk commands for commit-detail file groupings", () => {
     dir = createGitRepo(createTempDir());
     createTempFile(dir, "bulk-detail.txt", "visible detail line\n");

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -132,7 +132,7 @@ describe("commit history detail", () => {
 		git(dir, "commit", "-qm", "menu detail");
 
 		tui.start(dir);
-		tui.setSize(100, 30);
+		tui.setSize(70, 16);
 		tui.pressChord("ctrl+k", "c");
 		tui.waitStable(500);
 		tui.press("tab");
@@ -145,9 +145,13 @@ describe("commit history detail", () => {
 		for (let index = 0; index < 4; index++) tui.press("down");
 		tui.press("enter");
 		tui.rclick(50, 2);
+		const compactTabMenu = tui.snapshot();
+		for (let index = 0; index < 8; index++) tui.press("down");
+		tui.press("right");
 		const tabMenu = tui.snapshot();
 
 		const { snapshots } = tui.run();
+		expect(snapshots[compactTabMenu]).toContain("Diff View");
 		for (const label of ["Split", "Unified", "Changes Only", "Full File", "Wrap Lines"]) {
 			expect(snapshots[contentMenu]).toContain(label);
 			expect(snapshots[tabMenu]).toContain(label);


### PR DESCRIPTION
## Summary

- build one dynamic menu from the active `DiffModeSurface` and `DiffContextSurface`
- expose Split/Unified, Changes Only/Full File, and Wrap Lines with live checked state directly in the commit-detail content menu and under a compact `Diff View` tab submenu
- keep every tab control reachable at 70x16 instead of relying on the context menu's clipped overflow
- keep the existing content actions intact and route selections through the surface-local `diff.*` commands, without changing persisted Options defaults
- omit High Contrast because it remains a global preference rather than an inspectable per-surface override

## User-facing invariant

While viewing a past commit detail, both nearby right-click menus expose every applicable live diff-view control. Choosing one changes only that active reader; inactive diffs and global defaults stay unchanged.

## Test evidence

- `go test ./internal/app -run 'Test(ActiveDiffViewMenu|OptionsMenuSeparatesPresentationSubmenusFromCheckboxes|MenuBar)' -count=1`
- `go test ./tests/e2e -run 'Test(CommitDetailContentAndTabMenusControlOnlyActiveSurface|DiffPresentationCommands|ExplicitDiffOverridesDoNotPersistAndNextDiffUsesDefaults|OpenDiff)' -count=1`
- `go test ./tests/e2e -run 'TestCommitDetailTabMenuKeepsDiffControlsReachableAt70x16' -count=1`
- `go vet ./internal/app ./tests/e2e`
- `make build`
- `cd tests/functional && pnpm exec vitest run commit-history-detail.test.js` (1 file, 6 tests)
- built-in `--exec` harness before/after screenshots confirmed the content menu gained the five controls and accurate initial checks
- real-PTY termctrl verification at 70x16 opened `Diff View`, reached all five controls, activated Wrap Lines, and observed its checked state after reopening


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-menu controls for split or unified diff layouts.
  * Added options to show changes only or the full file.
  * Added line-wrapping controls with states reflecting the active diff view.
  * Diff settings now apply only to the currently active diff surface.

* **Bug Fixes**
  * Improved context-menu behavior in commit details and diff views.
  * Ensured all diff controls remain accessible in compact layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->