### PR TITLE
test: characterize highlighting boundary

### DIFF
--- a/internal/app/theme_highlight_test.go
+++ b/internal/app/theme_highlight_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/eugenioenko/ttt/internal/config"
+	"github.com/eugenioenko/ttt/internal/core/highlight"
+	"github.com/eugenioenko/ttt/internal/term"
+	"github.com/gdamore/tcell/v3"
+)
+
+func TestCachedHighlightStyleFollowsLiveStyleMap(t *testing.T) {
+	h := highlight.New("main.go")
+	line := "func main() {}"
+	spans := h.HighlightLine(line)
+	keyword := highlightStyleAt(spans, 0)
+	if keyword != term.StyleSyntaxKeyword {
+		t.Fatalf("func style = %v, want syntax keyword", keyword)
+	}
+
+	firstTheme := config.DefaultTheme()
+	firstTheme.Syntax.Keyword = config.StyleDef{Fg: "#112233"}
+	firstMap := BuildStyleMap(firstTheme)
+	if got := firstMap[keyword].GetForeground(); got != tcell.GetColor("#112233") {
+		t.Fatalf("first keyword foreground = %v, want #112233", got)
+	}
+
+	secondTheme := config.DefaultTheme()
+	secondTheme.Syntax.Keyword = config.StyleDef{Fg: "#abcdef"}
+	secondMap := BuildStyleMap(secondTheme)
+	cachedKeyword := highlightStyleAt(h.HighlightLine(line), 0)
+	if cachedKeyword != keyword {
+		t.Fatalf("cached keyword style = %v, want stable style slot %v", cachedKeyword, keyword)
+	}
+	if got := secondMap[cachedKeyword].GetForeground(); got != tcell.GetColor("#abcdef") {
+		t.Fatalf("cached keyword foreground after style-map change = %v, want #abcdef", got)
+	}
+}
+
+func highlightStyleAt(spans []highlight.Span, col int) term.Style {
+	for _, span := range spans {
+		if col >= span.Start && col < span.End {
+			return span.Style
+		}
+	}
+	return term.StyleDefault
+}

--- a/internal/core/highlight/highlighter_benchmark_test.go
+++ b/internal/core/highlight/highlighter_benchmark_test.go
@@ -1,0 +1,75 @@
+package highlight
+
+import (
+	"fmt"
+	"testing"
+)
+
+var benchmarkSpans []Span
+
+func BenchmarkHighlightLine(b *testing.B) {
+	const line = `func render(value string, count int) string { return fmt.Sprintf("%s:%d", value, count) } // display`
+
+	b.Run("cold", func(b *testing.B) {
+		h := New("benchmark.go")
+		b.ReportAllocs()
+		for b.Loop() {
+			h.ClearCache()
+			benchmarkSpans = h.HighlightLine(line)
+		}
+	})
+
+	b.Run("warm", func(b *testing.B) {
+		h := New("benchmark.go")
+		benchmarkSpans = h.HighlightLine(line)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			benchmarkSpans = h.HighlightLine(line)
+		}
+	})
+}
+
+func BenchmarkHighlightLineAtAfterInvalidation(b *testing.B) {
+	for _, lineCount := range []int{50_000, 200_000} {
+		b.Run(fmt.Sprintf("lines=%d/edit=end", lineCount), func(b *testing.B) {
+			lines := benchmarkLines(lineCount)
+			h := New("benchmark.go")
+			last := len(lines) - 1
+			benchmarkSpans = h.HighlightLineAt(lines, last)
+			variants := [2]string{"var tail = 1", "var tail = 2"}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				lines[last] = variants[i&1]
+				h.ClearCache()
+				benchmarkSpans = h.HighlightLineAt(lines, last)
+			}
+		})
+
+		b.Run(fmt.Sprintf("lines=%d/edit=start", lineCount), func(b *testing.B) {
+			lines := benchmarkLines(lineCount)
+			h := New("benchmark.go")
+			last := len(lines) - 1
+			benchmarkSpans = h.HighlightLineAt(lines, last)
+			variants := [2]string{"/* open", "var head = 1"}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				lines[0] = variants[i&1]
+				h.ClearCache()
+				benchmarkSpans = h.HighlightLineAt(lines, last)
+			}
+		})
+	}
+}
+
+func benchmarkLines(count int) []string {
+	lines := make([]string, count)
+	for i := range lines {
+		lines[i] = "var value = 1"
+	}
+	return lines
+}

