### PR TITLE
test: make functional readiness explicit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,8 @@ The project has four levels of testing:
 
 **Functional tests** (`tests/functional/`) — JavaScript tests using vitest that drive the real compiled `bin/ttt` binary via the `--exec` debug harness. The `tui.js` wrapper accumulates commands (type, press, exec, snapshot) and runs them in a single batch via `execFileSync`. No external dependencies beyond vitest. Run with `cd tests/functional && pnpm test`. The binary must be built first (`make build`).
 
+Scripted key, mouse, and command actions are acknowledged after main-thread handling and redraw, so do not add sleeps between synchronous actions. For genuinely asynchronous work, wait for a unique post-transition screen state that proves the result was applied. Use raw elapsed waits only when timing or delayed lifecycle behavior is itself the invariant.
+
 The batch pattern: `tui.start(file)` resets state, commands accumulate, `tui.snapshot()` returns an index, `tui.run()` executes all commands and returns `{ snapshots: string[] }`. Assertions happen after `run()`:
 ```js
 tui.start(file);
@@ -192,7 +194,7 @@ Choose the smallest deterministic layer that proves the intended invariant, then
 3. **Functional tests** — real-binary behavior that depends on startup, command dispatch, file effects, or visible composition. Use `tui.exec("Command Name")`, `tui.pressChord("ctrl+k", "x")`, and `tui.snapshot()`.
 4. **Integration tests** — only behavior that genuinely requires a live PTY or external process boundary, such as terminal byte encoding, terminal modes, or real language-server compatibility.
 
-Do not duplicate the same assertion at every layer. During implementation, run focused tests for the affected contract. CI remains the broad regression gate before merge.
+The functional suite is a compact real-binary contract, not a mandatory duplicate of lower-layer coverage. An invariant proved at a lower deterministic boundary does not also require a functional test; add a higher-boundary test only for behavior unique to that boundary. During implementation, run focused tests for the affected contract. CI remains the broad regression gate before merge.
 
 ### Debug harness (`--exec`, `--plugin`, `--size`, `--debug`, `--listen`)
 

--- a/README.md
+++ b/README.md
@@ -737,6 +737,8 @@ pnpm install
 pnpm test              # run all functional tests
 ```
 
