### PR TITLE
fix(ui): prevent tab drag from press that began outside widget

### DIFF
--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -15,6 +15,7 @@ type SidebarWidget struct {
 	capturedChild             Widget
 	pointerCaptureInvalidated func()
 	cancelingPointerCapture   bool
+	lastSeenBtn               tcell.ButtonMask
 }
 
 func NewSidebarWidget() *SidebarWidget {
@@ -126,7 +127,17 @@ func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
 	if tev, ok := ev.(*tcell.EventMouse); ok {
 		_, my := tev.Position()
 		r := s.GetRect()
-		if my == r.Y || s.Tabs.PointerGestureActive() {
+		btn := tev.Buttons()
+		prevBtn := s.lastSeenBtn
+		s.lastSeenBtn = btn
+
+		if s.Tabs.PointerGestureActive() {
+			return s.Tabs.HandleEvent(ev)
+		}
+		if my == r.Y {
+			if btn&tcell.Button1 != 0 && prevBtn&tcell.Button1 != 0 {
+				return EventIgnored
+			}
 			return s.Tabs.HandleEvent(ev)
 		}
 	}

--- a/internal/ui/sidebar_widget.go
+++ b/internal/ui/sidebar_widget.go
@@ -60,6 +60,7 @@ func (s *SidebarWidget) CancelPointerCapture() bool {
 		canceled = widgets.CancelPointerCapture(captured) || canceled
 	}
 	canceled = s.Tabs.CancelPointerCapture() || canceled
+	s.lastSeenBtn = 0
 	s.cancelingPointerCapture = false
 	if canceled && s.pointerCaptureInvalidated != nil {
 		s.pointerCaptureInvalidated()
@@ -87,6 +88,7 @@ func (s *SidebarWidget) InvalidatePointerInteraction() bool {
 		invalidated = widgets.InvalidatePointerInteraction(captured) || invalidated
 	}
 	invalidated = s.Tabs.InvalidatePointerInteraction() || invalidated
+	s.lastSeenBtn = 0
 	s.cancelingPointerCapture = false
 	if invalidated && s.pointerCaptureInvalidated != nil {
 		s.pointerCaptureInvalidated()
@@ -121,6 +123,7 @@ func (s *SidebarWidget) HandleEvent(ev tcell.Event) EventResult {
 		result := s.capturedChild.HandleEvent(ev)
 		if tev, ok := ev.(*tcell.EventMouse); ok && tev.Buttons() == tcell.ButtonNone {
 			s.capturedChild = nil
+			s.lastSeenBtn = tcell.ButtonNone
 		}
 		return result
 	}

--- a/internal/ui/sidebar_widget_capture_test.go
+++ b/internal/ui/sidebar_widget_capture_test.go
@@ -122,6 +122,60 @@ func TestSidebarTracksAndCancelsCapturedPanel(t *testing.T) {
 	}
 }
 
+func TestSidebarTabPressAfterCanceledCaptureReachesTabs(t *testing.T) {
+	sidebar := NewSidebarWidget()
+	sidebar.AddPanel("one", "one", &mockWidget{})
+	sidebar.Tabs.Config.Reorderable = true
+	sidebar.Tabs.Config.OnReorder = func(_, _ int) {}
+	root := NewRoot(sidebar)
+	root.SetSize(30, 3)
+	root.Render(makeGrid(30, 3))
+
+	press := func() {
+		t.Helper()
+		if got := root.HandleEvent(tcell.NewEventMouse(2, 0, tcell.Button1, 0)); got != EventConsumed {
+			t.Fatalf("tab press result = %v, want root-consumed", got)
+		}
+	}
+
+	press()
+	if !sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("tab press did not start a gesture")
+	}
+
+	// PushOverlay cancels pointer capture across the whole tree; the sidebar's
+	// stale button state must not swallow the next press.
+	root.CancelPointerCapture()
+
+	press()
+	if !sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("tab press after canceled capture never reached the tabs")
+	}
+}
+
+func TestSidebarTabPressAfterCapturedPanelReleaseReachesTabs(t *testing.T) {
+	panel := &sidebarCaptureProbe{}
+	sidebar := NewSidebarWidget()
+	sidebar.AddPanel("one", "one", panel)
+	sidebar.Tabs.Config.Reorderable = true
+	sidebar.Tabs.Config.OnReorder = func(_, _ int) {}
+	root := NewRoot(sidebar)
+	root.SetSize(30, 10)
+	root.Render(makeGrid(30, 10))
+
+	if got := root.HandleEvent(tcell.NewEventMouse(2, 3, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("panel press result = %v, want root-consumed capture", got)
+	}
+	root.HandleEvent(tcell.NewEventMouse(2, 3, tcell.ButtonNone, 0))
+
+	if got := root.HandleEvent(tcell.NewEventMouse(2, 0, tcell.Button1, 0)); got != EventConsumed {
+		t.Fatalf("tab press result = %v, want root-consumed", got)
+	}
+	if !sidebar.Tabs.PointerGestureActive() {
+		t.Fatal("tab press after captured panel release never reached the tabs")
+	}
+}
+
 func TestSidebarInvalidatesCapturedPanelAndPreservesNormalRelease(t *testing.T) {
 	panel := &sidebarCaptureProbe{}
 	sidebar := NewSidebarWidget()

--- a/internal/ui/tabbar_widget.go
+++ b/internal/ui/tabbar_widget.go
@@ -56,6 +56,7 @@ type TabBarWidget struct {
 	closeDownX                int // screen X where mouse-down hit a close button, -1 if none
 	closeDownY                int
 	wasPressed                bool
+	lastSeenBtn               tcell.ButtonMask
 	lastClickTime             int64
 	drag                      widgets.TabDragState
 	dragPointerX              int
@@ -286,6 +287,9 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 	mx, my := mev.Position()
 	btn := mev.Buttons()
 
+	prevBtn := t.lastSeenBtn
+	t.lastSeenBtn = btn
+
 	slog.Debug("tabBar", "mx", mx, "my", my, "btn", btn, "rect", r, "hasMore", t.MoreButton != nil)
 
 	if btn == tcell.ButtonNone && t.drag.Active() {
@@ -377,7 +381,7 @@ func (t *TabBarWidget) HandleEvent(ev tcell.Event) EventResult {
 		return EventIgnored
 	}
 
-	freshClick := !t.wasPressed
+	freshClick := !t.wasPressed && prevBtn&tcell.Button1 == 0
 	t.wasPressed = true
 	if !freshClick {
 		return EventConsumed
@@ -452,6 +456,7 @@ func (t *TabBarWidget) CancelPointerCapture() bool {
 		t.drag.Cancel()
 	}
 	t.wasPressed = false
+	t.lastSeenBtn = 0
 	t.closeDownX = -1
 	if active && t.pointerCaptureInvalidated != nil {
 		t.pointerCaptureInvalidated()

--- a/internal/ui/tabbar_widget_test.go
+++ b/internal/ui/tabbar_widget_test.go
@@ -606,3 +606,34 @@ func TestTabBarNoOverflowWhenFits(t *testing.T) {
 		t.Fatal("should not have overflow when all tabs fit")
 	}
 }
+
+func TestTabBarDragDoesNotStartFromPressOutsideTabs(t *testing.T) {
+	tb := NewTabBarWidget()
+	tb.SetTabs([]Tab{{Name: "one.go", Active: true}, {Name: "two.go"}})
+	root := NewRoot(tb)
+	root.SetSize(30, 3)
+	tb.Render(NewRenderSurface(makeGrid(30, 3), Rect{X: 0, Y: 0, W: 30, H: 3}))
+	tb.OnTabClick = func(int) {}
+	tb.OnTabReorder = func(_, _ int) {}
+
+	tabX := tb.tabSpans[1].start + 2
+
+	// Press outside the tab bar (below it), then move onto a tab with button held.
+	root.HandleEvent(tcell.NewEventMouse(tabX, 5, tcell.Button1, 0))
+	root.HandleEvent(tcell.NewEventMouse(tabX, 1, tcell.Button1, 0))
+
+	if tb.drag.Active() {
+		t.Fatal("drag started from a press that originated outside the tab bar")
+	}
+	if root.capturedWidget != nil {
+		t.Fatal("root captured widget from a foreign press")
+	}
+
+	// Release and do a real click — should work normally.
+	root.HandleEvent(tcell.NewEventMouse(tabX, 1, tcell.ButtonNone, 0))
+	root.HandleEvent(tcell.NewEventMouse(tabX, 1, tcell.Button1, 0))
+
+	if !tb.drag.Active() {
+		t.Fatal("legitimate click after foreign press did not start drag")
+	}
+}


### PR DESCRIPTION
## Summary
- Track `lastSeenBtn` in `TabBarWidget` so a held-button pointer entering the tab bar is not mistaken for a fresh click
- Gate sidebar tab dispatch so held-button events from the content area never reach the `TabsWidget`
- Reset `lastSeenBtn` on `CancelPointerCapture` to avoid stale state after gesture invalidation

Closes #532

## Test plan
- [x] `TestTabBarDragDoesNotStartFromPressOutsideTabs` — press below tab bar, move onto tab with button held, assert no drag; then verify real click still works
- [x] Existing `TestTabBarInvalidatedSourceDoesNotCaptureNextClick` still passes (covers `lastSeenBtn` reset on invalidation)
- [x] `go test ./...` and `tests/e2e` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab interaction handling to distinguish new mouse clicks from held-button events.
  * Prevented accidental tab dragging when a mouse press begins outside the tab bar.
  * Ensured pointer-capture cancellation correctly resets tab gesture state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->