### PR TITLE
fix(lsp): order signature-help requests after their triggering didChange

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -514,9 +514,9 @@ func (a *App) Init(screen *term.TcellScreen, renderer *render.Renderer, lspManag
 			lang = a.EditorGroup.Editor.Highlighter.Language()
 		}
 		text := strings.Join(a.EditorGroup.Editor.Buf.Lines, "\n")
-		a.NotifyLSPChange(path, lang, text)
+		changeDone := a.NotifyLSPChange(path, lang, text)
 		a.ScheduleAutocomplete()
-		a.CheckSignatureHelpTrigger()
+		a.CheckSignatureHelpTrigger(changeDone)
 		a.ScheduleGitGutter()
 		if a.PluginManager != nil {
 			a.PluginManager.DispatchEvent("editor.change", path)

--- a/internal/app/app_lsp.go
+++ b/internal/app/app_lsp.go
@@ -260,12 +260,8 @@ func (a *App) charBeforeCursor() string {
 	return string(runes[col-1])
 }
 
-// CheckSignatureHelpTrigger inspects the character just typed and, if it's a
-// signature-help trigger, requests signature help. changeDone must be the
-// channel returned by the NotifyLSPChange call for this same keystroke, so
-// the request is sent only after that change has reached the server —
-// otherwise the server could see the signatureHelp request before the
-// didChange that produced the triggering character.
+// changeDone must be the NotifyLSPChange channel for this same keystroke, so
+// the server sees that didChange before the signatureHelp request it triggers.
 func (a *App) CheckSignatureHelpTrigger(changeDone <-chan struct{}) {
 	if !a.Settings.Autocomplete.Enabled || !a.Settings.Autocomplete.SignatureHelp {
 		return
@@ -306,9 +302,8 @@ func (a *App) CheckSignatureHelpTrigger(changeDone <-chan struct{}) {
 	}
 }
 
-// RequestSignatureHelp sends a textDocument/signatureHelp request. If
-// changeDone is non-nil, it waits for that channel to close first, so the
-// request is ordered after the didChange notification for the same edit.
+// changeDone, if non-nil, is awaited first so the request lands after the
+// didChange notification for the same edit.
 func (a *App) RequestSignatureHelp(path, lang string, line, col int, changeDone <-chan struct{}) {
 	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
@@ -989,10 +984,9 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 	}()
 }
 
-// NotifyLSPChange sends a textDocument/didChange notification and returns a
-// channel that closes once that notification has been sent, so callers that
-// must not race ahead of it (e.g. a signature-help request for the same
-// keystroke) can wait on it.
+// The returned channel closes once the didChange notification has been sent,
+// so callers that must not race ahead of it (e.g. a signature-help request
+// for the same keystroke) can wait on it.
 func (a *App) NotifyLSPChange(path, lang, text string) <-chan struct{} {
 	done := make(chan struct{})
 	serverKey, _, ok := a.lspResolve(path, lang)

--- a/internal/app/app_lsp.go
+++ b/internal/app/app_lsp.go
@@ -260,7 +260,13 @@ func (a *App) charBeforeCursor() string {
 	return string(runes[col-1])
 }
 
-func (a *App) CheckSignatureHelpTrigger() {
+// CheckSignatureHelpTrigger inspects the character just typed and, if it's a
+// signature-help trigger, requests signature help. changeDone must be the
+// channel returned by the NotifyLSPChange call for this same keystroke, so
+// the request is sent only after that change has reached the server —
+// otherwise the server could see the signatureHelp request before the
+// didChange that produced the triggering character.
+func (a *App) CheckSignatureHelpTrigger(changeDone <-chan struct{}) {
 	if !a.Settings.Autocomplete.Enabled || !a.Settings.Autocomplete.SignatureHelp {
 		return
 	}
@@ -294,19 +300,25 @@ func (a *App) CheckSignatureHelpTrigger() {
 	triggers := a.LspManager.SignatureHelpTriggerCharacters(serverKey)
 	for _, tc := range triggers {
 		if ch == tc {
-			a.RequestSignatureHelp(path, lang, line, col)
+			a.RequestSignatureHelp(path, lang, line, col, changeDone)
 			return
 		}
 	}
 }
 
-func (a *App) RequestSignatureHelp(path, lang string, line, col int) {
+// RequestSignatureHelp sends a textDocument/signatureHelp request. If
+// changeDone is non-nil, it waits for that channel to close first, so the
+// request is ordered after the didChange notification for the same edit.
+func (a *App) RequestSignatureHelp(path, lang string, line, col int, changeDone <-chan struct{}) {
 	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
 		return
 	}
 	workDir := a.lspWorkDir(path)
 	go func() {
+		if changeDone != nil {
+			<-changeDone
+		}
 		client, err := a.LspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			slog.Error("lsp client", "err", err)
@@ -977,10 +989,16 @@ func (a *App) NotifyLSPOpen(path, lang, text string) {
 	}()
 }
 
-func (a *App) NotifyLSPChange(path, lang, text string) {
+// NotifyLSPChange sends a textDocument/didChange notification and returns a
+// channel that closes once that notification has been sent, so callers that
+// must not race ahead of it (e.g. a signature-help request for the same
+// keystroke) can wait on it.
+func (a *App) NotifyLSPChange(path, lang, text string) <-chan struct{} {
+	done := make(chan struct{})
 	serverKey, _, ok := a.lspResolve(path, lang)
 	if !ok {
-		return
+		close(done)
+		return done
 	}
 	workDir := a.lspWorkDir(path)
 	a.DocVersionsMu.Lock()
@@ -988,12 +1006,14 @@ func (a *App) NotifyLSPChange(path, lang, text string) {
 	version := a.DocVersions[path]
 	a.DocVersionsMu.Unlock()
 	go func() {
+		defer close(done)
 		client, err := a.LspManager.ClientForLanguage(serverKey, workDir)
 		if err != nil {
 			return
 		}
 		client.DidChange(FileURI(path), text, version)
 	}()
+	return done
 }
 
 func (a *App) NotifyLSPSave(path, lang, text string) {


### PR DESCRIPTION
## Summary
- `NotifyLSPChange` and `RequestSignatureHelp` each dispatched to the LSP server from independent goroutines with no ordering guarantee between them, so on rare scheduler timing the `textDocument/signatureHelp` request could reach the server before the `textDocument/didChange` for the keystroke that triggered it.
- `NotifyLSPChange` now returns a `<-chan struct{}` that closes once its `didChange` notification has been sent; `CheckSignatureHelpTrigger`/`RequestSignatureHelp` wait on it before issuing the `signatureHelp` request, guaranteeing wire order without blocking the UI goroutine.

Fixes #556

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/app/...`
- [x] `cd tests/functional && npx vitest run lsp-fake-protocol.test.js` looped 80x — 0 failures (was ~1.5% flaky before the fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature help accuracy after editing by ensuring the latest document changes are processed before suggestions appear.
  * Reduced timing-related issues that could cause signature information to be outdated or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->