### PR TITLE
fix(ui): reorder tab context menu to put close actions first

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -580,6 +580,11 @@ func registerWidgetCallbacks(app *App) {
 			pinLabel = "Unpin Tab"
 		}
 		tabContextMenu := []ui.ContextMenuItem{
+			{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
+			{Label: "Close Others", Command: "tab.closeOthers"},
+			{Label: "Close All", Command: "tab.closeAll"},
+			{Label: "Close All Saved", Command: "tab.closeAllSaved"},
+			ui.MenuSep(),
 			{Label: pinLabel, Shortcut: app.KeyFor("tab.pin"), Command: "tab.pin"},
 		}
 		if app.EditorGroup.CanMoveActiveTab(-1) {
@@ -589,11 +594,6 @@ func registerWidgetCallbacks(app *App) {
 			tabContextMenu = append(tabContextMenu, ui.ContextMenuItem{Label: "Move Tab Right", Command: "tab.moveRight"})
 		}
 		tabContextMenu = append(tabContextMenu,
-			ui.MenuSep(),
-			ui.ContextMenuItem{Label: "Close", Shortcut: app.KeyFor("tab.close"), Command: "tab.close"},
-			ui.ContextMenuItem{Label: "Close Others", Shortcut: "", Command: "tab.closeOthers"},
-			ui.ContextMenuItem{Label: "Close All", Shortcut: "", Command: "tab.closeAll"},
-			ui.ContextMenuItem{Label: "Close All Saved", Shortcut: "", Command: "tab.closeAllSaved"},
 			ui.MenuSep(),
 			ui.ContextMenuItem{Label: "Copy Absolute Path", Command: "file.copyAbsolutePath"},
 			ui.ContextMenuItem{Label: "Copy Relative Path", Command: "file.copyRelativePath"},


### PR DESCRIPTION
<!-- coderabbitai:ignore -->

## Summary
- Move Close, Close Others, Close All, Close All Saved to the top of the tab right-click context menu
- Pin/Move actions follow after a separator
- Copy path actions remain at the bottom
- Matches VS Code convention

Closes #536

## Test plan
- [x] Right-click a tab → Close actions appear first
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)