### PR TITLE
fix: stop selection  bleeding past text on last line

### DIFF
--- a/internal/core/selection/selection.go
+++ b/internal/core/selection/selection.go
@@ -36,6 +36,9 @@ func (s *Selection) Contains(line, col, curLine, curCol int) bool {
 	if line < start.Line || line > end.Line {
 		return false
 	}
+	if col < 0 {
+		return line != end.Line
+	}
 	if line == start.Line && col < start.Col {
 		return false
 	}

--- a/internal/core/selection/selection_test.go
+++ b/internal/core/selection/selection_test.go
@@ -35,6 +35,23 @@ func TestContains(t *testing.T) {
 	}
 }
 
+func TestContainsNegativeCol(t *testing.T) {
+	s := &Selection{Active: true, Anchor: Position{Line: 1, Col: 2}}
+
+	// col=-1 on the last line of selection should NOT be contained
+	if s.Contains(2, -1, 2, 5) {
+		t.Error("expected col=-1 on last line to NOT be in selection")
+	}
+	// col=-1 on a middle line should be contained
+	if !s.Contains(2, -1, 3, 5) {
+		t.Error("expected col=-1 on middle line to be in selection")
+	}
+	// col=-1 on the first line (multiline) should be contained
+	if !s.Contains(1, -1, 3, 5) {
+		t.Error("expected col=-1 on first line to be in selection")
+	}
+}
+
 func TestContainsInactive(t *testing.T) {
 	s := &Selection{Active: false, Anchor: Position{Line: 0, Col: 0}}
 	if s.Contains(0, 0, 1, 0) {


### PR DESCRIPTION
## Summary
- Fixes multiline selection highlight extending past the actual selected text on the last line
- Screen cells beyond line content use `bufCol=-1` as a sentinel; `Contains` now returns false for negative columns on the selection's end line, while still highlighting trailing cells on middle/first lines
- Adds test coverage for the negative-column edge case


## Note
Ah... finally got time to look into this one, it has been here for so long I almost got used to it XD 