### PR TITLE
fix(git): canonicalize active repository identity

### DIFF
--- a/audit/2026-07-12-ux-bug-audit.md
+++ b/audit/2026-07-12-ux-bug-audit.md
@@ -400,14 +400,14 @@ Basic search, result counts, case/regex behavior, empty/whitespace/CJK queries, 
 - **Actual:** `resolveArgs()` (`internal/app/widgets.go:75-84`) ignores `LoadFile`'s error and falls through to cwd; the CLI and interactive paths handle the identical failure inconsistently
 - **Test:** none — the fix defines the error-feedback signal; ledger-only (mirrors BUG-042)
 
-### BUG-044: Git branch/gutter missing when the opened file is below the repo root (no walk-up)
+### BUG-044: Git branch/gutter missing when the opened file is below the repo root (resolved)
 - **Area:** Workspace × git
 - **Severity:** medium
-- **Status:** confirmed (agent-reported; orchestrator re-verified with a clean control)
+- **Status:** resolved by canonical active-file repository observation, including linked worktrees
 - **Repro:** open a file in a repo SUBDIR by absolute path → no branch in the status bar. Control that nails it: opening ttt's own `internal/ui/root.go` by absolute path shows NO branch, while opening the repo at its root (cwd) shows `audit/bug-hunt` — same repo, different result.
 - **Expected:** branch/gutter work for any file inside a git working tree (the Changes panel already does — it uses `git rev-parse --show-toplevel`)
-- **Actual:** `workspace.isGitRepo()` (`internal/workspace/workspace.go`) only `os.Stat`s `.git` directly in the folder — no walk-up — so the indicator shows only when the workspace root IS the repo root. `internal/git/git.go` even has a walk-up-aware `IsRepo()` that isn't used here.
-- **Test:** `tests/functional/audit-workspace-bugs.test.js` (`it.fails`, git-repo fixture)
+- **Actual:** repository membership and branch now come from the repository observer's cached canonical Git identity instead of `workspace.isGitRepo()`; active-file discovery is asynchronous and accepts both `.git` directories and linked-worktree `.git` files.
+- **Test:** `tests/functional/audit-workspace-bugs.test.js` (nested-repository and linked-worktree fixtures)
 
 ### BUG-045: `.ttt` workspace files accept a folder entry pointing at a regular file (no IsDir validation)
 - **Area:** Workspace

--- a/audit/2026-07-12-ux-bug-audit.md
+++ b/audit/2026-07-12-ux-bug-audit.md
@@ -403,11 +403,11 @@ Basic search, result counts, case/regex behavior, empty/whitespace/CJK queries, 
 ### BUG-044: Git branch/gutter missing when the opened file is below the repo root (resolved)
 - **Area:** Workspace × git
 - **Severity:** medium
-- **Status:** resolved by canonical active-file repository observation, including linked worktrees
+- **Status:** resolved for active files whose file identity or nearest existing parent can be stably resolved, including linked worktrees
 - **Repro:** open a file in a repo SUBDIR by absolute path → no branch in the status bar. Control that nails it: opening ttt's own `internal/ui/root.go` by absolute path shows NO branch, while opening the repo at its root (cwd) shows `audit/bug-hunt` — same repo, different result.
 - **Expected:** branch/gutter work for any file inside a git working tree (the Changes panel already does — it uses `git rev-parse --show-toplevel`)
-- **Actual:** repository membership and branch now come from the repository observer's cached canonical Git identity instead of `workspace.isGitRepo()`; active-file discovery is asynchronous and accepts both `.git` directories and linked-worktree `.git` files.
-- **Test:** `tests/functional/audit-workspace-bugs.test.js` (nested-repository and linked-worktree fixtures)
+- **Actual:** repository membership and branch now come from the repository observer's cached canonical Git identity instead of `workspace.isGitRepo()`; active-file discovery resolves existing file and directory symlinks before choosing the Git directory, uses the nearest stably resolvable existing parent for missing files, and declines broken links or cycles.
+- **Test:** `tests/functional/audit-workspace-bugs.test.js` (nested-repository, linked-worktree, and external file-symlink fixtures)
 
 ### BUG-045: `.ttt` workspace files accept a folder entry pointing at a regular file (no IsDir validation)
 - **Area:** Workspace

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -40,15 +40,15 @@ func RunEventLoop(
 	lastBlameLine := -1
 	lastBlameFile := ""
 	lastGutterFile := ""
+	lastGutterRepo := ""
 	lastTabFile := ""
 	lastOutlineFile := ""
 	lastOutlineLine := -1
 	lastCursorLine := -1
 	lastCursorCol := -1
 	lastCursorFile := ""
-	lastBranchDir := app.Workspace.Primary()
+	lastBlameRepo := ""
 	blameGen := 0
-	app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: git.BranchName(lastBranchDir)})
 
 	syncStatus := func() {
 		app.syncRepositoryObservation()
@@ -94,25 +94,12 @@ func RunEventLoop(
 
 		app.SyncLanguageSegment()
 
-		repoDir := ""
-		if filePath != "" && !app.EditorGroup.IsActiveVirtual() {
-			if folder := app.Workspace.FolderForFile(filePath); folder != nil && folder.IsRepo {
-				repoDir = folder.Path
-			}
-		}
-
-		if repoDir != lastBranchDir {
-			lastBranchDir = repoDir
-			if repoDir != "" {
-				app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: git.BranchName(repoDir)})
-			} else {
-				app.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: ""})
-			}
-		}
+		repoDir := app.SyncRepositoryBranch()
 
 		// Trigger git gutter computation when switching to a new file
