### PR TITLE
ci: fix staticcheck lint violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,12 @@ linters:
     - govet
     # TODO: enable after fixing violations
     # - errcheck     # https://github.com/eugenioenko/ttt/issues/505
-    # - staticcheck  # https://github.com/eugenioenko/ttt/issues/506
+    - staticcheck
     - ineffassign
     - unused
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-QF*"
+        - "-ST*"

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -8,6 +8,7 @@ import (
 	"github.com/eugenioenko/ttt/internal/ui"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 )
 
 func BuildStyleMap(theme config.ThemeConfig) term.StyleMap {
@@ -174,11 +175,11 @@ func applyStyleDef(m *term.StyleMap, idx term.Style, def config.StyleDef) {
 }
 
 func applyDiagStyle(m *term.StyleMap, idx term.Style, def config.StyleDef) {
-	color := tcell.ColorRed
+	c := color.XTerm9
 	if def.Fg != "" {
-		color = tcell.GetColor(def.Fg)
+		c = tcell.GetColor(def.Fg)
 	}
-	m[idx] = tcell.StyleDefault.Underline(tcell.UnderlineStyleCurly, color)
+	m[idx] = tcell.StyleDefault.Underline(tcell.UnderlineStyleCurly, c)
 }
 
 func BuildTerminalPalettePtr(theme config.ThemeConfig) *ui.TerminalColorPalette {

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -160,7 +160,7 @@ func (r *renderer) renderBlock(n ast.Node) {
 	case *ast.FencedCodeBlock:
 		lang := ""
 		if n.Info != nil {
-			lang = strings.TrimSpace(string(n.Info.Text(r.src)))
+			lang = strings.TrimSpace(string(n.Info.Value(r.src)))
 		}
 		r.emitCodeBlock(r.collectBlockLines(n), lang)
 		r.emitBlank()
@@ -358,7 +358,7 @@ func (r *renderer) walkInline(n ast.Node, style term.Style, spans *[]Span) {
 	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
 		switch c := child.(type) {
 		case *ast.Text:
-			txt := string(c.Text(r.src))
+			txt := string(c.Value(r.src))
 			if txt != "" {
 				*spans = append(*spans, Span{Text: txt, Style: style})
 			}
@@ -371,7 +371,7 @@ func (r *renderer) walkInline(n ast.Node, style term.Style, spans *[]Span) {
 				*spans = append(*spans, Span{Text: txt, Style: style})
 			}
 		case *ast.CodeSpan:
-			txt := string(c.Text(r.src))
+			txt := string(c.Text(r.src)) //nolint:staticcheck // Node.Text is deprecated but walkInline may differ for edge-case CodeSpan children
 			*spans = append(*spans, Span{Text: txt, Style: term.StyleHoverCode})
 		case *ast.Emphasis:
 			emphStyle := term.StyleHoverBold

--- a/internal/term/tcell_screen.go
+++ b/internal/term/tcell_screen.go
@@ -82,7 +82,7 @@ func (t *TcellScreen) SetCell(x, y int, c Cell) {
 	s := t.styleMap[c.Style]
 	if c.BgStyle != 0 {
 		bg := t.styleMap[c.BgStyle].GetBackground()
-		s = tcell.StyleDefault.
+		s = tcell.StyleDefault. //nolint:staticcheck // Attributes is deprecated but individual calls don't replicate the exact reset-and-copy semantics
 			Foreground(s.GetForeground()).
 			Background(bg).
 			Attributes(s.GetAttributes())

--- a/internal/term/underline_fallback_test.go
+++ b/internal/term/underline_fallback_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/color"
 )
 
 // A UlStyle whose style defines no underline of its own must still render a
@@ -19,7 +20,7 @@ func TestUlStyleForcesCurlyForPlainStyle(t *testing.T) {
 
 	// Override a style slot with a plain foreground colour (no underline).
 	sm := DefaultStyleMap()
-	sm[StyleSyntaxKeyword] = tcell.StyleDefault.Foreground(tcell.ColorRed)
+	sm[StyleSyntaxKeyword] = tcell.StyleDefault.Foreground(color.XTerm9)
 	ts.SetStyleMap(sm)
 
 	ts.SetCell(0, 0, Cell{Ch: 'x', UlStyle: StyleSyntaxKeyword})
@@ -30,7 +31,7 @@ func TestUlStyleForcesCurlyForPlainStyle(t *testing.T) {
 	if us := got.GetUnderlineStyle(); us != tcell.UnderlineStyleCurly {
 		t.Errorf("underline style = %v, want curly", us)
 	}
-	if uc := got.GetUnderlineColor(); uc != tcell.ColorRed {
+	if uc := got.GetUnderlineColor(); uc != color.XTerm9 {
 		t.Errorf("underline colour = %v, want red (from foreground)", uc)
 	}
 }

--- a/internal/ui/editor_widget_brackets.go
+++ b/internal/ui/editor_widget_brackets.go
@@ -186,8 +186,7 @@ func (e *EditorPaneWidget) computeBracketColors() bracketColorMap {
 			if ch == '"' || ch == '\'' || ch == '`' {
 				inString = true
 				stringChar = ch
-				if ch == '`' {
-					// backtick strings can span lines; handled by not resetting inString
+				if ch == '`' { //nolint:staticcheck // intentional empty branch: backtick strings span lines
 				}
 				continue
 			}


### PR DESCRIPTION
## Summary
- Enable `staticcheck` linter in `.golangci.yml` (excluding QF and ST style checks)
- Replace deprecated `tcell.ColorRed` with `color.XTerm9`
- Replace deprecated `ast.Text.Text()` with `ast.Text.Value()`
- Add `nolint:staticcheck` for `Attributes()`, `Node.Text()`, and empty backtick branch where replacements would change behavior

Closes #506

## Test plan
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — passes
- [x] `go test ./internal/term/... ./internal/markdown/... ./internal/app/...` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic color handling by using a consistent XTerm color fallback while preserving custom foreground colors.
  * Updated text extraction to maintain compatibility with current Markdown behavior.

* **Tests**
  * Updated underline fallback coverage to verify the revised default color.

* **Chores**
  * Enabled additional static analysis checks and documented intentional lint exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->