### PR TITLE
refactor(widgets): canonicalize scrollbar range and interactions

### DIFF
--- a/internal/widgets/scrollbar.go
+++ b/internal/widgets/scrollbar.go
@@ -5,107 +5,214 @@ import (
 	"github.com/gdamore/tcell/v3"
 )
 
-type scrollbar struct {
-	X          int
-	Y          int
-	Height     int
-	TotalItems int
-	TopItem    int
-	dragging   bool
-	dragOffset int
+type scrollRange struct {
+	trackLength   int
+	contentLength int
+	offset        int
 }
 
-func (s *scrollbar) visible() bool {
-	return s.TotalItems > s.Height && s.Height > 0
+func newScrollRange(trackLength, contentLength, offset int) scrollRange {
+	if trackLength < 0 {
+		trackLength = 0
+	}
+	if contentLength < 0 {
+		contentLength = 0
+	}
+	r := scrollRange{trackLength: trackLength, contentLength: contentLength}
+	r.offset = r.clampOffset(offset)
+	return r
 }
 
-func (s *scrollbar) thumbPos() (top, height int) {
-	if s.TotalItems <= s.Height {
-		return 0, s.Height
-	}
-	height = s.Height * s.Height / s.TotalItems
-	if height < 1 {
-		height = 1
-	}
-	scrollable := s.TotalItems - s.Height
-	top = s.TopItem * (s.Height - height) / scrollable
-	if top+height > s.Height {
-		top = s.Height - height
-	}
-	return
+func (r scrollRange) visible() bool {
+	return r.trackLength > 0 && r.contentLength > r.trackLength
 }
 
-func (s *scrollbar) Render(surface Surface, rx, ry int) {
-	if !s.visible() {
-		return
-	}
-	thumbTop, thumbH := s.thumbPos()
-	for y := 0; y < s.Height; y++ {
-		style := term.StyleScrollbar
-		if y >= thumbTop && y < thumbTop+thumbH {
-			style = term.StyleScrollbarThumb
-		}
-		surface.SetCell(rx, ry+y, term.Cell{Ch: '█', Style: style})
-	}
-}
-
-func (s *scrollbar) HandleEvent(ev tcell.Event) (newTopItem int, consumed bool) {
-	mev, ok := ev.(*tcell.EventMouse)
-	if !ok {
-		return s.TopItem, false
-	}
-
-	mx, my := mev.Position()
-	btn := mev.Buttons()
-
-	if s.dragging {
-		if btn == tcell.ButtonNone {
-			s.dragging = false
-			return s.TopItem, false
-		}
-		if btn&tcell.Button1 != 0 {
-			relY := my - s.Y
-			return s.posToTopItem(relY - s.dragOffset), true
-		}
-	}
-
-	if btn&tcell.Button1 != 0 && mx == s.X && my >= s.Y && my < s.Y+s.Height {
-		relY := my - s.Y
-		thumbTop, thumbH := s.thumbPos()
-		s.dragging = true
-		if relY >= thumbTop && relY < thumbTop+thumbH {
-			s.dragOffset = relY - thumbTop
-		} else {
-			s.dragOffset = thumbH / 2
-			return s.posToTopItem(relY - s.dragOffset), true
-		}
-		return s.TopItem, true
-	}
-
-	return s.TopItem, false
-}
-
-func (s *scrollbar) isDragging() bool { return s.dragging }
-
-func (s *scrollbar) posToTopItem(thumbTop int) int {
-	_, thumbH := s.thumbPos()
-	maxThumbTop := s.Height - thumbH
-	if maxThumbTop <= 0 {
+func (r scrollRange) maxOffset() int {
+	if r.trackLength <= 0 || r.contentLength <= r.trackLength {
 		return 0
 	}
-	if thumbTop < 0 {
-		thumbTop = 0
-	}
-	if thumbTop > maxThumbTop {
-		thumbTop = maxThumbTop
-	}
-	scrollable := s.TotalItems - s.Height
-	top := thumbTop * scrollable / maxThumbTop
-	if top < 0 {
-		top = 0
-	}
-	if top > scrollable {
-		top = scrollable
-	}
-	return top
+	return r.contentLength - r.trackLength
 }
+
+func (r scrollRange) clampOffset(offset int) int {
+	if offset < 0 {
+		return 0
+	}
+	if maxOffset := r.maxOffset(); offset > maxOffset {
+		return maxOffset
+	}
+	return offset
+}
+
+func (r scrollRange) thumb() (start, length int) {
+	if !r.visible() {
+		return 0, r.trackLength
+	}
+	length = r.trackLength * r.trackLength / r.contentLength
+	if length < 1 {
+		length = 1
+	}
+	maxStart := r.trackLength - length
+	maxOffset := r.maxOffset()
+	if r.offset >= maxOffset {
+		return maxStart, length
+	}
+	return r.offset * maxStart / maxOffset, length
+}
+
+func (r scrollRange) offsetForThumb(start int) int {
+	_, length := r.thumb()
+	maxStart := r.trackLength - length
+	if start <= 0 {
+		return 0
+	}
+	if maxStart <= 0 {
+		return r.maxOffset()
+	}
+	if start >= maxStart {
+		return r.maxOffset()
+	}
+	return start * r.maxOffset() / maxStart
+}
+
+func (r scrollRange) offsetForPointer(position, grabOffset int) int {
+	return r.offsetForThumb(position - grabOffset)
+}
+
+type scrollbarGeometry struct {
+	localTrack Rect
+	hitTrack   Rect
+}
+
+type scrollbarInteraction struct {
+	rangeModel scrollRange
+	geometry   scrollbarGeometry
+	dragging   bool
+	grabOffset int
+}
+
+func (s *scrollbarInteraction) configure(r scrollRange, geometry scrollbarGeometry) (offset int, invalidated bool) {
+	s.rangeModel = r
+	if !r.visible() {
+		invalidated = s.dragging
+		s.dragging = false
+		s.grabOffset = 0
+		s.geometry = scrollbarGeometry{}
+		return r.offset, invalidated
+	}
+	s.geometry = geometry
+	return r.offset, false
+}
+
+func (s *scrollbarInteraction) handlePointer(position int, inside bool, buttons tcell.ButtonMask) (int, EventResult) {
+	if s.dragging {
+		if buttons == tcell.ButtonNone {
+			s.dragging = false
+			return s.rangeModel.offset, EventConsumed
+		}
+		if buttons&tcell.Button1 != 0 {
+			offset := s.rangeModel.offsetForPointer(position, s.grabOffset)
+			s.rangeModel.offset = offset
+			return offset, EventCaptured
+		}
+		return s.rangeModel.offset, EventCaptured
+	}
+
+	if !s.rangeModel.visible() || buttons&tcell.Button1 == 0 || !inside {
+		return s.rangeModel.offset, EventIgnored
+	}
+
+	thumbStart, thumbLength := s.rangeModel.thumb()
+	s.dragging = true
+	if position >= thumbStart && position < thumbStart+thumbLength {
+		s.grabOffset = position - thumbStart
+		return s.rangeModel.offset, EventCaptured
+	}
+
+	s.grabOffset = thumbLength / 2
+	offset := s.rangeModel.offsetForPointer(position, s.grabOffset)
+	s.rangeModel.offset = offset
+	return offset, EventCaptured
+}
+
+func (s *scrollbarInteraction) cancel() bool {
+	if !s.dragging {
+		return false
+	}
+	s.dragging = false
+	s.grabOffset = 0
+	return true
+}
+
+func (s *scrollbarInteraction) visible() bool    { return s.rangeModel.visible() }
+func (s *scrollbarInteraction) isDragging() bool { return s.dragging }
+
+type scrollbar struct {
+	interaction scrollbarInteraction
+}
+
+func (s *scrollbar) Render(surface Surface, geometry scrollbarGeometry, r scrollRange) (int, bool) {
+	offset, invalidated := s.interaction.configure(r, geometry)
+	if !s.visible() {
+		return offset, invalidated
+	}
+	thumbStart, thumbLength := s.interaction.rangeModel.thumb()
+	for y := range r.trackLength {
+		style := term.StyleScrollbar
+		if y >= thumbStart && y < thumbStart+thumbLength {
+			style = term.StyleScrollbarThumb
+		}
+		surface.SetCell(geometry.localTrack.X, geometry.localTrack.Y+y, term.Cell{Ch: '█', Style: style})
+	}
+	return offset, invalidated
+}
+
+func (s *scrollbar) HandleEvent(ev tcell.Event) (int, EventResult) {
+	mev, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return s.interaction.rangeModel.offset, EventIgnored
+	}
+	mx, my := mev.Position()
+	hit := s.interaction.geometry.hitTrack
+	inside := mx >= hit.X && mx < hit.X+hit.W && my >= hit.Y && my < hit.Y+hit.H
+	return s.interaction.handlePointer(my-hit.Y, inside, mev.Buttons())
+}
+
+func (s *scrollbar) visible() bool    { return s.interaction.visible() }
+func (s *scrollbar) isDragging() bool { return s.interaction.isDragging() }
+func (s *scrollbar) cancel() bool     { return s.interaction.cancel() }
+
+type horizontalScrollbar struct {
+	interaction scrollbarInteraction
+}
+
+func (s *horizontalScrollbar) Render(surface Surface, geometry scrollbarGeometry, r scrollRange) (int, bool) {
+	offset, invalidated := s.interaction.configure(r, geometry)
+	if !s.visible() {
+		return offset, invalidated
+	}
+	thumbStart, thumbLength := s.interaction.rangeModel.thumb()
+	for x := range r.trackLength {
+		style := term.StyleScrollbar
+		if x >= thumbStart && x < thumbStart+thumbLength {
+			style = term.StyleScrollbarThumb
+		}
+		surface.SetCell(geometry.localTrack.X+x, geometry.localTrack.Y, term.Cell{Ch: '▄', Style: style})
+	}
+	return offset, invalidated
+}
+
+func (s *horizontalScrollbar) HandleEvent(ev tcell.Event) (int, EventResult) {
+	mev, ok := ev.(*tcell.EventMouse)
+	if !ok {
+		return s.interaction.rangeModel.offset, EventIgnored
+	}
+	mx, my := mev.Position()
+	hit := s.interaction.geometry.hitTrack
+	inside := mx >= hit.X && mx < hit.X+hit.W && my >= hit.Y && my < hit.Y+hit.H
+	return s.interaction.handlePointer(mx-hit.X, inside, mev.Buttons())
+}
+
+func (s *horizontalScrollbar) visible() bool    { return s.interaction.visible() }
+func (s *horizontalScrollbar) isDragging() bool { return s.interaction.isDragging() }
+func (s *horizontalScrollbar) cancel() bool     { return s.interaction.cancel() }

--- a/internal/widgets/scrollbar_test.go
+++ b/internal/widgets/scrollbar_test.go
@@ -7,246 +7,244 @@ import (
 	"github.com/gdamore/tcell/v3"
 )
 
-func TestScrollbarThumbAtTop(t *testing.T) {
-	sb := &scrollbar{
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
+func TestScrollRangeEdgeCases(t *testing.T) {
+	tests := []struct {
+		name            string
+		track           int
+		content         int
+		offset          int
+		wantVisible     bool
+		wantOffset      int
+		wantThumbStart  int
+		wantThumbLength int
+	}{
+		{name: "zero track", track: 0, content: 10, offset: 4, wantOffset: 0},
+		{name: "negative dimensions", track: -2, content: -1, offset: 4, wantOffset: 0},
+		{name: "content smaller", track: 10, content: 5, offset: 4, wantOffset: 0, wantThumbLength: 10},
+		{name: "content equal", track: 10, content: 10, offset: 4, wantOffset: 0, wantThumbLength: 10},
+		{name: "one cell overflow", track: 1, content: 2, offset: 1, wantVisible: true, wantOffset: 1, wantThumbLength: 1},
+		{name: "negative offset", track: 10, content: 100, offset: -4, wantVisible: true, wantOffset: 0, wantThumbLength: 1},
+		{name: "oversized offset", track: 10, content: 100, offset: 500, wantVisible: true, wantOffset: 90, wantThumbStart: 9, wantThumbLength: 1},
+		{name: "middle offset", track: 10, content: 20, offset: 5, wantVisible: true, wantOffset: 5, wantThumbStart: 2, wantThumbLength: 5},
 	}
-	top, _ := sb.thumbPos()
-	if top != 0 {
-		t.Fatalf("expected thumb top=0 when scrolled to top, got %d", top)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newScrollRange(tt.track, tt.content, tt.offset)
+			if got := r.visible(); got != tt.wantVisible {
+				t.Fatalf("visible = %v, want %v", got, tt.wantVisible)
+			}
+			if r.offset != tt.wantOffset {
+				t.Fatalf("offset = %d, want %d", r.offset, tt.wantOffset)
+			}
+			start, length := r.thumb()
+			if start != tt.wantThumbStart || length != tt.wantThumbLength {
+				t.Fatalf("thumb = (%d,%d), want (%d,%d)", start, length, tt.wantThumbStart, tt.wantThumbLength)
+			}
+		})
 	}
 }
 
-func TestScrollbarThumbAtBottom(t *testing.T) {
-	sb := &scrollbar{
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    90, // max scroll = TotalItems - Height
-	}
-	top, thumbH := sb.thumbPos()
-	if top+thumbH != sb.Height {
-		t.Fatalf("expected thumb bottom at %d, got top=%d thumbH=%d (bottom=%d)", sb.Height, top, thumbH, top+thumbH)
-	}
-}
-
-func TestScrollbarThumbPositionMidScroll(t *testing.T) {
-	sb := &scrollbar{
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    45, // roughly half
-	}
-	top, thumbH := sb.thumbPos()
-	// Thumb should be in the middle area, not at 0 and not at bottom
-	if top <= 0 {
-		t.Errorf("expected thumb in middle, got top=%d", top)
-	}
-	if top+thumbH >= sb.Height {
-		t.Errorf("expected thumb not at bottom, got top=%d thumbH=%d", top, thumbH)
-	}
-}
-
-func TestScrollbarThumbHeightMinimum(t *testing.T) {
-	sb := &scrollbar{
-		Height:     5,
-		TotalItems: 10000,
-		TopItem:    0,
-	}
-	_, thumbH := sb.thumbPos()
-	if thumbH < 1 {
-		t.Fatalf("thumb height should be at least 1, got %d", thumbH)
-	}
-}
-
-func TestScrollbarNotVisibleWhenContentFits(t *testing.T) {
-	sb := &scrollbar{
-		Height:     20,
-		TotalItems: 10, // fewer items than height
-		TopItem:    0,
-	}
-	if sb.visible() {
-		t.Fatal("scrollbar should not be visible when content fits in view")
-	}
-}
-
-func TestScrollbarVisibleWhenContentOverflows(t *testing.T) {
-	sb := &scrollbar{
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
-	}
-	if !sb.visible() {
-		t.Fatal("scrollbar should be visible when content overflows")
-	}
-}
-
-func TestScrollbarRender(t *testing.T) {
-	sb := &scrollbar{
-		X:          0,
-		Y:          0,
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
-	}
-	s := newTestSurface(1, 10)
-	sb.Render(s, 0, 0)
-
-	thumbTop, thumbH := sb.thumbPos()
-
-	// Check that thumb cells use StyleScrollbarThumb and track cells use StyleScrollbar
-	for y := 0; y < 10; y++ {
-		expected := term.StyleScrollbar
-		if y >= thumbTop && y < thumbTop+thumbH {
-			expected = term.StyleScrollbarThumb
+func TestScrollRangeMappingIsMonotonicWithExactEndpoints(t *testing.T) {
+	for _, track := range []int{2, 3, 10, 17} {
+		r := newScrollRange(track, 101, 0)
+		_, thumbLength := r.thumb()
+		maxThumbStart := track - thumbLength
+		previous := -1
+		for position := -3; position <= maxThumbStart+3; position++ {
+			offset := r.offsetForThumb(position)
+			if offset < previous {
+				t.Fatalf("track %d mapping decreased at %d: %d < %d", track, position, offset, previous)
+			}
+			previous = offset
 		}
-		if s.cells[y][0].Style != expected {
-			t.Errorf("row %d: expected style %d, got %d", y, expected, s.cells[y][0].Style)
+		if got := r.offsetForThumb(0); got != 0 {
+			t.Fatalf("track %d start offset = %d, want 0", track, got)
+		}
+		if got := r.offsetForThumb(maxThumbStart); got != r.maxOffset() {
+			t.Fatalf("track %d end offset = %d, want %d", track, got, r.maxOffset())
+		}
+		bottom := newScrollRange(track, 101, r.maxOffset())
+		start, length := bottom.thumb()
+		if start+length != track {
+			t.Fatalf("track %d bottom thumb ends at %d, want %d", track, start+length, track)
 		}
 	}
 }
 
-func TestScrollbarRenderNotVisibleNoOp(t *testing.T) {
-	sb := &scrollbar{
-		Height:     10,
-		TotalItems: 5, // fits
-		TopItem:    0,
-	}
-	s := newTestSurface(1, 10)
-	sb.Render(s, 0, 0)
+type scrollbarHarness struct {
+	name       string
+	glyph      rune
+	geometry   scrollbarGeometry
+	render     func(Surface, scrollbarGeometry, scrollRange) (int, bool)
+	handle     func(tcell.Event) (int, EventResult)
+	cancel     func() bool
+	isDragging func() bool
+	mouse      func(position int, buttons tcell.ButtonMask) *tcell.EventMouse
+	cell       func(*testSurface, int) term.Cell
+}
 
-	// All cells should remain zero-value (not rendered)
-	for y := 0; y < 10; y++ {
-		if s.cells[y][0].Ch != 0 {
-			t.Errorf("row %d should be empty when scrollbar is not visible", y)
+func newScrollbarHarness(horizontal bool) scrollbarHarness {
+	if horizontal {
+		bar := &horizontalScrollbar{}
+		geometry := scrollbarGeometry{
+			localTrack: Rect{X: 2, Y: 1, W: 10, H: 1},
+			hitTrack:   Rect{X: 12, Y: 21, W: 10, H: 1},
+		}
+		return scrollbarHarness{
+			name:       "horizontal",
+			glyph:      '▄',
+			geometry:   geometry,
+			render:     bar.Render,
+			handle:     bar.HandleEvent,
+			cancel:     bar.cancel,
+			isDragging: bar.isDragging,
+			mouse: func(position int, buttons tcell.ButtonMask) *tcell.EventMouse {
+				return tcell.NewEventMouse(geometry.hitTrack.X+position, geometry.hitTrack.Y, buttons, 0)
+			},
+			cell: func(surface *testSurface, position int) term.Cell {
+				return surface.cells[geometry.localTrack.Y][geometry.localTrack.X+position]
+			},
 		}
 	}
-}
 
-func TestScrollbarClickOnThumb(t *testing.T) {
-	sb := &scrollbar{
-		X:          5,
-		Y:          0,
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
+	bar := &scrollbar{}
+	geometry := scrollbarGeometry{
+		localTrack: Rect{X: 2, Y: 1, W: 1, H: 10},
+		hitTrack:   Rect{X: 12, Y: 21, W: 1, H: 10},
 	}
-
-	// Click on the scrollbar column at its top position
-	click := tcell.NewEventMouse(5, 0, tcell.Button1, tcell.ModNone)
-	_, consumed := sb.HandleEvent(click)
-	if !consumed {
-		t.Fatal("click on scrollbar should be consumed")
-	}
-	if !sb.dragging {
-		t.Fatal("scrollbar should enter dragging state after click")
-	}
-}
-
-func TestScrollbarClickOutside(t *testing.T) {
-	sb := &scrollbar{
-		X:          5,
-		Y:          0,
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
-	}
-
-	// Click away from scrollbar column
-	click := tcell.NewEventMouse(0, 0, tcell.Button1, tcell.ModNone)
-	_, consumed := sb.HandleEvent(click)
-	if consumed {
-		t.Fatal("click outside scrollbar should not be consumed")
+	return scrollbarHarness{
+		name:       "vertical",
+		glyph:      '█',
+		geometry:   geometry,
+		render:     bar.Render,
+		handle:     bar.HandleEvent,
+		cancel:     bar.cancel,
+		isDragging: bar.isDragging,
+		mouse: func(position int, buttons tcell.ButtonMask) *tcell.EventMouse {
+			return tcell.NewEventMouse(geometry.hitTrack.X, geometry.hitTrack.Y+position, buttons, 0)
+		},
+		cell: func(surface *testSurface, position int) term.Cell {
+			return surface.cells[geometry.localTrack.Y+position][geometry.localTrack.X]
+		},
 	}
 }
 
-func TestScrollbarDragUpdatesTopItem(t *testing.T) {
-	sb := &scrollbar{
-		X:          0,
-		Y:          0,
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
-	}
+func TestScrollbarOrientationRenderAndInteractionParity(t *testing.T) {
+	for _, horizontal := range []bool{false, true} {
+		h := newScrollbarHarness(horizontal)
+		t.Run(h.name, func(t *testing.T) {
+			surface := newTestSurface(20, 20)
+			r := newScrollRange(10, 20, 0)
+			h.render(surface, h.geometry, r)
+			thumbStart, thumbLength := r.thumb()
+			for position := range 10 {
+				cell := h.cell(surface, position)
+				if cell.Ch != h.glyph {
+					t.Fatalf("cell %d glyph = %q, want %q", position, cell.Ch, h.glyph)
+				}
+				wantStyle := term.StyleScrollbar
+				if position >= thumbStart && position < thumbStart+thumbLength {
+					wantStyle = term.StyleScrollbarThumb
+				}
+				if cell.Style != wantStyle {
+					t.Fatalf("cell %d style = %v, want %v", position, cell.Style, wantStyle)
+				}
+			}
 
-	// Click on scrollbar to start drag
-	click := tcell.NewEventMouse(0, 0, tcell.Button1, tcell.ModNone)
-	sb.HandleEvent(click)
-
-	// Drag to the bottom
-	drag := tcell.NewEventMouse(0, 9, tcell.Button1, tcell.ModNone)
-	newTop, consumed := sb.HandleEvent(drag)
-	if !consumed {
-		t.Fatal("drag should be consumed")
-	}
-	if newTop <= 0 {
-		t.Fatalf("dragging to bottom should increase topItem, got %d", newTop)
-	}
-
-	// Release
-	release := tcell.NewEventMouse(0, 9, tcell.ButtonNone, tcell.ModNone)
-	_, consumed = sb.HandleEvent(release)
-	if consumed {
-		t.Fatal("release should not be consumed (ends drag)")
-	}
-	if sb.dragging {
-		t.Fatal("scrollbar should exit dragging state on release")
+			if offset, result := h.handle(h.mouse(6, tcell.Button1)); result != EventCaptured || offset != 8 {
+				t.Fatalf("centered track press = (%d,%v), want (8,captured)", offset, result)
+			}
+			if offset, result := h.handle(h.mouse(30, tcell.Button1)); result != EventCaptured || offset != 10 {
+				t.Fatalf("outside-track held drag = (%d,%v), want (10,captured)", offset, result)
+			}
+			if _, result := h.handle(h.mouse(30, tcell.ButtonNone)); result != EventConsumed {
+				t.Fatalf("owned release result = %v, want consumed", result)
+			}
+			if h.isDragging() {
+				t.Fatal("owned release retained drag state")
+			}
+		})
 	}
 }
 
-func TestScrollbarClickBelowThumb(t *testing.T) {
-	sb := &scrollbar{
-		X:          0,
-		Y:          0,
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
-	}
-
-	// Thumb starts at top. Click below thumb area to jump.
-	_, thumbH := sb.thumbPos()
-	clickY := thumbH + 2 // below the thumb
-	click := tcell.NewEventMouse(0, clickY, tcell.Button1, tcell.ModNone)
-	newTop, consumed := sb.HandleEvent(click)
-	if !consumed {
-		t.Fatal("click on scrollbar track should be consumed")
-	}
-	if newTop <= 0 {
-		t.Fatalf("clicking below thumb should scroll down, got topItem=%d", newTop)
+func TestScrollbarGrabOffsetPreserved(t *testing.T) {
+	for _, horizontal := range []bool{false, true} {
+		h := newScrollbarHarness(horizontal)
+		t.Run(h.name, func(t *testing.T) {
+			h.render(newTestSurface(20, 20), h.geometry, newScrollRange(10, 20, 5))
+			if _, result := h.handle(h.mouse(6, tcell.Button1)); result != EventCaptured {
+				t.Fatalf("thumb press result = %v, want captured", result)
+			}
+			if offset, result := h.handle(h.mouse(5, tcell.Button1)); result != EventCaptured || offset != 2 {
+				t.Fatalf("grab-offset drag = (%d,%v), want (2,captured)", offset, result)
+			}
+		})
 	}
 }
 
-func TestScrollbarKeyEventIgnored(t *testing.T) {
-	sb := &scrollbar{
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
-	}
+func TestScrollbarCancelAndRangeInvalidationParity(t *testing.T) {
+	for _, horizontal := range []bool{false, true} {
+		h := newScrollbarHarness(horizontal)
+		t.Run(h.name, func(t *testing.T) {
+			surface := newTestSurface(20, 20)
+			h.render(surface, h.geometry, newScrollRange(10, 20, 0))
+			h.handle(h.mouse(0, tcell.Button1))
+			if !h.cancel() || h.isDragging() || h.cancel() {
+				t.Fatal("explicit cancellation was not stateful and idempotent")
+			}
 
-	ev := tcell.NewEventKey(tcell.KeyDown, "", tcell.ModNone)
-	_, consumed := sb.HandleEvent(ev)
-	if consumed {
-		t.Fatal("key events should not be consumed by scrollbar")
+			h.handle(h.mouse(0, tcell.Button1))
+			if _, invalidated := h.render(surface, h.geometry, newScrollRange(10, 40, 0)); invalidated || !h.isDragging() {
+				t.Fatal("content growth canceled capture")
+			}
+			if _, invalidated := h.render(surface, h.geometry, newScrollRange(10, 10, 0)); !invalidated || h.isDragging() {
+				t.Fatal("shrink-to-fit did not invalidate capture")
+			}
+		})
 	}
 }
 
-func TestScrollbarPosToTopItemClamping(t *testing.T) {
-	sb := &scrollbar{
-		Height:     10,
-		TotalItems: 100,
-		TopItem:    0,
+func TestScrollbarOneCellTrackClampsOutsideDragToEndpoints(t *testing.T) {
+	for _, horizontal := range []bool{false, true} {
+		h := newScrollbarHarness(horizontal)
+		t.Run(h.name, func(t *testing.T) {
+			geometry := h.geometry
+			if horizontal {
+				geometry.localTrack.W = 1
+				geometry.hitTrack.W = 1
+			} else {
+				geometry.localTrack.H = 1
+				geometry.hitTrack.H = 1
+			}
+			h.geometry = geometry
+			h.render(newTestSurface(20, 20), geometry, newScrollRange(1, 5, 0))
+			if _, result := h.handle(h.mouse(0, tcell.Button1)); result != EventCaptured {
+				t.Fatalf("one-cell press result = %v, want captured", result)
+			}
+			if offset, result := h.handle(h.mouse(2, tcell.Button1)); result != EventCaptured || offset != 4 {
+				t.Fatalf("positive outside drag = (%d,%v), want (4,captured)", offset, result)
+			}
+			if offset, result := h.handle(h.mouse(-2, tcell.Button1)); result != EventCaptured || offset != 0 {
+				t.Fatalf("negative outside drag = (%d,%v), want (0,captured)", offset, result)
+			}
+		})
 	}
+}
 
-	// Negative thumbTop should clamp to 0
-	top := sb.posToTopItem(-10)
-	if top != 0 {
-		t.Fatalf("expected clamped topItem=0 for negative pos, got %d", top)
-	}
+func TestReleaseInvisibleScrollbarDoesNotCapture(t *testing.T) {
+	for _, horizontal := range []bool{false, true} {
+		h := newScrollbarHarness(horizontal)
+		t.Run(h.name, func(t *testing.T) {
+			h.render(newTestSurface(20, 20), h.geometry, newScrollRange(10, 2, 0))
+			if _, result := h.handle(h.mouse(0, tcell.Button1)); result != EventIgnored || h.isDragging() {
+				t.Fatal("invisible scrollbar intercepted a pointer press")
+			}
 
-	// Very large thumbTop should clamp to max scrollable
-	top = sb.posToTopItem(1000)
-	maxScrollable := sb.TotalItems - sb.Height
-	if top != maxScrollable {
-		t.Fatalf("expected clamped topItem=%d for huge pos, got %d", maxScrollable, top)
+			h.render(newTestSurface(20, 20), h.geometry, newScrollRange(10, 20, 0))
+			if _, result := h.handle(h.mouse(-1, tcell.Button1)); result != EventIgnored || h.isDragging() {
+				t.Fatal("idle scrollbar captured a press outside its stored hit track")
+			}
+		})
 	}
 }

--- a/internal/widgets/scrollview.go
+++ b/internal/widgets/scrollview.go
@@ -95,15 +95,7 @@ func (sv *ScrollViewWidget) viewportSize(w, h, contentW, contentH int) (int, int
 
 // viewportOrigin returns the screen position of the inner content area.
 func (sv *ScrollViewWidget) viewportOrigin() (int, int) {
-	ox := sv.rect.X + sv.Box.MarginLeft + sv.Box.PaddingLeft
-	oy := sv.rect.Y + sv.Box.MarginTop + sv.Box.PaddingTop
-	if sv.Box.BorderLeft {
-		ox++
-	}
-	if sv.Box.BorderTop {
-		oy++
-	}
-	return ox, oy
+	return sv.contentOrigin()
 }
 
 func (sv *ScrollViewWidget) Render(surface Surface) {

--- a/internal/widgets/scrollview.go
+++ b/internal/widgets/scrollview.go
@@ -12,9 +12,14 @@ type ScrollViewWidget struct {
 	scrollX                   int
 	scrollY                   int
 	vbar                      scrollbar
+	hbar                      horizontalScrollbar
 	focused                   bool
+	lastContentW              int
 	lastContentH              int
+	lastViewW                 int
 	lastViewH                 int
+	viewport                  Rect
+	layoutValid               bool
 	pointerCaptureInvalidated func()
 	cancelingPointerCapture   bool
 }
@@ -43,9 +48,12 @@ func (sv *ScrollViewWidget) ContentHeight() int {
 }
 
 func (sv *ScrollViewWidget) EnsureVisible(x, y int) {
+	if sv.Child == nil {
+		return
+	}
 	r := sv.rect
 	contentW, contentH := sv.Child.ScrollSize()
-	viewW, viewH := sv.viewportSize(r.W, r.H, contentW, contentH)
+	viewW, viewH := sv.viewportSize(r.W-sv.BoxOverheadW(), r.H-sv.BoxOverheadH(), contentW, contentH)
 
 	if y < sv.scrollY {
 		sv.scrollY = y
@@ -59,24 +67,28 @@ func (sv *ScrollViewWidget) EnsureVisible(x, y int) {
 	if x >= sv.scrollX+viewW {
 		sv.scrollX = x - viewW + 1
 	}
+	sv.clamp(contentW, contentH, viewW, viewH)
 }
 
 func (sv *ScrollViewWidget) viewportSize(w, h, contentW, contentH int) (int, int) {
+	w = max(w, 0)
+	h = max(h, 0)
 	vw, vh := w, h
-	if contentH > h {
-		vw--
-	}
-	if contentW > vw {
-		vh--
-	}
-	if contentH > vh && vw == w {
-		vw--
-	}
-	if vw < 0 {
-		vw = 0
-	}
-	if vh < 0 {
-		vh = 0
+	for {
+		nextW := w
+		nextH := h
+		if contentH > vh {
+			nextW--
+		}
+		if contentW > vw {
+			nextH--
+		}
+		nextW = max(nextW, 0)
+		nextH = max(nextH, 0)
+		if nextW == vw && nextH == vh {
+			break
+		}
+		vw, vh = nextW, nextH
 	}
 	return vw, vh
 }
@@ -97,23 +109,28 @@ func (sv *ScrollViewWidget) viewportOrigin() (int, int) {
 func (sv *ScrollViewWidget) Render(surface Surface) {
 	surface = sv.RenderBox(surface)
 	w, h := surface.Size()
+	surface.Fill(term.Cell{Ch: ' '})
 	if w <= 0 || h <= 0 || sv.Child == nil {
-		sv.InvalidatePointerInteraction()
+		sv.invalidateRenderState(surface)
 		return
 	}
 
 	contentW, contentH := sv.Child.ScrollSize()
+	contentW = max(contentW, 0)
+	contentH = max(contentH, 0)
 	viewW, viewH := sv.viewportSize(w, h, contentW, contentH)
-	hasVBar := contentH > viewH
-	hasHBar := contentW > viewW
 
+	sv.lastContentW = contentW
 	sv.lastContentH = contentH
+	sv.lastViewW = viewW
 	sv.lastViewH = viewH
 	sv.clamp(contentW, contentH, viewW, viewH)
 
 	virt := newVirtualSurface(contentW, contentH)
 	// Children keep screen-space rects: content origin = viewport origin minus scroll offset.
 	ox, oy := sv.viewportOrigin()
+	sv.viewport = Rect{X: ox, Y: oy, W: viewW, H: viewH}
+	sv.layoutValid = true
 	sv.Child.SetRect(Rect{X: ox - sv.scrollX, Y: oy - sv.scrollY, W: contentW, H: contentH})
 	sv.Child.Render(virt)
 
@@ -126,64 +143,41 @@ func (sv *ScrollViewWidget) Render(surface Surface) {
 		}
 	}
 
-	if hasVBar {
-		sv.vbar.X = sv.rect.X + sv.Box.MarginLeft + sv.Box.PaddingLeft + w - 1
-		sv.vbar.Y = sv.rect.Y + sv.Box.MarginTop + sv.Box.PaddingTop
-		sv.vbar.Height = viewH
-		sv.vbar.TotalItems = contentH
-		sv.vbar.TopItem = sv.scrollY
-		sv.vbar.Render(surface, w-1, 0)
+	vGeometry := scrollbarGeometry{
+		localTrack: Rect{X: viewW, Y: 0, W: 1, H: viewH},
+		hitTrack:   Rect{X: ox + viewW, Y: oy, W: 1, H: viewH},
 	}
-
-	if hasHBar {
-		sv.renderHBar(surface, viewW, h-1, contentW)
+	_, vInvalidated := sv.vbar.Render(surface, vGeometry, newScrollRange(viewH, contentH, sv.scrollY))
+	hGeometry := scrollbarGeometry{
+		localTrack: Rect{X: 0, Y: viewH, W: viewW, H: 1},
+		hitTrack:   Rect{X: ox, Y: oy + viewH, W: viewW, H: 1},
 	}
-}
-
-func (sv *ScrollViewWidget) renderHBar(surface Surface, barW, y, totalW int) {
-	if totalW <= barW || barW <= 0 {
-		return
+	_, hInvalidated := sv.hbar.Render(surface, hGeometry, newScrollRange(viewW, contentW, sv.scrollX))
+	if viewW < w && viewH < h {
+		surface.SetCell(viewW, viewH, term.Cell{Ch: ' '})
 	}
-	thumbH := barW * barW / totalW
-	if thumbH < 1 {
-		thumbH = 1
-	}
-	scrollable := totalW - barW
-	thumbPos := sv.scrollX * (barW - thumbH) / scrollable
-	if thumbPos+thumbH > barW {
-		thumbPos = barW - thumbH
-	}
-
-	for x := range barW {
-		style := term.StyleScrollbar
-		if x >= thumbPos && x < thumbPos+thumbH {
-			style = term.StyleScrollbarThumb
-		}
-		surface.SetCell(x, y, term.Cell{Ch: '▄', Style: style})
-	}
+	sv.notifyPointerCaptureInvalidated(vInvalidated || hInvalidated)
 }
 
 func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
-	if newTop, consumed := sv.vbar.HandleEvent(ev); consumed {
+	if newLeft, result := sv.hbar.HandleEvent(ev); result != EventIgnored {
+		sv.scrollX = newLeft
+		return result
+	}
+	if newTop, result := sv.vbar.HandleEvent(ev); result != EventIgnored {
 		sv.scrollY = newTop
-		if sv.vbar.isDragging() {
-			return EventCaptured
-		}
-		return EventConsumed
+		return result
 	}
 
 	switch e := ev.(type) {
 	case *tcell.EventMouse:
 		btn := e.Buttons()
 		mx, my := e.Position()
-		r := sv.rect
 
 		mod := e.Modifiers()
 		if btn&tcell.WheelLeft != 0 || (btn&tcell.WheelUp != 0 && mod&tcell.ModShift != 0) {
-			sv.scrollX -= 3
-			if sv.scrollX < 0 {
-				sv.scrollX = 0
-			}
+			horizontal, _ := sv.currentScrollRanges()
+			sv.scrollX = horizontal.clampOffset(sv.scrollX - 3)
 			return EventConsumed
 		}
 		if btn&tcell.WheelRight != 0 || (btn&tcell.WheelDown != 0 && mod&tcell.ModShift != 0) {
@@ -191,35 +185,14 @@ func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
 			return EventConsumed
 		}
 		if btn&tcell.WheelUp != 0 {
-			sv.scrollY -= 3
-			if sv.scrollY < 0 {
-				sv.scrollY = 0
-			}
+			_, vertical := sv.currentScrollRanges()
+			sv.scrollY = vertical.clampOffset(sv.scrollY - 3)
 			return EventConsumed
 		}
 		if btn&tcell.WheelDown != 0 {
-			sv.scrollY += 3
-			if sv.lastContentH > 0 {
-				maxY := sv.lastContentH - sv.lastViewH
-				if maxY < 0 {
-					maxY = 0
-				}
-				if sv.scrollY > maxY {
-					sv.scrollY = maxY
-				}
-			}
+			_, vertical := sv.currentScrollRanges()
+			sv.scrollY = vertical.clampOffset(sv.scrollY + 3)
 			return EventConsumed
-		}
-
-		if btn&tcell.Button1 != 0 && sv.Child != nil {
-			contentW, contentH := sv.Child.ScrollSize()
-			_, viewH := sv.viewportSize(r.W, r.H, contentW, contentH)
-			hasHBar := contentW > r.W
-			if hasHBar && my == r.Y+r.H-1 && mx >= r.X && mx < r.X+r.W {
-				sv.scrollHToClick(mx-r.X, r.W, contentW)
-				return EventConsumed
-			}
-			_ = viewH
 		}
 
 		// Scrolled-out widgets keep offscreen rects — don't let them catch stray clicks.
@@ -237,21 +210,23 @@ func (sv *ScrollViewWidget) HandleEvent(ev tcell.Event) EventResult {
 }
 
 func (sv *ScrollViewWidget) CancelPointerCapture() bool {
-	canceled := sv.vbar.isDragging()
-	sv.vbar.dragging = false
+	canceled := sv.vbar.cancel()
+	if sv.hbar.cancel() {
+		canceled = true
+	}
 	sv.cancelingPointerCapture = true
 	if sv.Child != nil {
-		canceled = CancelPointerCapture(sv.Child) || canceled
+		if CancelPointerCapture(sv.Child) {
+			canceled = true
+		}
 	}
 	sv.cancelingPointerCapture = false
-	if canceled && sv.pointerCaptureInvalidated != nil {
-		sv.pointerCaptureInvalidated()
-	}
+	sv.notifyPointerCaptureInvalidated(canceled)
 	return canceled
 }
 
 func (sv *ScrollViewWidget) OwnsPointerCapture() bool {
-	if sv.vbar.isDragging() {
+	if sv.vbar.isDragging() || sv.hbar.isDragging() {
 		return true
 	}
 	owner, ok := sv.Child.(PointerCaptureOwner)
@@ -259,16 +234,18 @@ func (sv *ScrollViewWidget) OwnsPointerCapture() bool {
 }
 
 func (sv *ScrollViewWidget) InvalidatePointerInteraction() bool {
-	invalidated := sv.vbar.isDragging()
-	sv.vbar.dragging = false
+	invalidated := sv.vbar.cancel()
+	if sv.hbar.cancel() {
+		invalidated = true
+	}
 	sv.cancelingPointerCapture = true
 	if sv.Child != nil {
-		invalidated = InvalidatePointerInteraction(sv.Child) || invalidated
+		if InvalidatePointerInteraction(sv.Child) {
+			invalidated = true
+		}
 	}
 	sv.cancelingPointerCapture = false
-	if invalidated && sv.pointerCaptureInvalidated != nil {
-		sv.pointerCaptureInvalidated()
-	}
+	sv.notifyPointerCaptureInvalidated(invalidated)
 	return invalidated
 }
 
@@ -284,45 +261,16 @@ func (sv *ScrollViewWidget) SetPointerCaptureInvalidated(invalidated func()) {
 }
 
 func (sv *ScrollViewWidget) viewportContains(mx, my int) bool {
-	if sv.Child == nil {
+	if !sv.layoutValid {
 		return false
 	}
-	ox, oy := sv.viewportOrigin()
-	contentW, contentH := sv.Child.ScrollSize()
-	innerW := sv.rect.W - sv.BoxOverheadW()
-	innerH := sv.rect.H - sv.BoxOverheadH()
-	viewW, viewH := sv.viewportSize(innerW, innerH, contentW, contentH)
-	return mx >= ox && mx < ox+viewW && my >= oy && my < oy+viewH
+	r := sv.viewport
+	return mx >= r.X && mx < r.X+r.W && my >= r.Y && my < r.Y+r.H
 }
 
 func (sv *ScrollViewWidget) scrollHRight(amount int) {
-	sv.scrollX += amount
-	if sv.Child != nil {
-		contentW, _ := sv.Child.ScrollSize()
-		r := sv.rect
-		maxX := contentW - r.W
-		if maxX < 0 {
-			maxX = 0
-		}
-		if sv.scrollX > maxX {
-			sv.scrollX = maxX
-		}
-	}
-}
-
-func (sv *ScrollViewWidget) scrollHToClick(clickX, barW, totalW int) {
-	if barW <= 0 || totalW <= barW {
-		return
-	}
-	ratio := float64(clickX) / float64(barW)
-	sv.scrollX = int(ratio * float64(totalW-barW))
-	if sv.scrollX < 0 {
-		sv.scrollX = 0
-	}
-	maxX := totalW - barW
-	if sv.scrollX > maxX {
-		sv.scrollX = maxX
-	}
+	horizontal, _ := sv.currentScrollRanges()
+	sv.scrollX = horizontal.clampOffset(sv.scrollX + amount)
 }
 
 func (sv *ScrollViewWidget) Focusable() bool         { return true }
@@ -330,25 +278,38 @@ func (sv *ScrollViewWidget) SetFocused(focused bool) { sv.focused = focused }
 func (sv *ScrollViewWidget) IsFocused() bool         { return sv.focused }
 
 func (sv *ScrollViewWidget) clamp(contentW, contentH, viewW, viewH int) {
-	maxY := contentH - viewH
-	if maxY < 0 {
-		maxY = 0
-	}
-	if sv.scrollY > maxY {
-		sv.scrollY = maxY
-	}
-	if sv.scrollY < 0 {
-		sv.scrollY = 0
-	}
+	sv.scrollY = newScrollRange(viewH, contentH, sv.scrollY).offset
+	sv.scrollX = newScrollRange(viewW, contentW, sv.scrollX).offset
+}
 
-	maxX := contentW - viewW
-	if maxX < 0 {
-		maxX = 0
+func (sv *ScrollViewWidget) currentScrollRanges() (horizontal, vertical scrollRange) {
+	if sv.layoutValid {
+		return newScrollRange(sv.lastViewW, sv.lastContentW, sv.scrollX), newScrollRange(sv.lastViewH, sv.lastContentH, sv.scrollY)
 	}
-	if sv.scrollX > maxX {
-		sv.scrollX = maxX
+	if sv.Child == nil {
+		return newScrollRange(0, 0, sv.scrollX), newScrollRange(0, 0, sv.scrollY)
 	}
-	if sv.scrollX < 0 {
-		sv.scrollX = 0
+	contentW, contentH := sv.Child.ScrollSize()
+	viewW, viewH := sv.viewportSize(sv.rect.W-sv.BoxOverheadW(), sv.rect.H-sv.BoxOverheadH(), contentW, contentH)
+	return newScrollRange(viewW, contentW, sv.scrollX), newScrollRange(viewH, contentH, sv.scrollY)
+}
+
+func (sv *ScrollViewWidget) invalidateRenderState(surface Surface) {
+	sv.layoutValid = false
+	sv.viewport = Rect{}
+	_, vInvalidated := sv.vbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, 0, sv.scrollY))
+	_, hInvalidated := sv.hbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, 0, sv.scrollX))
+	sv.cancelingPointerCapture = true
+	childInvalidated := false
+	if sv.Child != nil {
+		childInvalidated = InvalidatePointerInteraction(sv.Child)
+	}
+	sv.cancelingPointerCapture = false
+	sv.notifyPointerCaptureInvalidated(vInvalidated || hInvalidated || childInvalidated)
+}
+
+func (sv *ScrollViewWidget) notifyPointerCaptureInvalidated(invalidated bool) {
+	if invalidated && sv.pointerCaptureInvalidated != nil {
+		sv.pointerCaptureInvalidated()
 	}
 }

--- a/internal/widgets/scrollview_test.go
+++ b/internal/widgets/scrollview_test.go
@@ -94,7 +94,9 @@ func TestScrollViewScrollbarCaptureLifecycle(t *testing.T) {
 	if !sv.OwnsPointerCapture() {
 		t.Fatal("scroll view did not report scrollbar capture")
 	}
-	sv.HandleEvent(tcell.NewEventMouse(30, 30, tcell.ButtonNone, 0))
+	if got := sv.HandleEvent(tcell.NewEventMouse(30, 30, tcell.ButtonNone, 0)); got != EventConsumed {
+		t.Fatalf("owned release result = %v, want consumed", got)
+	}
 	if sv.OwnsPointerCapture() || invalidations != 0 {
 		t.Fatalf("normal release retained capture or notified: invalidations=%d", invalidations)
 	}
@@ -391,11 +393,22 @@ func TestScrollViewHorizontalBarClick(t *testing.T) {
 	// hbar is at bottom row (y=9), click in the middle
 	ev := tcell.NewEventMouse(10, 9, tcell.Button1, tcell.ModNone)
 	result := sv.HandleEvent(ev)
-	if result != EventConsumed {
-		t.Error("click on horizontal scrollbar should be consumed")
+	if result != EventCaptured {
+		t.Error("click on horizontal scrollbar should capture")
 	}
 	if sv.scrollX == 0 {
 		t.Error("clicking in middle of hbar should scroll horizontally")
+	}
+}
+
+func TestReleaseHorizontalBarCreatedByVerticalBarCanBeClicked(t *testing.T) {
+	child := newScrollTestChild(20, 15)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+
+	result := sv.HandleEvent(tcell.NewEventMouse(18, 9, tcell.Button1, tcell.ModNone))
+	if result != EventCaptured || sv.scrollX == 0 {
+		t.Fatalf("rendered horizontal bar was not interactive: result=%v scrollX=%d", result, sv.scrollX)
 	}
 }
 
@@ -415,5 +428,104 @@ func TestScrollViewHorizontalBarRendersHalfBlock(t *testing.T) {
 	}
 	if !foundHBar {
 		t.Error("expected horizontal scrollbar with '▄' character")
+	}
+}
+
+func TestScrollViewSimultaneousBarsRespectBoxAndScreenGeometry(t *testing.T) {
+	child := newScrollTestChild(8, 5)
+	sv := NewScrollViewWidget(child)
+	sv.SetBoxModel(BoxModel{
+		MarginTop: 1, MarginBottom: 1, MarginLeft: 1, MarginRight: 1,
+		BorderTop: true, BorderBottom: true, BorderLeft: true, BorderRight: true,
+		PaddingTop: 1, PaddingBottom: 1, PaddingLeft: 1, PaddingRight: 1,
+		Borders: term.RoundedBorderSet(),
+	})
+	surface := renderWidget(sv, 7, 4, 14, 10)
+
+	if sv.viewport != (Rect{X: 10, Y: 7, W: 7, H: 3}) {
+		t.Fatalf("viewport = %+v, want x=10 y=7 w=7 h=3", sv.viewport)
+	}
+	for y := 3; y < 6; y++ {
+		if surface.cells[y][10].Ch != '█' {
+			t.Fatalf("vertical bar missing at local (10,%d)", y)
+		}
+	}
+	for x := 3; x < 10; x++ {
+		if surface.cells[6][x].Ch != '▄' {
+			t.Fatalf("horizontal bar missing at local (%d,6)", x)
+		}
+	}
+	if surface.cells[6][10].Ch != ' ' {
+		t.Fatalf("bottom-right corner = %q, want blank", surface.cells[6][10].Ch)
+	}
+
+	if got := sv.HandleEvent(tcell.NewEventMouse(16, 10, tcell.Button1, 0)); got != EventCaptured || sv.scrollX != 1 {
+		t.Fatalf("induced horizontal endpoint press: result=%v scrollX=%d", got, sv.scrollX)
+	}
+	if got := sv.HandleEvent(tcell.NewEventMouse(40, 40, tcell.ButtonNone, 0)); got != EventConsumed {
+		t.Fatalf("boxed off-widget release result = %v, want consumed", got)
+	}
+	if got := sv.HandleEvent(tcell.NewEventMouse(9, 6, tcell.Button1, 0)); got != EventIgnored {
+		t.Fatalf("coordinate outside stored inner geometry = %v, want ignored", got)
+	}
+}
+
+func TestScrollViewOneCellTracksAndZeroViewport(t *testing.T) {
+	sv := NewScrollViewWidget(newScrollTestChild(3, 3))
+	surface := renderWidget(sv, 0, 0, 2, 2)
+	if sv.viewport.W != 1 || sv.viewport.H != 1 {
+		t.Fatalf("one-cell viewport = %+v, want 1x1", sv.viewport)
+	}
+	if surface.cells[0][1].Ch != '█' || surface.cells[1][0].Ch != '▄' || surface.cells[1][1].Ch != ' ' {
+		t.Fatalf("one-cell bar geometry = %q %q corner=%q", surface.cells[0][1].Ch, surface.cells[1][0].Ch, surface.cells[1][1].Ch)
+	}
+
+	zero := NewScrollViewWidget(newScrollTestChild(3, 3))
+	zeroSurface := renderWidget(zero, 0, 0, 1, 1)
+	if zero.viewport.W != 0 || zero.viewport.H != 0 || zeroSurface.cells[0][0].Ch != ' ' {
+		t.Fatalf("zero viewport geometry = %+v cell=%q", zero.viewport, zeroSurface.cells[0][0].Ch)
+	}
+}
+
+func TestScrollViewDragGrowthAndShrinkToFit(t *testing.T) {
+	child := newScrollTestChild(10, 30)
+	sv := NewScrollViewWidget(child)
+	renderWidget(sv, 0, 0, 20, 10)
+	invalidations := 0
+	sv.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	if got := sv.HandleEvent(tcell.NewEventMouse(19, 0, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("initial press result = %v, want captured", got)
+	}
+	child.contentH = 60
+	renderWidget(sv, 0, 0, 20, 10)
+	if !sv.OwnsPointerCapture() || invalidations != 0 {
+		t.Fatalf("growth changed capture: owns=%v invalidations=%d", sv.OwnsPointerCapture(), invalidations)
+	}
+
+	child.contentH = 5
+	renderWidget(sv, 0, 0, 20, 10)
+	if sv.OwnsPointerCapture() || invalidations != 1 {
+		t.Fatalf("shrink-to-fit failed to invalidate: owns=%v invalidations=%d", sv.OwnsPointerCapture(), invalidations)
+	}
+	if got := sv.HandleEvent(tcell.NewEventMouse(19, 0, tcell.Button1, 0)); got != EventIgnored {
+		t.Fatalf("stale hidden geometry result = %v, want ignored", got)
+	}
+}
+
+func TestScrollViewHorizontalDragReachesExactEnd(t *testing.T) {
+	sv := NewScrollViewWidget(newScrollTestChild(60, 15))
+	renderWidget(sv, 0, 0, 20, 10)
+	if got := sv.HandleEvent(tcell.NewEventMouse(0, 9, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("thumb press result = %v, want captured", got)
+	}
+	if got := sv.HandleEvent(tcell.NewEventMouse(200, 9, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("off-track drag result = %v, want captured", got)
+	}
+	if sv.scrollX != 41 {
+		t.Fatalf("horizontal end offset = %d, want 41", sv.scrollX)
+	}
+	if got := sv.HandleEvent(tcell.NewEventMouse(200, 9, tcell.ButtonNone, 0)); got != EventConsumed {
+		t.Fatalf("horizontal release result = %v, want consumed", got)
 	}
 }

--- a/internal/widgets/select_test.go
+++ b/internal/widgets/select_test.go
@@ -319,3 +319,39 @@ func TestSelectOnChangeOnFilter(t *testing.T) {
 		t.Errorf("expected OnChange with 'Banana' after filter, got '%s'", changedID)
 	}
 }
+
+func TestSelectPopupScrollbarOffWidgetCaptureLifecycle(t *testing.T) {
+	labels := make([]string, 20)
+	for i := range labels {
+		labels[i] = string(rune('a' + i))
+	}
+	sw := NewSelectWidget(SelectConfig{Items: makeSelectItems(labels...), Collapsible: true})
+	sw.SetRect(Rect{X: 10, Y: 5, W: 10, H: 1})
+	sw.setOpen(true)
+	sw.Render(newVirtualSurface(10, 1))
+	popup := sw.PopupRect()
+	sw.RenderPopup(newVirtualSurface(popup.W, popup.H))
+	invalidations := 0
+	sw.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	barX := popup.X + popup.W - 2
+	barY := popup.Y + 1
+	if got := sw.HandleEvent(tcell.NewEventMouse(barX, barY, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("popup scrollbar press result = %v, want captured", got)
+	}
+	if got := sw.HandleEvent(tcell.NewEventMouse(80, 80, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("off-popup drag result = %v, want captured", got)
+	}
+	if got := sw.HandleEvent(tcell.NewEventMouse(80, 80, tcell.ButtonNone, 0)); got != EventConsumed {
+		t.Fatalf("off-popup release result = %v, want consumed", got)
+	}
+	if sw.OwnsPointerCapture() || invalidations != 0 {
+		t.Fatalf("normal release retained or invalidated capture: invalidations=%d", invalidations)
+	}
+
+	sw.HandleEvent(tcell.NewEventMouse(barX, barY, tcell.Button1, 0))
+	sw.ClosePopup()
+	if sw.OwnsPointerCapture() || invalidations != 1 {
+		t.Fatalf("closing popup did not invalidate capture: owns=%v invalidations=%d", sw.OwnsPointerCapture(), invalidations)
+	}
+}

--- a/internal/widgets/select_widget.go
+++ b/internal/widgets/select_widget.go
@@ -36,12 +36,13 @@ type SelectWidget struct {
 	selected   int
 	focused    bool
 
-	scrollTop   int
-	scrollbar   scrollbar
-	popupBounds Rect
-	open        bool
-	suppress    bool
-	currentID   string
+	scrollTop                 int
+	scrollbar                 scrollbar
+	popupBounds               Rect
+	open                      bool
+	suppress                  bool
+	currentID                 string
+	pointerCaptureInvalidated func()
 }
 
 func NewSelectWidget(config SelectConfig) *SelectWidget {
@@ -144,6 +145,7 @@ func (s *SelectWidget) setOpen(open bool) {
 	wasOpen := s.open
 	s.open = open
 	if !open {
+		s.notifyPointerCaptureInvalidated(s.scrollbar.cancel())
 		s.suppress = true
 		s.input.SetText("")
 		s.suppress = false
@@ -208,10 +210,14 @@ func (s *SelectWidget) RenderPopup(surface Surface) {
 	w, h := pr.W, pr.H
 	listH := h - 2
 	if w <= 2 || listH <= 0 {
+		_, invalidated := s.scrollbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, len(s.filtered), s.scrollTop))
+		s.notifyPointerCaptureInvalidated(invalidated)
 		return
 	}
 
 	s.ensureVisible(listH)
+	rangeModel := newScrollRange(listH, len(s.filtered), s.scrollTop)
+	s.scrollTop = rangeModel.offset
 
 	// Fill first so the popup is opaque over whatever it covers.
 	for y := range h {
@@ -220,12 +226,6 @@ func (s *SelectWidget) RenderPopup(surface Surface) {
 		}
 	}
 	surface.DrawBorder(0, 0, w, h, widgetBorders(s.Box), term.StyleBorder)
-
-	s.scrollbar.X = pr.X + w - 2
-	s.scrollbar.Y = pr.Y + 1
-	s.scrollbar.Height = listH
-	s.scrollbar.TotalItems = len(s.filtered)
-	s.scrollbar.TopItem = s.scrollTop
 
 	for i := range listH {
 		idx := s.scrollTop + i
@@ -243,7 +243,12 @@ func (s *SelectWidget) RenderPopup(surface Surface) {
 		surface.DrawText(2, i+1, item.Label, w-4, style)
 	}
 
-	s.scrollbar.Render(surface, w-2, 1)
+	geometry := scrollbarGeometry{
+		localTrack: Rect{X: w - 2, Y: 1, W: 1, H: listH},
+		hitTrack:   Rect{X: pr.X + w - 2, Y: pr.Y + 1, W: 1, H: listH},
+	}
+	_, invalidated := s.scrollbar.Render(surface, geometry, rangeModel)
+	s.notifyPointerCaptureInvalidated(invalidated)
 }
 func (s *SelectWidget) Width() int { return s.FixedWidth }
 
@@ -297,6 +302,8 @@ func (s *SelectWidget) ensureVisible(visibleH int) {
 func (s *SelectWidget) Render(surface Surface) {
 	w, h := surface.Size()
 	if w <= 0 || h <= 0 {
+		_, invalidated := s.scrollbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, len(s.filtered), s.scrollTop))
+		s.notifyPointerCaptureInvalidated(invalidated)
 		return
 	}
 
@@ -322,6 +329,10 @@ func (s *SelectWidget) Render(surface Surface) {
 
 	// A collapsed select is just the one-line control; its list lives in a popup.
 	if s.Config.Collapsible {
+		if !s.open {
+			_, invalidated := s.scrollbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, len(s.filtered), s.scrollTop))
+			s.notifyPointerCaptureInvalidated(invalidated)
+		}
 		return
 	}
 
@@ -335,14 +346,13 @@ func (s *SelectWidget) Render(surface Surface) {
 	listStart := y
 	listH := h - listStart
 	if listH <= 0 {
+		_, invalidated := s.scrollbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, len(s.filtered), s.scrollTop))
+		s.notifyPointerCaptureInvalidated(invalidated)
 		return
 	}
 
-	s.scrollbar.X = s.rect.X + w - 1
-	s.scrollbar.Y = s.rect.Y + listStart
-	s.scrollbar.Height = listH
-	s.scrollbar.TotalItems = len(s.filtered)
-	s.scrollbar.TopItem = s.scrollTop
+	rangeModel := newScrollRange(listH, len(s.filtered), s.scrollTop)
+	s.scrollTop = rangeModel.offset
 
 	for i := range listH {
 		idx := s.scrollTop + i
@@ -361,13 +371,18 @@ func (s *SelectWidget) Render(surface Surface) {
 		surface.DrawText(1, ly, item.Label, w-1, style)
 	}
 
-	s.scrollbar.Render(surface, w-1, listStart)
+	geometry := scrollbarGeometry{
+		localTrack: Rect{X: w - 1, Y: listStart, W: 1, H: listH},
+		hitTrack:   Rect{X: s.rect.X + w - 1, Y: s.rect.Y + listStart, W: 1, H: listH},
+	}
+	_, invalidated := s.scrollbar.Render(surface, geometry, rangeModel)
+	s.notifyPointerCaptureInvalidated(invalidated)
 }
 
 func (s *SelectWidget) HandleEvent(ev tcell.Event) EventResult {
-	if newTop, consumed := s.scrollbar.HandleEvent(ev); consumed {
+	if newTop, result := s.scrollbar.HandleEvent(ev); result != EventIgnored {
 		s.scrollTop = newTop
-		return EventConsumed
+		return result
 	}
 
 	switch tev := ev.(type) {
@@ -377,6 +392,30 @@ func (s *SelectWidget) HandleEvent(ev tcell.Event) EventResult {
 		return s.handleMouse(tev)
 	}
 	return EventIgnored
+}
+
+func (s *SelectWidget) CancelPointerCapture() bool {
+	canceled := s.scrollbar.cancel()
+	s.notifyPointerCaptureInvalidated(canceled)
+	return canceled
+}
+
+func (s *SelectWidget) OwnsPointerCapture() bool {
+	return s.scrollbar.isDragging()
+}
+
+func (s *SelectWidget) InvalidatePointerInteraction() bool {
+	return s.CancelPointerCapture()
+}
+
+func (s *SelectWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	s.pointerCaptureInvalidated = invalidated
+}
+
+func (s *SelectWidget) notifyPointerCaptureInvalidated(invalidated bool) {
+	if invalidated && s.pointerCaptureInvalidated != nil {
+		s.pointerCaptureInvalidated()
+	}
 }
 
 func (s *SelectWidget) handleKey(ev *tcell.EventKey) EventResult {

--- a/internal/widgets/surface.go
+++ b/internal/widgets/surface.go
@@ -168,6 +168,18 @@ func (b *BaseWidget) SetRect(r Rect)          { b.rect = r }
 func (b *BaseWidget) GetRect() Rect           { return b.rect }
 func (b *BaseWidget) SetBoxModel(bm BoxModel) { b.Box = bm }
 
+func (b *BaseWidget) contentOrigin() (int, int) {
+	x := b.rect.X + b.Box.MarginLeft + b.Box.PaddingLeft
+	y := b.rect.Y + b.Box.MarginTop + b.Box.PaddingTop
+	if b.Box.BorderLeft {
+		x++
+	}
+	if b.Box.BorderTop {
+		y++
+	}
+	return x, y
+}
+
 func (b *BaseWidget) BoxOverheadH() int {
 	h := b.Box.MarginTop + b.Box.MarginBottom + b.Box.PaddingTop + b.Box.PaddingBottom
 	if b.Box.BorderTop {

--- a/internal/widgets/table.go
+++ b/internal/widgets/table.go
@@ -30,9 +30,10 @@ type TableWidget struct {
 	lastSel   int
 	focused   bool
 
-	scrollbar scrollbar
-	contentW  int
-	widths    []int
+	scrollbar                 scrollbar
+	contentW                  int
+	widths                    []int
+	pointerCaptureInvalidated func()
 }
 
 func NewTableWidget(cfg TableConfig) *TableWidget {
@@ -87,6 +88,8 @@ func (t *TableWidget) Render(surface Surface) {
 	surface.Fill(term.Cell{Ch: ' '})
 
 	if h <= 0 || w <= 0 || len(t.Config.Columns) == 0 {
+		_, invalidated := t.scrollbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, len(t.Config.Rows), t.scrollTop))
+		t.notifyPointerCaptureInvalidated(invalidated)
 		return
 	}
 
@@ -97,24 +100,15 @@ func (t *TableWidget) Render(surface Surface) {
 		dataH = 0
 	}
 
-	maxScroll := len(t.Config.Rows) - dataH
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
-	if t.scrollTop > maxScroll {
-		t.scrollTop = maxScroll
-	}
+	rangeModel := newScrollRange(dataH, len(t.Config.Rows), t.scrollTop)
+	t.scrollTop = rangeModel.offset
 
 	t.ensureVisible(dataH)
-
-	t.scrollbar.X = t.rect.X + w - 1
-	t.scrollbar.Y = t.rect.Y + headerH
-	t.scrollbar.Height = dataH
-	t.scrollbar.TotalItems = len(t.Config.Rows)
-	t.scrollbar.TopItem = t.scrollTop
+	rangeModel = newScrollRange(dataH, len(t.Config.Rows), t.scrollTop)
+	t.scrollTop = rangeModel.offset
 
 	t.contentW = w
-	if t.scrollbar.visible() {
+	if rangeModel.visible() {
 		t.contentW = w - 1
 	}
 	t.widths = t.effectiveWidths(t.contentW)
@@ -129,7 +123,25 @@ func (t *TableWidget) Render(surface Surface) {
 		t.renderRow(surface, idx, headerH+i, t.contentW)
 	}
 
-	t.scrollbar.Render(surface, w-1, headerH)
+	ox, oy := t.contentOrigin()
+	geometry := scrollbarGeometry{
+		localTrack: Rect{X: w - 1, Y: headerH, W: 1, H: dataH},
+		hitTrack:   Rect{X: ox + w - 1, Y: oy + headerH, W: 1, H: dataH},
+	}
+	_, invalidated := t.scrollbar.Render(surface, geometry, rangeModel)
+	t.notifyPointerCaptureInvalidated(invalidated)
+}
+
+func (t *TableWidget) contentOrigin() (int, int) {
+	ox := t.rect.X + t.Box.MarginLeft + t.Box.PaddingLeft
+	oy := t.rect.Y + t.Box.MarginTop + t.Box.PaddingTop
+	if t.Box.BorderLeft {
+		ox++
+	}
+	if t.Box.BorderTop {
+		oy++
+	}
+	return ox, oy
 }
 
 // effectiveWidths keeps fixed widths; auto columns split the remaining space (min 1 cell).
@@ -263,9 +275,9 @@ func (t *TableWidget) renderCell(surface Surface, text string, col TableColumn, 
 }
 
 func (t *TableWidget) HandleEvent(ev tcell.Event) EventResult {
-	if newTop, consumed := t.scrollbar.HandleEvent(ev); consumed {
+	if newTop, result := t.scrollbar.HandleEvent(ev); result != EventIgnored {
 		t.scrollTop = newTop
-		return EventConsumed
+		return result
 	}
 
 	switch tev := ev.(type) {
@@ -281,6 +293,30 @@ func (t *TableWidget) HandleEvent(ev tcell.Event) EventResult {
 		return result
 	}
 	return EventIgnored
+}
+
+func (t *TableWidget) CancelPointerCapture() bool {
+	canceled := t.scrollbar.cancel()
+	t.notifyPointerCaptureInvalidated(canceled)
+	return canceled
+}
+
+func (t *TableWidget) OwnsPointerCapture() bool {
+	return t.scrollbar.isDragging()
+}
+
+func (t *TableWidget) InvalidatePointerInteraction() bool {
+	return t.CancelPointerCapture()
+}
+
+func (t *TableWidget) SetPointerCaptureInvalidated(invalidated func()) {
+	t.pointerCaptureInvalidated = invalidated
+}
+
+func (t *TableWidget) notifyPointerCaptureInvalidated(invalidated bool) {
+	if invalidated && t.pointerCaptureInvalidated != nil {
+		t.pointerCaptureInvalidated()
+	}
 }
 
 func (t *TableWidget) handleMouse(ev *tcell.EventMouse) EventResult {

--- a/internal/widgets/table.go
+++ b/internal/widgets/table.go
@@ -132,18 +132,6 @@ func (t *TableWidget) Render(surface Surface) {
 	t.notifyPointerCaptureInvalidated(invalidated)
 }
 
-func (t *TableWidget) contentOrigin() (int, int) {
-	ox := t.rect.X + t.Box.MarginLeft + t.Box.PaddingLeft
-	oy := t.rect.Y + t.Box.MarginTop + t.Box.PaddingTop
-	if t.Box.BorderLeft {
-		ox++
-	}
-	if t.Box.BorderTop {
-		oy++
-	}
-	return ox, oy
-}
-
 // effectiveWidths keeps fixed widths; auto columns split the remaining space (min 1 cell).
 func (t *TableWidget) effectiveWidths(w int) []int {
 	n := len(t.Config.Columns)

--- a/internal/widgets/table_test.go
+++ b/internal/widgets/table_test.go
@@ -609,6 +609,35 @@ func TestTableHeightAndWidthZero(t *testing.T) {
 	}
 }
 
+func TestTableScrollbarOffWidgetCaptureLifecycle(t *testing.T) {
+	tbl := NewTableWidget(TableConfig{
+		Columns: []TableColumn{{Label: "Name"}},
+		Rows:    makeRows(20),
+	})
+	tbl.SetRect(Rect{X: 7, Y: 3, W: 6, H: 6})
+	tbl.Render(newVirtualSurface(6, 6))
+	invalidations := 0
+	tbl.SetPointerCaptureInvalidated(func() { invalidations++ })
+
+	if got := tbl.HandleEvent(tcell.NewEventMouse(12, 5, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("scrollbar press result = %v, want captured", got)
+	}
+	if got := tbl.HandleEvent(tcell.NewEventMouse(80, 80, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("off-widget drag result = %v, want captured", got)
+	}
+	if got := tbl.HandleEvent(tcell.NewEventMouse(80, 80, tcell.ButtonNone, 0)); got != EventConsumed {
+		t.Fatalf("off-widget release result = %v, want consumed", got)
+	}
+	if tbl.OwnsPointerCapture() || invalidations != 0 {
+		t.Fatalf("normal release retained or invalidated capture: invalidations=%d", invalidations)
+	}
+
+	tbl.HandleEvent(tcell.NewEventMouse(12, 5, tcell.Button1, 0))
+	if !tbl.InvalidatePointerInteraction() || tbl.OwnsPointerCapture() || invalidations != 1 {
+		t.Fatalf("explicit invalidation failed: owns=%v invalidations=%d", tbl.OwnsPointerCapture(), invalidations)
+	}
+}
+
 // --- helpers ---
 
 func makeRows(n int) [][]string {

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -305,16 +305,7 @@ func (t *TreeWidget) Render(surface Surface) {
 	w, h := surface.Size()
 	surface.Fill(term.Cell{Ch: ' '})
 
-	ox := t.Box.MarginLeft + t.Box.PaddingLeft
-	oy := t.Box.MarginTop + t.Box.PaddingTop
-	if t.Box.BorderLeft {
-		ox++
-	}
-	if t.Box.BorderTop {
-		oy++
-	}
-	t.contentX = t.rect.X + ox
-	t.contentY = t.rect.Y + oy
+	t.contentX, t.contentY = t.contentOrigin()
 
 	if h <= 0 || w <= 0 {
 		_, invalidated := t.scrollbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, len(t.flatList), t.scrollTop))

--- a/internal/widgets/tree.go
+++ b/internal/widgets/tree.go
@@ -305,10 +305,6 @@ func (t *TreeWidget) Render(surface Surface) {
 	w, h := surface.Size()
 	surface.Fill(term.Cell{Ch: ' '})
 
-	if h <= 0 || w <= 0 {
-		return
-	}
-
 	ox := t.Box.MarginLeft + t.Box.PaddingLeft
 	oy := t.Box.MarginTop + t.Box.PaddingTop
 	if t.Box.BorderLeft {
@@ -320,6 +316,12 @@ func (t *TreeWidget) Render(surface Surface) {
 	t.contentX = t.rect.X + ox
 	t.contentY = t.rect.Y + oy
 
+	if h <= 0 || w <= 0 {
+		_, invalidated := t.scrollbar.Render(surface, scrollbarGeometry{}, newScrollRange(0, len(t.flatList), t.scrollTop))
+		t.notifyPointerCaptureInvalidated(invalidated)
+		return
+	}
+
 	if len(t.flatList) == 0 && t.Config.EmptyText != "" {
 		x := 1
 		for _, ch := range t.Config.EmptyText {
@@ -329,27 +331,17 @@ func (t *TreeWidget) Render(surface Surface) {
 			surface.SetCell(x, 0, term.Cell{Ch: ch, Style: term.StyleDefault})
 			x++
 		}
-		return
 	}
 
-	maxScroll := len(t.flatList) - h
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
-	if t.scrollTop > maxScroll {
-		t.scrollTop = maxScroll
-	}
+	rangeModel := newScrollRange(h, len(t.flatList), t.scrollTop)
+	t.scrollTop = rangeModel.offset
 
 	t.ensureVisible(h)
-
-	t.scrollbar.X = t.contentX + w - 1
-	t.scrollbar.Y = t.contentY
-	t.scrollbar.Height = h
-	t.scrollbar.TotalItems = len(t.flatList)
-	t.scrollbar.TopItem = t.scrollTop
+	rangeModel = newScrollRange(h, len(t.flatList), t.scrollTop)
+	t.scrollTop = rangeModel.offset
 
 	t.contentW = w
-	if t.scrollbar.visible() {
+	if rangeModel.visible() {
 		t.contentW = w - 1
 	}
 	for i := range h {
@@ -361,7 +353,12 @@ func (t *TreeWidget) Render(surface Surface) {
 		t.renderNode(surface, node, idx, i, t.contentW)
 	}
 
-	t.scrollbar.Render(surface, w-1, 0)
+	geometry := scrollbarGeometry{
+		localTrack: Rect{X: w - 1, Y: 0, W: 1, H: h},
+		hitTrack:   Rect{X: t.contentX + w - 1, Y: t.contentY, W: 1, H: h},
+	}
+	_, invalidated := t.scrollbar.Render(surface, geometry, rangeModel)
+	t.notifyPointerCaptureInvalidated(invalidated)
 }
 
 func (t *TreeWidget) menuIconWidth() int {
@@ -532,12 +529,9 @@ func (t *TreeWidget) renderNode(surface Surface, node *TreeNode, idx, y, w int) 
 }
 
 func (t *TreeWidget) HandleEvent(ev tcell.Event) EventResult {
-	if newTop, consumed := t.scrollbar.HandleEvent(ev); consumed {
+	if newTop, result := t.scrollbar.HandleEvent(ev); result != EventIgnored {
 		t.scrollTop = newTop
-		if t.scrollbar.isDragging() {
-			return EventCaptured
-		}
-		return EventConsumed
+		return result
 	}
 
 	prev := t.selected
@@ -557,8 +551,7 @@ func (t *TreeWidget) HandleEvent(ev tcell.Event) EventResult {
 }
 
 func (t *TreeWidget) CancelPointerCapture() bool {
-	canceled := t.scrollbar.isDragging()
-	t.scrollbar.dragging = false
+	canceled := t.scrollbar.cancel()
 	if canceled && t.pointerCaptureInvalidated != nil {
 		t.pointerCaptureInvalidated()
 	}
@@ -575,6 +568,12 @@ func (t *TreeWidget) InvalidatePointerInteraction() bool {
 
 func (t *TreeWidget) SetPointerCaptureInvalidated(invalidated func()) {
 	t.pointerCaptureInvalidated = invalidated
+}
+
+func (t *TreeWidget) notifyPointerCaptureInvalidated(invalidated bool) {
+	if invalidated && t.pointerCaptureInvalidated != nil {
+		t.pointerCaptureInvalidated()
+	}
 }
 
 func (t *TreeWidget) handleMouse(ev *tcell.EventMouse) EventResult {

--- a/internal/widgets/tree_pointer_capture_test.go
+++ b/internal/widgets/tree_pointer_capture_test.go
@@ -36,3 +36,23 @@ func TestTreeScrollbarCaptureCanBeCanceled(t *testing.T) {
 		t.Fatalf("post-cancel out-of-bounds drag result = %v, want ignored", got)
 	}
 }
+
+func TestTreeScrollbarUsesStoredScreenGeometryOnVirtualSurface(t *testing.T) {
+	items := make([]*TreeNode, 10)
+	for i := range items {
+		items[i] = &TreeNode{ID: string(rune('a' + i)), Label: "item"}
+	}
+	tree := NewTreeWidget(TreeConfig{Items: items})
+	tree.SetRect(Rect{X: 20, Y: 30, W: 5, H: 3})
+	tree.Render(newVirtualSurface(5, 3))
+
+	if got := tree.HandleEvent(tcell.NewEventMouse(4, 0, tcell.Button1, 0)); got != EventIgnored {
+		t.Fatalf("render-local coordinate result = %v, want ignored", got)
+	}
+	if got := tree.HandleEvent(tcell.NewEventMouse(24, 30, tcell.Button1, 0)); got != EventCaptured {
+		t.Fatalf("stored screen coordinate result = %v, want captured", got)
+	}
+	if got := tree.HandleEvent(tcell.NewEventMouse(50, 50, tcell.ButtonNone, 0)); got != EventConsumed {
+		t.Fatalf("off-widget release result = %v, want consumed", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add one pure scrollbar range model for visibility, clamping, thumb geometry, endpoint mapping, centered track presses, and pointer-to-offset conversion
- add thin vertical and horizontal adapters with fixed glyphs, stored render/hit geometry, drag capture, release, cancellation, and invalidation behavior
- migrate widget-native Tree, Table, Select, and both ScrollView axes to the canonical implementation
- make ScrollView solve induced and simultaneous bars with explicit bottom-right, border, padding, zero/one-cell, and horizontal endpoint geometry
- propagate Table and Select scrollbar capture through off-widget drag and release
- centralize absolute box content-origin arithmetic in an unexported BaseWidget helper, preserving render-derived hit geometry

## Verification

- focused coordinate tests for boxed ScrollView geometry, virtual-surface Tree geometry, and Table off-widget capture
- `go test -count=1 ./internal/widgets`
- `go test -race -count=1 ./internal/widgets`
- `go vet ./...`
- `make build`
- focused red-before-green characterization for hidden scrollbar presses and vertical-induced horizontal bars
- `go test -count=1 ./...` passes outside four integrated-terminal mouse-forwarding timeouts in `internal/ui`; the same four timeouts reproduce from a disposable clean archive of base `1984283`