### PR TITLE
plugin: API v3 gate + no-op Replace (prep for ttt-vim, 1.4.0)

### DIFF
--- a/internal/app/plugin_api.go
+++ b/internal/app/plugin_api.go
@@ -206,6 +206,9 @@ func (e *PluginEditorAPI) Replace(startLine, startCol, endLine, endCol int, text
 		StartLine: startLine, StartCol: startCol,
 		EndLine: endLine, EndCol: endCol,
 	}
+	if delCmd.ComputeDeleted(ed.Buf) == text {
+		return
+	}
 	delCmd.Apply(ed.Buf)
 
 	if text == "" {

--- a/internal/core/undo/undo.go
+++ b/internal/core/undo/undo.go
@@ -441,9 +441,9 @@ type DeleteSelectionCommand struct {
 	Deleted             string
 }
 
-func (c *DeleteSelectionCommand) Apply(b *buffer.Buffer) {
+func (c *DeleteSelectionCommand) ComputeDeleted(b *buffer.Buffer) string {
 	if c.StartLine >= len(b.Lines) {
-		return
+		return ""
 	}
 	if c.EndLine >= len(b.Lines) {
 		c.EndLine = len(b.Lines) - 1
@@ -451,47 +451,48 @@ func (c *DeleteSelectionCommand) Apply(b *buffer.Buffer) {
 	}
 
 	startRunes := []rune(b.Lines[c.StartLine])
-	sc := c.StartCol
-	if sc > len(startRunes) {
-		sc = len(startRunes)
+	if c.StartCol > len(startRunes) {
+		c.StartCol = len(startRunes)
 	}
 
 	if c.StartLine == c.EndLine {
 		endRunes := []rune(b.Lines[c.StartLine])
-		ec := c.EndCol
-		if ec > len(endRunes) {
-			ec = len(endRunes)
+		if c.EndCol > len(endRunes) {
+			c.EndCol = len(endRunes)
 		}
-		if sc > ec {
-			sc = ec
+		if c.StartCol > c.EndCol {
+			c.StartCol = c.EndCol
 		}
-		c.Deleted = string(endRunes[sc:ec])
-		b.Lines[c.StartLine] = string(startRunes[:sc]) + string(endRunes[ec:])
-		b.Dirty = true
-		return
+		c.Deleted = string(endRunes[c.StartCol:c.EndCol])
+		return c.Deleted
 	}
 
 	endRunes := []rune(b.Lines[c.EndLine])
-	ec := c.EndCol
-	if ec > len(endRunes) {
-		ec = len(endRunes)
+	if c.EndCol > len(endRunes) {
+		c.EndCol = len(endRunes)
 	}
 
-	// Build deleted text
 	var del []rune
-	del = append(del, startRunes[sc:]...)
+	del = append(del, startRunes[c.StartCol:]...)
 	del = append(del, '\n')
 	for l := c.StartLine + 1; l < c.EndLine; l++ {
 		del = append(del, []rune(b.Lines[l])...)
 		del = append(del, '\n')
 	}
-	del = append(del, endRunes[:ec]...)
+	del = append(del, endRunes[:c.EndCol]...)
 	c.Deleted = string(del)
+	return c.Deleted
+}
 
-	// Merge start prefix with end suffix
-	b.Lines[c.StartLine] = string(startRunes[:sc]) + string(endRunes[ec:])
+func (c *DeleteSelectionCommand) Apply(b *buffer.Buffer) {
+	if c.StartLine >= len(b.Lines) {
+		return
+	}
+	c.ComputeDeleted(b)
 
-	// Remove lines between
+	startRunes := []rune(b.Lines[c.StartLine])
+	endRunes := []rune(b.Lines[c.EndLine])
+	b.Lines[c.StartLine] = string(startRunes[:c.StartCol]) + string(endRunes[c.EndCol:])
 	if c.EndLine > c.StartLine {
 		b.Lines = append(b.Lines[:c.StartLine+1], b.Lines[c.EndLine+1:]...)
 	}

--- a/internal/core/undo/undo_test.go
+++ b/internal/core/undo/undo_test.go
@@ -825,3 +825,55 @@ func TestEndTransactionWithoutBegin(t *testing.T) {
 	s := &UndoStack{}
 	s.EndTransaction()
 }
+
+func TestDeleteSelectionCommandComputeDeleted(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		cmd   DeleteSelectionCommand
+		want  string
+	}{
+		{
+			name:  "single line range",
+			lines: []string{"alpha beta"},
+			cmd:   DeleteSelectionCommand{StartLine: 0, StartCol: 0, EndLine: 0, EndCol: 5},
+			want:  "alpha",
+		},
+		{
+			name:  "cols clamp to line length",
+			lines: []string{"alpha"},
+			cmd:   DeleteSelectionCommand{StartLine: 0, StartCol: 0, EndLine: 0, EndCol: 99},
+			want:  "alpha",
+		},
+		{
+			name:  "multi line range joins with newlines",
+			lines: []string{"alpha", "beta", "gamma"},
+			cmd:   DeleteSelectionCommand{StartLine: 0, StartCol: 2, EndLine: 2, EndCol: 3},
+			want:  "pha\nbeta\ngam",
+		},
+		{
+			name:  "end line clamps to last line",
+			lines: []string{"alpha"},
+			cmd:   DeleteSelectionCommand{StartLine: 0, StartCol: 0, EndLine: 5, EndCol: 0},
+			want:  "alpha",
+		},
+		{
+			name:  "invalid start line deletes nothing",
+			lines: []string{"alpha"},
+			cmd:   DeleteSelectionCommand{StartLine: 1, StartCol: 0, EndLine: 1, EndCol: 0},
+			want:  "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := &buffer.Buffer{Lines: test.lines}
+			if got := test.cmd.ComputeDeleted(b); got != test.want {
+				t.Errorf("ComputeDeleted = %q, want %q", got, test.want)
+			}
+			if len(b.Lines) != len(test.lines) {
+				t.Errorf("ComputeDeleted mutated the buffer: %v", b.Lines)
+			}
+		})
+	}
+}

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -15,7 +15,11 @@ import (
 // that needs any of these declares "api": 2; older builds (which only know v1)
 // already reject it via the check in LoadManifest, so it fails cleanly instead
 // of loading into a broken half-state.
-const SupportedAPIVersion = 2
+//
+// v3 (ttt 1.4.0) is the settings/editor-API surface used by vim-mode-style
+// plugins: editor.* settings in settings_keys and the plugin editor API
+// additions shipping with 1.4.0.
+const SupportedAPIVersion = 3
 
 type Manifest struct {
 	Name        string        `json:"name"`

--- a/tests/e2e/undo_dirty_test.go
+++ b/tests/e2e/undo_dirty_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/eugenioenko/ttt/internal/app"
 )
 
 func TestUndoToClearsDirty(t *testing.T) {
@@ -61,5 +63,52 @@ func TestUndoToSavePoint(t *testing.T) {
 
 	if h.app.EditorGroup.IsDirty() {
 		t.Fatal("expected clean after undo to save point")
+	}
+}
+
+func TestPluginSetLineIdenticalTextIsUndoNoop(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "noop.txt")
+	os.WriteFile(f, []byte("hello\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	h.pressRune('X')
+	h.redraw()
+
+	api := app.NewPluginEditorAPI(h.app)
+	api.SetLine(0, "Xhello")
+	h.redraw()
+
+	h.exec("editor.undo")
+	h.redraw()
+
+	buf := h.app.EditorGroup.ActiveBuffer()
+	if got := buf.Lines[0]; got != "hello" {
+		t.Fatalf("undo after no-op set_line should undo the typed edit, got %q", got)
+	}
+}
+
+func TestPluginSetLineDifferentTextPushesUndo(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	f := filepath.Join(h.dir, "change.txt")
+	os.WriteFile(f, []byte("hello\n"), 0644)
+	h.app.EditorGroup.OpenFile(f)
+	h.redraw()
+
+	api := app.NewPluginEditorAPI(h.app)
+	api.SetLine(0, "world")
+	h.redraw()
+
+	h.exec("editor.undo")
+	h.redraw()
+
+	buf := h.app.EditorGroup.ActiveBuffer()
+	if got := buf.Lines[0]; got != "hello" {
+		t.Fatalf("undo after set_line change should restore the original line, got %q", got)
 	}
 }


### PR DESCRIPTION
Two changes for the ttt-vim compatibility effort:

1. **Bump `SupportedAPIVersion` to 3** so plugins can require the editor/API surface shipping with ttt 1.4.0 (the ttt-vim plugin now declares `"api": 3` — see eugenioenko/ttt-vim#7). Older builds already refuse unknown API versions via the existing `LoadManifest` check with a clear error.

2. **`PluginEditorAPI.Replace` no-ops when the replacement equals the range's current text.** Split `DeleteSelectionCommand` into `ComputeDeleted` (clamp + deleted-text computation, no mutation) and `Apply`; `Replace` skips the edit entirely on identical content. Calling `set_line` with unchanged text (e.g. the vim plugin's `=` reindent) no longer pushes a phantom undo group or triggers a redraw.

Tests: 5 new `ComputeDeleted` unit tests, 2 e2e tests (identical `set_line` doesn't consume an undo step; a real change does). `go test ./internal/core/undo/ ./internal/app/ ./tests/e2e/ -run 'TestPluginSetLine|TestUndoTo|TestDeleteSelection'` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for version 3 plugin manifests, including updated editor settings and API capabilities.
* **Bug Fixes**
  * Avoided creating unnecessary editor changes or undo entries when replacement text matches the selected content.
  * Improved handling of deleted selections across lines, including boundary and cursor normalization.
* **Tests**
  * Added coverage for multi-line deletion behavior and plugin line-edit undo scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->