### PR TITLE
fix(git): bound repository identity retries

### DIFF
--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,10 +23,13 @@ const (
 
 	RepositoryStatus = RepositoryWorktree
 
-	repositoryRefreshDebounce = 150 * time.Millisecond
-	repositoryPollInterval    = 2 * time.Second
-	repositoryStatusTimeout   = 10 * time.Second
+	repositoryRefreshDebounce         = 150 * time.Millisecond
+	repositoryPollInterval            = 2 * time.Second
+	repositoryStatusTimeout           = 10 * time.Second
+	repositoryPathIdentityMaxAttempts = 8
 )
+
+var errRepositoryPathIdentityUnstable = errors.New("repository path identity is transiently unstable")
 
 type repositoryStatusEntry struct {
 	SourceDir   string
@@ -779,7 +783,7 @@ func resolveRepositoryPathIdentityWith(
 	abs = filepath.Clean(abs)
 
 resolve:
-	for {
+	for attempt := 0; attempt < repositoryPathIdentityMaxAttempts; attempt++ {
 		resolved, resolveErr := stableSymlinkIdentityWith(abs, evalSymlinks)
 		if resolveErr == nil {
 			return resolved, nil
@@ -827,6 +831,7 @@ resolve:
 			ancestor = parent
 		}
 	}
+	return "", fmt.Errorf("%w after %d attempts for %s", errRepositoryPathIdentityUnstable, repositoryPathIdentityMaxAttempts, abs)
 }
 
 func stableSymlinkIdentityWith(path string, evalSymlinks func(string) (string, error)) (string, error) {

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -298,17 +298,18 @@ func TestRepositoryDiscoveryDirectoryHandlesSymlinksMissingPathsAndInvalidLinks(
 	}
 
 	tests := []struct {
-		name    string
-		path    string
-		wantDir string
-		wantErr bool
+		name         string
+		path         string
+		wantDir      string
+		wantErr      bool
+		wantNotExist bool
 	}{
 		{name: "file symlink", path: fileLink, wantDir: nested},
 		{name: "directory symlink", path: filepath.Join(dirLink, "file.txt"), wantDir: nested},
 		{name: "missing file", path: filepath.Join(nested, "missing.txt"), wantDir: nested},
 		{name: "deep missing path", path: filepath.Join(dirLink, "missing", "deeper", "file.txt"), wantDir: nested},
-		{name: "broken file symlink", path: broken, wantErr: true},
-		{name: "broken directory symlink", path: filepath.Join(broken, "file.txt"), wantErr: true},
+		{name: "broken file symlink", path: broken, wantErr: true, wantNotExist: true},
+		{name: "broken directory symlink", path: filepath.Join(broken, "file.txt"), wantErr: true, wantNotExist: true},
 		{name: "file symlink cycle", path: cycleA, wantErr: true},
 		{name: "directory symlink cycle", path: filepath.Join(cycleA, "file.txt"), wantErr: true},
 	}
@@ -318,6 +319,12 @@ func TestRepositoryDiscoveryDirectoryHandlesSymlinksMissingPathsAndInvalidLinks(
 			if test.wantErr {
 				if err == nil {
 					t.Fatalf("discovery directory = %q, want error", dir)
+				}
+				if errors.Is(err, errRepositoryPathIdentityUnstable) {
+					t.Fatalf("permanent path error misclassified as transient instability: %v", err)
+				}
+				if test.wantNotExist && !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("broken link error = %v, want os.ErrNotExist", err)
 				}
 				return
 			}
@@ -698,6 +705,123 @@ func TestRepositoryScanCarriesSourceIdentityAndRootFailure(t *testing.T) {
 	}
 }
 
+func TestResolveRepositoryPathIdentityBoundsPersistentChurn(t *testing.T) {
+	if os.Getenv("TTT_TEST_REPOSITORY_PATH_CHURN") == "1" {
+		testResolveRepositoryPathIdentityPersistentChurn(t)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestResolveRepositoryPathIdentityBoundsPersistentChurn$")
+	cmd.Env = append(os.Environ(), "TTT_TEST_REPOSITORY_PATH_CHURN=1")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("persistent churn resolution did not terminate within 3s: %v", ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("persistent churn subprocess failed: %v\n%s", err, output)
+	}
+}
+
+func testResolveRepositoryPathIdentityPersistentChurn(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "repo")
+	ancestor := filepath.Join(base, "missing")
+	target := filepath.Join(ancestor, "file.txt")
+	stableTarget := filepath.Join(base, "canonical.txt")
+	churning := true
+	succeedOnAttempt := 0
+	stableAttempt := false
+	attempts := 0
+	targetRestarts := 0
+	ancestorRestarts := 0
+	targetLstatCalls := 0
+	ancestorLstatCalls := 0
+	notExist := func(op, path string) error {
+		return &os.PathError{Op: op, Path: path, Err: os.ErrNotExist}
+	}
+
+	evalSymlinks := func(path string) (string, error) {
+		if !churning && path == target {
+			return stableTarget, nil
+		}
+		switch path {
+		case target:
+			if stableAttempt {
+				return stableTarget, nil
+			}
+			attempts++
+			targetLstatCalls = 0
+			ancestorLstatCalls = 0
+			if attempts == succeedOnAttempt {
+				stableAttempt = true
+				return stableTarget, nil
+			}
+			return "", notExist("evalsymlinks", path)
+		case ancestor:
+			if attempts%2 == 0 {
+				return "", notExist("evalsymlinks", path)
+			}
+			return path, nil
+		case base:
+			return path, nil
+		default:
+			t.Fatalf("unexpected EvalSymlinks path %q", path)
+			return "", nil
+		}
+	}
+	lstat := func(path string) (os.FileInfo, error) {
+		switch path {
+		case target:
+			targetLstatCalls++
+			if attempts%2 == 1 && targetLstatCalls == 2 {
+				targetRestarts++
+				return nil, nil
+			}
+			return nil, notExist("lstat", path)
+		case ancestor:
+			ancestorLstatCalls++
+			if attempts%2 == 0 && ancestorLstatCalls == 2 {
+				ancestorRestarts++
+				return nil, nil
+			}
+			return nil, notExist("lstat", path)
+		default:
+			t.Fatalf("unexpected lstat path %q", path)
+			return nil, nil
+		}
+	}
+
+	resolved, err := resolveRepositoryPathIdentityWith(target, lstat, evalSymlinks)
+	wantErr := "repository path identity is transiently unstable after 8 attempts for " + target
+	if resolved != "" || err == nil || err.Error() != wantErr || !errors.Is(err, errRepositoryPathIdentityUnstable) {
+		t.Fatalf("persistent churn resolved=%q err=%v, want classified error %q", resolved, err, wantErr)
+	}
+	if attempts != repositoryPathIdentityMaxAttempts || targetRestarts != 4 || ancestorRestarts != 4 {
+		t.Fatalf("persistent churn attempts=%d target restarts=%d ancestor restarts=%d, want 8, 4, 4", attempts, targetRestarts, ancestorRestarts)
+	}
+
+	churning = false
+	resolved, err = resolveRepositoryPathIdentityWith(target, lstat, evalSymlinks)
+	if err != nil || resolved != stableTarget {
+		t.Fatalf("later stable retry resolved=%q err=%v, want %q", resolved, err, stableTarget)
+	}
+
+	churning = true
+	succeedOnAttempt = repositoryPathIdentityMaxAttempts
+	stableAttempt = false
+	attempts = 0
+	targetRestarts = 0
+	ancestorRestarts = 0
+	resolved, err = resolveRepositoryPathIdentityWith(target, lstat, evalSymlinks)
+	if err != nil || resolved != stableTarget {
+		t.Fatalf("last-attempt recovery resolved=%q err=%v, want %q", resolved, err, stableTarget)
+	}
+	if attempts != repositoryPathIdentityMaxAttempts || targetRestarts != 4 || ancestorRestarts != 3 {
+		t.Fatalf("last-attempt recovery attempts=%d target restarts=%d ancestor restarts=%d, want 8, 4, 3", attempts, targetRestarts, ancestorRestarts)
+	}
+}
+
 func TestRepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePositives(t *testing.T) {
 	repo := t.TempDir()
 	outside := t.TempDir()
@@ -873,8 +997,12 @@ func TestRepositoryInvalidationRejectsUnprovablePermissionAncestors(t *testing.T
 		t.Run(test.name, func(t *testing.T) {
 			s, _, _ := testRepositoryState(nil, repo)
 			s.pathIdentity = permissionDeniedRepositoryPathResolver(test.denied)
-			if resolved, err := s.resolvePathIdentity(test.path); resolved != "" || !errors.Is(err, os.ErrPermission) {
+			resolved, err := s.resolvePathIdentity(test.path)
+			if resolved != "" || !errors.Is(err, os.ErrPermission) {
 				t.Fatalf("permission seam resolved=%q err=%v, want os.ErrPermission", resolved, err)
+			}
+			if errors.Is(err, errRepositoryPathIdentityUnstable) {
+				t.Fatalf("permission error misclassified as transient instability: %v", err)
 			}
 			s.InvalidatePath(test.path, RepositoryWorktree)
 			if s.requested != 0 || s.dirty != 0 {


### PR DESCRIPTION
## Summary

- cap each repository path identity request at eight total outer-loop attempts, shared by both reappearance restart paths
- fail closed with an empty identity and a wrapped transient instability sentinel that includes the absolute path and attempt count
- keep retry state request-local so later refreshes retry normally, while preserving stable symlink, missing-path, broken-link, cycle, and permission behavior

## Invariant

One `resolveRepositoryPathIdentityWith` call enters the outer resolution loop at most eight times. Each `continue resolve` consumes the shared budget. The eighth attempt may still succeed; only another requested restart exhausts the request and returns `errRepositoryPathIdentityUnstable`. Incidental ENOENT and permanent permission or link errors retain their existing classification.

## Regression evidence

The injected lstat/EvalSymlinks regression alternates requested-path reappearance on odd attempts and missing-intermediate-ancestor reappearance on even attempts. It asserts exactly eight attempts, four visits through each restart branch, empty output plus `errors.Is(err, errRepositoryPathIdentityUnstable)`, successful retry by a later call, and success when stability returns on the final permitted attempt.

With the `origin/main` unbounded resolver body temporarily restored while retaining only the test declarations, the bounded subprocess failed before the fix:

```
--- FAIL: TestResolveRepositoryPathIdentityBoundsPersistentChurn (3.00s)
    repository_state_test.go:713: persistent churn resolution did not terminate within 3s: context deadline exceeded
```

At `3e67706`, the same test passes in 0.009s.

## Verification

- `go test ./internal/app -run Test\(ResolveRepositoryPathIdentityBoundsPersistentChurn\|ReadRepositoryIdentityUsesStableFileSymlinkIdentity\|RepositoryDiscoveryDirectoryHandlesSymlinksMissingPathsAndInvalidLinks\|RepositoryInvalidationResolvesSymlinkedParentsWithoutExternalFalsePositives\|RepositoryInvalidationRejectsUnprovablePermissionAncestors\|RepositoryInvalidationUsesCurrentSymlinkTargetAfterRetarget\)$ -count=1`
- `go test -race ./internal/app -count=1`
- `go test ./tests/e2e -count=1`
- `make build`
- `gofmt -d internal/app/repository_state.go internal/app/repository_state_test.go`
- `git diff --check`

`go test ./... -count=1` passed every package except the four established environment/baseline 5s timeouts in untouched `internal/ui/terminal_mouse_forward_test.go`: `TestTerminalWidget_ForwardsSGRMouseClickAndRelease`, `TestTerminalWidget_ForwardsSGRWheel`, `TestTerminalWidget_CtrlClickStaysLocalEvenWithMouseReporting`, and `TestTerminalWidget_TrackingWithoutSGRStaysLocal`. This branch has no UI, terminal, or dependency changes.

Closes #524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository path detection now stops after a limited number of retries when filesystem changes remain unstable.
  * Reports a clear transient-instability error when path resolution cannot complete.
  * Preserves accurate handling for missing paths and permission errors.

* **Tests**
  * Added coverage for persistent path changes, recovery after retries, broken links, and permission-denied scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->