### PR TITLE
fix(git): canonicalize external symlink blame

### DIFF
--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -143,8 +143,12 @@ func RunEventLoop(
 				blameGen++
 				gen := blameGen
 				blameLine := line + 1
+				blameFile, ok := app.Repository.gitRelativePath(repoDir, filePath)
 				go func() {
-					info := git.BlameLine(repoDir, filePath, blameLine)
+					var info *git.BlameInfo
+					if ok {
+						info = git.BlameLine(repoDir, blameFile, blameLine)
+					}
 					screen.PostEvent(tcell.NewEventInterrupt(&BlameResult{Gen: gen, Info: info}))
 				}()
 			}

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -138,9 +138,9 @@ func RunEventLoop(
 			lastBlameFile = filePath
 			lastBlameLine = line
 			lastBlameRepo = repoDir
+			blameGen++
 			app.Status.SetSegment(view.StatusSegment{ID: "blame", Side: "left", Priority: 200, Text: ""})
 			if repoDir != "" {
-				blameGen++
 				gen := blameGen
 				blameLine := line + 1
 				blameFile, ok := app.Repository.gitRelativePath(repoDir, filePath)

--- a/internal/app/gitgutter.go
+++ b/internal/app/gitgutter.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,16 +35,10 @@ func (a *App) RequestGitGutter(filePath string, bufferLines []string) {
 		return
 	}
 
-	gitPath, err := a.Repository.resolvePathIdentity(filePath)
-	if err != nil || !pathWithin(repoDir, gitPath) {
+	relPath, ok := a.Repository.gitRelativePath(repoDir, filePath)
+	if !ok {
 		return
 	}
-	relPath, err := filepath.Rel(repoDir, gitPath)
-	if err != nil {
-		return
-	}
-	// Normalize to forward slashes for git
-	relPath = filepath.ToSlash(relPath)
 
 	a.GitGutterGen++
 	gen := a.GitGutterGen

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -867,6 +867,21 @@ func pathWithin(root, path string) bool {
 	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
+func (s *RepositoryState) gitRelativePath(root, path string) (string, bool) {
+	if s == nil || root == "" || path == "" {
+		return "", false
+	}
+	resolved, err := s.resolvePathIdentity(path)
+	if err != nil || !pathWithin(root, resolved) {
+		return "", false
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
 func (a *App) syncRepositoryObservation() {
 	if a == nil || a.Repository == nil || a.Sidebar == nil || a.SplitPanel == nil {
 		return

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -192,7 +192,7 @@ func TestActiveRepositoryIdentityIsCachedPerFileAndClearsOutsideGit(t *testing.T
 }
 
 func TestReadRepositoryIdentityUsesStableFileSymlinkIdentity(t *testing.T) {
-	repo := testAppRepository(t)
+	repo := canonicalTestPath(t, testAppRepository(t))
 	target := filepath.Join(repo, "nested", "file.txt")
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		t.Fatal(err)
@@ -200,7 +200,7 @@ func TestReadRepositoryIdentityUsesStableFileSymlinkIdentity(t *testing.T) {
 	if err := os.WriteFile(target, []byte("content\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	external := t.TempDir()
+	external := canonicalTestPath(t, t.TempDir())
 	link := filepath.Join(external, "file-link.txt")
 	if err := os.Symlink(target, link); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
@@ -224,10 +224,54 @@ func TestReadRepositoryIdentityUsesStableFileSymlinkIdentity(t *testing.T) {
 	}
 }
 
+func TestGitRelativePathEnablesBlameForExternalFileSymlink(t *testing.T) {
+	repo := canonicalTestPath(t, testAppRepository(t))
+	target := filepath.Join(repo, "nested", "blamed.txt")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("blamed line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testAppGit(t, repo, "add", "nested/blamed.txt")
+	testAppGit(t, repo, "commit", "-m", "add blamed file")
+
+	external := canonicalTestPath(t, t.TempDir())
+	link := filepath.Join(external, "blamed-link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if info := git.BlameLine(repo, link, 1); info != nil {
+		t.Fatalf("raw external blame = %+v, want nil", info)
+	}
+
+	state := NewRepositoryState(nil, nil)
+	blamePath, ok := state.gitRelativePath(repo, link)
+	if !ok || blamePath != "nested/blamed.txt" {
+		t.Fatalf("canonical blame path = (%q, %t), want nested/blamed.txt", blamePath, ok)
+	}
+	info := git.BlameLine(repo, blamePath, 1)
+	if info == nil || info.Author != "Test User" {
+		t.Fatalf("canonical blame = %+v, want Test User", info)
+	}
+
+	outsideTarget := filepath.Join(external, "outside.txt")
+	if err := os.WriteFile(outsideTarget, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outsideLink := filepath.Join(canonicalTestPath(t, t.TempDir()), "outside-link.txt")
+	if err := os.Symlink(outsideTarget, outsideLink); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if path, ok := state.gitRelativePath(repo, outsideLink); ok {
+		t.Fatalf("outside blame path = %q, want containment rejection", path)
+	}
+}
+
 func TestRepositoryDiscoveryDirectoryHandlesSymlinksMissingPathsAndInvalidLinks(t *testing.T) {
-	repo := t.TempDir()
+	repo := canonicalTestPath(t, t.TempDir())
 	nested := filepath.Join(repo, "nested")
-	external := t.TempDir()
+	external := canonicalTestPath(t, t.TempDir())
 	if err := os.Mkdir(nested, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +329,7 @@ func TestRepositoryDiscoveryDirectoryHandlesSymlinksMissingPathsAndInvalidLinks(
 }
 
 func TestRepositoryForPathUsesStableFileIdentityAndLongestNestedRoot(t *testing.T) {
-	outer := t.TempDir()
+	outer := canonicalTestPath(t, t.TempDir())
 	inner := filepath.Join(outer, "nested")
 	if err := os.Mkdir(inner, 0o755); err != nil {
 		t.Fatal(err)
@@ -1124,6 +1168,15 @@ func testAppRepository(t *testing.T) string {
 	testAppGit(t, dir, "add", "initial.txt")
 	testAppGit(t, dir, "commit", "-m", "initial")
 	return dir
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
 }
 
 func testAppGit(t *testing.T, dir string, args ...string) {

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -587,7 +587,7 @@ func TestRepositoryRootFailurePreservesCanonicalMultiRootOrderAndRecovers(t *tes
 }
 
 func TestRepositoryRootFailureDeduplicatesCanonicalRepositoryAndRecovers(t *testing.T) {
-	repo := t.TempDir()
+	repo := canonicalTestPath(t, t.TempDir())
 	sourceA := filepath.Join(repo, "workspace-a")
 	sourceB := filepath.Join(repo, "workspace-b")
 	for _, source := range []string{sourceA, sourceB} {
@@ -830,8 +830,8 @@ func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePosit
 }
 
 func TestRepositoryInvalidationRejectsUnprovablePermissionAncestors(t *testing.T) {
-	repo := t.TempDir()
-	external := t.TempDir()
+	repo := canonicalTestPath(t, t.TempDir())
+	external := canonicalTestPath(t, t.TempDir())
 	restricted := filepath.Join(repo, "restricted")
 	plain := filepath.Join(repo, "plain")
 	for _, dir := range []string{restricted, plain} {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -199,7 +199,8 @@ func TestReadRepositoryIdentityFindsLinkedWorktreeFromNestedDirectory(t *testing
 	gitRun(t, repo, "add", "initial.txt")
 	gitRun(t, repo, "commit", "-m", "initial")
 
-	linked := filepath.Join(t.TempDir(), "linked")
+	linkedBase := canonicalTestPath(t, t.TempDir())
+	linked := filepath.Join(linkedBase, "linked")
 	gitRun(t, repo, "worktree", "add", "-q", "-b", "linkedbranch", linked)
 	info, err := os.Stat(filepath.Join(linked, ".git"))
 	if err != nil || !info.Mode().IsRegular() {
@@ -217,6 +218,15 @@ func TestReadRepositoryIdentityFindsLinkedWorktreeFromNestedDirectory(t *testing
 	if identity.Root != linked || identity.Branch != "linkedbranch" {
 		t.Fatalf("linked identity = %+v, want root %q branch linkedbranch", identity, linked)
 	}
+}
+
+func canonicalTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
 }
 
 func TestRevisionIdentityRequiresVerifiedUnbornHead(t *testing.T) {

--- a/tests/functional/audit-workspace-bugs.test.js
+++ b/tests/functional/audit-workspace-bugs.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, readFileSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";
+import { delimiter, join } from "node:path";
 import * as tui from "./tui.js";
 import { createGitRepo, createLinkedWorktree, createTempDir, cleanupDir, git } from "./helpers.js";
 
@@ -111,5 +111,32 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
     const { snapshots } = tui.run();
     expect(snapshots[screen]).toContain("modified target");
     expect(snapshots[screen]).toContain("│▎");
+  });
+
+  it("drops delayed external-symlink blame after switching to a non-repository tab", () => {
+    const { link } = createExternalFileSymlinkFixture();
+    const plainFile = join(dir, "plain", "plain.txt");
+    writeFileSync(plainFile, "plain content\n");
+
+    const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+    const binDir = join(dir, "bin");
+    mkdirSync(binDir);
+    const gitWrapper = join(binDir, "git");
+    writeFileSync(
+      gitWrapper,
+      '#!/bin/sh\nif [ "$3" = "blame" ]; then sleep 1; fi\nexec "$TTT_REAL_GIT" "$@"\n',
+    );
+    chmodSync(gitWrapper, 0o755);
+
+    tui.start(plainFile, link);
+    tui.setEnv({ PATH: `${binDir}${delimiter}${process.env.PATH}`, TTT_REAL_GIT: realGit });
+    tui.waitFor("filesymlinkbranch");
+    tui.exec("View: Previous Tab");
+    tui.wait(1300);
+    const screen = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[screen]).toContain("plain content");
+    expect(snapshots[screen]).not.toContain("filesymlinkbranch");
+    expect(snapshots[screen]).not.toContain("Test User");
   });
 });

--- a/tests/functional/audit-workspace-bugs.test.js
+++ b/tests/functional/audit-workspace-bugs.test.js
@@ -12,6 +12,27 @@ afterEach(() => {
   if (dir) cleanupDir(dir);
 });
 
+function createExternalFileSymlinkFixture() {
+  dir = createTempDir();
+  const repo = join(dir, "repo");
+  mkdirSync(repo);
+  createGitRepo(repo);
+  git(repo, "branch", "-m", "filesymlinkbranch");
+
+  const nested = join(repo, "nested");
+  mkdirSync(nested);
+  const target = join(nested, "file.txt");
+  writeFileSync(target, "symlink target\n");
+  git(repo, "add", "nested/file.txt");
+  git(repo, "commit", "-qm", "add symlink target");
+
+  const plain = join(dir, "plain");
+  mkdirSync(plain);
+  const link = join(plain, "file-link.txt");
+  symlinkSync(target, link);
+  return { target, link };
+}
+
 describe("BUG-044: git branch indicator missing when the opened file is below the repo root", () => {
   it("status bar shows the branch for a file in a repo subdirectory", () => {
     dir = createTempDir();
@@ -65,31 +86,30 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
     expect(snapshots[plain]).not.toContain("linkedbranch");
   });
 
-  it("shows the target repository branch without false gutter markers through an external file symlink", () => {
-    dir = createTempDir();
-    const repo = join(dir, "repo");
-    mkdirSync(repo);
-    createGitRepo(repo);
-    git(repo, "branch", "-m", "filesymlinkbranch");
-
-    const nested = join(repo, "nested");
-    mkdirSync(nested);
-    const target = join(nested, "file.txt");
-    writeFileSync(target, "symlink target\n");
-    git(repo, "add", "nested/file.txt");
-    git(repo, "commit", "-qm", "add symlink target");
-
-    const plain = join(dir, "plain");
-    mkdirSync(plain);
-    const link = join(plain, "file-link.txt");
-    symlinkSync(target, link);
+  it("shows target repository branch and blame without false gutter markers through an external file symlink", () => {
+    const { link } = createExternalFileSymlinkFixture();
 
     tui.start(link);
     tui.waitFor("filesymlinkbranch");
+    tui.waitFor("Test User");
     tui.waitStable();
     const screen = tui.snapshot();
     const { snapshots } = tui.run();
     expect(snapshots[screen]).toContain("filesymlinkbranch");
+    expect(snapshots[screen]).toContain("Test User");
     expect(snapshots[screen]).not.toContain("│▎");
+  });
+
+  it("shows a modified tracked target gutter marker through an external file symlink", () => {
+    const { target, link } = createExternalFileSymlinkFixture();
+    writeFileSync(target, "modified target\n");
+
+    tui.start(link);
+    tui.waitFor("filesymlinkbranch");
+    tui.waitFor("│▎");
+    const screen = tui.snapshot();
+    const { snapshots } = tui.run();
+    expect(snapshots[screen]).toContain("modified target");
+    expect(snapshots[screen]).toContain("│▎");
   });
 });


### PR DESCRIPTION
## Summary

- resolve active file identity to a contained repository-relative path before blame, sharing the Git gutter path rule while retaining lexical editor and tab paths
- invalidate blame generations on every blame-context change, including transitions to non-repository files, so delayed repository results cannot repopulate a cleared plain tab
- canonicalize all reviewed TempDir-derived expected repository roots so physical Git roots compare correctly under macOS-style aliased temp directories
- retain the unchanged external-symlink gutter regression and add positive modified-target and delayed-blame regressions

## Corrected invariant

For a file presented through an external symlink into a repository, branch, gutter, and blame operate on the canonical contained repository file while editor/tab presentation remains lexical. Every file, line, or repository blame-context change advances the generation before clearing status. Each attempted repository-backed refresh still posts exactly one `BlameResult`, and only a result matching the current generation may populate the status segment.

This PR does not include retry-loop bounding (#524) or repository refresh debouncing (#525).

## Fail-before / pass-after

### Canonical external-symlink blame

On pre-change main `286233b`, the new visible blame assertion timed out after `filesymlinkbranch` appeared: raw `git.BlameLine(repo, externalLink, 1)` returned nil, while the canonical `nested/file.txt` control returned `author Test User`. After correction, the visible frame contains the branch and `Test User`, keeps the lexical debug path, and retains correct unchanged/modified gutter behavior.

### Stale delayed blame

At reviewed head `d83fd68`, a controlled Git wrapper delayed external-symlink blame, the editor switched to an owned plain tab, and the eventual `Test User, just now` result incorrectly populated that plain tab. Moving generation invalidation ahead of the repository check makes the same regression pass: the plain content remains visible with neither repository branch nor blame.

### Aliased temporary roots

At `d83fd68`, the focused race run under a symlinked `TMPDIR` failed in `TestRepositoryRootFailureDeduplicatesCanonicalRepositoryAndRecovers` and `TestRepositoryInvalidationRejectsUnprovablePermissionAncestors`. Canonicalizing the reviewed `repo`/`external` expectations makes the full repository-identity focus pass without weakening comparisons.

## Verification at `fdde7b7`

- symlinked-`TMPDIR` `go test -race ./internal/app -run 'Test(ActiveRepositoryIdentity|ReadRepositoryIdentity|GitRelativePath|RepositoryDiscoveryDirectory|RepositoryForPath|RepositoryRootFailure|RepositoryInvalidation)' -count=1`
- symlinked-`TMPDIR` `go test -race ./internal/git -run 'Test(ReadRepositoryIdentity|BlameLine)' -count=1`
- `go test ./tests/e2e -run TestLinkedWorktreeBranchFollowsActiveFileAndClearsOutsideRepository -count=1`
- `make build`
- `pnpm --dir tests/functional exec vitest run audit-workspace-bugs.test.js --reporter=verbose` (5 passed)
- `git diff --check`

All disposable alias and functional fixtures were rooted in validated temp directories and removed after their runs.
