### PR TITLE
ci: enable unused linter, remove dead code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,4 +8,4 @@ linters:
     # - errcheck     # https://github.com/eugenioenko/ttt/issues/505
     # - staticcheck  # https://github.com/eugenioenko/ttt/issues/506
     # - ineffassign  # https://github.com/eugenioenko/ttt/issues/507
-    # - unused       # https://github.com/eugenioenko/ttt/issues/508
+    - unused

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -1112,10 +1112,6 @@ func (d *CommitDetailWidget) renderUnifiedDiffRow(surface Surface, rowIndex int,
 	renderDiffText(surface, contentStart, y, contentW, line.Text, style, diffKindForeground(line.Kind, d.highContrast), spans, visual.leftStart, leftScroll, d.selectionDecorator(rowIndex, false))
 }
 
-func (d *CommitDetailWidget) drawText(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool, segmentStart int) {
-	d.drawTextRow(surface, x, y, width, text, style, bg, bold, segmentStart, -1)
-}
-
 func (d *CommitDetailWidget) drawStaticText(surface Surface, x, y, width int, text string, style, bg term.Style, bold bool) {
 	blank := term.Cell{Ch: ' ', Style: style, BgStyle: bg}
 	drawTextSegment(surface, x, y, width, text, 0, 0, blank, func(_ int, ch rune) term.Cell {


### PR DESCRIPTION
## Summary
- Removes `CommitDetailWidget.drawText` (`internal/ui/commit_detail_widget.go`), a dead method with zero call sites elsewhere in the repo
- Uncomments the `unused` linter in `.golangci.yml`, which was disabled in #477 pending this cleanup

## Test plan
- [x] `golangci-lint run --enable-only=unused ./...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...`
- [x] `go test ./...`

Closes #508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled additional automated checks for unused code.
  * Removed an unused internal helper without changing visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->