+The harness acknowledges scripted input and commands after main-thread handling and redraw. Tests should wait only for genuine asynchronous work, using a unique visible post-transition state; raw elapsed waits belong only in tests whose invariant is timing or delayed lifecycle behavior.
+
 ### Integration Tests (vitest + tui-use)
 
 Tests that require live PTY interaction or a real external process boundary. Built with [vitest](https://vitest.dev/) and [tui-use](https://github.com/onesuper/tui-use), they cover real language servers, external file changes, settings roundtrips, and bracketed paste.
@@ -747,7 +749,7 @@ pnpm install
 pnpm test
 ```
 
-Use the smallest deterministic layer that proves a behavior. Broader tests should establish a distinct boundary rather than duplicate the same assertion. CI runs the broad regression lanes on pull requests.
+Use the smallest deterministic layer that proves an invariant. Functional tests are a compact real-binary contract, not a mandatory copy of lower-layer coverage. Add a broader test only when it establishes behavior unique to that boundary. CI runs the broad regression lanes on pull requests.
 
 ### Chaos Monkey (Fuzz Testing)
 

--- a/tests/functional/audit-explorer-bugs.test.js
+++ b/tests/functional/audit-explorer-bugs.test.js
@@ -25,14 +25,10 @@ describe("BUG-028: command-palette Explorer: Delete lacks the isRoot guard the r
     writeFileSync(join(dir, "file.txt"), "hi\n");
 
     tui.start(dir);
-    tui.waitStable(300);
     tui.exec("Show Explorer");
-    tui.waitStable();
     tui.exec("Explorer: Delete");
-    tui.waitStable();
     tui.press("right"); // move to "Yes" in confirm dialog
     tui.press("enter");
-    tui.waitStable(300);
     tui.run();
 
     // Buggy: explorerNodePath() falls back to Tree.Selected()==0 (root),
@@ -48,22 +44,16 @@ describe("BUG-029: renaming an open file leaves the tab tracking the old path", 
     writeFileSync(join(dir, "root.txt"), "root file");
 
     tui.start(dir);
-    tui.waitStable(300);
     tui.exec("Show Explorer");
-    tui.waitStable();
     tui.press("arrow_down"); // select root.txt
     tui.press("enter"); // open it
-    tui.waitStable();
     tui.exec("Explorer: Rename");
-    tui.waitStable();
     tui.press("ctrl+a");
     tui.type("renamed.txt");
     tui.press("enter");
-    tui.waitStable();
     tui.press("end");
     tui.type("APPENDED");
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Correct: the edit lands in renamed.txt and no phantom root.txt is
@@ -82,14 +72,10 @@ describe("BUG-030: New File / Rename silently clobber an existing file", () => {
     writeFileSync(join(dir, "dup.txt"), "existing content - keep me");
 
     tui.start(dir);
-    tui.waitStable(300);
     tui.exec("Show Explorer");
-    tui.waitStable();
     tui.exec("Explorer: New File");
-    tui.waitStable();
     tui.type("dup.txt");
     tui.press("enter");
-    tui.waitStable();
     tui.run();
 
     // Fixed: FileOpNewFile now checks for an existing file before writing
@@ -105,16 +91,12 @@ describe("BUG-030: New File / Rename silently clobber an existing file", () => {
     writeFileSync(join(dir, "bbb.txt"), "bbb content - keep me");
 
     tui.start(dir);
-    tui.waitStable(300);
     tui.exec("Show Explorer");
-    tui.waitStable();
     tui.press("arrow_down"); // select aaa.txt (alphabetically first)
     tui.exec("Explorer: Rename");
-    tui.waitStable();
     tui.press("ctrl+a");
     tui.type("bbb.txt");
     tui.press("enter");
-    tui.waitStable();
     tui.run();
 
     // Fixed: FileOpRename now checks for an existing target before

--- a/tests/functional/audit-findreplace-bugs.test.js
+++ b/tests/functional/audit-findreplace-bugs.test.js
@@ -27,7 +27,6 @@ describe("BUG-010: search matches go stale after buffer edits", () => {
 
     tui.press("ctrl+f");
     tui.type("alpha");
-    tui.waitStable(300);
     // Click into the editor (find bar stays open but unfocused), then
     // insert a line above the matches so every match shifts down by one.
     tui.click(10, 4);
@@ -37,10 +36,8 @@ describe("BUG-010: search matches go stale after buffer edits", () => {
     tui.press("f3"); // find next — must land on a line still containing "alpha"
     tui.press("home");
     tui.type("Z"); // marker: reveals which line the cursor is on
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior: matches are never recomputed, f3 jumps to the stale
@@ -59,17 +56,13 @@ describe("BUG-011: Replace All ignores case-sensitive toggle", () => {
 
     tui.press("ctrl+r");
     tui.type("Foo");
-    tui.waitStable();
     tui.press("alt+c"); // case-sensitive on — bar shows 1/1
-    tui.waitStable();
     tui.press("tab");
     tui.type("X");
     tui.press("alt+r"); // replace all
-    tui.waitStable(300);
     tui.press("escape");
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Fixed: ReplaceAll now threads the bar's current Options (case/regex)
@@ -88,17 +81,13 @@ describe("BUG-012: Replace All is not a single undo step", () => {
 
     tui.press("ctrl+r");
     tui.type("cat");
-    tui.waitStable();
     tui.press("tab");
     tui.type("dog");
     tui.press("alt+r");
-    tui.waitStable(300);
     tui.press("escape");
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior: each of the 4 replacements pushes 2 ungrouped undo
@@ -124,17 +113,13 @@ describe("BUG-013: stale search follows tab switch", () => {
     tui.press("alt+,"); // to tabC
     tui.press("ctrl+f");
     tui.type("alpha");
-    tui.waitStable(300);
     tui.press("alt+."); // to tabD — no "alpha" anywhere in it
-    tui.waitStable(300);
     tui.press("f3"); // must be a no-op here
     tui.press("escape");
     tui.press("home");
     tui.type("Z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior: tabC's matches survive the switch, f3 clamps the
@@ -155,14 +140,11 @@ describe("BUG-014: replace bar swallows global keybindings", () => {
     tui.press("alt+,"); // to tabE
     tui.press("ctrl+r");
     tui.press("alt+."); // should switch to tabF (works with the FIND bar)
-    tui.waitStable();
     tui.press("escape");
     tui.press("home");
     tui.type("Z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior: ReplaceBarWidget.handleKey unconditionally returns
@@ -182,7 +164,6 @@ describe("BUG-015: find does not seed query from selection", () => {
     tui.press("end");
     tui.press("shift+ctrl+left"); // select "world"
     tui.press("ctrl+f");
-    tui.waitStable(300);
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/audit-fold-bugs.test.js
+++ b/tests/functional/audit-fold-bugs.test.js
@@ -33,7 +33,6 @@ describe("BUG-026: fold reattaches to an unrelated block after edits above", () 
     tui.press("enter");
     tui.press("home");
     tui.press("enter"); // insert a blank line at the top
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -59,10 +58,8 @@ describe("BUG-027: Move Line on a folded header swaps in hidden content", () => 
     tui.press("enter");
     tui.pressChord("ctrl+k", "["); // fold the if-block
     tui.press("alt+down"); // move line down on the folded header
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Correct: the whole folded block moves as a unit (VS Code) or the

--- a/tests/functional/audit-global-search-bugs.test.js
+++ b/tests/functional/audit-global-search-bugs.test.js
@@ -23,16 +23,14 @@ describe("BUG-047: global-search navigation ignores the match column (lands at c
     );
 
     tui.start(dir);
-    tui.waitStable(300);
+    tui.waitFor("Explore");
     tui.pressChord("ctrl+k", "f"); // open global search
     tui.type("needle");
-    tui.waitStable(700); // debounce + rg
+    tui.waitFor("another needle line");
     tui.press("arrow_down");
     tui.press("arrow_down"); // to the "another needle line" match
     tui.press("enter"); // navigate
-    tui.waitStable();
     tui.type("Z"); // marker at the cursor's landing column
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/audit-goalcolumn-bug.test.js
+++ b/tests/functional/audit-goalcolumn-bug.test.js
@@ -30,7 +30,6 @@ describe("BUG-051: goal column not preserved through a shorter line", () => {
     tui.press("arrow_down"); // line1 "short" — clamps to col 5
     tui.press("arrow_down"); // line2 (long) — goal should restore to col 12
     tui.type("Z"); // marker at the landing column
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/audit-grapheme-bugs.test.js
+++ b/tests/functional/audit-grapheme-bugs.test.js
@@ -26,10 +26,8 @@ describe("BUG-009: cursor and backspace split ZWJ grapheme clusters", () => {
     tui.press("arrow_right");
     tui.press("arrow_right");
     tui.press("backspace");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior: the second right stops mid-cluster (rune col 2) and

--- a/tests/functional/audit-mouse-bugs.test.js
+++ b/tests/functional/audit-mouse-bugs.test.js
@@ -22,9 +22,7 @@ describe("BUG-018: clicking another menu header closes instead of switching", ()
     tui.waitFor("hello");
 
     tui.click(4, 0); // open "File" menu
-    tui.waitStable();
     tui.click(30, 0); // click "View" header while File is open
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -42,14 +40,11 @@ describe("BUG-019: rightmost column of explorer tree rows is click-dead", () => 
     createTempFile(dir, "b.txt", "bbb\n");
 
     tui.start(dir);
-    tui.waitStable(300);
     tui.exec("Show Explorer");
-    tui.waitStable(300);
 
     // Tree widget rect is {x:1, w:30} → x=30 is the rightmost column of
     // the row rect; x=29 (control, verified) opens the file fine.
     tui.click(30, 6); // a.txt row
-    tui.waitStable(300);
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/audit-multicursor-bugs.test.js
+++ b/tests/functional/audit-multicursor-bugs.test.js
@@ -32,10 +32,8 @@ describe("BUG-006: case transforms under multicursor only affect primary cursor"
 
     tui.pressChord("ctrl+k", "l");
     tui.exec("Transform to Uppercase");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior uppercases only the first occurrence while the
@@ -59,10 +57,8 @@ describe("BUG-007: paste under multicursor only replaces the primary selection",
     tui.press("home");
     tui.pressChord("ctrl+k", "l");
     tui.press("ctrl+v");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior replaces only the first "foo".
@@ -82,10 +78,8 @@ describe("BUG-008: undo after multicursor edit strands cursor and stale e.Multi"
     tui.type("X"); // replaces all 4 occurrences
     tui.press("ctrl+z"); // restores text, but leaves Multi.Cursors stale
     tui.type("Z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Correct behavior: undo restores text AND multicursor selections, so
@@ -107,10 +101,8 @@ describe("BUG-005: line commands under multicursor corrupt the buffer", () => {
     tui.pressChord("ctrl+k", "l"); // Select All Occurrences (4 cursors)
     tui.exec("Duplicate Line");
     tui.type("Y");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Minimal correct behavior: cursors shift with the inserted line and

--- a/tests/functional/audit-navigation-bugs.test.js
+++ b/tests/functional/audit-navigation-bugs.test.js
@@ -23,10 +23,8 @@ describe("BUG-017: ctrl+home/ctrl+end document navigation missing", () => {
 
     tui.press("ctrl+end");
     tui.type("Z"); // marker: reveals where the cursor actually is
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior: the KeyEnd handler ignores ModCtrl entirely — the

--- a/tests/functional/audit-resize-bugs.test.js
+++ b/tests/functional/audit-resize-bugs.test.js
@@ -41,7 +41,6 @@ describe("BUG-039: Discard button vanishes from the quit-confirm dialog at narro
     tui.waitFor("hello");
     tui.type("X"); // make it dirty
     tui.press("ctrl+w"); // close tab -> unsaved-changes confirm dialog
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/audit-selection-bugs.test.js
+++ b/tests/functional/audit-selection-bugs.test.js
@@ -31,10 +31,8 @@ describe("BUG-003: Duplicate/Delete Line ignore active multi-line selection", ()
     tui.press("shift+down");
     tui.press("shift+down");
     tui.exec("Duplicate Line");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior duplicates only the cursor's line (line3), which per
@@ -53,10 +51,8 @@ describe("BUG-003: Duplicate/Delete Line ignore active multi-line selection", ()
     tui.press("shift+down");
     tui.press("shift+down");
     tui.exec("Delete Line");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior deletes only the cursor's line (line3), leaving the
@@ -77,10 +73,8 @@ describe("BUG-002: Tab indent with selection ending at col 0", () => {
     tui.press("arrow_down");
     tui.press("shift+down");
     tui.press("tab");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy behavior indents line2 as well.
@@ -102,10 +96,8 @@ describe("BUG-001: Move Line with selection ending at col 0", () => {
     tui.press("shift+down");
     tui.press("shift+down");
     tui.exec("Move Line Down");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Block line2+line3 swaps past line4. Buggy behavior instead swaps the

--- a/tests/functional/audit-tabbar-bugs.test.js
+++ b/tests/functional/audit-tabbar-bugs.test.js
@@ -24,13 +24,10 @@ describe("BUG-016: tab-bar overflow chevron switches tabs instead of scrolling",
     tui.waitFor("content");
 
     tui.click(2, 2); // the "◀" overflow chevron
-    tui.waitStable();
     tui.press("home");
     tui.type("Z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Correct behavior: the chevron only scrolls the tab strip; tf5 (last

--- a/tests/functional/audit-theme-bugs.test.js
+++ b/tests/functional/audit-theme-bugs.test.js
@@ -23,7 +23,6 @@ describe("BUG-041: theme picker cancel leaves border charset stuck on the previe
     tui.exec("Switch Theme");
     tui.type("turbo"); // preview turbo-vision (double-line borders)
     tui.press("escape"); // cancel — should fully revert
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/audit-undo-bugs.test.js
+++ b/tests/functional/audit-undo-bugs.test.js
@@ -28,10 +28,8 @@ describe("BUG-020: undo of line commands does not restore the cursor", () => {
     tui.press("arrow_down"); // wander away
     tui.press("ctrl+z");
     tui.type("Z"); // marker: reveals where the cursor is after undo
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Correct: cursor returns to the restored line ("C"), like it does for
@@ -53,10 +51,8 @@ describe("BUG-021: multi-line indent is not one undo step", () => {
     tui.press("shift+down");
     tui.press("tab"); // indents all three lines (BUG-002 makes it three)
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy: each line's indent is a separate undo command (no
@@ -78,10 +74,8 @@ describe("BUG-022: Enter with auto-indent is not one undo step", () => {
     tui.press("end");
     tui.press("enter"); // split + auto-indent insert (2 undo commands)
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.run();
 
     // Buggy: first undo removes only the auto-indent whitespace, leaving
@@ -107,7 +101,6 @@ describe("BUG-023: viewport does not follow an off-screen undo", () => {
     tui.type("1");
     tui.press("enter"); // back to the top
     tui.press("ctrl+z"); // undo the far-away edit
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -135,7 +128,6 @@ describe("BUG-024: undo on a folded header line silently unfolds it", () => {
     tui.pressChord("ctrl+k", "["); // fold
     tui.type("X");
     tui.press("ctrl+z"); // buffer now byte-identical to pre-edit
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/audit-workspace-bugs.test.js
+++ b/tests/functional/audit-workspace-bugs.test.js
@@ -78,7 +78,6 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
     tui.waitFor("linkedbranch");
     const linked = tui.snapshot();
     tui.exec("View: Previous Tab");
-    tui.waitStable();
     const plain = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -92,7 +91,6 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
     tui.start(link);
     tui.waitFor("filesymlinkbranch");
     tui.waitFor("Test User");
-    tui.waitStable();
     const screen = tui.snapshot();
     const { snapshots } = tui.run();
     expect(snapshots[screen]).toContain("filesymlinkbranch");
@@ -132,7 +130,9 @@ describe("BUG-044: git branch indicator missing when the opened file is below th
     tui.setEnv({ PATH: `${binDir}${delimiter}${process.env.PATH}`, TTT_REAL_GIT: realGit });
     tui.waitFor("filesymlinkbranch");
     tui.exec("View: Previous Tab");
-    tui.wait(1300);
+    // Cross the wrapper's one-second blame delay so this specifically proves
+    // that the late result cannot overwrite the newly active plain-file tab.
+    tui.elapse(1300);
     const screen = tui.snapshot();
     const { snapshots } = tui.run();
     expect(snapshots[screen]).toContain("plain content");

--- a/tests/functional/auto-indent.test.js
+++ b/tests/functional/auto-indent.test.js
@@ -15,12 +15,10 @@ describe("auto indent", () => {
     const file = createTempFile(dir, "test.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     tui.type("if x {");
     tui.press("enter");
     tui.type("return");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -33,14 +31,12 @@ describe("auto indent", () => {
     const file = createTempFile(dir, "test.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     tui.type("if x {");
     tui.press("enter");
     tui.type("return");
     tui.press("enter");
     tui.type("}");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/case-transform.test.js
+++ b/tests/functional/case-transform.test.js
@@ -18,10 +18,8 @@ describe("case transforms", () => {
     tui.waitFor("hello");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Transform to Uppercase");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -36,10 +34,8 @@ describe("case transforms", () => {
     tui.waitFor("HELLO");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Transform to Lowercase");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -54,10 +50,8 @@ describe("case transforms", () => {
     tui.waitFor("hello");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Transform to Titlecase");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -72,15 +66,12 @@ describe("case transforms", () => {
     tui.waitFor("hello");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Transform to Uppercase");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/cli-file-line-col.test.js
+++ b/tests/functional/cli-file-line-col.test.js
@@ -15,7 +15,6 @@ describe("file:line:col command line arguments", () => {
     const file = createMultiLineFile(dir, "lines.txt", 80);
 
     tui.start(`${file}:42`);
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -28,7 +27,6 @@ describe("file:line:col command line arguments", () => {
     const file = createMultiLineFile(dir, "lines.txt", 80);
 
     tui.start(`${file}:42:6`);
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -41,7 +39,6 @@ describe("file:line:col command line arguments", () => {
     const file = createMultiLineFile(dir, "lines.txt", 80);
 
     tui.start(`${file}:42:`);
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -55,7 +52,6 @@ describe("file:line:col command line arguments", () => {
     const file = createTempFile(dir, "report:12", "alpha\nbeta\n");
 
     tui.start(file);
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -73,7 +69,6 @@ describe("file:line:col command line arguments", () => {
     const second = createMultiLineFile(dir, "second.txt", 80);
 
     tui.start(`${first}:10`, `${second}:20`);
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -86,7 +81,6 @@ describe("file:line:col command line arguments", () => {
     const file = createMultiLineFile(dir, "lines.txt", 80);
 
     tui.start(file);
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/clipboard-roundtrip.test.js
+++ b/tests/functional/clipboard-roundtrip.test.js
@@ -20,19 +20,15 @@ describe("clipboard roundtrip", () => {
     // Select "hello" using ctrl+d (select word at cursor)
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
 
     // Copy
     tui.press("ctrl+c");
-    tui.waitStable();
 
     // Move to end of line and paste
     tui.press("end");
     tui.press("ctrl+v");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -50,11 +46,9 @@ describe("clipboard roundtrip", () => {
     // Select "REMOVE" using ctrl+d (select word at cursor)
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
 
     // Cut
     tui.press("ctrl+x");
-    tui.waitStable();
 
     // Verify "REMOVE" is gone from the visible text
     const s0 = tui.snapshot();
@@ -62,10 +56,8 @@ describe("clipboard roundtrip", () => {
     // Move to end and paste
     tui.press("end");
     tui.press("ctrl+v");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -85,16 +77,13 @@ describe("clipboard roundtrip", () => {
 
     // Cursor is on line 1, no selection — copy the whole line
     tui.press("ctrl+c");
-    tui.waitStable();
 
     // Move to line 2 and paste
     tui.press("arrow_down");
     tui.press("end");
     tui.press("ctrl+v");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -113,10 +102,8 @@ describe("clipboard roundtrip", () => {
     // Move to line 2 ("beta"), no selection — cut the whole line
     tui.press("arrow_down");
     tui.press("ctrl+x");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -136,25 +123,19 @@ describe("clipboard roundtrip", () => {
     // Select word "abc" with ctrl+d
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
 
     // Copy
     tui.press("ctrl+c");
-    tui.waitStable();
 
     // Move to end of line
     tui.press("end");
 
     // Paste 3 times
     tui.press("ctrl+v");
-    tui.waitStable();
     tui.press("ctrl+v");
-    tui.waitStable();
     tui.press("ctrl+v");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/close-tabs.test.js
+++ b/tests/functional/close-tabs.test.js
@@ -23,10 +23,8 @@ describe("close tabs commands", () => {
     tui.press("alt+,");
     tui.waitFor("content-b");
     tui.type("dirty");
-    tui.waitStable();
 
     tui.exec("View: Close All Saved Tabs");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -52,7 +50,6 @@ describe("close tabs commands", () => {
     tui.waitFor("content-b");
 
     tui.exec("View: Close Other Tabs");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -72,7 +69,6 @@ describe("close tabs commands", () => {
     tui.waitFor("b.txt");
 
     tui.exec("View: Close All Tabs");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -92,10 +88,8 @@ describe("close tabs commands", () => {
 
     // Make the file dirty
     tui.type("dirty");
-    tui.waitStable();
 
     tui.exec("View: Close All Tabs");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/code-folding.test.js
+++ b/tests/functional/code-folding.test.js
@@ -30,18 +30,14 @@ describe("code folding", () => {
     tui.waitFor("hello");
 
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("3");
     tui.press("enter");
-    tui.waitStable();
 
     tui.exec("Toggle Fold");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.exec("Toggle Fold");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -59,12 +55,10 @@ describe("code folding", () => {
     tui.waitFor("hello");
 
     tui.pressChord("ctrl+k", "0");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.pressChord("ctrl+k", "9");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -83,13 +77,10 @@ describe("code folding", () => {
     tui.waitFor("hello");
 
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("3");
     tui.press("enter");
-    tui.waitStable();
 
     tui.exec("Toggle Fold");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -105,19 +96,14 @@ describe("code folding", () => {
 
     // Collapse all folds using keybinding
     tui.pressChord("ctrl+k", "0");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Search for text inside collapsed fold
     tui.press("ctrl+f");
-    tui.waitStable();
     tui.type("hello");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
     tui.press("escape");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -135,13 +121,10 @@ describe("code folding", () => {
     tui.waitFor("hello");
 
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("3");
     tui.press("enter");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/command-palette.test.js
+++ b/tests/functional/command-palette.test.js
@@ -24,7 +24,6 @@ describe("command palette", () => {
     tui.waitFor("palette.txt");
 
     tui.press("ctrl+p");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -39,7 +38,6 @@ describe("command palette", () => {
     tui.waitFor("Explore");
 
     tui.exec("View: Toggle Sidebar");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -54,10 +52,8 @@ describe("command palette", () => {
     tui.waitFor("dismiss.txt");
 
     tui.press("ctrl+p");
-    tui.waitStable();
 
     tui.press("escape");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -138,7 +134,6 @@ describe("command palette", () => {
     tui.waitFor("help.txt");
     tui.press("ctrl+p");
     tui.type("?");
-    tui.waitStable();
 
     const topics = tui.snapshot();
     tui.press("arrow_down");
@@ -159,7 +154,6 @@ describe("command palette", () => {
     tui.waitFor("help-search.txt");
     tui.press("ctrl+p");
     tui.type("?saved tabs");
-    tui.waitStable();
 
     const result = tui.snapshot();
     const { snapshots } = tui.run();
@@ -176,12 +170,10 @@ describe("command palette", () => {
     tui.waitFor("help-precision.txt");
     tui.press("ctrl+p");
     tui.type("?undo");
-    tui.waitStable();
     const precise = tui.snapshot();
 
     for (let i = 0; i < 4; i++) tui.press("backspace");
     tui.type("qxzvjk");
-    tui.waitStable();
     const empty = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/commandline.test.js
+++ b/tests/functional/commandline.test.js
@@ -49,14 +49,10 @@ describe("plugin command line", () => {
     const plugin = writePlugin(dir, "cmdline.lua", CMDLINE_PLUGIN);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.type(":");
-    tui.waitStable();
     tui.type("wq");
-    tui.waitStable();
     const open = tui.snapshot();
     tui.press("enter");
-    tui.waitStable();
     const after = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -77,16 +73,11 @@ describe("plugin command line", () => {
     const plugin = writePlugin(dir, "cmdline.lua", CMDLINE_PLUGIN);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.type(":");
-    tui.waitStable();
     tui.type("q");
-    tui.waitStable();
     tui.press("escape");
-    tui.waitStable();
     tui.press("end");
     tui.type("Z");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -120,13 +111,9 @@ describe("plugin command line", () => {
     );
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.type("a");
-    tui.waitStable();
     tui.type(":");
-    tui.waitStable();
     tui.type("bcd");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -18,12 +18,12 @@ describe("commit history detail", () => {
 
     tui.start(dir);
     tui.pressChord("ctrl+k", "c");
-    tui.waitStable(500);
+    tui.waitFor("selected detail");
     tui.press("tab");
     tui.press("tab");
     tui.press("down");
     tui.press("right");
-    tui.waitStable(500);
+    tui.waitFor("selected-detail.txt");
     tui.press("down");
     tui.exec("Git: Open Changes Only");
     tui.waitFor("selected-detail.txt @");
@@ -42,17 +42,17 @@ describe("commit history detail", () => {
 
     tui.start(dir);
     tui.pressChord("ctrl+k", "c");
-    tui.waitStable(500);
+    tui.waitFor("paged 60");
     tui.press("tab");
     tui.press("tab");
     for (let index = 0; index < 11; index++) tui.press("down");
     const sentinel = tui.snapshot();
     tui.press("enter");
-    tui.waitStable(900);
+    tui.waitFor("paged 50");
     const firstPage = tui.snapshot();
     for (let index = 0; index < 50; index++) tui.press("down");
     tui.press("enter");
-    tui.waitStable(900);
+    tui.waitFor("initial commit");
     const lastPage = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -71,14 +71,14 @@ describe("commit history detail", () => {
 
     tui.start(dir);
     tui.pressChord("ctrl+k", "c");
-    tui.waitStable(500);
+    tui.waitFor("detail subject");
     // Changes focus starts in the working tree. The next two stops are the
     // commit input and the responsive Commit History tree.
     tui.press("tab");
     tui.press("tab");
     tui.press("down");
     tui.press("enter");
-    tui.waitStable(900);
+    tui.waitFor("Full detail body.");
     const detail = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -106,15 +106,15 @@ describe("commit history detail", () => {
 
 		tui.start(dir);
 		tui.pressChord("ctrl+k", "c");
-		tui.waitStable(500);
+		tui.waitFor("two distant edits");
 		tui.press("tab");
 		tui.press("tab");
 		tui.press("down");
 		tui.press("enter");
-		tui.waitStable(900);
+		tui.waitFor("changed near top");
 		const changesOnly = tui.snapshot();
 		tui.exec("Git: Show Full File");
-		tui.waitStable(900);
+		tui.waitFor("unchanged line 15");
 		const fullFile = tui.snapshot();
 
 		const { snapshots } = tui.run();
@@ -134,12 +134,12 @@ describe("commit history detail", () => {
 		tui.start(dir);
 		tui.setSize(70, 16);
 		tui.pressChord("ctrl+k", "c");
-		tui.waitStable(500);
+		tui.waitFor("menu detail");
 		tui.press("tab");
 		tui.press("tab");
 		tui.press("down");
 		tui.press("enter");
-		tui.waitStable(900);
+		tui.waitFor("Authored");
 		tui.rclick(60, 12);
 		const contentMenu = tui.snapshot();
 		for (let index = 0; index < 4; index++) tui.press("down");
@@ -167,12 +167,12 @@ describe("commit history detail", () => {
 
     tui.start(dir);
     tui.pressChord("ctrl+k", "c");
-    tui.waitStable(500);
+    tui.waitFor("bulk detail");
     tui.press("tab");
     tui.press("tab");
     tui.press("down");
     tui.press("enter");
-    tui.waitStable(900);
+    tui.waitFor("visible detail line");
     const expanded = tui.snapshot();
     tui.exec("Git: Collapse All File Trees");
     const collapsed = tui.snapshot();

--- a/tests/functional/current-changes-view.test.js
+++ b/tests/functional/current-changes-view.test.js
@@ -22,10 +22,9 @@ describe("current changes document", () => {
 
     tui.start(dir);
     tui.exec("Git: Open Current Changes");
-    tui.waitStable(500);
+    tui.waitFor("final working version 界");
     const first = tui.snapshot();
     tui.exec("Git: Open Current Changes");
-    tui.waitStable(300);
     const reopened = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -54,7 +53,7 @@ describe("current changes document", () => {
 
     tui.start(dir);
     tui.exec("Git: Open Current Changes");
-    tui.waitStable(500);
+    tui.waitFor("conflict (UD)");
     const conflict = tui.snapshot();
     const { snapshots } = tui.run();
     const screen = snapshots[conflict];

--- a/tests/functional/cyrillic-cursor.test.js
+++ b/tests/functional/cyrillic-cursor.test.js
@@ -15,11 +15,9 @@ describe("cursor position with multi-byte UTF-8 characters", () => {
     const file = createTempFile(dir, "cyrillic.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     // Type 6 Cyrillic characters: привет
     tui.type("привет");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -34,11 +32,9 @@ describe("cursor position with multi-byte UTF-8 characters", () => {
     const file = createTempFile(dir, "mixed2.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     // Type: hiпривет (2 ASCII + 6 Cyrillic = 8 runes)
     tui.type("hiпривет");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -52,11 +48,9 @@ describe("cursor position with multi-byte UTF-8 characters", () => {
     const file = createTempFile(dir, "nav.txt", "привет\n");
 
     tui.start(file);
-    tui.waitStable();
 
     // Move to end of line
     tui.press("end");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -70,17 +64,14 @@ describe("cursor position with multi-byte UTF-8 characters", () => {
     const file = createTempFile(dir, "cyrline.txt", "привет\n");
 
     tui.start(file);
-    tui.waitStable();
 
     // Start at Col 1
     const s0 = tui.snapshot();
 
     tui.press("end");
-    tui.waitStable();
     const s1 = tui.snapshot();
 
     tui.press("home");
-    tui.waitStable();
     const s2 = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/delete-line.test.js
+++ b/tests/functional/delete-line.test.js
@@ -18,10 +18,8 @@ describe("delete line", () => {
     tui.waitFor("AAA");
 
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -37,13 +35,10 @@ describe("delete line", () => {
     tui.waitFor("AAA");
 
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -59,15 +54,11 @@ describe("delete line", () => {
     tui.waitFor("AAA");
 
     tui.press("arrow_down");
-    tui.waitStable();
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -83,10 +74,8 @@ describe("delete line", () => {
     tui.waitFor("ONLY");
 
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -102,14 +91,10 @@ describe("delete line", () => {
     tui.waitFor("AAA");
 
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -125,13 +110,10 @@ describe("delete line", () => {
     tui.waitFor("AAA");
 
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/dialog-paste.test.js
+++ b/tests/functional/dialog-paste.test.js
@@ -16,21 +16,17 @@ describe("dialog paste", () => {
     const filePath = join(dir, "pasted.txt");
 
     tui.start();
-    tui.waitStable();
 
     // Open Save As dialog (new file has no path)
     tui.press("ctrl+s");
-    tui.waitStable();
 
     // Simulate bracketed paste into the dialog
     tui.paste(filePath);
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Confirm with Enter
     tui.press("enter");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/diff-preferences.test.js
+++ b/tests/functional/diff-preferences.test.js
@@ -44,13 +44,11 @@ function startWithConfig({ file, configDir, plugin }) {
   tui.start("--plugin", plugin, file);
   tui.setEnv({ TTT_CONFIG_DIR: configDir });
   tui.setSize(42, 14);
-  tui.waitStable(300);
 }
 
 function enableUnifiedWrappedDefaults() {
   tui.exec("Use Unified Diff by Default");
   tui.exec("Toggle Diff Word Wrap Default");
-  tui.waitStable();
 }
 
 function savedSettings(configDir) {
@@ -66,7 +64,6 @@ describe("diff reading preferences", () => {
     const fixture = diffFixture();
     startWithConfig(fixture);
     tui.exec("Test Preference Diff");
-    tui.waitStable();
     const snapshot = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -77,7 +74,6 @@ describe("diff reading preferences", () => {
     const fixture = diffFixture();
     startWithConfig(fixture);
     tui.exec("Menu: Options");
-    tui.waitStable();
     const options = tui.snapshot();
     for (let i = 0; i < 9; i++) tui.press("down");
     tui.press("right");
@@ -111,7 +107,6 @@ describe("diff reading preferences", () => {
     const fixture = diffFixture();
     startWithConfig(fixture);
     tui.exec("Test Preference Diff");
-    tui.waitStable();
     const before = tui.snapshot();
     enableUnifiedWrappedDefaults();
     const after = tui.snapshot();
@@ -133,7 +128,6 @@ describe("diff reading preferences", () => {
     enableUnifiedWrappedDefaults();
     tui.exec("Use Split Diff by Default");
     tui.exec("Toggle Diff Word Wrap Default");
-    tui.waitStable();
     const overridden = tui.snapshot();
     tui.exec("View: Previous Tab");
     const inherited = tui.snapshot();
@@ -153,7 +147,6 @@ describe("diff reading preferences", () => {
 
     startWithConfig(fixture);
     tui.exec("Test Preference Diff");
-    tui.waitStable();
     const reopened = tui.snapshot();
     const { snapshots } = tui.run();
     expect(diffRow(snapshots[reopened], "left-prefix")).toBeLessThan(diffRow(snapshots[reopened], "right-prefix"));

--- a/tests/functional/duplicate-line.test.js
+++ b/tests/functional/duplicate-line.test.js
@@ -18,13 +18,10 @@ describe("duplicate line", () => {
     tui.waitFor("AAA");
 
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.exec("Duplicate Line");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -40,13 +37,10 @@ describe("duplicate line", () => {
     tui.waitFor("First");
 
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.exec("Duplicate Line");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -62,13 +56,10 @@ describe("duplicate line", () => {
     tui.waitFor("Only");
 
     tui.exec("Duplicate Line");
-    tui.waitStable();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/editor-tab-reorder.test.js
+++ b/tests/functional/editor-tab-reorder.test.js
@@ -19,10 +19,8 @@ describe("editor tab order", () => {
     tui.start(alpha, beta, gamma);
     const before = tui.snapshot();
     tui.drag(38, 2, 2, 2);
-    tui.waitStable();
     const dragged = tui.snapshot();
     tui.exec("View: Move Tab Right");
-    tui.waitStable();
     const moved = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/explorer-rename.test.js
+++ b/tests/functional/explorer-rename.test.js
@@ -21,11 +21,9 @@ afterEach(() => {
 // selection, so the old name has to be cleared before typing the new one.
 function renameSelectedTo(oldName, newName) {
   tui.exec("Explorer: Rename");
-  tui.waitStable();
   for (let i = 0; i < oldName.length; i++) tui.press("backspace");
   tui.type(newName);
   tui.press("enter");
-  tui.waitStable();
 }
 
 describe("explorer rename", () => {
@@ -37,10 +35,8 @@ describe("explorer rename", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+0");
-    tui.waitStable();
     tui.press("arrow_down");
     tui.press("enter");
-    tui.waitStable();
 
     renameSelectedTo("alpha.txt", "renamed.txt");
 
@@ -61,16 +57,13 @@ describe("explorer rename", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+0");
-    tui.waitStable();
     tui.press("arrow_down");
     tui.press("enter");
-    tui.waitStable();
 
     renameSelectedTo("alpha.txt", "renamed.txt");
 
     tui.type("EDITED ");
     tui.exec("Save File");
-    tui.waitStable();
     tui.run();
 
     expect(fileExists(join(dir, "alpha.txt"))).toBe(false);
@@ -86,10 +79,8 @@ describe("explorer rename", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+0");
-    tui.waitStable();
     tui.press("arrow_down");
     tui.press("enter");
-    tui.waitStable();
 
     renameSelectedTo("alpha.txt", "renamed.txt");
 
@@ -109,13 +100,11 @@ describe("explorer refresh", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+0");
-    tui.waitStable();
 
     // The explorer has already listed the directory; add a file behind its back.
     writeFileSync(join(dir, "created-outside.txt"), "outside");
 
     tui.press("r");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/explorer.test.js
+++ b/tests/functional/explorer.test.js
@@ -37,14 +37,12 @@ describe("explorer", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+0");
-    tui.waitStable();
 
     // Navigate down to the file and open it
     tui.press("arrow_down");
     tui.press("arrow_down");
     tui.press("arrow_down");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -75,13 +73,11 @@ describe("explorer", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+0");
-    tui.waitStable();
 
     // Navigate to subdir and expand it
     tui.press("arrow_down");
     tui.press("arrow_down");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -97,14 +93,11 @@ describe("explorer", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+0");
-    tui.waitStable();
 
     tui.exec("Explorer: New File");
-    tui.waitStable();
 
     tui.type("newfile.txt");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/find-navigation.test.js
+++ b/tests/functional/find-navigation.test.js
@@ -23,23 +23,19 @@ describe("find navigation (F3 / Shift+F3)", () => {
     tui.waitFor("cat here");
 
     tui.press("ctrl+f");
-    tui.waitStable();
 
     tui.type("cat");
-    tui.waitStable();
 
     // Initial match is on line 1
     const s0 = tui.snapshot();
 
     // F3 moves to next match (line 3)
     tui.press("f3");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // F3 moves to next match (line 5)
     tui.press("f3");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
 
@@ -62,23 +58,19 @@ describe("find navigation (F3 / Shift+F3)", () => {
     tui.waitFor("cat here");
 
     tui.press("ctrl+f");
-    tui.waitStable();
 
     tui.type("cat");
-    tui.waitStable();
 
     // Start at match 1 on line 1
     const s0 = tui.snapshot();
 
     // F3 advances to match 2 on line 3
     tui.press("f3");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // Shift+F3 goes back to match 1 on line 1
     tui.press("shift+f3");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
 
@@ -100,23 +92,19 @@ describe("find navigation (F3 / Shift+F3)", () => {
     tui.waitFor("cat start");
 
     tui.press("ctrl+f");
-    tui.waitStable();
 
     tui.type("cat");
-    tui.waitStable();
 
     // Start at match 1 on line 1
     const s0 = tui.snapshot();
 
     // F3 advances to match 2 on line 3
     tui.press("f3");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // F3 wraps around back to match 1 on line 1
     tui.press("f3");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
 
@@ -139,10 +127,8 @@ describe("find navigation (F3 / Shift+F3)", () => {
     tui.waitFor("cat here");
 
     tui.press("ctrl+f");
-    tui.waitStable();
 
     tui.type("zzzzz");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 

--- a/tests/functional/find-replace.test.js
+++ b/tests/functional/find-replace.test.js
@@ -19,10 +19,8 @@ describe("find and replace", () => {
     tui.waitFor("foo bar foo baz foo");
 
     tui.press("ctrl+f");
-    tui.waitStable();
 
     tui.type("foo");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -37,15 +35,12 @@ describe("find and replace", () => {
     tui.waitFor("apple banana");
 
     tui.press("ctrl+f");
-    tui.waitStable();
 
     tui.type("apple");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("enter");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -61,7 +56,6 @@ describe("find and replace", () => {
     tui.waitFor("hello world hello");
 
     tui.press("ctrl+r");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -76,25 +70,19 @@ describe("find and replace", () => {
     tui.waitFor("old value old again");
 
     tui.press("ctrl+r");
-    tui.waitStable();
 
     tui.type("old");
-    tui.waitStable();
 
     // Tab to replace input
     tui.press("tab");
     tui.type("new");
-    tui.waitStable();
 
     // Enter on replace row replaces current match
     tui.press("enter");
-    tui.waitStable();
 
     // Close replace bar and save
     tui.press("escape");
-    tui.waitStable();
     tui.press("ctrl+s");
-    tui.waitStable(500);
 
     tui.run();
 
@@ -112,31 +100,23 @@ describe("find and replace", () => {
     tui.waitFor("cat dog cat bird cat");
 
     tui.press("ctrl+r");
-    tui.waitStable();
 
     tui.type("cat");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Tab to replace input
     tui.press("tab");
     tui.type("fish");
-    tui.waitStable();
 
     // Replace each occurrence (3 matches)
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
 
     // Close replace bar and save
     tui.press("escape");
-    tui.waitStable();
     tui.press("ctrl+s");
-    tui.waitStable(500);
 
     const { snapshots } = tui.run();
     expect(snapshots[s0]).toContain("1/3");
@@ -158,28 +138,20 @@ describe("find and replace", () => {
     tui.waitFor("ZZ keep ZZ stay ZZ end");
 
     tui.press("ctrl+r");
-    tui.waitStable();
 
     tui.type("ZZ");
-    tui.waitStable();
 
     // Tab to replace field but leave it empty (empty replacement = deletion)
     tui.press("tab");
-    tui.waitStable();
 
     // Replace each occurrence (3 matches)
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
 
     // Close replace bar and save
     tui.press("escape");
-    tui.waitStable();
     tui.press("ctrl+s");
-    tui.waitStable(500);
 
     tui.run();
 
@@ -199,25 +171,19 @@ describe("find and replace", () => {
     tui.waitFor("alpha beta gamma");
 
     tui.press("ctrl+r");
-    tui.waitStable();
 
     tui.type("zzzznotfound");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Tab to replace, type replacement, try to replace
     tui.press("tab");
     tui.type("replaced");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
 
     // Close and save
     tui.press("escape");
-    tui.waitStable();
     tui.press("ctrl+s");
-    tui.waitStable(500);
 
     const { snapshots } = tui.run();
     expect(snapshots[s0]).toContain("0/0");
@@ -240,31 +206,23 @@ describe("find and replace", () => {
     tui.waitFor("line one");
 
     tui.press("ctrl+r");
-    tui.waitStable();
 
     tui.type("foo");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Tab to replace input
     tui.press("tab");
     tui.type("bar");
-    tui.waitStable();
 
     // Replace each occurrence (3 matches across lines)
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
 
     // Close replace bar and save
     tui.press("escape");
-    tui.waitStable();
     tui.press("ctrl+s");
-    tui.waitStable(500);
 
     const { snapshots } = tui.run();
     expect(snapshots[s0]).toContain("1/3");
@@ -285,30 +243,23 @@ describe("find and replace", () => {
     tui.waitFor("aaa bbb aaa ccc aaa");
 
     tui.press("ctrl+r");
-    tui.waitStable();
 
     tui.type("aaa");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Tab to replace input
     tui.press("tab");
     tui.type("xxx");
-    tui.waitStable();
 
     // Replace all three
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
 
     // After replacing all, match count should be 0/0
     // Tab back to search row to see match count
     tui.press("tab");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/fullwidth-render.test.js
+++ b/tests/functional/fullwidth-render.test.js
@@ -180,7 +180,6 @@ describe("fullwidth CJK outside the editor", () => {
 
     tui.start(dir, file);
     tui.waitFor("한국어파일.txt");
-    tui.wait(400);
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -197,9 +196,7 @@ describe("fullwidth CJK outside the editor", () => {
     tui.start(file);
     tui.waitFor("search.txt");
     tui.press("ctrl+f");
-    tui.wait(200);
     tui.type("가나다");
-    tui.wait(300);
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -216,9 +213,7 @@ describe("fullwidth CJK outside the editor", () => {
     tui.start(file);
     tui.waitFor("palette.txt");
     tui.press("ctrl+p");
-    tui.wait(200);
     tui.type("한국");
-    tui.wait(300);
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/git-changes-reactive.test.js
+++ b/tests/functional/git-changes-reactive.test.js
@@ -18,14 +18,14 @@ describe("reactive git changes", () => {
     tui.start(dir, tracked);
     tui.waitFor("Explore");
     tui.exec("Show Changes");
-    tui.waitStable(300);
+    tui.waitFor("No changes");
     const clean = tui.snapshot();
 
     tui.exec("View: Focus Editor");
     tui.press("end");
     tui.type("changed");
     tui.exec("Save File");
-    tui.waitStable(600);
+    tui.waitFor("Changes (1)");
     const updated = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/git-changes.test.js
+++ b/tests/functional/git-changes.test.js
@@ -14,9 +14,9 @@ afterEach(() => {
 // The Changes panel's action icons are not reachable through synthetic clicks,
 // so these drive the keyboard equivalents: a = stage all, u = unstage all,
 // D = discard all.
-function openChanges() {
+function openChanges(expectedState) {
   tui.exec("Show Changes");
-  tui.waitStable();
+  tui.waitFor(expectedState);
 }
 
 describe("git changes panel", () => {
@@ -31,13 +31,13 @@ describe("git changes panel", () => {
     writeFileSync(join(dir, "新規", "深い", "同名.go"), "package exact\n", "utf8");
 
     tui.start(dir);
-    openChanges();
+    openChanges("Changes (2)");
     tui.exec("View Git Files as Tree");
     const rendered = tui.snapshot();
     tui.press("down");
     tui.press("down");
     tui.exec("Git: Stage File");
-    tui.waitStable();
+    tui.waitFor("Staged (1)");
 
     const { snapshots } = tui.run();
     expect(snapshots[rendered]).toContain("界-wide.txt");
@@ -54,11 +54,11 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (2)");
 
     const before = tui.snapshot();
     tui.press("a");
-    tui.waitStable();
+    tui.waitFor("Staged (2)");
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -79,12 +79,12 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (2)");
 
     tui.press("a");
-    tui.waitStable();
+    tui.waitFor("Staged (2)");
     tui.press("u");
-    tui.waitStable();
+    tui.waitFor("Changes (2)");
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -101,15 +101,15 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (1)");
 
     tui.press("a");
-    tui.waitStable();
+    tui.waitFor("Staged (1)");
     // Tab moves focus from the file tree to the commit message input.
     tui.press("tab");
     tui.type("a commit from the editor");
     tui.press("enter");
-    tui.waitStable();
+    tui.waitFor("No changes");
 
     const after = tui.snapshot();
     const { snapshots } = tui.run();
@@ -126,17 +126,17 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (1)");
 
     tui.press("a");
-    tui.waitStable();
+    tui.waitFor("Staged (1)");
     tui.press("tab");
     tui.type("logged commit");
     tui.press("enter");
-    tui.waitStable();
+    tui.waitFor("No changes");
 
     tui.exec("Output: Show Panel");
-    tui.waitStable();
+    tui.waitFor("[notice] Committed: logged commit");
     const output = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -153,15 +153,14 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (2)");
 
     tui.type("D");
-    tui.waitStable();
     const dialog = tui.snapshot();
     // The dialog defaults to Cancel; move to Discard before confirming.
     tui.press("right");
     tui.press("enter");
-    tui.waitStable();
+    tui.waitFor("No changes");
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -181,13 +180,12 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (2)");
 
     tui.type("D");
-    tui.waitStable();
     tui.press("right");
     tui.press("enter");
-    tui.waitStable();
+    tui.waitFor("No changes");
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -205,15 +203,15 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (2)");
 
     tui.press("down");
     tui.exec("Git: Stage File");
-    tui.waitStable();
+    tui.waitFor("Staged (1)");
     const staged = tui.snapshot();
 
     tui.exec("Git: Unstage File");
-    tui.waitStable();
+    tui.waitFor("Changes (2)");
     const unstaged = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -232,15 +230,15 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (1)");
 
     tui.press("down");
     tui.press("space");
-    tui.waitStable();
+    tui.waitFor("Staged (1)");
     const on = tui.snapshot();
 
     tui.press("space");
-    tui.waitStable();
+    tui.waitFor("Changes (1)");
     const off = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -257,14 +255,13 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (2)");
 
     tui.press("down");
     tui.type("d");
-    tui.waitStable();
     tui.press("right");
     tui.press("enter");
-    tui.waitStable();
+    tui.waitFor("Changes (1)");
 
     const { snapshots } = tui.run();
     void snapshots;
@@ -281,14 +278,14 @@ describe("git changes panel", () => {
 
     tui.start(dir);
     tui.waitFor("Explore");
-    openChanges();
+    openChanges("Changes (1)");
 
     tui.press("a");
-    tui.waitStable();
+    tui.waitFor("Staged (1)");
     tui.press("tab");
     tui.type("first message");
     tui.press("enter");
-    tui.waitStable();
+    tui.waitFor("● first message");
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -308,8 +305,7 @@ describe("git changes panel", () => {
 
     // The repo has no remote, so the push fails inside the background task.
     tui.exec("Git: Push");
-    tui.waitStable();
-    tui.waitStable();
+    tui.waitFor("Pushing failed");
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/git-file-tree.test.js
+++ b/tests/functional/git-file-tree.test.js
@@ -27,16 +27,15 @@ describe("git file tree", () => {
     dir = nestedRepo();
     tui.start(dir);
     tui.pressChord("ctrl+k", "c");
-    tui.waitStable(500);
+    tui.waitFor("nested history");
     tui.press("tab");
     tui.press("tab");
     tui.press("down");
     tui.press("right");
-    tui.waitStable(500);
+    tui.waitFor("pkg/history/committed.go");
     const list = tui.snapshot();
 
     tui.exec("View Git Files as Tree");
-    tui.waitStable();
     const tree = tui.snapshot();
     tui.exec("Git: Collapse All File Trees");
     const collapsed = tui.snapshot();
@@ -44,14 +43,12 @@ describe("git file tree", () => {
     const expanded = tui.snapshot();
 
     tui.rclick(5, 5);
-    tui.waitStable();
     tui.press("down");
     tui.press("down");
     tui.press("right");
     const context = tui.snapshot();
     tui.press("escape");
     tui.click(29, 2);
-    tui.waitStable();
     tui.press("down");
     tui.press("down");
     tui.press("right");

--- a/tests/functional/go-to-line.test.js
+++ b/tests/functional/go-to-line.test.js
@@ -18,11 +18,9 @@ describe("go to line", () => {
     tui.waitFor("Line 1");
 
     tui.press("ctrl+g");
-    tui.waitStable();
 
     tui.type("25");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -37,10 +35,8 @@ describe("go to line", () => {
     tui.waitFor("Line 1");
 
     tui.press("ctrl+g");
-    tui.waitStable();
 
     tui.press("escape");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/home-end-keys.test.js
+++ b/tests/functional/home-end-keys.test.js
@@ -19,10 +19,8 @@ describe("home and end keys", () => {
 
     tui.press("end");
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -40,10 +38,8 @@ describe("home and end keys", () => {
     tui.press("end");
     tui.press("home");
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -61,10 +57,8 @@ describe("home and end keys", () => {
     tui.press("arrow_down");
     tui.press("end");
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -82,10 +76,8 @@ describe("home and end keys", () => {
     tui.press("end");
     tui.press("home");
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -106,10 +98,8 @@ describe("home and end keys", () => {
     tui.press("arrow_down");
     tui.press("end");
     tui.type("MIDDLE");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/indent-detection.test.js
+++ b/tests/functional/indent-detection.test.js
@@ -31,7 +31,6 @@ describe("indent detection", () => {
 
     tui.start("--config", configFile, file);
     tui.waitFor("astro.config.mjs");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -57,7 +56,6 @@ describe("indent detection", () => {
 
     tui.start("--config", configFile, file);
     tui.waitFor("main.go");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -80,7 +78,6 @@ describe("indent detection", () => {
 
     tui.start("--config", configFile, file);
     tui.waitFor("config.mjs");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -102,7 +99,6 @@ describe("indent detection", () => {
 
     tui.start("--config", configFile, file);
     tui.waitFor("app.py");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/insert-final-newline.test.js
+++ b/tests/functional/insert-final-newline.test.js
@@ -20,7 +20,6 @@ describe("insertFinalNewline", () => {
     tui.waitFor("no newline at end");
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -42,7 +41,6 @@ describe("insertFinalNewline", () => {
     tui.waitFor("no trailing newline!");
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -60,7 +58,6 @@ describe("insertFinalNewline", () => {
     tui.waitFor("AAA");
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -76,7 +73,6 @@ describe("insertFinalNewline", () => {
     tui.waitFor("line one");
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/insert-line.test.js
+++ b/tests/functional/insert-line.test.js
@@ -19,10 +19,8 @@ describe("insert line", () => {
 
     tui.press("ctrl+enter");
     tui.type("NEW");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -38,15 +36,11 @@ describe("insert line", () => {
     tui.waitFor("AAA");
 
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.exec("Insert Line Above");
-    tui.waitStable();
     tui.type("NEW");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -63,14 +57,11 @@ describe("insert line", () => {
 
     tui.press("arrow_down");
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.press("ctrl+enter");
     tui.type("END");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -87,10 +78,8 @@ describe("insert line", () => {
 
     tui.press("ctrl+enter");
     tui.type("x");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -107,14 +96,11 @@ describe("insert line", () => {
 
     tui.press("ctrl+enter");
     tui.type("NEW");
-    tui.waitStable();
 
     tui.press("ctrl+z");
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/join-lines.test.js
+++ b/tests/functional/join-lines.test.js
@@ -19,7 +19,6 @@ describe("join lines", () => {
 
     // Cursor starts on line 1
     tui.pressChord("ctrl+k", "j");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -34,7 +33,6 @@ describe("join lines", () => {
     tui.waitFor("only line");
 
     tui.pressChord("ctrl+k", "j");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -49,11 +47,9 @@ describe("join lines", () => {
     tui.waitFor("AAA");
 
     tui.pressChord("ctrl+k", "j");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -70,10 +66,8 @@ describe("join lines", () => {
     tui.waitFor("Line1");
 
     tui.pressChord("ctrl+k", "j");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/large-file.test.js
+++ b/tests/functional/large-file.test.js
@@ -19,10 +19,8 @@ describe("large file scroll stability", () => {
 
     // Jump to the last line using go-to-line
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("500");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -40,18 +38,14 @@ describe("large file scroll stability", () => {
 
     // Jump to bottom first
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("500");
     tui.press("enter");
-    tui.waitStable();
     tui.waitFor("Line 500");
 
     // Now jump back to top
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("1");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -67,10 +61,8 @@ describe("large file scroll stability", () => {
     tui.waitFor("big3.txt");
 
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("250");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -90,22 +82,16 @@ describe("large file scroll stability", () => {
 
     // Press page down to scroll away from the top
     tui.press("page_down");
-    tui.waitStable(200);
     tui.press("page_down");
-    tui.waitStable(200);
     tui.press("page_down");
-    tui.waitStable(200);
 
     // Cursor should have moved past line 1
     const s1 = tui.snapshot();
 
     // Press page up the same number of times to return near the top
     tui.press("page_up");
-    tui.waitStable(200);
     tui.press("page_up");
-    tui.waitStable(200);
     tui.press("page_up");
-    tui.waitStable(200);
 
     // Should be back at line 1
     const s2 = tui.snapshot();

--- a/tests/functional/line-endings.test.js
+++ b/tests/functional/line-endings.test.js
@@ -19,7 +19,6 @@ describe("line ending detection and preservation", () => {
 
     tui.start(file);
     tui.waitFor("line1");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -35,7 +34,6 @@ describe("line ending detection and preservation", () => {
 
     tui.start(file);
     tui.waitFor("line1");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -54,7 +52,6 @@ describe("line ending detection and preservation", () => {
     tui.type(" edited");
     tui.waitFor("hello edited");
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -72,21 +69,16 @@ describe("line ending detection and preservation", () => {
 
     tui.start(file);
     tui.waitFor("aaa");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.exec("Change Line Ending");
-    tui.waitStable();
     tui.type("CRLF");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -107,16 +99,12 @@ describe("line ending detection and preservation", () => {
     tui.waitFor("CRLF");
 
     tui.exec("Change Line Ending");
-    tui.waitStable();
     tui.type("LF");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -140,7 +128,6 @@ describe("line ending detection and preservation", () => {
     tui.type(" edited");
     tui.waitFor("hello edited");
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/line-manipulation.test.js
+++ b/tests/functional/line-manipulation.test.js
@@ -19,16 +19,13 @@ describe("line manipulation", () => {
 
     // Move to line 2
     tui.press("arrow_down");
-    tui.waitStable();
 
     // Delete line (ctrl+k k chord)
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -50,15 +47,12 @@ describe("line manipulation", () => {
     tui.waitFor("Alpha");
 
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "k");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 

--- a/tests/functional/lsp-fake-protocol.test.js
+++ b/tests/functional/lsp-fake-protocol.test.js
@@ -59,10 +59,8 @@ function startCase(name) {
   tui.waitFor("FAKE_LSP_READY");
   tui.exec("View: Focus Editor");
   tui.press("ctrl+g");
-  tui.waitStable();
   tui.type("2");
   tui.press("enter");
-  tui.waitStable();
 
   return { file, trace };
 }

--- a/tests/functional/matching-bracket.test.js
+++ b/tests/functional/matching-bracket.test.js
@@ -22,15 +22,12 @@ describe("go to matching bracket", () => {
 
     // Go to end of line 1 where '{' is the last character
     tui.press("end");
-    tui.waitStable();
 
     // Move one left to land on '{'
     tui.press("arrow_left");
-    tui.waitStable();
 
     // Now jump to matching bracket
     tui.pressChord("ctrl+k", "m");
-    tui.waitStable();
 
     // The status bar should show we're on line 3 (the } line)
     const s0 = tui.snapshot();

--- a/tests/functional/menu-dismiss-focus.test.js
+++ b/tests/functional/menu-dismiss-focus.test.js
@@ -20,9 +20,7 @@ describe("focus after dismissing a menu", () => {
     tui.press("alt+v");
     tui.waitFor("Command Palette");
     tui.press("escape");
-    tui.waitStable();
     tui.type("ZZZ");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -39,9 +37,7 @@ describe("focus after dismissing a menu", () => {
     tui.rclick(30, 6);
     tui.waitFor("Go to Definition");
     tui.press("escape");
-    tui.waitStable();
     tui.type("QQQ");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/menubar-toggle.test.js
+++ b/tests/functional/menubar-toggle.test.js
@@ -19,11 +19,9 @@ describe("menu bar toggle", () => {
     const s0 = tui.snapshot();
 
     tui.press("alt+shift+m");
-    tui.waitStable();
     const s1 = tui.snapshot();
 
     tui.press("alt+shift+m");
-    tui.waitStable();
     const s2 = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -40,7 +38,6 @@ describe("menu bar toggle", () => {
     tui.waitFor("Options");
 
     tui.exec("View: Toggle Menu Bar");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -57,14 +54,11 @@ describe("menu bar toggle", () => {
     tui.waitFor("Options");
 
     tui.press("alt+shift+m");
-    tui.waitStable();
 
     tui.exec("Menu: View");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     tui.press("escape");
-    tui.waitStable();
     const s1 = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/move-line.test.js
+++ b/tests/functional/move-line.test.js
@@ -18,10 +18,8 @@ describe("move line", () => {
     tui.waitFor("AAA");
 
     tui.exec("Move Line Down");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -38,13 +36,10 @@ describe("move line", () => {
 
     tui.press("arrow_down");
     tui.press("arrow_down");
-    tui.waitStable();
 
     tui.exec("Move Line Up");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -60,10 +55,8 @@ describe("move line", () => {
     tui.waitFor("First");
 
     tui.exec("Move Line Up");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -79,13 +72,10 @@ describe("move line", () => {
     tui.waitFor("One");
 
     tui.exec("Move Line Down");
-    tui.waitStable();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/multi-cursor.test.js
+++ b/tests/functional/multi-cursor.test.js
@@ -19,17 +19,12 @@ describe("multi-cursor", () => {
 
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
 
     tui.type("qux");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -46,16 +41,12 @@ describe("multi-cursor", () => {
 
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
 
     tui.exec("Select All Occurrences");
-    tui.waitStable();
 
     tui.type("pet");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -72,20 +63,14 @@ describe("multi-cursor", () => {
 
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
 
     tui.type("cc");
-    tui.waitStable();
 
     tui.press("ctrl+z");
-    tui.waitStable();
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -103,18 +88,13 @@ describe("multi-cursor", () => {
 
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
 
     tui.press("escape");
-    tui.waitStable();
 
     tui.type("Z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -133,16 +113,12 @@ describe("multi-cursor", () => {
 
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
 
     // Cursors have "ABC" selected at both positions, type to replace
     tui.press("delete");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -159,17 +135,12 @@ describe("multi-cursor", () => {
 
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
 
     tui.type("let");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -186,23 +157,16 @@ describe("multi-cursor", () => {
 
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
     tui.press("ctrl+d");
-    tui.waitStable();
 
     // All cursors have "test" selected; word-right x2: skip space, then jump to end of number word
     tui.exec("Move Word Right");
-    tui.waitStable();
     tui.exec("Move Word Right");
-    tui.waitStable();
 
     tui.type("!");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/multi-tab-state.test.js
+++ b/tests/functional/multi-tab-state.test.js
@@ -70,10 +70,8 @@ describe("multi-tab state isolation", () => {
 
     // Move cursor to line 5 in file A
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("5");
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
@@ -82,17 +80,14 @@ describe("multi-tab state isolation", () => {
     tui.waitFor("cursb.txt");
 
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("3");
     tui.press("enter");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // Switch back to file A - cursor should still be on line 5
     switchToPrevTab();
     tui.waitFor("cursa.txt");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -160,7 +155,6 @@ describe("multi-tab state isolation", () => {
 
     // Edit file A to make it dirty
     tui.type("x");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 

--- a/tests/functional/new-file.test.js
+++ b/tests/functional/new-file.test.js
@@ -37,10 +37,8 @@ describe("new file", () => {
     tui.press("ctrl+n");
     tui.waitFor("untitled");
     tui.type("some text");
-    tui.waitStable();
 
     tui.press("ctrl+n");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -67,7 +65,6 @@ describe("new file", () => {
 
     tui.type(newFile);
     tui.press("enter");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/open-edit-save.test.js
+++ b/tests/functional/open-edit-save.test.js
@@ -34,10 +34,8 @@ describe("open, edit, save", () => {
     tui.press("end");
     tui.press("space");
     tui.type("Modified");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -55,7 +53,6 @@ describe("open, edit, save", () => {
     tui.waitFor("dirty.txt");
 
     tui.type("x");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/options-toggle.test.js
+++ b/tests/functional/options-toggle.test.js
@@ -20,18 +20,15 @@ describe("options toggle", () => {
 
     tui.start(file);
     tui.waitFor("first line");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.exec("Toggle Line Numbers");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // Toggle back to restore original state
     tui.exec("Toggle Line Numbers");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -61,18 +58,15 @@ describe("options toggle", () => {
 
     tui.start(file);
     tui.waitFor("package main");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.exec("Toggle Syntax Highlight");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // Toggle back to restore
     tui.exec("Toggle Syntax Highlight");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -93,18 +87,15 @@ describe("options toggle", () => {
 
     tui.start(file);
     tui.waitFor("package main");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.exec("Toggle Bracket Pair Colorization");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // Toggle back to restore
     tui.exec("Toggle Bracket Pair Colorization");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/outline.test.js
+++ b/tests/functional/outline.test.js
@@ -31,7 +31,6 @@ describe("outline panel", () => {
     tui.press("down");
     tui.press("enter");
     tui.type("JUMPED");
-    tui.waitStable();
     const s1 = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -72,7 +71,6 @@ describe("outline panel", () => {
     tui.start(dir, file);
     tui.waitFor("Explore");
     tui.exec("Show Outline");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/output-panel.test.js
+++ b/tests/functional/output-panel.test.js
@@ -19,10 +19,8 @@ describe("output panel", () => {
 
     // Any command that reports through the status bar should leave a trail.
     tui.exec("File: Copy Absolute Path");
-    tui.waitStable();
 
     tui.exec("Output: Show Panel");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -38,14 +36,11 @@ describe("output panel", () => {
     tui.waitFor("hello");
 
     tui.exec("File: Copy Absolute Path");
-    tui.waitStable();
     tui.exec("Output: Show Panel");
-    tui.waitStable();
 
     const before = tui.snapshot();
 
     tui.exec("Output: Clear");
-    tui.waitStable();
 
     const after = tui.snapshot();
     const { snapshots } = tui.run();
@@ -65,12 +60,9 @@ describe("output panel", () => {
     tui.waitFor("hello");
 
     tui.exec("File: Copy Absolute Path");
-    tui.waitStable();
     tui.exec("Output: Show Panel");
-    tui.waitStable();
 
     tui.exec("Output: Copy Selected Line");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/plugin-editor-api.test.js
+++ b/tests/functional/plugin-editor-api.test.js
@@ -36,9 +36,7 @@ describe("editor.get_line plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test GetLine");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -66,9 +64,7 @@ describe("editor.line_count plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test Count");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -95,9 +91,7 @@ describe("editor.set_line plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test SetLine");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -127,9 +121,7 @@ describe("editor.viewport plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test Viewport");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -158,9 +150,7 @@ describe("editor.viewport plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test Scroll");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -191,13 +181,10 @@ describe("editor.begin_undo_group / end_undo_group plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test Group");
-    tui.waitStable();
     const s1 = tui.snapshot();
     // Single undo should revert all three changes
     tui.exec("Undo");
-    tui.waitStable();
     const s2 = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -233,9 +220,7 @@ describe("editor.add_cursor / get_cursors / clear_cursors plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test AddCursors");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -265,9 +250,7 @@ describe("editor.add_cursor / get_cursors / clear_cursors plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test ClearCursors");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/plugin-exec-command.test.js
+++ b/tests/functional/plugin-exec-command.test.js
@@ -35,11 +35,8 @@ describe("ttt.exec_command plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.type("hello");
-    tui.waitStable();
     tui.exec("Test Run Exec");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -64,9 +61,7 @@ describe("ttt.exec_command plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test Run Bad");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -101,9 +96,7 @@ describe("ttt.list_commands plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test List");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/plugin-key-intercept.test.js
+++ b/tests/functional/plugin-key-intercept.test.js
@@ -35,10 +35,8 @@ describe("key.press event", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.press("end");
     tui.type("j");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -59,10 +57,8 @@ describe("key.press event", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.press("end");
     tui.type("x");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/plugin-menu-checked.test.js
+++ b/tests/functional/plugin-menu-checked.test.js
@@ -50,9 +50,7 @@ ttt.register({
 
     tui.start("--plugin", plugin, file);
     tui.setSize(80, 20);
-    tui.waitStable(300);
     tui.panel("plugin.menu-indicators");
-    tui.waitStable();
 
     tui.click(35, 12);
     const checkedStates = tui.snapshot();
@@ -101,13 +99,9 @@ ttt.register({
 
     tui.start("--plugin", plugin, dir);
     tui.setSize(80, 20);
-    tui.waitStable(300);
     tui.click(27, 2);
-    tui.waitStable();
     tui.click(29, 5);
-    tui.waitStable();
     tui.click(29, 2);
-    tui.waitStable();
     const mixed = tui.snapshot();
     tui.press("arrow_down");
     tui.press("enter");
@@ -176,22 +170,17 @@ ttt.register({
 
     tui.start("--plugin", plugin, file);
     tui.setSize(80, 20);
-    tui.waitStable(300);
     tui.panel("plugin.dynamic-menu-indicators");
-    tui.waitStable();
 
     tui.click(35, 12);
     const checked = tui.snapshot();
     tui.press("enter");
-    tui.waitStable();
     tui.click(35, 12);
     const unchecked = tui.snapshot();
     tui.press("enter");
-    tui.waitStable();
     tui.click(35, 12);
     const omitted = tui.snapshot();
     tui.press("enter");
-    tui.waitStable();
     tui.click(35, 12);
     const checkedAgain = tui.snapshot();
     tui.press("arrow_down");

--- a/tests/functional/plugin-open-diff.test.js
+++ b/tests/functional/plugin-open-diff.test.js
@@ -34,9 +34,7 @@ describe("ttt.open_diff plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test Diff");
-    tui.waitStable(300);
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -61,9 +59,7 @@ describe("ttt.open_readonly plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test ReadOnly");
-    tui.waitStable(300);
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -87,11 +83,8 @@ describe("ttt.open_readonly plugin API", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test ReadOnly");
-    tui.waitStable(300);
     tui.type("should not appear");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -118,11 +111,8 @@ describe("ttt.open_file readonly mode", () => {
     `);
 
     tui.start("--plugin", plugin, file);
