### PR TITLE
style(changes): rebalance changes/history split and persist panel sizes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -201,6 +201,14 @@ func (a *App) SetSidebarWidth(w int) {
 	a.SplitPanel.DividerPos = w
 }
 
+func (a *App) persistSidebarWidth(w int) {
+	a.SetSidebarWidth(w)
+	a.Settings.Sidebar.Width = a.SplitPanel.DividerPos
+	if err := config.SaveSettings(*a.Settings); err != nil {
+		a.StatusError("Failed to save sidebar width: " + err.Error())
+	}
+}
+
 func (a *App) FocusEditor() {
 	a.Root.SetFocus(a.EditorGroup)
 }

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -683,6 +683,7 @@ func registerWidgetCallbacks(app *App) {
 			app.Repository.HandleHistory(err)
 		}
 	}
+	app.Changes.Split.OnResize = app.persistCommitHistoryHeight
 
 	app.ContentSplit.OnResize = func(height int) {
 		if height <= 0 {
@@ -708,9 +709,7 @@ func registerWidgetCallbacks(app *App) {
 		}
 	}
 
-	app.SplitPanel.OnResize = func(width int) {
-		app.SetSidebarWidth(width)
-	}
+	app.SplitPanel.OnResize = app.persistSidebarWidth
 
 	app.BottomPanel.Tabs.Config.OnTabClick = func(index int) {
 		panels := app.BottomPanel.PanelIDs()

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -259,7 +259,7 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp.Split.Bottom = bottom
 	cp.Split.ShowBottom = true
 	cp.Split.BottomH = 0
-	cp.Split.BottomRatio = 1.0 / 3.0
+	cp.Split.BottomRatio = 0.5
 	cp.Split.MinBottomH = changesHistoryMinHeight
 	cp.Split.MinTopH = changesWorkingTreeMinHeight
 	cp.Split.OnResize = func(height int) {

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -155,6 +155,14 @@ type prGroup struct {
 	PRHeadSHA string
 }
 
+func (a *App) persistCommitHistoryHeight(height int) {
+	a.Changes.Split.BottomH = height
+	a.Settings.Sidebar.CommitHistoryHeight = height
+	if err := config.SaveSettings(*a.Settings); err != nil {
+		a.StatusError("Failed to save commit history height: " + err.Error())
+	}
+}
+
 func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp := &ChangesPanel{
 		Dirs:               dirs,
@@ -251,12 +259,12 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 	cp.Split.Bottom = bottom
 	cp.Split.ShowBottom = true
 	cp.Split.BottomH = 0
-	cp.Split.BottomRatio = 0.5
+	cp.Split.BottomRatio = 1.0 / 3.0
 	cp.Split.MinBottomH = changesHistoryMinHeight
 	cp.Split.MinTopH = changesWorkingTreeMinHeight
 	cp.Split.OnResize = func(height int) {
-		// Like the sidebar width, this value lives for the panel's lifetime but is
-		// not written to settings. The split itself applies both child minimums.
+		// Default for standalone/test use; App wires this to persistCommitHistoryHeight
+		// (see registerWidgetCallbacks) once the panel is attached to Settings.
 		cp.Split.BottomH = height
 	}
 

--- a/internal/app/settings_apply_test.go
+++ b/internal/app/settings_apply_test.go
@@ -6,6 +6,46 @@ import (
 	"github.com/eugenioenko/ttt/internal/config"
 )
 
+func TestCommitHistoryHeightRestoresAndPersists(t *testing.T) {
+	config.OverrideConfigDir = t.TempDir()
+	t.Cleanup(func() { config.OverrideConfigDir = "" })
+
+	settings := config.DefaultSettings()
+	settings.Sidebar.CommitHistoryHeight = 17
+	a := buildTestApp(t, settings)
+	if a.Changes.Split.BottomH != 17 || a.Changes.Split.BottomRatio != 0 {
+		t.Fatalf("restored split = height %d ratio %v, want height 17 ratio 0", a.Changes.Split.BottomH, a.Changes.Split.BottomRatio)
+	}
+
+	a.persistCommitHistoryHeight(12)
+	if got := a.Settings.Sidebar.CommitHistoryHeight; got != 12 {
+		t.Fatalf("commitHistoryHeight = %d, want 12", got)
+	}
+	if got := config.LoadSettings().Sidebar.CommitHistoryHeight; got != 12 {
+		t.Fatalf("persisted commitHistoryHeight = %d, want 12", got)
+	}
+}
+
+func TestSidebarWidthRestoresAndPersists(t *testing.T) {
+	config.OverrideConfigDir = t.TempDir()
+	t.Cleanup(func() { config.OverrideConfigDir = "" })
+
+	settings := config.DefaultSettings()
+	settings.Sidebar.Width = 22
+	a := buildTestApp(t, settings)
+	if a.SplitPanel.DividerPos != 22 {
+		t.Fatalf("restored sidebar width = %d, want 22", a.SplitPanel.DividerPos)
+	}
+
+	a.persistSidebarWidth(18)
+	if got := a.Settings.Sidebar.Width; got != 18 {
+		t.Fatalf("sidebar width = %d, want 18", got)
+	}
+	if got := config.LoadSettings().Sidebar.Width; got != 18 {
+		t.Fatalf("persisted sidebar width = %d, want 18", got)
+	}
+}
+
 // commitTo writes only the fields the form owns. Settings changed elsewhere
 // while the tab sat open — including ones the form never shows — must survive.
 // Assigning the whole working struct instead would roll them back.

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -268,6 +268,10 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	search.Debounce.DelayMs = cfg.Settings.Search.Debounce
 	changes := NewChangesPanel(ws.Paths()...)
 	changes.SetFileView(cfg.Settings.Git.FileView)
+	if cfg.Settings.Sidebar.CommitHistoryHeight > 0 {
+		changes.Split.BottomH = cfg.Settings.Sidebar.CommitHistoryHeight
+		changes.Split.BottomRatio = 0
+	}
 	symbols := NewSymbolsPanel()
 
 	explorer := NewNavigationPanel(cfg.Settings.Explorer, ws.Paths()...)
@@ -288,6 +292,9 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	splitPanel.Right = contentSplit
 	splitPanel.Borders = borders
 	splitPanel.DividerPos = ui.DefaultSidebarWidth
+	if cfg.Settings.Sidebar.Width > 0 {
+		splitPanel.DividerPos = cfg.Settings.Sidebar.Width
+	}
 	splitPanel.ShowLeft = sidebar.Visible
 	splitPanel.RightBorderStartY = 2
 	contentSplit.RightBorderStartY = &splitPanel.RightBorderStartY

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -166,7 +166,9 @@ type ExplorerSettings struct {
 }
 
 type SidebarSettings struct {
-	PanelOrder []string `json:"panelOrder,omitempty"`
+	PanelOrder          []string `json:"panelOrder,omitempty"`
+	Width               int      `json:"width,omitempty"`
+	CommitHistoryHeight int      `json:"commitHistoryHeight,omitempty"`
 }
 
 type GitSettings struct {
@@ -319,6 +321,12 @@ func normalizeSettings(s *Settings) {
 		panelOrder = append(panelOrder, id)
 	}
 	s.Sidebar.PanelOrder = panelOrder
+	if s.Sidebar.Width < 0 {
+		s.Sidebar.Width = 0
+	}
+	if s.Sidebar.CommitHistoryHeight < 0 {
+		s.Sidebar.CommitHistoryHeight = 0
+	}
 	if !slices.Contains(DiffModes, s.Editor.DiffMode) {
 		s.Editor.DiffMode = DiffModeSplit
 	}

--- a/internal/config/settings_save_test.go
+++ b/internal/config/settings_save_test.go
@@ -23,6 +23,8 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	s.Editor.TabSize = 7
 	s.Editor.WordWrap = true
 	s.Sidebar.PanelOrder = []string{"changes", "plugin.todo", "explorer"}
+	s.Sidebar.Width = 22
+	s.Sidebar.CommitHistoryHeight = 17
 	s.Git.FileView = GitFileViewTree
 	enabled := false
 	s.Editor.SyntaxHighlight = &enabled
@@ -41,6 +43,12 @@ func TestSaveSettingsRoundTrips(t *testing.T) {
 	}
 	if !slices.Equal(got.Sidebar.PanelOrder, []string{"changes", "plugin.todo", "explorer"}) {
 		t.Errorf("sidebar.panelOrder = %v", got.Sidebar.PanelOrder)
+	}
+	if got.Sidebar.Width != 22 {
+		t.Errorf("sidebar.width = %d, want 22", got.Sidebar.Width)
+	}
+	if got.Sidebar.CommitHistoryHeight != 17 {
+		t.Errorf("sidebar.commitHistoryHeight = %d, want 17", got.Sidebar.CommitHistoryHeight)
 	}
 	if got.Git.FileView != GitFileViewTree {
 		t.Errorf("git.fileView = %q, want %q", got.Git.FileView, GitFileViewTree)

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -50,6 +50,19 @@ func TestNormalizeSidebarPanelOrder(t *testing.T) {
 	}
 }
 
+func TestNormalizeSidebarDimensionsRejectsNegative(t *testing.T) {
+	s := DefaultSettings()
+	s.Sidebar.Width = -5
+	s.Sidebar.CommitHistoryHeight = -5
+	normalizeSettings(&s)
+	if s.Sidebar.Width != 0 {
+		t.Errorf("sidebar.width = %d, want 0", s.Sidebar.Width)
+	}
+	if s.Sidebar.CommitHistoryHeight != 0 {
+		t.Errorf("sidebar.commitHistoryHeight = %d, want 0", s.Sidebar.CommitHistoryHeight)
+	}
+}
+
 func TestNormalizeSettingsValidGutterStyles(t *testing.T) {
 	for _, style := range []string{"minimal", "compact", "extended"} {
 		s := DefaultSettings()

--- a/internal/ui/split_panel.go
+++ b/internal/ui/split_panel.go
@@ -65,13 +65,7 @@ func (s *SplitPanelWidget) Render(surface Surface) {
 		return
 	}
 
-	divX := s.DividerPos + 1
-	if divX < 2 {
-		divX = 2
-	}
-	if divX >= w-2 {
-		divX = w - 3
-	}
+	divX := s.clampedDividerX(w)
 
 	// Top border — left side only: ┌───┐
 	surface.SetCell(0, 0, term.Cell{Ch: b.TopLeft, Style: bs})
@@ -294,9 +288,23 @@ func (s *SplitPanelWidget) HandleEvent(ev tcell.Event) EventResult {
 	return EventIgnored
 }
 
+// clampedDividerX mirrors the divider clamp applied in Render, so hit
+// testing lines up with what's actually drawn when a restored DividerPos
+// exceeds the viewport.
+func (s *SplitPanelWidget) clampedDividerX(w int) int {
+	divX := s.DividerPos + 1
+	if divX < 2 {
+		divX = 2
+	}
+	if divX >= w-2 {
+		divX = w - 3
+	}
+	return divX
+}
+
 func (s *SplitPanelWidget) DividerScreenX() int {
 	r := s.GetRect()
-	return r.X + s.DividerPos + 1
+	return r.X + s.clampedDividerX(r.W)
 }
 
 func (s *SplitPanelWidget) CancelPointerCapture() bool {


### PR DESCRIPTION
## Summary
- Commit history height and sidebar width now persist to settings on resize and restore on launch (mirrors how tabs are already persisted).
- Default changes/history split stays 50/50 — an earlier version of this PR rebalanced it to 2/3 : 1/3, but that broke `TestChangesHistoryUsesResponsiveHalfLayoutAndKeyboardNavigation`, which asserts a half-derived layout. Persisting the height still lets a reader resize it once and have it stick.
- Restored/loaded values are clamped by the existing split-widget render logic (`constrainedBottomHeight`, the divider-position clamp in `split_panel.go`), so an oversized stored value can't break layout on a smaller terminal.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Added `TestSidebarWidthRestoresAndPersists` and `TestCommitHistoryHeightRestoresAndPersists` (app) and round-trip coverage in `settings_save_test.go`

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar width and commit-history panel height are now restored from saved settings.
  * Resizing the sidebar or commit-history panel automatically saves the updated layout.
  * Invalid negative layout values are safely normalized.

* **Bug Fixes**
  * Layout changes now consistently persist and report save failures through the status bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->