### PR TITLE
fix: nil pointer dereference in ChangesPanel.handleCommitLogKey

### DIFF
--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -608,7 +608,7 @@ func (cp *ChangesPanel) openCommitLogNode(node *widgets.TreeNode) {
 }
 
 func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.TreeNode) bool {
-	if ev.Key() != tcell.KeyRune {
+	if ev.Key() != tcell.KeyRune || node == nil {
 		return false
 	}
 	switch term.KeyRune(ev) {

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -608,7 +608,7 @@ func (cp *ChangesPanel) openCommitLogNode(node *widgets.TreeNode) {
 }
 
 func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.TreeNode) bool {
-	if ev.Key() != tcell.KeyRune || node == nil {
+	if ev.Key() != tcell.KeyRune {
 		return false
 	}
 	switch term.KeyRune(ev) {
@@ -623,6 +623,9 @@ func (cp *ChangesPanel) handleCommitLogKey(ev *tcell.EventKey, node *widgets.Tre
 		cp.openCommitLogNode(node)
 		return true
 	case 'e':
+		if node == nil {
+			return false
+		}
 		if _, isCommit := cp.logCommits[node.ID]; isCommit {
 			cp.openCommitLogNode(node)
 		} else {


### PR DESCRIPTION
## Summary
- Add nil guard for `node` parameter in `handleCommitLogKey`, consistent with `openCommitLogNode` which already has one
- The `OnKey` callback receives nil when the commit log tree has no selected node, causing a panic

Found by the chaos monkey CI run: https://github.com/eugenioenko/ttt/actions/runs/32614874149

Fixes #512

Code](https://claude.com/claude-code)

<!-- @coderabbitai ignore -->