### PR TITLE
ci: fix ineffassign lint violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,5 +7,5 @@ linters:
     # TODO: enable after fixing violations
     # - errcheck     # https://github.com/eugenioenko/ttt/issues/505
     # - staticcheck  # https://github.com/eugenioenko/ttt/issues/506
-    # - ineffassign  # https://github.com/eugenioenko/ttt/issues/507
+    - ineffassign
     - unused

--- a/internal/ui/hover_widget.go
+++ b/internal/ui/hover_widget.go
@@ -102,7 +102,6 @@ func (h *HoverWidget) Render(surface Surface) {
 			y = localY + 1
 			if y+menuH > sh {
 				menuH = sh - y
-				visLines = menuH - 2
 			}
 		} else {
 			y = 0

--- a/internal/widgets/focus.go
+++ b/internal/widgets/focus.go
@@ -330,7 +330,7 @@ func (fm *FocusManager) HandleEvent(ev tcell.Event) EventResult {
 		}
 	case *tcell.EventMouse:
 		mx, my := tev.Position()
-		hit := -1
+		var hit int
 		if tev.Buttons()&tcell.Button1 != 0 {
 			hit = fm.innermostVisibleHit(mx, my)
 			if hit >= 0 {

--- a/tests/e2e/bracket_colorization_test.go
+++ b/tests/e2e/bracket_colorization_test.go
@@ -145,7 +145,7 @@ func main() {
 	colorizedFg := cells[parenRow*w+parenCol].Style.GetForeground()
 
 	h.exec("options.toggleBracketColors")
-	cells, _, _ = h.screen.GetContents()
+	_, _, _ = h.screen.GetContents()
 
 	if h.app.Settings.Editor.BracketPairColorization {
 		t.Error("expected BracketPairColorization to be false after toggle")


### PR DESCRIPTION
## Summary
- Enable `ineffassign` linter in `.golangci.yml`
- Fix all 3 violations: dead `visLines` assignment in hover widget, unused initial value in focus manager, unused `cells` return in bracket colorization test

Closes #507

## Test plan
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — passes

<!-- @coderabbitai ignore -->
