### PR TITLE
docs: rename CLAUDE.md to AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
                   docs-web/*)
                     docs_web=true
                     ;;
-                  README.md|CLAUDE.md|ARCHITECTURE.md|LICENSE|audit/*.md|workflows/*.md)
+                  README.md|AGENTS.md|ARCHITECTURE.md|LICENSE|audit/*.md|workflows/*.md)
                     ;;
                   *)
                     runtime=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents (Claude Code, Codex, Cursor, and others) when working with code in this repository.
 
 ## Project Overview
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document describes ttt's current architecture, its intended dependency
 boundaries, and the incremental program for improving them. It is the source of
-truth for package ownership. `CLAUDE.md` summarizes the constraints agents most
+truth for package ownership. `AGENTS.md` summarizes the constraints agents most
 often need while working in the repository.
 
 ## Current shape


### PR DESCRIPTION
## Summary
- Renames `CLAUDE.md` to `AGENTS.md`, adopting the cross-agent instructions-file convention (read natively by Claude Code, Codex, Cursor, and others)
- Updates the two references called out in the issue: `ARCHITECTURE.md:5` and the docs-only classifier in `.github/workflows/ci.yml:76`
- Leaves `audit/2026-07-12-ux-bug-audit.md` untouched (historical references, per issue notes)

Closes #547



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed the project’s AI coding guidance from `CLAUDE.md` to `AGENTS.md`.
  - Expanded the guidance to cover multiple AI coding tools.
  - Updated architecture documentation to reference the new guidance file.

- **Chores**
  - Updated continuous integration change classification so guidance-only edits are handled without triggering unnecessary runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->