### PR TITLE
feat(plugin): expose host platform, arch, and ttt version to plugins

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -262,6 +262,8 @@ Docs: https://tttedit.dev
 				screen.PostEvent(tcell.NewEventInterrupt(nil))
 			}
 		})
+		// Before LoadAll, so ttt.version() is available during plugin init.
+		pluginManager.SetAppVersion(editor.Version)
 
 		pendingApprovals := pluginManager.LoadAll()
 

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -574,6 +574,26 @@ local ok, err = fs.write(state_file, json.encode(state))
 
 Note: the plugin directory is a git clone that `Plugins: Update` pulls into, and it is deleted on uninstall — keep only regenerable state there.
 
+### `ttt.platform()` / `ttt.arch()` / `ttt.version()`
+
+Return the host OS, CPU architecture, and running ttt version. No permission required.
+
+| Function          | Returns                                                                 |
+|-------------------|--------------------------------------------------------------------------|
+| `ttt.platform()`  | Go `GOOS` value: `"linux"`, `"darwin"`, or `"windows"`.                 |
+| `ttt.arch()`      | Go `GOARCH` value, e.g. `"amd64"`, `"arm64"`.                           |
+| `ttt.version()`   | ttt's version string, e.g. `"1.2.3"` (`"dev"` for unreleased builds).   |
+
+```lua
+local ttt = require("ttt")
+
+if ttt.platform() == "windows" then
+  sys.exec("tasklist", {})
+else
+  sys.exec("ps", {"-eo", "pid,comm"})
+end
+```
+
 ### `ttt.set_timeout(ms, callback)` / `ttt.set_interval(ms, callback)`
 
 Schedule a callback to run later on the editor's main loop. `set_timeout` fires once after `ms` milliseconds; `set_interval` fires every `ms` milliseconds until cleared. Both return a numeric timer id. No permission required.
@@ -2240,7 +2260,7 @@ local id = crypto.uuid()               -- "550e8400-e29b-41d4-a716-446655440000"
 
 | Module         | Description                    |
 |----------------|--------------------------------|
-| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `notify`, `set_status_item`, `remove_status_item`, `exec_command`, `list_commands`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown`, `screenshot`, `debug`, `click`, `drag`, `quit` |
+| `ttt`          | Core module: `register`, `log`, `confirm`, `show_info`, `notify`, `set_status_item`, `remove_status_item`, `exec_command`, `list_commands`, `open_drawer`, `close_drawer`, `open_tab`, `close_tab`, `open_file`, `plugin_dir`, `platform`, `arch`, `version`, `set_timeout`, `set_interval`, `clear_timeout`, `clear_interval`, `on_install`, `on_uninstall`, `markdown`, `screenshot`, `debug`, `click`, `drag`, `quit` |
 | `ttt.json`     | JSON encode/decode             |
 | `ttt.editor`   | Editor buffer read/write       |
 | `ttt.diagnostics` | Publish editor diagnostics (squiggles) |

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -586,6 +586,7 @@ Return the host OS, CPU architecture, and running ttt version. No permission req
 
 ```lua
 local ttt = require("ttt")
+local sys = require("ttt.system")
 
 if ttt.platform() == "windows" then
   sys.exec("tasklist", {})

