### PR TITLE
perf(render): avoid full-grid copy on every frame

### DIFF
--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -23,12 +23,10 @@ func (r *Renderer) Render(screen term.Screen) {
 		}
 	}
 	screen.Show()
-	// Swap buffers
-	r.prev = make([][]term.Cell, len(r.curr))
-	for i := range r.curr {
-		r.prev[i] = make([]term.Cell, len(r.curr[i]))
-		copy(r.prev[i], r.curr[i])
-	}
+	// No copy needed: callers always pass a freshly allocated grid to
+	// SetCurrent each frame, so retaining the reference is safe and avoids
+	// a full-grid alloc+copy on every render.
+	r.prev = r.curr
 }
 
 // Clear resets the renderer's buffers.

--- a/internal/render/renderer_test.go
+++ b/internal/render/renderer_test.go
@@ -3,6 +3,7 @@ package render
 import (
 	"github.com/eugenioenko/ttt/internal/term"
 	"testing"
+	"unsafe"
 )
 
 func makeCells(rows ...string) [][]term.Cell {
@@ -36,6 +37,20 @@ func TestRenderer_RenderDiff(t *testing.T) {
 	c, ok := screen.Cells[[2]int{2, 0}]
 	if !ok || c.Ch != 'x' {
 		t.Errorf("expected cell (2,0) to be 'x'")
+	}
+}
+
+func TestRenderer_RenderNoCopy(t *testing.T) {
+	r := &Renderer{}
+	screen := term.NewMockScreen(5, 2)
+	cells := makeCells("abcde", "fghij")
+	r.SetCurrent(cells)
+	r.Render(screen)
+
+	for y := range cells {
+		if unsafe.SliceData(r.prev[y]) != unsafe.SliceData(cells[y]) {
+			t.Errorf("row %d: r.prev does not share cells' backing array; Render is copying instead of retaining the reference", y)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `Renderer.Render` deep-copied the entire prev/curr cell grid into a fresh allocation on every single render call instead of swapping buffer references
- Profiling (`make profiler`, cpu.prof/mem.prof) showed this was the single largest allocator in the app — 624MB flat / 973MB cumulative, 59% of all allocations in a ~40s session — and a major source of GC pressure (34% of on-CPU time went to background GC marking despite the app being ~91% idle overall)
- Callers (`eventloop.go` `redraw()`) always pass a freshly allocated grid to `SetCurrent` each frame and never reuse/mutate the old one, so retaining the reference instead of copying is safe

Closes #528.

## Results
Before → after, comparable ~40s profiling sessions:
- Total heap allocations: 1639MB → 1245MB (**-24%**)
- `Renderer.Render`'s allocation cost dropped to zero (no longer appears in mem profile's top allocators at all)
- Remaining cost inside `Render` is 100% legitimate work (`screen.SetCell` + `screen.Show()`)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `go test ./internal/render/... -v` — renderer unit tests pass
- [x] Re-profiled with `make profiler` after the fix and confirmed the allocation and CPU improvements above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved rendering efficiency by reusing the current grid instead of copying the entire grid after each render.
- **Bug Fixes**
  - Ensured rendered grid data remains correctly retained between rendering cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->