--- a/internal/core/highlight/highlighter_test.go
+++ b/internal/core/highlight/highlighter_test.go
@@ -1,8 +1,11 @@
 package highlight
 
 import (
-	"github.com/eugenioenko/ttt/internal/term"
+	"errors"
 	"testing"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/eugenioenko/ttt/internal/term"
 )
 
 func TestHighlightGo_Comment(t *testing.T) {
@@ -349,4 +352,172 @@ func TestInvalidationUnchangedBufferKeepsTable(t *testing.T) {
 	if styleAt(h.HighlightLineAt(lines, 3), 0) != term.StyleSyntaxKeyword {
 		t.Error("styling changed after a no-op edit")
 	}
+}
+
+func TestHighlightRuneIndexedHalfOpenSpans(t *testing.T) {
+	h := New("main.go")
+	if h == nil {
+		t.Fatal("expected Go highlighter")
+	}
+
+	for _, tc := range []struct {
+		name   string
+		prefix string
+	}{
+		{name: "multibyte", prefix: "é "},
+		{name: "fullwidth", prefix: "界 "},
+		{name: "combining", prefix: "e\u0301 "},
+		{name: "mixed", prefix: "é界e\u0301 "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			line := tc.prefix + "func main() {}"
+			start := len([]rune(tc.prefix))
+			want := Span{Start: start, End: start + len([]rune("func")), Style: term.StyleSyntaxKeyword}
+			spans := h.HighlightLine(line)
+			if !containsSpan(spans, want) {
+				t.Fatalf("spans for %q = %#v, want exact half-open rune span %#v", line, spans, want)
+			}
+			if styleAt(spans, want.End-1) != want.Style {
+				t.Fatalf("last rune inside %#v lost keyword style", want)
+			}
+			if styleAt(spans, want.End) == want.Style {
+				t.Fatalf("end rune %d must be outside half-open span %#v", want.End, want)
+			}
+		})
+	}
+}
+
+func TestHighlightStringSpanCountsUnicodeRunes(t *testing.T) {
+	h := New("main.go")
+	line := "x := \"é界e\u0301\""
+	want := Span{Start: 5, End: 11, Style: term.StyleSyntaxString}
+	spans := h.HighlightLine(line)
+	if !containsSpan(spans, want) {
+		t.Fatalf("spans for %q = %#v, want %#v", line, spans, want)
+	}
+}
+
+func TestHighlightEmptyInvalidAndDefaultGaps(t *testing.T) {
+	h := New("main.go")
+	if spans := h.HighlightLine(""); len(spans) != 0 {
+		t.Fatalf("empty line spans = %#v, want none", spans)
+	}
+	lines := []string{"package main"}
+	if spans := h.HighlightLineAt(lines, -1); spans != nil {
+		t.Fatalf("negative line spans = %#v, want nil", spans)
+	}
+	if spans := h.HighlightLineAt(lines, len(lines)); spans != nil {
+		t.Fatalf("past-end line spans = %#v, want nil", spans)
+	}
+
+	spans := h.HighlightLine(lines[0])
+	if got := styleAt(spans, 0); got != term.StyleSyntaxKeyword {
+		t.Fatalf("package style = %v, want keyword", got)
+	}
+	for _, span := range spans {
+		if span.Style == term.StyleDefault {
+			t.Fatalf("default token emitted as explicit span: %#v", span)
+		}
+	}
+	for _, col := range []int{7, 8, 11} {
+		if got := styleAt(spans, col); got != term.StyleDefault {
+			t.Fatalf("default gap at rune %d = %v, want default", col, got)
+		}
+	}
+}
+
+func TestHighlightFilenameSelectionAndFallback(t *testing.T) {
+	for _, tc := range []struct {
+		filename string
+		language string
+	}{
+		{filename: "main.go", language: "Go"},
+		{filename: "/tmp/project/main.go", language: "Go"},
+		{filename: "main.go.bak", language: "Go"},
+		{filename: "Dockerfile", language: "Docker"},
+		{filename: "Gemfile", language: "Ruby"},
+	} {
+		t.Run(tc.filename, func(t *testing.T) {
+			h := New(tc.filename)
+			if h == nil {
+				t.Fatalf("New(%q) = nil, want %s", tc.filename, tc.language)
+			}
+			if got := h.Language(); got != tc.language {
+				t.Fatalf("New(%q).Language() = %q, want %q", tc.filename, got, tc.language)
+			}
+		})
+	}
+	if h := New("file.unknown-ttt-language"); h != nil {
+		t.Fatalf("unknown filename selected %q, want nil fallback", h.Language())
+	}
+}
+
+func TestMapTokenTypePresentationContract(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		token chroma.TokenType
+		style term.Style
+	}{
+		{name: "keyword type", token: chroma.KeywordType, style: term.StyleSyntaxType},
+		{name: "keyword subcategory", token: chroma.KeywordConstant, style: term.StyleSyntaxKeyword},
+		{name: "comment subcategory", token: chroma.CommentSpecial, style: term.StyleSyntaxComment},
+		{name: "string subcategory", token: chroma.StringDouble, style: term.StyleSyntaxString},
+		{name: "number subcategory", token: chroma.NumberInteger, style: term.StyleSyntaxNumber},
+		{name: "operator subcategory", token: chroma.OperatorWord, style: term.StyleSyntaxOperator},
+		{name: "function", token: chroma.NameFunction, style: term.StyleSyntaxFunction},
+		{name: "function magic", token: chroma.NameFunctionMagic, style: term.StyleSyntaxFunction},
+		{name: "builtin", token: chroma.NameBuiltin, style: term.StyleSyntaxBuiltin},
+		{name: "builtin pseudo", token: chroma.NameBuiltinPseudo, style: term.StyleSyntaxBuiltin},
+		{name: "class", token: chroma.NameClass, style: term.StyleSyntaxType},
+		{name: "decorator", token: chroma.NameDecorator, style: term.StyleSyntaxType},
+		{name: "tag", token: chroma.NameTag, style: term.StyleSyntaxTag},
+		{name: "attribute", token: chroma.NameAttribute, style: term.StyleSyntaxAttribute},
+		{name: "variable subcategory", token: chroma.NameVariableGlobal, style: term.StyleSyntaxVariable},
+		{name: "heading", token: chroma.GenericHeading, style: term.StyleSyntaxKeyword},
+		{name: "subheading", token: chroma.GenericSubheading, style: term.StyleSyntaxKeyword},
+		{name: "strong", token: chroma.GenericStrong, style: term.StyleSyntaxType},
+		{name: "emphasis", token: chroma.GenericEmph, style: term.StyleSyntaxString},
+		{name: "inserted", token: chroma.GenericInserted, style: term.StyleDiffAdded},
+		{name: "deleted", token: chroma.GenericDeleted, style: term.StyleDiffDeleted},
+		{name: "punctuation", token: chroma.Punctuation, style: term.StyleSyntaxPunctuation},
+		{name: "unmapped text", token: chroma.Text, style: term.StyleDefault},
+		{name: "unmapped name", token: chroma.Name, style: term.StyleDefault},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mapTokenType(tc.token); got != tc.style {
+				t.Fatalf("mapTokenType(%v) = %v, want %v", tc.token, got, tc.style)
+			}
+		})
+	}
+}
+
+type tokeniseErrorLexer struct {
+	chroma.Lexer
+}
+
+func (tokeniseErrorLexer) Tokenise(*chroma.TokeniseOptions, string) (chroma.Iterator, error) {
+	return nil, errors.New("tokenise failed")
+}
+
+func TestLexerErrorsProduceNoSpansOrBlockState(t *testing.T) {
+	lx := tokeniseErrorLexer{}
+	h := &Highlighter{lexer: lx, blockOpen: "/*", blockClose: "*/"}
+	if spans := h.lexLine("func main() {}"); spans != nil {
+		t.Fatalf("lexLine error spans = %#v, want nil", spans)
+	}
+	if got := h.computeOpensAt("/* open"); got != -1 {
+		t.Fatalf("computeOpensAt error = %d, want -1", got)
+	}
+	if open, close := detectBlockComment(lx); open != "" || close != "" {
+		t.Fatalf("detectBlockComment error = %q/%q, want no delimiters", open, close)
+	}
+}
+
+func containsSpan(spans []Span, want Span) bool {
+	for _, span := range spans {
+		if span == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -76,6 +76,83 @@ func TestRenderCodeBlock(t *testing.T) {
 	}
 }
 
+func TestRenderCodeBlockHighlightAndFallbackStyles(t *testing.T) {
+	known := renderCodeBlock([]string{"func main() {}"}, "go")
+	if got := styleForText(known[0], "func"); got != term.StyleSyntaxKeyword {
+		t.Fatalf("known Go fence func style = %v, want syntax keyword", got)
+	}
+	if got := styleForText(known[0], "main"); got != term.StyleSyntaxFunction {
+		t.Fatalf("known Go fence main style = %v, want syntax function", got)
+	}
+	if got := styleForText(known[0], " "); got != term.StyleHoverCode {
+		t.Fatalf("known Go fence unmapped gap style = %v, want hover code fallback", got)
+	}
+	renderedKnown := lineForText(t, Render("```go\nfunc main() {}\n```"), "func main() {}")
+	if got := styleForText(renderedKnown, "func"); got != term.StyleSyntaxKeyword {
+		t.Fatalf("rendered Go fence func style = %v, want syntax keyword", got)
+	}
+	if got := styleForText(renderedKnown, "main"); got != term.StyleSyntaxFunction {
+		t.Fatalf("rendered Go fence main style = %v, want syntax function", got)
+	}
+
+	unknown := renderCodeBlock([]string{"plain text"}, "unknown-ttt-language")
+	if len(unknown[0].Spans) != 1 || unknown[0].Spans[0] != (Span{Text: "plain text", Style: term.StyleHoverCode}) {
+		t.Fatalf("unknown fence spans = %#v, want one hover-code fallback span", unknown[0].Spans)
+	}
+
+	empty := renderCodeBlock([]string{""}, "go")
+	if len(empty[0].Spans) != 1 || empty[0].Spans[0] != (Span{Text: "", Style: term.StyleHoverCode}) {
+		t.Fatalf("empty known fence spans = %#v, want empty hover-code fallback span", empty[0].Spans)
+	}
+}
+
+func TestRenderDiffFenceUsesDedicatedStyles(t *testing.T) {
+	lines := renderCodeBlock([]string{"+added line", "-deleted line"}, "diff")
+	if got := styleForText(lines[0], "+added line"); got != term.StyleDiffAdded {
+		t.Fatalf("added diff fence style = %v, want diff added", got)
+	}
+	if got := styleForText(lines[1], "-deleted line"); got != term.StyleDiffDeleted {
+		t.Fatalf("deleted diff fence style = %v, want diff deleted", got)
+	}
+	rendered := Render("```diff\n+added line\n-deleted line\n```")
+	if got := styleForText(lineForText(t, rendered, "+added line"), "+added line"); got != term.StyleDiffAdded {
+		t.Fatalf("rendered added diff fence style = %v, want diff added", got)
+	}
+	if got := styleForText(lineForText(t, rendered, "-deleted line"), "-deleted line"); got != term.StyleDiffDeleted {
+		t.Fatalf("rendered deleted diff fence style = %v, want diff deleted", got)
+	}
+}
+
+func TestRenderCodeBlockKeepsLineIsolatedLexerState(t *testing.T) {
+	lines := renderCodeBlock([]string{"/* open", "inside", "*/"}, "go")
+	if got := styleForText(lines[0], "/* open"); got != term.StyleSyntaxComment {
+		t.Fatalf("opener style = %v, want syntax comment", got)
+	}
+	if got := styleForText(lines[1], "inside"); got != term.StyleHoverCode {
+		t.Fatalf("isolated interior style = %v, want hover code fallback", got)
+	}
+}
+
+func styleForText(line Line, text string) term.Style {
+	for _, span := range line.Spans {
+		if span.Text == text || strings.Contains(span.Text, text) {
+			return span.Style
+		}
+	}
+	return term.StyleDefault
+}
+
+func lineForText(t *testing.T, lines []Line, text string) Line {
+	t.Helper()
+	for _, line := range lines {
+		if line.Text() == text {
+			return line
+		}
+	}
+	t.Fatalf("rendered lines do not contain %q: %v", text, textLines(lines))
+	return Line{}
+}
+
 func TestRenderDivider(t *testing.T) {
 	lines := Render("above\n\n---\n\nbelow")
 	foundDivider := false

--- a/internal/ui/diff_widget_test.go
+++ b/internal/ui/diff_widget_test.go
@@ -634,6 +634,32 @@ func TestDiffWidgetHighContrastUsesSemanticChangeForegrounds(t *testing.T) {
 	}
 }
 
+func TestDiffWidgetSyntaxSearchAndSelectionLayering(t *testing.T) {
+	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-var oldValue = 1\n+var newValue = 2\n")
+	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)
+	dv.ApplySearchHighlight("var", SearchOptions{})
+
+	const width, height = 60, 2
+	dv.SetRect(Rect{W: width, H: height})
+	grid := makeGrid(width, height)
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+	cell := grid[0][dv.layoutLeftStart]
+	if cell.Style != term.StyleSearchMatch || cell.BgStyle != 0 {
+		t.Fatalf("searched diff syntax cell = %+v, want search style replacing diff background", cell)
+	}
+
+	dv.hasSelection = true
+	dv.selRight = false
+	dv.selection.Anchor = diffSelPos{Line: 0, Col: 0}
+	dv.selection.Current = diffSelPos{Line: 0, Col: 3}
+	grid = makeGrid(width, height)
+	dv.Render(NewRenderSurface(grid, Rect{W: width, H: height}))
+	cell = grid[0][dv.layoutLeftStart]
+	if cell.Style != term.StyleSearchMatch || cell.BgStyle != term.StyleSelection {
+		t.Fatalf("selected searched diff syntax cell = %+v, want search style with selection background", cell)
+	}
+}
+
 func TestDiffWidgetWrappedScrollbarUsesVisualRows(t *testing.T) {
 	fd := diff.Parse("--- a/test.go\n+++ b/test.go\n@@ -1 +1 @@\n-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\n+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\n")
 	dv := NewDiffViewWidget("test.go", fd, nil, nil, false)

--- a/internal/ui/editor_widget_test.go
+++ b/internal/ui/editor_widget_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"github.com/eugenioenko/ttt/internal/core/buffer"
 	"github.com/eugenioenko/ttt/internal/core/cursor"
+	"github.com/eugenioenko/ttt/internal/core/highlight"
 	"github.com/eugenioenko/ttt/internal/core/selection"
 	"github.com/eugenioenko/ttt/internal/term"
 	"github.com/eugenioenko/ttt/internal/view"
@@ -171,6 +172,37 @@ func TestEditorSelectionHighlight(t *testing.T) {
 	}
 	if grid[0][g+4].BgStyle == term.StyleSelection {
 		t.Error("col 4 should not be selected")
+	}
+}
+
+func TestEditorSyntaxSearchAndSelectionLayering(t *testing.T) {
+	e := NewEditorPaneWidget(
+		&buffer.Buffer{Lines: []string{"func main() {}"}},
+		&cursor.Cursor{Line: 0, Col: 0},
+		&view.Viewport{TopLine: 0, LeftCol: 0, Width: 20, Height: 10},
+	)
+	e.Highlighter = highlight.New("main.go")
+	e.Selection = &selection.Selection{Active: true, Anchor: selection.Position{Line: 0, Col: 0}}
+	e.Cursor.Line = 0
+	e.Cursor.Col = 4
+	e.SetRect(Rect{X: 0, Y: 0, W: 20, H: 4})
+
+	grid := makeGrid(20, 4)
+	e.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 20, H: 4}))
+	cell := grid[0][e.GutterWidth()]
+	if cell.Style != term.StyleSyntaxKeyword || cell.BgStyle != term.StyleSelection {
+		t.Fatalf("selected syntax cell = %+v, want keyword foreground with selection background", cell)
+	}
+
+	e.Selection.Active = false
+	e.SearchMatches = []FindMatch{{Line: 0, Col: 0, Len: 4}}
+	e.SearchActive = 0
+	e.buildSearchIndex()
+	grid = makeGrid(20, 4)
+	e.Render(NewRenderSurface(grid, Rect{X: 0, Y: 0, W: 20, H: 4}))
+	cell = grid[0][e.GutterWidth()]
+	if cell.Style != term.StyleSearchActive || cell.BgStyle != 0 {
+		t.Fatalf("searched syntax cell = %+v, want active search style with no layered background", cell)
 	}
 }
 