-		if filePath != lastGutterFile {
+		if filePath != lastGutterFile || repoDir != lastGutterRepo {
 			lastGutterFile = filePath
+			lastGutterRepo = repoDir
 			app.RequestGitGutterForActiveFile()
 		}
 
@@ -147,9 +134,10 @@ func RunEventLoop(
 			}
 		}
 
-		if filePath != lastBlameFile || line != lastBlameLine {
+		if filePath != lastBlameFile || line != lastBlameLine || repoDir != lastBlameRepo {
 			lastBlameFile = filePath
 			lastBlameLine = line
+			lastBlameRepo = repoDir
 			app.Status.SetSegment(view.StatusSegment{ID: "blame", Side: "left", Priority: 200, Text: ""})
 			if repoDir != "" {
 				blameGen++
@@ -384,6 +372,10 @@ func RunEventLoop(
 				app.HandleRepoOpResult(v)
 			case *RepositoryStatusResult:
 				app.Repository.HandleStatus(v)
+				syncStatus()
+			case *RepositoryIdentityResult:
+				app.Repository.HandleIdentity(v)
+				syncStatus()
 			case *CurrentChangesResult:
 				app.Repository.HandleCurrentChanges(v)
 			case *RepositoryInvalidationRequest:

--- a/internal/app/gitgutter.go
+++ b/internal/app/gitgutter.go
@@ -28,11 +28,13 @@ func (a *App) RequestGitGutter(filePath string, bufferLines []string) {
 		return
 	}
 
-	folder := a.Workspace.FolderForFile(filePath)
-	if folder == nil || !folder.IsRepo {
+	if a.Repository == nil {
 		return
 	}
-	repoDir := folder.Path
+	repoDir, _ := a.Repository.RepositoryForPath(filePath)
+	if repoDir == "" {
+		return
+	}
 
 	relPath, err := filepath.Rel(repoDir, filePath)
 	if err != nil {

--- a/internal/app/gitgutter.go
+++ b/internal/app/gitgutter.go
@@ -36,7 +36,11 @@ func (a *App) RequestGitGutter(filePath string, bufferLines []string) {
 		return
 	}
 
-	relPath, err := filepath.Rel(repoDir, filePath)
+	gitPath, err := a.Repository.resolvePathIdentity(filePath)
+	if err != nil || !pathWithin(repoDir, gitPath) {
+		return
+	}
+	relPath, err := filepath.Rel(repoDir, gitPath)
 	if err != nil {
 		return
 	}

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -570,8 +570,43 @@ func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatus
 }
 
 func readRepositoryIdentity(ctx context.Context, filePath string, seq uint64) *RepositoryIdentityResult {
-	identity, err := git.ReadRepositoryIdentityContext(ctx, filepath.Dir(filePath))
+	if err := ctx.Err(); err != nil {
+		return &RepositoryIdentityResult{Seq: seq, FilePath: filePath, Err: err}
+	}
+	dir, err := repositoryDiscoveryDirectory(filePath)
+	if err != nil {
+		return &RepositoryIdentityResult{Seq: seq, FilePath: filePath, Err: err}
+	}
+	if err := ctx.Err(); err != nil {
+		return &RepositoryIdentityResult{Seq: seq, FilePath: filePath, Err: err}
+	}
+	identity, err := git.ReadRepositoryIdentityContext(ctx, dir)
 	return &RepositoryIdentityResult{Seq: seq, FilePath: filePath, Identity: identity, Err: err}
+}
+
+func repositoryDiscoveryDirectory(filePath string) (string, error) {
+	identity, err := resolveRepositoryPathIdentity(filePath)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(identity)
+	for {
+		info, statErr := os.Stat(dir)
+		if statErr == nil {
+			if !info.IsDir() {
+				return "", errors.New("repository discovery ancestor is not a directory")
+			}
+			return dir, nil
+		}
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return "", statErr
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", statErr
+		}
+		dir = parent
+	}
 }
 
 func (s *RepositoryState) SetActiveFile(filePath string) {
@@ -742,30 +777,56 @@ func resolveRepositoryPathIdentityWith(
 		return "", err
 	}
 	abs = filepath.Clean(abs)
-	resolved, resolveErr := stableSymlinkIdentityWith(abs, evalSymlinks)
-	if resolveErr == nil {
-		return resolved, nil
+
+resolve:
+	for {
+		resolved, resolveErr := stableSymlinkIdentityWith(abs, evalSymlinks)
+		if resolveErr == nil {
+			return resolved, nil
+		}
+		if _, lstatErr := lstat(abs); lstatErr == nil {
+			return "", resolveErr
+		} else if !errors.Is(lstatErr, os.ErrNotExist) {
+			return "", lstatErr
+		}
+		ancestor := filepath.Dir(abs)
+		for {
+			resolvedAncestor, ancestorErr := stableSymlinkIdentityWith(ancestor, evalSymlinks)
+			if ancestorErr == nil {
+				if _, lstatErr := lstat(abs); lstatErr == nil {
+					continue resolve
+				} else if !errors.Is(lstatErr, os.ErrNotExist) {
+					return "", lstatErr
+				}
+				for candidate := filepath.Dir(abs); candidate != ancestor; candidate = filepath.Dir(candidate) {
+					if _, lstatErr := lstat(candidate); lstatErr == nil {
+						continue resolve
+					} else if !errors.Is(lstatErr, os.ErrNotExist) {
+						return "", lstatErr
+					}
+				}
+				confirmedAncestor, err := stableSymlinkIdentityWith(ancestor, evalSymlinks)
+				if err != nil || confirmedAncestor != resolvedAncestor {
+					return "", errors.New("repository path ancestor changed while resolving")
+				}
+				rel, err := filepath.Rel(ancestor, abs)
+				if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+					return "", errors.New("repository path escaped its resolved ancestor")
+				}
+				return filepath.Join(resolvedAncestor, rel), nil
+			}
+			if _, lstatErr := lstat(ancestor); lstatErr == nil {
+				return "", ancestorErr
+			} else if !errors.Is(lstatErr, os.ErrNotExist) {
+				return "", lstatErr
+			}
+			parent := filepath.Dir(ancestor)
+			if parent == ancestor {
+				return "", ancestorErr
+			}
+			ancestor = parent
+		}
 	}
-	if _, lstatErr := lstat(abs); lstatErr == nil {
-		return "", resolveErr
-	} else if !errors.Is(lstatErr, os.ErrNotExist) {
-		return "", lstatErr
-	}
-	parent := filepath.Dir(abs)
-	resolvedParent, parentErr := stableSymlinkIdentityWith(parent, evalSymlinks)
-	if parentErr != nil {
-		return "", resolveErr
-	}
-	if _, lstatErr := lstat(abs); lstatErr == nil {
-		return stableSymlinkIdentityWith(abs, evalSymlinks)
-	} else if !errors.Is(lstatErr, os.ErrNotExist) {
-		return "", lstatErr
-	}
-	confirmedParent, err := stableSymlinkIdentityWith(parent, evalSymlinks)
-	if err != nil || confirmedParent != resolvedParent {
-		return "", errors.New("repository path parent changed while resolving")
-	}
-	return filepath.Join(resolvedParent, filepath.Base(abs)), nil
 }
 
 func stableSymlinkIdentityWith(path string, evalSymlinks func(string) (string, error)) (string, error) {

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/eugenioenko/ttt/internal/git"
+	"github.com/eugenioenko/ttt/internal/view"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -40,6 +41,13 @@ type RepositoryStatusResult struct {
 	Entries []repositoryStatusEntry
 }
 
+type RepositoryIdentityResult struct {
+	Seq      uint64
+	FilePath string
+	Identity git.RepositoryIdentity
+	Err      error
+}
+
 type RepositoryInvalidationRequest struct {
 	Path      string
 	Resources RepositoryResource
@@ -69,6 +77,7 @@ type RepositoryState struct {
 
 	scheduler    repositoryScheduler
 	readStatus   func(context.Context, []string, uint64) *RepositoryStatusResult
+	readIdentity func(context.Context, string, uint64) *RepositoryIdentityResult
 	pathIdentity func(string) (string, error)
 	debounceWait time.Duration
 	pollWait     time.Duration
@@ -92,6 +101,13 @@ type RepositoryState struct {
 	lastGroups    map[string]changesGroup
 	lastRevisions map[string]string
 	lastRoots     map[string]string
+	identities    map[string]git.RepositoryIdentity
+
+	activeFile     string
+	activeRoot     string
+	activeBranch   string
+	identitySeq    uint64
+	identityCancel context.CancelFunc
 
 	currentRoot               string
 	currentTabID              string
@@ -116,12 +132,14 @@ func NewRepositoryState(changes *ChangesPanel, dirs []string) *RepositoryState {
 		dirs:               append([]string(nil), dirs...),
 		scheduler:          realRepositoryScheduler{},
 		readStatus:         readRepositoryStatus,
+		readIdentity:       readRepositoryIdentity,
 		debounceWait:       repositoryRefreshDebounce,
 		pollWait:           repositoryPollInterval,
 		statusWait:         repositoryStatusTimeout,
 		lastGroups:         make(map[string]changesGroup),
 		lastRevisions:      make(map[string]string),
 		lastRoots:          make(map[string]string),
+		identities:         make(map[string]git.RepositoryIdentity),
 		currentInputs:      make(map[string]currentChangesInput),
 		readCurrentChanges: readCurrentChanges,
 	}
@@ -198,6 +216,9 @@ func (s *RepositoryState) InvalidateAll(resources RepositoryResource) {
 		return
 	}
 	s.dirty |= resources
+	if resources&RepositoryWorktree != 0 {
+		s.refreshActiveIdentity()
+	}
 	if resources&RepositoryWorktree != 0 && s.currentRoot != "" {
 		s.dirty |= RepositoryCurrentChanges
 		s.currentDirty = true
@@ -243,6 +264,9 @@ func (s *RepositoryState) RefreshNow(resources RepositoryResource) {
 		return
 	}
 	s.dirty |= resources
+	if resources&RepositoryWorktree != 0 {
+		s.refreshActiveIdentity()
+	}
 	if resources&RepositoryWorktree != 0 && s.currentRoot != "" {
 		s.dirty |= RepositoryCurrentChanges
 		s.currentDirty = true
@@ -340,7 +364,6 @@ func (s *RepositoryState) HandleStatus(result *RepositoryStatusResult) {
 				group = previous
 			}
 		}
-
 		revision := entry.Revision
 		if entry.RevisionErr != nil {
 			hadError = true
@@ -490,6 +513,10 @@ func (s *RepositoryState) Close() {
 		s.statusCancel()
 		s.statusCancel = nil
 	}
+	if s.identityCancel != nil {
+		s.identityCancel()
+		s.identityCancel = nil
+	}
 	if s.changes != nil {
 		s.changes.CancelHistoryRead()
 	}
@@ -542,6 +569,115 @@ func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatus
 	return entries
 }
 
+func readRepositoryIdentity(ctx context.Context, filePath string, seq uint64) *RepositoryIdentityResult {
+	identity, err := git.ReadRepositoryIdentityContext(ctx, filepath.Dir(filePath))
+	return &RepositoryIdentityResult{Seq: seq, FilePath: filePath, Identity: identity, Err: err}
+}
+
+func (s *RepositoryState) SetActiveFile(filePath string) {
+	if s == nil || s.closed {
+		return
+	}
+	filePath = cleanAbsolutePath(filePath)
+	if filePath == s.activeFile {
+		return
+	}
+	if s.identityCancel != nil {
+		s.identityCancel()
+		s.identityCancel = nil
+	}
+	s.identitySeq++
+	s.activeFile = filePath
+	s.activeRoot = ""
+	s.activeBranch = ""
+	if filePath == "" {
+		return
+	}
+	if identity, ok := s.repositoryForPath(filePath); ok {
+		s.activeRoot = identity.Root
+		s.activeBranch = identity.Branch
+	}
+	s.refreshActiveIdentity()
+}
+
+func (s *RepositoryState) refreshActiveIdentity() {
+	if s == nil || s.closed || s.activeFile == "" {
+		return
+	}
+	if s.identityCancel != nil {
+		s.identityCancel()
+		s.identityCancel = nil
+	}
+	s.identitySeq++
+	seq := s.identitySeq
+	filePath := s.activeFile
+	read := s.readIdentity
+	ctx, cancel := context.WithTimeout(context.Background(), s.statusWait)
+	s.identityCancel = cancel
+	if s.poster == nil {
+		result := read(ctx, filePath, seq)
+		cancel()
+		s.HandleIdentity(result)
+		return
+	}
+	poster := s.poster
+	go func() {
+		result := read(ctx, filePath, seq)
+		cancel()
+		_ = poster.PostEvent(tcell.NewEventInterrupt(result))
+	}()
+}
+
+func (s *RepositoryState) HandleIdentity(result *RepositoryIdentityResult) {
+	if s == nil || result == nil || s.closed || result.Seq != s.identitySeq || result.FilePath != s.activeFile {
+		return
+	}
+	s.identityCancel = nil
+	if result.Err != nil {
+		return
+	}
+	identity := result.Identity
+	identity.Root = cleanAbsolutePath(identity.Root)
+	if identity.Root == "" {
+		return
+	}
+	s.identities[identity.Root] = identity
+	s.activeRoot = identity.Root
+	s.activeBranch = identity.Branch
+}
+
+func (s *RepositoryState) ActiveRepository() (string, string) {
+	if s == nil {
+		return "", ""
+	}
+	return s.activeRoot, s.activeBranch
+}
+
+func (s *RepositoryState) RepositoryForPath(path string) (string, string) {
+	identity, ok := s.repositoryForPath(path)
+	if !ok {
+		return "", ""
+	}
+	return identity.Root, identity.Branch
+}
+
+func (s *RepositoryState) repositoryForPath(path string) (git.RepositoryIdentity, bool) {
+	if s == nil || path == "" {
+		return git.RepositoryIdentity{}, false
+	}
+	identityPath, err := s.resolvePathIdentity(path)
+	if err != nil {
+		return git.RepositoryIdentity{}, false
+	}
+	best := git.RepositoryIdentity{}
+	for root, identity := range s.identities {
+		if pathWithin(root, identityPath) && len(root) > len(best.Root) {
+			best = identity
+		}
+	}
+	return best, best.Root != ""
+}
+
 func (s *RepositoryState) previousRootForSource(source string) string {
 	if root := s.lastRoots[source]; root != "" {
 		return root
@@ -578,6 +714,9 @@ func (s *RepositoryState) repositoryIdentityRoots() []string {
 	}
 	for _, dir := range s.dirs {
 		add(dir)
+	}
+	for root := range s.identities {
+		add(root)
 	}
 	return roots
 }
@@ -681,6 +820,20 @@ func (a *App) syncRepositoryObservation() {
 		a.Repository.SetCurrentChangesRoot("", "")
 	}
 	a.Repository.SetVisible(visible)
+}
+
+func (a *App) SyncRepositoryBranch() string {
+	if a == nil || a.Repository == nil || a.Status == nil || a.EditorGroup == nil {
+		return ""
+	}
+	filePath := a.EditorGroup.ActiveFilePath()
+	if a.EditorGroup.IsActiveVirtual() {
+		filePath = ""
+	}
+	a.Repository.SetActiveFile(filePath)
+	root, branch := a.Repository.ActiveRepository()
+	a.Status.SetSegment(view.StatusSegment{ID: "branch", Side: "left", Priority: 100, Text: branch})
+	return root
 }
 
 func (a *App) invalidateRepositoryPath(path string, resources RepositoryResource) {

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -133,6 +133,64 @@ func TestRepositoryInvalidationBurstCoalesces(t *testing.T) {
 	}
 }
 
+func TestActiveRepositoryIdentityIsCachedPerFileAndClearsOutsideGit(t *testing.T) {
+	repo := t.TempDir()
+	nested := filepath.Join(repo, "nested", "file.txt")
+	plain := filepath.Join(t.TempDir(), "plain.txt")
+	if err := os.MkdirAll(filepath.Dir(nested), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{nested, plain} {
+		if err := os.WriteFile(path, []byte("content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := NewRepositoryState(nil, nil)
+	reads := 0
+	branch := "feature"
+	fail := false
+	s.readIdentity = func(_ context.Context, path string, seq uint64) *RepositoryIdentityResult {
+		reads++
+		result := &RepositoryIdentityResult{Seq: seq, FilePath: path}
+		if path == nested && !fail {
+			result.Identity = git.RepositoryIdentity{Root: repo, Branch: branch}
+		} else {
+			result.Err = errors.New("not a repository")
+		}
+		return result
+	}
+
+	s.SetActiveFile(nested)
+	for range 10 {
+		s.SetActiveFile(nested)
+	}
+	if root, branch := s.ActiveRepository(); root != repo || branch != "feature" || reads != 1 {
+		t.Fatalf("cached active identity = (%q, %q), reads=%d", root, branch, reads)
+	}
+
+	fail = true
+	s.refreshActiveIdentity()
+	if root, branch := s.ActiveRepository(); root != repo || branch != "feature" || reads != 2 {
+		t.Fatalf("failed refresh replaced active identity = (%q, %q), reads=%d", root, branch, reads)
+	}
+	fail = false
+	branch = "updated"
+	s.refreshActiveIdentity()
+	if root, activeBranch := s.ActiveRepository(); root != repo || activeBranch != "updated" || reads != 3 {
+		t.Fatalf("successful refresh identity = (%q, %q), reads=%d", root, activeBranch, reads)
+	}
+
+	s.SetActiveFile(plain)
+	if root, branch := s.ActiveRepository(); root != "" || branch != "" || reads != 4 {
+		t.Fatalf("plain active identity = (%q, %q), reads=%d, want cleared", root, branch, reads)
+	}
+	s.SetActiveFile("")
+	if root, branch := s.ActiveRepository(); root != "" || branch != "" {
+		t.Fatalf("virtual active identity = (%q, %q), want cleared", root, branch)
+	}
+}
+
 func TestRepositoryInFlightInvalidationPublishesOnlyOneFollowUp(t *testing.T) {
 	cp := NewChangesPanel("/repo")
 	publications := 0

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -191,6 +191,182 @@ func TestActiveRepositoryIdentityIsCachedPerFileAndClearsOutsideGit(t *testing.T
 	}
 }
 
+func TestReadRepositoryIdentityUsesStableFileSymlinkIdentity(t *testing.T) {
+	repo := testAppRepository(t)
+	target := filepath.Join(repo, "nested", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	external := t.TempDir()
+	link := filepath.Join(external, "file-link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	result := readRepositoryIdentity(context.Background(), link, 7)
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	if result.Seq != 7 || result.FilePath != link {
+		t.Fatalf("result identity = seq %d path %q, want seq 7 presentation path %q", result.Seq, result.FilePath, link)
+	}
+	if result.Identity.Root != repo || result.Identity.Branch != "main" {
+		t.Fatalf("repository identity = %+v, want root %q branch main", result.Identity, repo)
+	}
+
+	missing := filepath.Join(repo, "missing", "deeper", "file.txt")
+	result = readRepositoryIdentity(context.Background(), missing, 8)
+	if result.Err != nil || result.FilePath != missing || result.Identity.Root != repo || result.Identity.Branch != "main" {
+		t.Fatalf("missing-file repository identity = %+v, want presentation path %q root %q branch main", result, missing, repo)
+	}
+}
+
+func TestRepositoryDiscoveryDirectoryHandlesSymlinksMissingPathsAndInvalidLinks(t *testing.T) {
+	repo := t.TempDir()
+	nested := filepath.Join(repo, "nested")
+	external := t.TempDir()
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(nested, "file.txt")
+	if err := os.WriteFile(target, []byte("content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fileLink := filepath.Join(external, "file-link.txt")
+	dirLink := filepath.Join(external, "dir-link")
+	broken := filepath.Join(external, "broken")
+	cycleA := filepath.Join(external, "cycle-a")
+	cycleB := filepath.Join(external, "cycle-b")
+	links := [][2]string{
+		{target, fileLink},
+		{nested, dirLink},
+		{filepath.Join(external, "missing-target"), broken},
+		{cycleB, cycleA},
+		{cycleA, cycleB},
+	}
+	for _, link := range links {
+		if err := os.Symlink(link[0], link[1]); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantDir string
+		wantErr bool
+	}{
+		{name: "file symlink", path: fileLink, wantDir: nested},
+		{name: "directory symlink", path: filepath.Join(dirLink, "file.txt"), wantDir: nested},
+		{name: "missing file", path: filepath.Join(nested, "missing.txt"), wantDir: nested},
+		{name: "deep missing path", path: filepath.Join(dirLink, "missing", "deeper", "file.txt"), wantDir: nested},
+		{name: "broken file symlink", path: broken, wantErr: true},
+		{name: "broken directory symlink", path: filepath.Join(broken, "file.txt"), wantErr: true},
+		{name: "file symlink cycle", path: cycleA, wantErr: true},
+		{name: "directory symlink cycle", path: filepath.Join(cycleA, "file.txt"), wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, err := repositoryDiscoveryDirectory(test.path)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("discovery directory = %q, want error", dir)
+				}
+				return
+			}
+			if err != nil || dir != test.wantDir {
+				t.Fatalf("discovery directory = (%q, %v), want %q", dir, err, test.wantDir)
+			}
+		})
+	}
+}
+
+func TestRepositoryForPathUsesStableFileIdentityAndLongestNestedRoot(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "nested")
+	if err := os.Mkdir(inner, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(inner, "file.txt")
+	if err := os.WriteFile(target, []byte("content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "file-link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	s := NewRepositoryState(nil, nil)
+	s.identities[outer] = git.RepositoryIdentity{Root: outer, Branch: "outer"}
+	s.identities[inner] = git.RepositoryIdentity{Root: inner, Branch: "inner"}
+	root, branch := s.RepositoryForPath(link)
+	if root != inner || branch != "inner" {
+		t.Fatalf("linked nested identity = (%q, %q), want (%q, inner)", root, branch, inner)
+	}
+}
+
+func TestActiveRepositoryIdentityCancelsSupersededReadAndDropsStaleGeneration(t *testing.T) {
+	first := filepath.Join(t.TempDir(), "first.txt")
+	second := filepath.Join(t.TempDir(), "second.txt")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte("content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s, _, poster := testRepositoryState(nil, "")
+	s.statusWait = time.Hour
+	firstStarted := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	s.readIdentity = func(ctx context.Context, path string, seq uint64) *RepositoryIdentityResult {
+		if path == first {
+			close(firstStarted)
+			<-ctx.Done()
+			close(firstCanceled)
+			return &RepositoryIdentityResult{Seq: seq, FilePath: path, Err: ctx.Err()}
+		}
+		return &RepositoryIdentityResult{
+			Seq:      seq,
+			FilePath: path,
+			Identity: git.RepositoryIdentity{Root: filepath.Dir(path), Branch: "second"},
+		}
+	}
+
+	s.SetActiveFile(first)
+	<-firstStarted
+	firstSeq := s.identitySeq
+	s.SetActiveFile(second)
+	select {
+	case <-firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("superseded identity read was not canceled")
+	}
+	for range 2 {
+		data := poster.await(t)
+		result, ok := data.(*RepositoryIdentityResult)
+		if !ok {
+			t.Fatalf("identity event type = %T", data)
+		}
+		s.HandleIdentity(result)
+	}
+	if root, branch := s.ActiveRepository(); root != filepath.Dir(second) || branch != "second" {
+		t.Fatalf("active identity = (%q, %q), want second file identity", root, branch)
+	}
+
+	s.HandleIdentity(&RepositoryIdentityResult{
+		Seq:      firstSeq,
+		FilePath: first,
+		Identity: git.RepositoryIdentity{Root: filepath.Dir(first), Branch: "stale"},
+	})
+	if root, branch := s.ActiveRepository(); root != filepath.Dir(second) || branch != "second" {
+		t.Fatalf("stale generation replaced active identity = (%q, %q)", root, branch)
+	}
+	s.Close()
+}
+
 func TestRepositoryInFlightInvalidationPublishesOnlyOneFollowUp(t *testing.T) {
 	cp := NewChangesPanel("/repo")
 	publications := 0

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -19,6 +19,23 @@ type FileStatus struct {
 	Staged  bool
 }
 
+type RepositoryIdentity struct {
+	Root   string
+	Branch string
+}
+
+func ReadRepositoryIdentityContext(ctx context.Context, dir string) (RepositoryIdentity, error) {
+	root, err := RepoRootWithErrorContext(ctx, dir)
+	if err != nil {
+		return RepositoryIdentity{}, err
+	}
+	branch, err := BranchNameContext(ctx, root)
+	if err != nil {
+		return RepositoryIdentity{}, err
+	}
+	return RepositoryIdentity{Root: root, Branch: branch}, nil
+}
+
 func RepoRoot(dir string) string {
 	return RepoRootContext(context.Background(), dir)
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -193,6 +193,32 @@ func TestRevisionIdentityAllowsUnbornRepository(t *testing.T) {
 	}
 }
 
+func TestReadRepositoryIdentityFindsLinkedWorktreeFromNestedDirectory(t *testing.T) {
+	repo := setupTestRepo(t)
+	writeFile(t, repo, "initial.txt", "initial\n")
+	gitRun(t, repo, "add", "initial.txt")
+	gitRun(t, repo, "commit", "-m", "initial")
+
+	linked := filepath.Join(t.TempDir(), "linked")
+	gitRun(t, repo, "worktree", "add", "-q", "-b", "linkedbranch", linked)
+	info, err := os.Stat(filepath.Join(linked, ".git"))
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("linked worktree .git = (%v, %v), want regular file", info, err)
+	}
+	nested := filepath.Join(linked, "nested", "deeper")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := ReadRepositoryIdentityContext(context.Background(), nested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Root != linked || identity.Branch != "linkedbranch" {
+		t.Fatalf("linked identity = %+v, want root %q branch linkedbranch", identity, linked)
+	}
+}
+
 func TestRevisionIdentityRequiresVerifiedUnbornHead(t *testing.T) {
 	bin := t.TempDir()
 	script := `#!/bin/sh

--- a/tests/e2e/repository_identity_test.go
+++ b/tests/e2e/repository_identity_test.go
@@ -1,0 +1,51 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestLinkedWorktreeBranchFollowsActiveFileAndClearsOutsideRepository(t *testing.T) {
+	h := newTestHarness(t, 100, 30)
+	defer h.stop()
+
+	container := t.TempDir()
+	repo := filepath.Join(container, "primary")
+	linked := filepath.Join(container, "linked")
+	if err := os.Mkdir(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "initial.txt"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	initializeHarnessRepository(t, repo)
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", "-q", "-b", "linkedbranch", linked)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, output)
+	}
+	info, err := os.Stat(filepath.Join(linked, ".git"))
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("linked worktree .git = (%v, %v), want regular file", info, err)
+	}
+
+	nested := filepath.Join(linked, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkedFile := filepath.Join(nested, "linked.txt")
+	if err := os.WriteFile(linkedFile, []byte("linked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h.app.EditorGroup.OpenFile(linkedFile)
+	h.app.SyncRepositoryBranch()
+	h.redraw()
+	h.assertContains("linkedbranch")
+
+	h.app.EditorGroup.OpenFile(filepath.Join(h.dir, "alpha.txt"))
+	h.app.SyncRepositoryBranch()
+	h.redraw()
+	h.assertNotContains("linkedbranch")
+}

--- a/tests/functional/audit-workspace-bugs.test.js
+++ b/tests/functional/audit-workspace-bugs.test.js
@@ -1,12 +1,9 @@
-// Repro test for confirmed bug from audit/2026-07-12-ux-bug-audit.md (branch audit/bug-hunt).
-// Asserts the CORRECT behavior with `it.fails` — passes while the bug
-// exists, goes red when fixed. Remove `.fails` + audit entry when fixing.
 import { describe, it, expect, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import * as tui from "./tui.js";
-import { createTempDir, cleanupDir } from "./helpers.js";
+import { createLinkedWorktree, createTempDir, cleanupDir } from "./helpers.js";
 
 let dir;
 
@@ -16,7 +13,7 @@ afterEach(() => {
 });
 
 describe("BUG-044: git branch indicator missing when the opened file is below the repo root", () => {
-  it.fails("status bar shows the branch for a file in a repo subdirectory", () => {
+  it("status bar shows the branch for a file in a repo subdirectory", () => {
     dir = createTempDir();
     // Make `dir` a git repo with a subdirectory and a distinctively-named
     // branch so the assertion can't match incidental "main" text elsewhere.
@@ -38,9 +35,33 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
-    // Correct: isGitRepo should walk up and find dir/.git (as the Changes
-    // panel does via `git rev-parse --show-toplevel`), so the branch shows.
-    // Buggy: no walk-up, so the status bar has no branch segment.
     expect(snapshots[s]).toContain("auditbranch");
+  });
+
+  it("uses linked-worktree identity and clears it on a non-repository tab", () => {
+    dir = createTempDir();
+    const { worktree } = createLinkedWorktree(dir, "linkedbranch");
+    expect(readFileSync(join(worktree, ".git"), "utf8")).toMatch(/^gitdir: /);
+
+    const nested = join(worktree, "nested");
+    mkdirSync(nested);
+    const linkedFile = join(nested, "linked.txt");
+    writeFileSync(linkedFile, "linked content\n");
+
+    const plainDir = join(dir, "plain");
+    mkdirSync(plainDir);
+    const plainFile = join(plainDir, "plain.txt");
+    writeFileSync(plainFile, "plain content\n");
+
+    tui.start(plainFile, linkedFile);
+    tui.waitFor("linkedbranch");
+    const linked = tui.snapshot();
+    tui.exec("View: Previous Tab");
+    tui.waitStable();
+    const plain = tui.snapshot();
+    const { snapshots } = tui.run();
+
+    expect(snapshots[linked]).toContain("linkedbranch");
+    expect(snapshots[plain]).not.toContain("linkedbranch");
   });
 });

--- a/tests/functional/audit-workspace-bugs.test.js
+++ b/tests/functional/audit-workspace-bugs.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import * as tui from "./tui.js";
-import { createLinkedWorktree, createTempDir, cleanupDir } from "./helpers.js";
+import { createGitRepo, createLinkedWorktree, createTempDir, cleanupDir, git } from "./helpers.js";
 
 let dir;
 
@@ -63,5 +63,31 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
 
     expect(snapshots[linked]).toContain("linkedbranch");
     expect(snapshots[plain]).not.toContain("linkedbranch");
+  });
+
+  it("shows the target repository branch through an external file symlink", () => {
+    dir = createTempDir();
+    const repo = join(dir, "repo");
+    mkdirSync(repo);
+    createGitRepo(repo);
+    git(repo, "branch", "-m", "filesymlinkbranch");
+
+    const nested = join(repo, "nested");
+    mkdirSync(nested);
+    const target = join(nested, "file.txt");
+    writeFileSync(target, "symlink target\n");
+    git(repo, "add", "nested/file.txt");
+    git(repo, "commit", "-qm", "add symlink target");
+
+    const plain = join(dir, "plain");
+    mkdirSync(plain);
+    const link = join(plain, "file-link.txt");
+    symlinkSync(target, link);
+
+    tui.start(link);
+    tui.waitFor("filesymlinkbranch");
+    const screen = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[screen]).toContain("filesymlinkbranch");
   });
 });

--- a/tests/functional/audit-workspace-bugs.test.js
+++ b/tests/functional/audit-workspace-bugs.test.js
@@ -65,7 +65,7 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
     expect(snapshots[plain]).not.toContain("linkedbranch");
   });
 
-  it("shows the target repository branch through an external file symlink", () => {
+  it("shows the target repository branch without false gutter markers through an external file symlink", () => {
     dir = createTempDir();
     const repo = join(dir, "repo");
     mkdirSync(repo);
@@ -86,8 +86,10 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
 
     tui.start(link);
     tui.waitFor("filesymlinkbranch");
+    tui.waitStable();
     const screen = tui.snapshot();
     const { snapshots } = tui.run();
     expect(snapshots[screen]).toContain("filesymlinkbranch");
+    expect(snapshots[screen]).not.toContain("│▎");
   });
 });

--- a/tests/functional/helpers.js
+++ b/tests/functional/helpers.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -27,6 +27,15 @@ export function createGitRepo(dir) {
   git(dir, "add", "tracked.txt");
   git(dir, "commit", "-qm", "initial commit");
   return dir;
+}
+
+export function createLinkedWorktree(dir, branch = "linkedbranch") {
+  const repo = join(dir, "primary");
+  const worktree = join(dir, "linked");
+  mkdirSync(repo);
+  createGitRepo(repo);
+  git(repo, "worktree", "add", "-q", "-b", branch, worktree);
+  return { repo, worktree };
 }
 
 // gitStatus returns porcelain status lines, e.g. ["M  tracked.txt"].


### PR DESCRIPTION
## Summary

- observe each active non-virtual file through `RepositoryState` and cache its canonical Git worktree root and branch
- resolve the stable real identity of the full file path before choosing a Git discovery directory, while keeping editor and tab presentation paths lexical
- use the nearest stably resolvable existing parent for missing files; decline broken links, symlink cycles, permission failures, or unstable identities
- use canonical file identity for the Git-relative gutter lookup, so an unchanged tracked target opened through an external file symlink has no false added-line markers
- clear repository presentation when the active tab is plain or virtual

## Corrected invariant

For every active non-virtual file whose identity can be stably resolved inside a valid Git worktree, TTT shows that worktree's canonical branch regardless of whether the opened path is below the repository root, the worktree uses a `.git` file, or the presentation path traverses a directory or file symlink. For an unchanged tracked file opened through an external symlink, the gutter is computed from the canonical target path and renders no change markers, while the editor retains the lexical presentation path.

Missing files use their nearest stably resolvable existing parent. Broken links and symlink cycles produce no repository identity. Switching to a non-repository or virtual file clears the branch. Longest nested-root selection, linked-worktree identity, cancellation, stale-generation rejection, and last-good identity preservation on transient failures remain intact.

## Adversarial blocker corrections

- At `5014512`, `/plain/file-link.txt -> /repo/nested/file.txt` rendered target content but left the branch blank because Git discovery started from `/plain`. Full-file stable identity now drives repository discovery.
- At `2df8835`, branch identity was correct, but `RequestGitGutter` still computed `filepath.Rel(repoDir, lexicalPath)`, escaped the repository, and rendered every unchanged line as added. Gutter lookup now resolves the stable file identity before deriving its Git-relative path; the async result still carries the lexical path.

The permanent functional regression failed before the second correction with the visible frame containing both `filesymlinkbranch` and `│▎`, then passed after the correction with the branch present and no marker.

## Verification at `1bca401`

- `go test -race ./internal/app -run 'Test(ActiveRepositoryIdentity|ReadRepositoryIdentity|RepositoryDiscoveryDirectory|RepositoryForPath|RepositoryInvalidation)' -count=1`
- `go test ./tests/e2e -run TestLinkedWorktreeBranchFollowsActiveFileAndClearsOutsideRepository -count=1`
- `make build`
- `pnpm --dir tests/functional exec vitest run audit-workspace-bugs.test.js --reporter=verbose` (3 passed)
- `git diff --check`

The deterministic `--exec` proof used one validated, owned temp root containing a repository, an external plain directory, and a file symlink. It checked both output files existed before assertions, then verified:

- the visible frame showed `filesymlinkbranch`
- the unchanged target rendered `│  1` / `│  2` with no `│▎`
- debug state retained the lexical `/plain/file-link.txt` presentation path
- the exact temp root was removed by its cleanup trap

The earlier disposable named real-PTY pass verified linked/file-symlink repository presentation and plain-tab clearing; its session was stopped and its exact fixture root removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed branch indicators for files in nested repositories and linked worktrees.
  * Improved repository detection for files accessed through symlinks, missing-file paths, and files below repository roots.
  * Prevented incorrect gutter markers for external or invalid symlink paths.
  * Branch information now refreshes when switching files or repositories and clears outside Git repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->