--- a/internal/app/commands_plugin.go
+++ b/internal/app/commands_plugin.go
@@ -498,6 +498,7 @@ func (a *App) WirePlugin(p *plugin.Plugin) {
 	a.wirePluginLog(p)
 	p.Markdown = a.Settings.Markdown
 	p.Borders = a.Borders
+	p.AppVersion = a.Version
 	p.ShowInfoDialog = func(title string, entries []widgets.KeyValueEntry) {
 		a.ShowInfoDialog(title, entries)
 	}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -40,6 +40,7 @@ type Manager struct {
 	systemAPI   SystemAPI
 	fsFactory   func(pluginDir string) FilesystemAPI
 	logFactory  func(pluginName string) func(level, message string)
+	appVersion  string
 }
 
 func NewManager(pluginsDir, registryPath string, extraDirs ...string) *Manager {
@@ -115,6 +116,7 @@ func (m *Manager) LoadAll() []*Plugin {
 			if m.logFactory != nil {
 				p.Log = m.logFactory(p.Name)
 			}
+			p.AppVersion = m.appVersion
 			if err := p.Init(); err != nil {
 				continue
 			}
@@ -242,6 +244,13 @@ func (m *Manager) SetLogFactory(factory func(pluginName string) func(level, mess
 	m.logFactory = factory
 	for _, p := range m.plugins {
 		p.Log = factory(p.Name)
+	}
+}
+
+func (m *Manager) SetAppVersion(version string) {
+	m.appVersion = version
+	for _, p := range m.plugins {
+		p.AppVersion = version
 	}
 }
 

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -185,3 +185,32 @@ func TestLoadAllWiresLogForHealthyPlugin(t *testing.T) {
 		t.Errorf("logged = %v, want a single %q", logged, "hello from init")
 	}
 }
+
+// A plugin's AppVersion must be set before Init runs, so ttt.version() works
+// from the plugin's own init during startup LoadAll.
+func TestLoadAllWiresAppVersionForHealthyPlugin(t *testing.T) {
+	pluginsDir := t.TempDir()
+	regPath := filepath.Join(t.TempDir(), "registry.json")
+
+	dir := writePluginDir(t, pluginsDir, "healthy")
+	entry := filepath.Join(dir, "main.ttt.lua")
+	if err := os.WriteFile(entry, []byte(`local ttt = require("ttt")`+"\n"+`ttt.log(ttt.version())`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	reg := `[{"name":"healthy","version":"1.0.0","enabled":true,"permissions":{}}]`
+	if err := os.WriteFile(regPath, []byte(reg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logged []string
+	m := NewManager(pluginsDir, regPath)
+	m.SetLogFactory(func(name string) func(string, string) {
+		return func(level, message string) { logged = append(logged, message) }
+	})
+	m.SetAppVersion("9.9.9")
+	m.LoadAll()
+
+	if len(logged) != 1 || logged[0] != "9.9.9" {
+		t.Errorf("logged = %v, want a single %q", logged, "9.9.9")
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -74,6 +74,7 @@ type Plugin struct {
 	RenderMarkdown     func(text string) []MarkdownLine
 	Markdown           config.MarkdownSettings
 	Borders            *term.BorderSet
+	AppVersion         string
 	SimulateClick      func(x, y int)
 	SimulateDrag       func(x1, y1, x2, y2 int)
 	ScreenshotToFile   func(path string) error

--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -569,6 +570,21 @@ func setupTTTModule(L *lua.LState, p *Plugin) {
 
 		L.SetField(mod, "plugin_dir", L.NewFunction(func(L *lua.LState) int {
 			L.Push(lua.LString(p.Dir))
+			return 1
+		}))
+
+		L.SetField(mod, "platform", L.NewFunction(func(L *lua.LState) int {
+			L.Push(lua.LString(runtime.GOOS))
+			return 1
+		}))
+
+		L.SetField(mod, "arch", L.NewFunction(func(L *lua.LState) int {
+			L.Push(lua.LString(runtime.GOARCH))
+			return 1
+		}))
+
+		L.SetField(mod, "version", L.NewFunction(func(L *lua.LState) int {
+			L.Push(lua.LString(p.AppVersion))
 			return 1
 		}))
 

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -280,5 +281,32 @@ func TestPluginDirExposed(t *testing.T) {
 	got := p.State.GetGlobal("result").String()
 	if got != "/some/plugin/dir" {
 		t.Errorf("expected /some/plugin/dir, got %q", got)
+	}
+}
+
+func TestPlatformArchVersionExposed(t *testing.T) {
+	p := &Plugin{Name: "test", AppVersion: "1.2.3"}
+	p.State = NewSandbox()
+	defer p.State.Close()
+	setupTTTModule(p.State, p)
+
+	err := p.State.DoString(`
+		local ttt = require("ttt")
+		platform = ttt.platform()
+		arch = ttt.arch()
+		version = ttt.version()
+	`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := p.State.GetGlobal("platform").String(); got != runtime.GOOS {
+		t.Errorf("expected platform %q, got %q", runtime.GOOS, got)
+	}
+	if got := p.State.GetGlobal("arch").String(); got != runtime.GOARCH {
+		t.Errorf("expected arch %q, got %q", runtime.GOARCH, got)
+	}
+	if got := p.State.GetGlobal("version").String(); got != "1.2.3" {
+		t.Errorf("expected version %q, got %q", "1.2.3", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `ttt.platform()` (`runtime.GOOS`), `ttt.arch()` (`runtime.GOARCH`), and `ttt.version()` (running ttt version) to the plugin Lua API, no permission required — same pattern as `ttt.plugin_dir()`.
- Wires `Plugin.AppVersion` from `app.Editor.Version` in `commands_plugin.go`.
- Documents the new functions in the plugin authoring guide, including the module summary table.

Motivated by a planned cross-platform "processes" plugin (list running processes/ports, kill by PID) that needs to branch its `sys.exec` calls per OS (`ss`/`ps`/`kill` on Linux, `lsof`/`ps`/`kill` on macOS, `netstat`/`tasklist`/`taskkill` on Windows) without sniffing env vars.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/plugin/... ./internal/app/...`
- [x] New test `TestPlatformArchVersionExposed` in `internal/plugin/sandbox_test.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plugins can now detect the host platform and architecture at runtime.
  - Plugins can access the application version through the Lua `ttt` module, enabling version-aware behavior and compatibility checks.
  - Application version information is available during plugin initialization, supporting version-aware startup behavior.

- **Documentation**
  - Updated the plugin authoring guide with the new functions, return values, sandbox availability, and a platform-specific usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->