### PR TITLE
fix: clarify Changes panel menu item naming

### DIFF
--- a/internal/app/commands_git.go
+++ b/internal/app/commands_git.go
@@ -228,7 +228,7 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "changes.openDiff", Title: "Git: Open Changes Only",
+		ID: "changes.openDiff", Title: "Git: Open Changes",
 		Keywords: []string{"git", "changes", "diff", "compare"},
 		Handler: func() {
 			app.openSelectedDiff(false)
@@ -236,7 +236,7 @@ func registerGitCommands(app *App) {
 	})
 
 	reg.Register(command.Command{
-		ID: "changes.openExtendedDiff", Title: "Git: Open Full File",
+		ID: "changes.openExtendedDiff", Title: "Git: Open Full Diff",
 		Keywords: []string{"git", "changes", "diff", "compare"},
 		Handler: func() {
 			app.openSelectedDiff(true)

--- a/internal/app/menus.go
+++ b/internal/app/menus.go
@@ -117,16 +117,16 @@ var commitDetailContextMenu = []ui.ContextMenuItem{
 }
 
 var changesContextMenuStaged = []ui.ContextMenuItem{
-	{Label: "Open Changes Only", Command: "changes.openDiff"},
-	{Label: "Open Full File", Command: "changes.openExtendedDiff"},
+	{Label: "Open Changes", Command: "changes.openDiff"},
+	{Label: "Open Full Diff", Command: "changes.openExtendedDiff"},
 	{Label: "Open File", Command: "changes.openFile"},
 	ui.MenuSep(),
 	{Label: "Unstage", Command: "changes.unstage"},
 }
 
 var changesContextMenuUnstaged = []ui.ContextMenuItem{
-	{Label: "Open Changes Only", Command: "changes.openDiff"},
-	{Label: "Open Full File", Command: "changes.openExtendedDiff"},
+	{Label: "Open Changes", Command: "changes.openDiff"},
+	{Label: "Open Full Diff", Command: "changes.openExtendedDiff"},
 	{Label: "Open File", Command: "changes.openFile"},
 	ui.MenuSep(),
 	{Label: "Stage", Command: "changes.stage"},

--- a/tests/functional/commit-history-detail.test.js
+++ b/tests/functional/commit-history-detail.test.js
@@ -25,7 +25,7 @@ describe("commit history detail", () => {
     tui.press("right");
     tui.waitFor("selected-detail.txt");
     tui.press("down");
-    tui.exec("Git: Open Changes Only");
+    tui.exec("Git: Open Changes");
     tui.waitFor("selected-detail.txt @");
     const opened = tui.snapshot();
 


### PR DESCRIPTION
@coderabbitai: ignore

## Summary
- Rename "Open Changes Only" -> "Open Changes" and "Open Full File" -> "Open Full Diff" in the Changes panel context menu (`internal/app/menus.go`) and command palette titles (`internal/app/commands_git.go`)
- "Open Full File" was easily confused with the unrelated "Open File" item despite being a diff view

Fixes #522

## Test plan
- [x] `make build`
- [x] `cd tests/functional && npx vitest run commit-history-detail.test.js` (updated to match new command title)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Git diff command labels to “Git: Open Changes” and “Git: Open Full Diff” for clearer, more consistent wording.
  * Updated staged and unstaged changes menu labels to match the revised command names.
  * Git command behavior and keyboard bindings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->