### PR TITLE
style(git): make commit message header a padded box

### DIFF
--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -26,7 +26,7 @@ func BuildStyleMap(theme config.ThemeConfig) term.StyleMap {
 	m[term.StyleSelection] = base.Reverse(true)
 
 	applyStyleDef(&m, term.StyleStatusBar, theme.StatusBar)
-	applyStyleDef(&m, term.StyleCommitMessage, theme.CommitMessage)
+	applyStyleDef(&m, term.StyleCommitHeader, theme.CommitHeader)
 	applyStyleDef(&m, term.StyleActiveTab, theme.Tabs.Active)
 	applyStyleDef(&m, term.StyleInactiveTab, theme.Tabs.Inactive)
 	selectedTab := theme.Tabs.Selected

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -206,28 +206,28 @@ type HoverStyles struct {
 }
 
 type ThemeConfig struct {
-	Default       StyleDef       `json:"default"`
-	Muted         StyleDef       `json:"muted"`
-	Success       StyleDef       `json:"success"`
-	Danger        StyleDef       `json:"danger"`
-	Warning       StyleDef       `json:"warning"`
-	StatusBar     StyleDef       `json:"statusBar"`
-	CommitMessage StyleDef       `json:"commitMessage"`
-	Tabs          TabStyles      `json:"tabs"`
-	Sidebar       SidebarStyles  `json:"sidebar"`
-	Dialog        DialogStyles   `json:"dialog"`
-	Editor        EditorStyles   `json:"editor"`
-	Menu          MenuStyles     `json:"menu"`
-	Input         InputStyles    `json:"input"`
-	Button        ButtonStyles   `json:"button"`
-	Hover         HoverStyles    `json:"hover"`
-	Border        StyleDef       `json:"border"`
-	BorderActive  StyleDef       `json:"borderActive"`
-	Diff          DiffStyles     `json:"diff"`
-	Scrollbar     StyleDef       `json:"scrollbar"`
-	Syntax        SyntaxStyles   `json:"syntax"`
-	Borders       BorderChars    `json:"borders"`
-	Terminal      TerminalColors `json:"terminal,omitempty"`
+	Default      StyleDef       `json:"default"`
+	Muted        StyleDef       `json:"muted"`
+	Success      StyleDef       `json:"success"`
+	Danger       StyleDef       `json:"danger"`
+	Warning      StyleDef       `json:"warning"`
+	StatusBar    StyleDef       `json:"statusBar"`
+	CommitHeader StyleDef       `json:"commitHeader"`
+	Tabs         TabStyles      `json:"tabs"`
+	Sidebar      SidebarStyles  `json:"sidebar"`
+	Dialog       DialogStyles   `json:"dialog"`
+	Editor       EditorStyles   `json:"editor"`
+	Menu         MenuStyles     `json:"menu"`
+	Input        InputStyles    `json:"input"`
+	Button       ButtonStyles   `json:"button"`
+	Hover        HoverStyles    `json:"hover"`
+	Border       StyleDef       `json:"border"`
+	BorderActive StyleDef       `json:"borderActive"`
+	Diff         DiffStyles     `json:"diff"`
+	Scrollbar    StyleDef       `json:"scrollbar"`
+	Syntax       SyntaxStyles   `json:"syntax"`
+	Borders      BorderChars    `json:"borders"`
+	Terminal     TerminalColors `json:"terminal,omitempty"`
 }
 
 func DefaultTheme() ThemeConfig {
@@ -239,8 +239,7 @@ func DefaultTheme() ThemeConfig {
 		Menu: MenuStyles{
 			Active: StyleDef{Fg: "#ffffff", Bg: "#505050", Bold: true},
 		},
-		StatusBar:     StyleDef{},
-		CommitMessage: StyleDef{Fg: "#fafafa", Bg: "#2a2f3a"},
+		StatusBar: StyleDef{},
 
 		Tabs: TabStyles{
 			Active:   StyleDef{Fg: "#ffffff", Bold: true},
@@ -304,6 +303,8 @@ func DefaultTheme() ThemeConfig {
 }
 
 func (t *ThemeConfig) ResolveColors() {
+	fillFg(&t.CommitHeader, t.Default.Fg)
+	fillBg(&t.CommitHeader, t.Default.Bg)
 	fillFg(&t.Dialog.Muted, t.Muted.Fg)
 	fillBg(&t.Input.Item, t.Default.Bg)
 	fillFg(&t.Input.Item, t.Default.Fg)

--- a/internal/term/screen.go
+++ b/internal/term/screen.go
@@ -5,7 +5,7 @@ type Style int
 const (
 	StyleDefault Style = iota
 	StyleStatusBar
-	StyleCommitMessage
+	StyleCommitHeader
 	StyleActiveTab
 	StyleInactiveTab
 	StyleSidebarSelected

--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -84,6 +84,7 @@ type commitDetailRowKind uint8
 
 const (
 	commitDetailMessageHeaderRow commitDetailRowKind = iota
+	commitDetailHeaderDividerRow
 	commitDetailMetadataRow
 	commitDetailMessageRow
 	commitDetailSpacerRow
@@ -617,6 +618,7 @@ func (d *CommitDetailWidget) rebuildRows() {
 	if d.Metadata != "" {
 		d.rows = append(d.rows, commitDetailRow{kind: commitDetailMetadataRow, text: d.Metadata})
 		d.recordWidth(d.Metadata)
+		d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
 	}
 	message := strings.TrimRight(d.Message, "\r\n")
 	if message == "" {
@@ -634,6 +636,7 @@ func (d *CommitDetailWidget) rebuildRows() {
 		d.rows = append(d.rows, commitDetailRow{kind: commitDetailNoticeRow, text: d.RefreshError, danger: true})
 		d.recordWidth(d.RefreshError)
 	}
+	d.rows = append(d.rows, commitDetailRow{kind: commitDetailHeaderDividerRow})
 	d.rows = append(d.rows, commitDetailRow{kind: commitDetailSpacerRow})
 
 	maxLine := 0
@@ -904,10 +907,13 @@ func (d *CommitDetailWidget) buildVisualRows(viewW int) []commitDetailVisualRow 
 		leftStarts := []int{0}
 		rightStarts := []int{0}
 		switch row.kind {
-		case commitDetailMessageHeaderRow, commitDetailSpacerRow:
+		case commitDetailMessageHeaderRow, commitDetailHeaderDividerRow, commitDetailSpacerRow:
 			rightStarts = nil
 		case commitDetailHeadingRow:
 			leftStarts = diffWrapStarts(row.text, viewW-3)
+			rightStarts = nil
+		case commitDetailMetadataRow, commitDetailMessageRow:
+			leftStarts = diffWrapStarts(row.text, viewW-2)
 			rightStarts = nil
 		case commitDetailDiffRow:
 			if row.fileIndex >= 0 && row.fileIndex < len(d.Files) && row.lineIndex >= 0 && leftW > 0 {
@@ -967,12 +973,14 @@ func (d *CommitDetailWidget) renderRow(surface Surface, rowIndex int, row commit
 	switch row.kind {
 	case commitDetailMessageHeaderRow:
 		d.renderMessageHeader(surface, y, viewW)
+	case commitDetailHeaderDividerRow:
+		d.renderHeaderDivider(surface, y, viewW)
 	case commitDetailMetadataRow:
-		d.drawTextRow(surface, 0, y, viewW, row.text, term.StyleMuted, term.StyleCommitMessage, false, visual.leftStart, rowIndex)
+		d.drawTextRow(surface, 1, y, viewW-2, row.text, term.StyleMuted, term.StyleCommitHeader, false, visual.leftStart, rowIndex)
 	case commitDetailSpacerRow:
 		return
 	case commitDetailMessageRow:
-		d.drawTextRow(surface, 0, y, viewW, row.text, term.StyleCommitMessage, term.StyleCommitMessage, row.bold, visual.leftStart, rowIndex)
+		d.drawTextRow(surface, 1, y, viewW-2, row.text, term.StyleCommitHeader, term.StyleCommitHeader, row.bold, visual.leftStart, rowIndex)
 	case commitDetailHeadingRow:
 		d.renderHeading(surface, rowIndex, row, visual, y, viewW)
 	case commitDetailNoticeRow:
@@ -988,13 +996,13 @@ func (d *CommitDetailWidget) renderRow(surface Surface, rowIndex int, row commit
 
 func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) {
 	for column := 0; column < viewW; column++ {
-		surface.SetCell(column, y, term.Cell{Ch: ' ', Style: term.StyleCommitMessage})
+		surface.SetCell(column, y, term.Cell{Ch: ' ', Style: term.StyleCommitHeader})
 	}
 	header := d.Header
 	if header == "" {
 		header = "Commit message"
 	}
-	d.drawStaticText(surface, 0, y, viewW, header, term.StyleCommitMessage, term.StyleCommitMessage, true)
+	d.drawStaticText(surface, 1, y, viewW-2, header, term.StyleCommitHeader, term.StyleCommitHeader, true)
 	if len(d.Files) == 0 {
 		return
 	}
@@ -1003,13 +1011,19 @@ func (d *CommitDetailWidget) renderMessageHeader(surface Surface, y, viewW int) 
 		label = "Expand all"
 	}
 	controlW := textwidth.String(label)
-	controlX := viewW - controlW
-	if controlX <= textwidth.String(header) {
+	controlX := viewW - controlW - 1
+	if controlX <= 1+textwidth.String(header) {
 		return
 	}
-	d.drawStaticText(surface, controlX, y, controlW, label, term.StyleCommitMessage, term.StyleCommitMessage, true)
+	d.drawStaticText(surface, controlX, y, controlW, label, term.StyleCommitHeader, term.StyleCommitHeader, true)
 	r := d.GetRect()
 	d.topControl = Rect{X: r.X + controlX, Y: r.Y + y, W: controlW, H: 1}
+}
+
+func (d *CommitDetailWidget) renderHeaderDivider(surface Surface, y, viewW int) {
+	for column := 0; column < viewW; column++ {
+		surface.SetCell(column, y, term.Cell{Ch: '─', Style: term.StyleBorder})
+	}
 }
 
 func (d *CommitDetailWidget) renderHeading(surface Surface, rowIndex int, row commitDetailRow, visual commitDetailVisualRow, y, viewW int) {
@@ -1204,7 +1218,9 @@ func (d *CommitDetailWidget) screenToSelection(mx, my int) (pos diffSelPos, righ
 	row := d.rows[rowIndex]
 	textX, textW, segmentStart := 0, d.layoutViewW, visual.leftStart
 	switch row.kind {
-	case commitDetailMessageRow, commitDetailNoticeRow:
+	case commitDetailMessageRow:
+		textX, textW = 1, d.layoutViewW-2
+	case commitDetailNoticeRow:
 	case commitDetailHeadingRow:
 		textX, textW = 3, d.layoutViewW-3
 	case commitDetailDiffRow:


### PR DESCRIPTION
## Summary
- Rename the `CommitMessage` theme style to `CommitHeader` and derive its fg/bg from the editor's `Default` style instead of a hardcoded hex, so the commit-detail header now tracks whatever theme is active (previously every built-in theme except the Go default silently fell back to a stale hardcoded navy color regardless of the theme's own palette).
- Give the commit-detail header section (title + metadata + message body) 1-col left/right padding.
- Add a blank line after the "Authored ..." metadata line, before the subject.
- Add a border-bottom that closes the section off right after the message body, before the file diffs begin.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (clean)
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `cd tests/functional && pnpm test` (333 passed, 26 pre-existing expected fails)
- [x] Manually verified via `--exec`/screenshot that the header box renders with padding, blank line, and border-bottom in the correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated divider between commit metadata and the commit message.
  * Improved commit detail layout with consistent margins and clearer header styling.
  * Updated text wrapping and collapse/expand controls for improved readability and interaction.

* **Bug Fixes**
  * Corrected message selection boundaries to align with the updated layout.
  * Prevented controls from overlapping commit header text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->