### PR DESCRIPTION
Pin rune-indexed half-open spans, Unicode cases, filename and fallback selection, Chroma mapping and failure behavior, Markdown fences, and editor, diff, and live-theme composition.

Add cold and warm line benchmarks plus 50k and 200k invalidation benchmarks. Five-run medians on an AMD Ryzen 9 9950X3D: cold 65.944 us with 38624 B and 599 allocs; warm 13.36 ns with zero allocations; 50k end 60.125 us with 8528 B and 138 allocs; 50k start 324.140 us with 4508 B and 70 allocs; 200k end 215.801 us with 8528 B and 138 allocs; 200k start 1.278443 ms with 4510 B and 70 allocs. HL2 should stop on greater than 10 percent median regression or allocation growth; these benchmarks intentionally impose no deterministic threshold.

Verification: focused package tests, meaningful race runs, full Go suite with the four known issue #533 terminal mouse-forwarding fixtures skipped, make build, and benchmark count 5. The unfiltered suite reached only those known unrelated #533 timeouts.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for syntax highlighting, including Unicode spans, language detection, fallback behavior, lexer errors, and theme updates.
  * Added validation for Markdown code blocks and diff rendering.
  * Verified search and selection styling layers correctly in editor and diff views.
  * Added performance benchmarks for highlighting with warm, cold, and invalidated caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->