-    tui.waitStable(300);
     tui.exec("Test OpenRO");
-    tui.waitStable(300);
     tui.type("nope");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/plugin-timers.test.js
+++ b/tests/functional/plugin-timers.test.js
@@ -36,9 +36,11 @@ ttt.clear_timeout(cancelled)
 
     tui.start("--plugin", pluginFile, file);
     tui.waitFor("hello timers");
-    tui.wait(550);
+    // These elapsed intervals are the subject of the test: cross the timer
+    // deadlines before and after opening the output panel.
+    tui.elapse(550);
     tui.panel("output");
-    tui.wait(150);
+    tui.elapse(150);
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/quick-open.test.js
+++ b/tests/functional/quick-open.test.js
@@ -19,7 +19,6 @@ describe("quick open (Go to File)", () => {
     tui.waitFor("Explore");
 
     tui.pressChord("ctrl+k", "p");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -38,10 +37,8 @@ describe("quick open (Go to File)", () => {
     tui.waitFor("Explore");
 
     tui.pressChord("ctrl+k", "p");
-    tui.waitStable();
 
     tui.type("ban");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -57,13 +54,10 @@ describe("quick open (Go to File)", () => {
     tui.waitFor("Explore");
 
     tui.pressChord("ctrl+k", "p");
-    tui.waitStable();
 
     tui.type("target");
-    tui.waitStable();
 
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -79,12 +73,10 @@ describe("quick open (Go to File)", () => {
     tui.waitFor("Explore");
 
     tui.pressChord("ctrl+k", "p");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("escape");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/quit-confirm.test.js
+++ b/tests/functional/quit-confirm.test.js
@@ -18,7 +18,6 @@ describe("quit confirmation dialog", () => {
     tui.waitFor("clean.txt");
 
     tui.press("ctrl+q");
-    tui.waitStable(500);
 
     // Editor should have quit; screenshot won't execute on exited process
     const s0 = tui.snapshot();
@@ -34,10 +33,8 @@ describe("quit confirmation dialog", () => {
     tui.waitFor("dirty.txt");
 
     tui.type("x");
-    tui.waitStable();
 
     tui.press("ctrl+q");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -54,13 +51,11 @@ describe("quit confirmation dialog", () => {
     tui.waitFor("cancel.txt");
 
     tui.type("x");
-    tui.waitStable();
 
     tui.press("ctrl+q");
     tui.waitFor("Unsaved changes");
 
     tui.type("c");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -76,13 +71,11 @@ describe("quit confirmation dialog", () => {
     tui.waitFor("quit-q.txt");
 
     tui.type("x");
-    tui.waitStable();
 
     tui.press("ctrl+q");
     tui.waitFor("Unsaved changes");
 
     tui.type("q");
-    tui.waitStable(500);
 
     // Editor should have quit; screenshot won't execute on exited process
     const s0 = tui.snapshot();
@@ -98,13 +91,11 @@ describe("quit confirmation dialog", () => {
     tui.waitFor("force.txt");
 
     tui.type("x");
-    tui.waitStable();
 
     tui.press("ctrl+q");
     tui.waitFor("Unsaved changes");
 
     tui.press("ctrl+q");
-    tui.waitStable(500);
 
     // Editor should have quit; screenshot won't execute on exited process
     const s0 = tui.snapshot();

--- a/tests/functional/rapid-input.test.js
+++ b/tests/functional/rapid-input.test.js
@@ -22,14 +22,11 @@ describe("rapid input", () => {
     }
 
     tui.start(file);
-    tui.waitStable();
 
     tui.type(longString);
-    tui.waitStable();
 
     // Save and verify every character was captured
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -42,7 +39,6 @@ describe("rapid input", () => {
     const file = createTempFile(dir, "lines.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     // Type 20 lines rapidly
     for (let i = 1; i <= 20; i++) {
@@ -51,14 +47,12 @@ describe("rapid input", () => {
         tui.press("enter");
       }
     }
-    tui.waitStable();
 
     // The status bar should show we are on line 20
     const s0 = tui.snapshot();
 
     // Save and verify all lines are present
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
     expect(snapshots[s0]).toContain("Ln 20");
@@ -79,11 +73,9 @@ describe("rapid input", () => {
       "How vexingly quick daft zebras jump.";
 
     tui.start(file);
-    tui.waitStable();
 
     tui.type(paragraph);
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/save-file.test.js
+++ b/tests/functional/save-file.test.js
@@ -16,19 +16,15 @@ describe("save file", () => {
     const filePath = join(dir, "hello.txt");
 
     tui.start();
-    tui.waitStable();
 
     tui.type("Hello World");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.type(filePath);
     tui.press("enter");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/save-noop.test.js
+++ b/tests/functional/save-noop.test.js
@@ -17,11 +17,9 @@ describe("save behavior edge cases", () => {
 
     tui.start(file);
     tui.waitFor("original content");
-    tui.waitStable();
 
     // Save without making any edits
     tui.press("ctrl+s");
-    tui.waitStable(500);
 
     const { snapshots } = tui.run();
 
@@ -44,7 +42,6 @@ describe("save behavior edge cases", () => {
     tui.waitFor("no newline here!");
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -61,13 +58,11 @@ describe("save behavior edge cases", () => {
 
     // Type something to make the buffer dirty
     tui.type("x");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Save the file
     tui.press("ctrl+s");
-    tui.waitStable(500);
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -81,19 +76,15 @@ describe("save behavior edge cases", () => {
     const newFilePath = join(dir, "created.txt");
 
     tui.start();
-    tui.waitStable();
 
     tui.type("new content here");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.type(newFilePath);
     tui.press("enter");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/save-trim-undo.test.js
+++ b/tests/functional/save-trim-undo.test.js
@@ -31,17 +31,14 @@ describe("save-time trim is undoable", () => {
     const typed = tui.snapshot();
 
     tui.press("ctrl+s");
-    tui.waitStable();
     tui.press("end");
     const saved = tui.snapshot();
 
     tui.press("ctrl+z");
-    tui.waitStable();
     tui.press("end");
     const undoneOnce = tui.snapshot();
 
     tui.press("ctrl+z");
-    tui.waitStable();
     tui.press("end");
     const undoneTwice = tui.snapshot();
 
@@ -68,7 +65,6 @@ describe("save-time trim is undoable", () => {
     tui.press("home");
     tui.type("X");
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const saved = tui.snapshot();
     const { snapshots } = tui.run();
@@ -91,11 +87,9 @@ describe("save-time trim is undoable", () => {
     tui.press("home");
     tui.type("X");
     tui.press("ctrl+s");
-    tui.waitStable();
 
     // A single undo must reach the typing, not a no-op cleanup command.
     tui.press("ctrl+z");
-    tui.waitStable();
     tui.press("end");
     const undone = tui.snapshot();
 

--- a/tests/functional/search-folds.test.js
+++ b/tests/functional/search-folds.test.js
@@ -33,20 +33,15 @@ describe("search interaction with code folding", () => {
 
     // Fold all functions
     tui.pressChord("ctrl+k", "0");
-    tui.waitStable();
 
     // Verify both folds are collapsed
     const s0 = tui.snapshot();
 
     // Search for text in the second fold
     tui.press("ctrl+f");
-    tui.waitStable();
     tui.type("secretBeta");
-    tui.waitStable();
     tui.press("enter");
-    tui.waitStable();
     tui.press("escape");
-    tui.waitStable();
 
     // The second fold should have expanded to reveal the match
     const s1 = tui.snapshot();

--- a/tests/functional/select-all.test.js
+++ b/tests/functional/select-all.test.js
@@ -18,13 +18,10 @@ describe("select all and overwrite", () => {
     tui.waitFor("old content");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.type("replaced");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -41,17 +38,14 @@ describe("select all and overwrite", () => {
     tui.waitFor("preserve");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.type("x");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // undo the typed char, then undo the deletion
     tui.press("ctrl+z");
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/select-word.test.js
+++ b/tests/functional/select-word.test.js
@@ -18,16 +18,12 @@ describe("word-level cursor movement and selection", () => {
     tui.waitFor("hello");
 
     tui.press("home");
-    tui.waitStable();
 
     tui.press("ctrl+right");
-    tui.waitStable();
 
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -43,16 +39,12 @@ describe("word-level cursor movement and selection", () => {
     tui.waitFor("hello");
 
     tui.press("end");
-    tui.waitStable();
 
     tui.press("ctrl+left");
-    tui.waitStable();
 
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -68,20 +60,15 @@ describe("word-level cursor movement and selection", () => {
     tui.waitFor("hello");
 
     tui.press("home");
-    tui.waitStable();
 
     tui.press("ctrl+right");
-    tui.waitStable();
 
     tui.exec("Select Word Right");
     tui.exec("Select Word Right");
-    tui.waitStable();
 
     tui.press("backspace");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -97,16 +84,12 @@ describe("word-level cursor movement and selection", () => {
     tui.waitFor("hello");
 
     tui.press("home");
-    tui.waitStable();
 
     tui.exec("Select Word Right");
-    tui.waitStable();
 
     tui.type("HI");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -122,18 +105,14 @@ describe("word-level cursor movement and selection", () => {
     tui.waitFor("one");
 
     tui.press("home");
-    tui.waitStable();
 
     tui.press("ctrl+right");
     tui.press("ctrl+right");
     tui.press("ctrl+right");
-    tui.waitStable();
 
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/settings-ui.test.js
+++ b/tests/functional/settings-ui.test.js
@@ -14,7 +14,6 @@ function openEditor() {
   const file = createTempFile(dir, "sample.txt", "alpha\nbeta\ngamma\n");
   tui.start(file);
   tui.waitFor("alpha");
-  tui.waitStable();
   return file;
 }
 
@@ -23,7 +22,6 @@ describe("settings editor", () => {
     openEditor();
 
     tui.exec("Settings: Open Editor Settings");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -45,7 +43,6 @@ describe("settings editor", () => {
     openEditor();
 
     tui.exec("Settings: Open Editor Settings");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -64,7 +61,6 @@ describe("settings editor", () => {
     openEditor();
 
     tui.exec("Settings: Open Editor Settings");
-    tui.waitStable();
 
     // Tab onto Word wrap. The assertions name that row, so a traversal that
     // lands elsewhere fails loudly instead of passing on a no-op.
@@ -72,22 +68,17 @@ describe("settings editor", () => {
     tui.press("tab");
     tui.press("tab");
     tui.press("space");
-    tui.waitStable();
     const toggled = tui.snapshot();
 
     tui.exec("Settings: Apply Changes");
-    tui.waitStable();
     const applied = tui.snapshot();
 
     // Reload from disk, then close and reopen. Without the reload the form is
     // rebuilt from the in-memory settings ApplySettings already updated, and
     // would pass even if nothing ever reached settings.json.
     tui.exec("Reload Settings");
-    tui.waitStable();
     tui.exec("Settings: Discard Changes");
-    tui.waitStable();
     tui.exec("Settings: Open Editor Settings");
-    tui.waitStable();
     const reopened = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -100,9 +91,7 @@ describe("settings editor", () => {
     openEditor();
 
     tui.exec("Settings: Open Editor Settings");
-    tui.waitStable();
     tui.exec("Settings: Open Editor Settings");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -119,12 +108,10 @@ describe("settings editor", () => {
     openEditor();
 
     tui.exec("Settings: Open Editor Settings");
-    tui.waitStable();
     tui.press("ctrl+c");
     tui.press("ctrl+x");
     tui.press("ctrl+v");
     tui.press("ctrl+a");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -139,7 +126,6 @@ describe("settings editor", () => {
     openEditor();
 
     tui.exec("Settings: Open settings.json");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/sidebar-tab-reorder.test.js
+++ b/tests/functional/sidebar-tab-reorder.test.js
@@ -21,10 +21,8 @@ describe("sidebar tab order", () => {
     tui.start(file);
     tui.setEnv({ TTT_CONFIG_DIR: configDir });
     tui.pressChord("ctrl+k", "c");
-    tui.waitStable();
     const before = tui.snapshot();
     tui.drag(16, 2, 1, 2);
-    tui.waitStable();
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/sidebar-toggle.test.js
+++ b/tests/functional/sidebar-toggle.test.js
@@ -18,7 +18,6 @@ describe("sidebar toggle", () => {
     tui.waitFor("Explore");
 
     tui.press("ctrl+b");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
@@ -41,12 +40,10 @@ describe("sidebar toggle", () => {
     // Narrow sidebar to near-zero width using the command palette
     for (let i = 0; i < 25; i++) {
       tui.exec("View: Decrease Sidebar Width");
-      tui.waitStable(50);
     }
 
     // Toggle sidebar off
     tui.press("ctrl+b");
-    tui.waitStable();
     const s0 = tui.snapshot();
 
     // Toggle sidebar back on — should reset to usable default width

--- a/tests/functional/sort-lines.test.js
+++ b/tests/functional/sort-lines.test.js
@@ -18,13 +18,10 @@ describe("sort lines", () => {
     tui.waitFor("cherry");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Sort Lines Ascending");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -41,13 +38,10 @@ describe("sort lines", () => {
     tui.waitFor("apple");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Sort Lines Descending");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -64,13 +58,10 @@ describe("sort lines", () => {
     tui.waitFor("first");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Reverse Lines");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -91,13 +82,10 @@ describe("sort lines", () => {
     tui.waitFor("apple");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Unique Lines");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -114,13 +102,10 @@ describe("sort lines", () => {
     tui.waitFor("cherry");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "o");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -137,17 +122,13 @@ describe("sort lines", () => {
     tui.waitFor("cherry");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Sort Lines Ascending");
-    tui.waitStable();
 
     // Undo
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/split-selection.test.js
+++ b/tests/functional/split-selection.test.js
@@ -19,17 +19,13 @@ describe("split selection into lines", () => {
 
     // Select all text (3 lines)
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Split Selection into Lines");
-    tui.waitStable();
 
     // Type 'X' — should appear on each of the 3 lines with cursors
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -47,14 +43,11 @@ describe("split selection into lines", () => {
     tui.waitFor("hello");
 
     tui.exec("Split Selection into Lines");
-    tui.waitStable();
 
     // Type 'Z' — should only appear once (single cursor)
     tui.type("Z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/statusbar-tab-switch.test.js
+++ b/tests/functional/statusbar-tab-switch.test.js
@@ -18,19 +18,15 @@ describe("status bar after a scripted tab switch", () => {
     const second = createMultiLineFile(dir, "second.txt", 80);
 
     tui.start(first, second);
-    tui.waitStable();
 
     // second.txt is active; move it to line 20 so the two tabs differ.
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("20");
     tui.press("enter");
-    tui.waitStable();
 
     const onSecond = tui.snapshot();
 
     tui.exec("View: Previous Tab");
-    tui.waitStable();
     const onFirst = tui.snapshot();
 
     const { snapshots } = tui.run();

--- a/tests/functional/statusbar.test.js
+++ b/tests/functional/statusbar.test.js
@@ -15,7 +15,6 @@ describe("status bar segments", () => {
     const file = createTempFile(dir, "hello.go", 'package main\n\nfunc main() {\n}\n');
 
     tui.start(file);
-    tui.waitStable(300);
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -31,13 +30,11 @@ describe("status bar segments", () => {
     const file = createTempFile(dir, "nav.txt", "hello world\nline two\nline three\n");
 
     tui.start(file);
-    tui.waitStable(300);
     tui.press("arrow_down");
     tui.press("arrow_down");
     tui.press("arrow_right");
     tui.press("arrow_right");
     tui.press("arrow_right");
-    tui.waitStable();
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -50,7 +47,6 @@ describe("status bar segments", () => {
     const file = createTempFile(dir, "spaces.js", "const x = 1;\n");
 
     tui.start(file);
-    tui.waitStable(300);
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 
@@ -58,14 +54,14 @@ describe("status bar segments", () => {
     expect(lastLine).toContain("Spaces:");
   });
 
-  it("shows notification and dismisses after expiry", () => {
+  it("shows a notification from a delayed debug action", () => {
     dir = createTempDir();
     const file = createTempFile(dir, "note.txt", "hello\n");
 
     tui.start(file);
-    tui.waitStable(300);
+    tui.waitFor("note.txt");
     tui.exec("Debug: Screenshot");
-    tui.waitStable();
+    tui.waitFor("Screenshot saved: screenshot.txt");
     const s = tui.snapshot();
     const { snapshots } = tui.run();
 

--- a/tests/functional/syntax-fold.test.js
+++ b/tests/functional/syntax-fold.test.js
@@ -33,20 +33,16 @@ describe("syntax highlighting consistency after fold/unfold", () => {
 
     // Go to the func main() line and fold it
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("5");
     tui.press("enter");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     // Content inside the fold should be hidden
     const s1 = tui.snapshot();
 
     // Unfold using toggle
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     // Content should be restored exactly
     const s2 = tui.snapshot();
@@ -75,11 +71,9 @@ describe("syntax highlighting consistency after fold/unfold", () => {
     const unfoldedSnaps = [];
     for (let i = 0; i < 3; i++) {
       tui.pressChord("ctrl+k", "0");
-      tui.waitStable();
       foldedSnaps.push(tui.snapshot());
 
       tui.pressChord("ctrl+k", "9");
-      tui.waitStable();
       unfoldedSnaps.push(tui.snapshot());
     }
 
@@ -111,52 +105,40 @@ describe("syntax highlighting consistency after fold/unfold", () => {
 
     // Go to the func main() line and fold
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("5");
     tui.press("enter");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Unfold to edit inside
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // Navigate to the "hello" line and add text
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("6");
     tui.press("enter");
-    tui.waitStable();
 
     // Go to end of line and add a comment
     tui.press("end");
-    tui.waitStable();
     tui.type(" // edited");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
 
     // Fold again
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("5");
     tui.press("enter");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     const s3 = tui.snapshot();
 
     // Unfold and verify the edit persisted
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     const s4 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -186,20 +168,16 @@ describe("syntax highlighting consistency after fold/unfold", () => {
 
     // Go to func main() line and fold
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("5");
     tui.press("enter");
-    tui.waitStable();
 
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     // Fold indicator should appear
     const s1 = tui.snapshot();
 
     // Unfold
     tui.pressChord("ctrl+k", "[");
-    tui.waitStable();
 
     // Fold indicator should disappear
     const s2 = tui.snapshot();

--- a/tests/functional/tab-close-click.test.js
+++ b/tests/functional/tab-close-click.test.js
@@ -15,11 +15,9 @@ describe("tab close button hit test (#354)", () => {
     tui.press("ctrl+n");
     tui.press("ctrl+n");
     tui.press("ctrl+n");
-    tui.waitStable();
     const before = tui.snapshot();
 
     tui.click(72, 2);
-    tui.waitStable();
     const after = tui.snapshot();
 
     const { snapshots } = tui.run();
@@ -37,9 +35,7 @@ describe("tab close button hit test (#354)", () => {
     tui.setSize(150, 30);
 
     for (let i = 0; i < 20; i++) tui.press("ctrl+n");
-    tui.waitStable();
     for (let i = 0; i < 11; i++) tui.press("ctrl+w");
-    tui.waitStable();
 
     const s = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/tab-management.test.js
+++ b/tests/functional/tab-management.test.js
@@ -16,7 +16,6 @@ describe("tab management", () => {
     const file2 = createTempFile(dir, "second.txt", "Second file");
 
     tui.start(file1, file2);
-    tui.waitStable();
     tui.waitFor("second.txt");
 
     const s0 = tui.snapshot();
@@ -33,7 +32,6 @@ describe("tab management", () => {
     tui.waitFor("Close this content");
 
     tui.press("ctrl+w");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -49,7 +47,6 @@ describe("tab management", () => {
     tui.waitFor("unsaved.txt");
 
     tui.type("dirty");
-    tui.waitStable();
 
     tui.press("ctrl+w");
     tui.waitFor("Save changes");
@@ -58,7 +55,6 @@ describe("tab management", () => {
 
     // Cancel the dialog
     tui.press("escape");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -75,13 +71,11 @@ describe("tab management", () => {
     tui.waitFor("Original content");
 
     tui.type("dirty");
-    tui.waitStable();
 
     tui.press("ctrl+w");
     tui.waitFor("Save changes");
 
     tui.press("enter");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/terminal-toggle.test.js
+++ b/tests/functional/terminal-toggle.test.js
@@ -18,8 +18,6 @@ describe("terminal toggle", () => {
     tui.waitFor("term.txt");
 
     tui.press("ctrl+t");
-    tui.waitStable();
-    tui.wait(500);
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -34,17 +32,12 @@ describe("terminal toggle", () => {
     tui.waitFor("toggle.txt");
 
     tui.press("ctrl+t");
-    tui.waitStable();
-    tui.wait(500);
 
     tui.press("ctrl+t");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+t");
-    tui.waitStable();
-    tui.wait(500);
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/toggle-comment.test.js
+++ b/tests/functional/toggle-comment.test.js
@@ -21,10 +21,8 @@ describe("toggle line comment", () => {
     tui.waitFor("package main");
 
     tui.exec("Toggle Line Comment");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -41,10 +39,8 @@ describe("toggle line comment", () => {
     tui.waitFor("// package main");
 
     tui.exec("Toggle Line Comment");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -62,13 +58,10 @@ describe("toggle line comment", () => {
     tui.waitFor("line1");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Toggle Line Comment");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -87,13 +80,10 @@ describe("toggle line comment", () => {
     tui.waitFor("// line1");
 
     tui.press("ctrl+a");
-    tui.waitStable();
 
     tui.exec("Toggle Line Comment");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -113,10 +103,8 @@ describe("toggle line comment", () => {
     tui.waitFor("print");
 
     tui.exec("Toggle Line Comment");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/tree-actions.test.js
+++ b/tests/functional/tree-actions.test.js
@@ -26,7 +26,6 @@ describe("tree actions", () => {
     tui.start(dir);
     tui.setSize(100, 50);
     tui.pressChord("ctrl+k", "e");
-    tui.waitStable();
     tui.exec("Explorer: Collapse All");
     const collapsed = tui.snapshot();
     tui.exec("Explorer: Expand All");

--- a/tests/functional/trim-whitespace.test.js
+++ b/tests/functional/trim-whitespace.test.js
@@ -26,7 +26,6 @@ describe("trim trailing whitespace on save", () => {
     tui.start(file);
     tui.waitFor("hello");
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -44,7 +43,6 @@ describe("trim trailing whitespace on save", () => {
     tui.start("--config", configFile, file);
     tui.waitFor("foo");
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -60,7 +58,6 @@ describe("trim trailing whitespace on save", () => {
     tui.start(file);
     tui.waitFor("hello");
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/tui.js
+++ b/tests/functional/tui.js
@@ -104,16 +104,12 @@ export function panel(id) {
   commands.push(`panel ${id}`);
 }
 
-export function wait(ms = 200) {
+export function elapse(ms) {
   commands.push(`wait ${ms}`);
 }
 
 export function waitFor(text) {
   commands.push(`wait-for ${JSON.stringify(String(text))}`);
-}
-
-export function waitStable(ms = 200) {
-  commands.push(`wait ${ms}`);
 }
 
 export function snapshot() {

--- a/tests/functional/undo-dirty-flag.test.js
+++ b/tests/functional/undo-dirty-flag.test.js
@@ -20,7 +20,6 @@ describe("undo/redo dirty flag tracking", () => {
     const s0 = tui.snapshot();
 
     tui.type("x");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -37,12 +36,10 @@ describe("undo/redo dirty flag tracking", () => {
     tui.waitFor("hello");
 
     tui.type("x");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -59,15 +56,12 @@ describe("undo/redo dirty flag tracking", () => {
     tui.waitFor("hello");
 
     tui.type("x");
-    tui.waitStable();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+y");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -84,12 +78,10 @@ describe("undo/redo dirty flag tracking", () => {
     tui.waitFor("hello");
 
     tui.type("x");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -107,19 +99,15 @@ describe("undo/redo dirty flag tracking", () => {
 
     tui.press("end");
     tui.type("abc");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.type("xyz");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Undo "xyz" — back to the saved state "helloabc"
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/undo-redo.test.js
+++ b/tests/functional/undo-redo.test.js
@@ -23,7 +23,6 @@ describe("undo and redo", () => {
 
     // " Added" is one group (space joins next word) → 1 undo
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -44,12 +43,10 @@ describe("undo and redo", () => {
 
     // " Extra" is one group → 1 undo
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.press("ctrl+y");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -69,7 +66,6 @@ describe("undo and redo", () => {
     tui.waitFor("First Second");
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     // Verify screen shows "First Second" after save
     const s0 = tui.snapshot();
@@ -79,10 +75,8 @@ describe("undo and redo", () => {
 
     // " Third" is one group → 1 undo
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -99,20 +93,17 @@ describe("undo and redo", () => {
     const file = createTempFile(dir, "group.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     tui.type("hello world");
     tui.waitFor("hello world");
 
     // One undo removes " world" (space belongs with next word)
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Next undo removes "hello"
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -126,7 +117,6 @@ describe("undo and redo", () => {
     const file = createTempFile(dir, "cursor.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     tui.type("ab");
     tui.press("arrow_left");
@@ -136,7 +126,6 @@ describe("undo and redo", () => {
 
     // First undo removes "cd" (typed after cursor movement)
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
     const { snapshots } = tui.run();

--- a/tests/functional/undo-stress.test.js
+++ b/tests/functional/undo-stress.test.js
@@ -23,48 +23,37 @@ describe("undo/redo stress", () => {
 
     // Edit 1-2: type " jumps"
     tui.type(" jumps");
-    tui.waitStable();
 
     // Edit 3: press Enter to create a new line
     tui.press("enter");
-    tui.waitStable();
 
     // Edit 4-5: type "over the"
     tui.type("over the");
-    tui.waitStable();
 
     // Edit 6: press Enter again
     tui.press("enter");
-    tui.waitStable();
 
     // Edit 7-8: type "lazy dog"
     tui.type("lazy dog");
-    tui.waitStable();
 
     // Edit 9: backspace to delete "g"
     tui.press("backspace");
-    tui.waitStable();
 
     // Edit 10: backspace to delete "o"
     tui.press("backspace");
-    tui.waitStable();
 
     // Edit 11-12: type "og!"
     tui.type("og!");
-    tui.waitStable();
 
     // Edit 13: go to beginning of "lazy" line and select the word
     tui.press("home");
     tui.press("ctrl+d");
-    tui.waitStable();
 
     // Edit 14: delete the selection ("lazy")
     tui.press("backspace");
-    tui.waitStable();
 
     // Edit 15: type replacement
     tui.type("LAZY");
-    tui.waitStable();
 
     // Snapshot after all edits
     const s0 = tui.snapshot();
@@ -73,7 +62,6 @@ describe("undo/redo stress", () => {
     for (let i = 0; i < 20; i++) {
       tui.press("ctrl+z");
     }
-    tui.waitStable();
 
     // Snapshot after full undo - should show original
     const s1 = tui.snapshot();
@@ -82,11 +70,9 @@ describe("undo/redo stress", () => {
     for (let i = 0; i < 20; i++) {
       tui.press("ctrl+y");
     }
-    tui.waitStable();
 
     // Save the final redo state
     tui.press("ctrl+s");
-    tui.waitStable();
 
     // Snapshot after full redo
     const s2 = tui.snapshot();
@@ -121,29 +107,23 @@ describe("undo/redo stress", () => {
 
     // Navigate to end of last line (line 3)
     tui.press("ctrl+g");
-    tui.waitStable();
     tui.type("3");
     tui.press("enter");
-    tui.waitStable();
     tui.press("end");
     tui.press("enter");
     tui.type("line four");
     tui.press("enter");
     tui.type("line five");
-    tui.waitStable();
 
     // Select all and delete
     tui.press("ctrl+a");
-    tui.waitStable();
     tui.press("backspace");
-    tui.waitStable();
 
     // Verify the buffer is empty (no original lines visible)
     const s0 = tui.snapshot();
 
     // Undo the delete and the typed text to get back to original
     tui.press("ctrl+z");
-    tui.waitStable();
 
     // After undoing the delete, all content (including typed lines) should be restored
     const s1 = tui.snapshot();
@@ -152,11 +132,9 @@ describe("undo/redo stress", () => {
     for (let i = 0; i < 10; i++) {
       tui.press("ctrl+z");
     }
-    tui.waitStable();
 
     // Save and verify original content is restored
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -180,23 +158,18 @@ describe("undo/redo stress", () => {
 
     // Make 5 edits (each separated by cursor movement to force separate undo groups)
     tui.type(" one");
-    tui.waitStable();
     tui.press("arrow_left");
     tui.press("end");
     tui.type(" two");
-    tui.waitStable();
     tui.press("arrow_left");
     tui.press("end");
     tui.type(" three");
-    tui.waitStable();
     tui.press("arrow_left");
     tui.press("end");
     tui.type(" four");
-    tui.waitStable();
     tui.press("arrow_left");
     tui.press("end");
     tui.type(" five");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
@@ -204,17 +177,14 @@ describe("undo/redo stress", () => {
     tui.press("ctrl+z");
     tui.press("ctrl+z");
     tui.press("ctrl+z");
-    tui.waitStable();
 
     const s1 = tui.snapshot();
 
     // Make 2 new edits (this should discard the redo stack)
     tui.type(" alpha");
-    tui.waitStable();
     tui.press("arrow_left");
     tui.press("end");
     tui.type(" beta");
-    tui.waitStable();
 
     const s2 = tui.snapshot();
 
@@ -222,11 +192,9 @@ describe("undo/redo stress", () => {
     tui.press("ctrl+y");
     tui.press("ctrl+y");
     tui.press("ctrl+y");
-    tui.waitStable();
 
     // Verify content is unchanged (redo did nothing)
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/unicode-stress.test.js
+++ b/tests/functional/unicode-stress.test.js
@@ -15,24 +15,18 @@ describe("unicode stress tests", () => {
     const file = createTempFile(dir, "symbols.txt", "");
 
     tui.start(file);
-    tui.waitStable();
 
     // Use simple single-codepoint symbols that terminals handle reliably
     tui.type("ABC");
-    tui.waitStable();
 
     // Select all and delete
     tui.press("ctrl+a");
-    tui.waitStable();
     tui.press("backspace");
-    tui.waitStable();
 
     // Type new symbols
     tui.type("XYZ");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -54,10 +48,8 @@ describe("unicode stress tests", () => {
 
     // Type "X" — should insert between β and γ
     tui.type("X");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -76,10 +68,8 @@ describe("unicode stress tests", () => {
     tui.press("end");
     tui.press("backspace");
     tui.type("é");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     // Take snapshot to verify intermediate state (café on screen)
     const s0 = tui.snapshot();
@@ -89,10 +79,8 @@ describe("unicode stress tests", () => {
     tui.press("arrow_left");
     tui.press("arrow_left");
     tui.type("Z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/unicode.test.js
+++ b/tests/functional/unicode.test.js
@@ -19,10 +19,8 @@ describe("unicode editing", () => {
 
     tui.press("end");
     tui.type(" über");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -39,10 +37,8 @@ describe("unicode editing", () => {
 
     tui.press("end");
     tui.type(" 你好世界");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -59,10 +55,8 @@ describe("unicode editing", () => {
 
     tui.press("end");
     tui.type(" 🎉🚀");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 
@@ -79,10 +73,8 @@ describe("unicode editing", () => {
 
     tui.press("home");
     tui.type("→ ");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     const { snapshots } = tui.run();
 

--- a/tests/functional/word-delete.test.js
+++ b/tests/functional/word-delete.test.js
@@ -18,13 +18,10 @@ describe("word delete", () => {
     tui.waitFor("hello");
 
     tui.press("end");
-    tui.waitStable();
 
     tui.exec("Delete Word Left");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -40,13 +37,10 @@ describe("word delete", () => {
     tui.waitFor("hello");
 
     tui.press("home");
-    tui.waitStable();
 
     tui.exec("Delete Word Right");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 
@@ -62,16 +56,12 @@ describe("word delete", () => {
     tui.waitFor("keep");
 
     tui.press("end");
-    tui.waitStable();
 
     tui.exec("Delete Word Left");
-    tui.waitStable();
 
     tui.press("ctrl+z");
-    tui.waitStable();
 
     tui.press("ctrl+s");
-    tui.waitStable();
 
     tui.run();
 

--- a/tests/functional/word-wrap.test.js
+++ b/tests/functional/word-wrap.test.js
@@ -17,12 +17,10 @@ describe("word wrap", () => {
 
     tui.start(file);
     tui.waitFor("VISIBLE_");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     tui.exec("Toggle Word Wrap");
-    tui.wait(500);
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -39,13 +37,11 @@ describe("word wrap", () => {
 
     tui.start(file);
     tui.waitFor("HELLO");
-    tui.waitStable();
 
     const s0 = tui.snapshot();
 
     // Toggle word wrap
     tui.exec("Toggle Word Wrap");
-    tui.wait(500);
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();
@@ -63,15 +59,12 @@ describe("word wrap", () => {
 
     tui.start(file);
     tui.waitFor("VISIBLE_");
-    tui.waitStable();
 
     tui.exec("Toggle Word Wrap");
-    tui.wait(500);
 
     const s0 = tui.snapshot();
 
     tui.exec("Toggle Word Wrap");
-    tui.wait(500);
 
     const s1 = tui.snapshot();
     const { snapshots } = tui.run();


### PR DESCRIPTION
## Summary

- remove 832 redundant `waitStable` calls now covered by acknowledged `--exec` main-thread actions, and remove the misleading helper
- replace genuine Git, watcher, search, process, and delayed-debug synchronization with unique visible post-transition readiness
- keep only three explicit elapsed-time calls (2.0s total) where timer or delayed-result lifecycle is the invariant
- document lowest-deterministic-boundary ownership and keep functional coverage as a compact real-binary contract

## Readiness invariants

- scripted key, mouse, and command actions need no extra wait after main-thread handling and redraw are acknowledged
- genuine async work proceeds only after a unique state proving its result was applied
- elapsed time is used only when crossing a timer deadline or deliberately delayed stale result is the behavior under test

## Evidence

Fresh baseline at `3c9fc55`:

- 359/359 tests passed
- 21.69s wall
- 429,106.969ms accumulated test duration

Bounded no-wait reproduction:

- 350/359 passed in 18.96s
- failures were exactly seven async Git mutation refresh assertions, one saved-file watcher/repository refresh assertion, and one delayed screenshot notification assertion

Final:

- 359/359 tests passed
- 18.98s wall (12.5% lower)
- 192,014.166ms accumulated test duration (55.3% lower)
- affected async tranche: 3 consecutive green stress runs, 33 tests per run (32 pass, 1 expected fail)
- `env SHELL=/bin/bash go test ./...`
- `go vet ./...`
- `git diff --check`

## Residual limits

- three `elapse` calls remain: 550ms + 150ms for plugin timer scheduling and 1300ms to cross an intentionally delayed blame result
- no production/debug API was added; semantic readiness uses the existing main-loop-observed visible-screen contract with targets chosen to be unique post-transition states
- local `make lint` could not run because `golangci-lint` is not installed; CI remains the lint gate