### PR TITLE
fix(plugin): preserve input chevron on reconcile; add node actions API

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -90,16 +90,6 @@
     "tags": ["notes", "scratchpad", "productivity", "utility"]
   },
   {
-    "name": "port-finder",
-    "displayName": "Port Finder",
-    "author": "eugenioenko",
-    "description": "Find processes listening on TCP ports, filter by name or port, and kill them",
-    "repo": "https://github.com/eugenioenko/ttt-plugins",
-    "path": "port-finder",
-    "version": "0.1.0",
-    "tags": ["ports", "network", "process", "utility"]
-  },
-  {
     "name": "spell",
     "displayName": "Spell Check",
     "author": "eugenioenko",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -90,6 +90,16 @@
     "tags": ["notes", "scratchpad", "productivity", "utility"]
   },
   {
+    "name": "port-finder",
+    "displayName": "Port Finder",
+    "author": "eugenioenko",
+    "description": "Find processes listening on TCP ports, filter by name or port, and kill them",
+    "repo": "https://github.com/eugenioenko/ttt-plugins",
+    "path": "port-finder",
+    "version": "0.1.0",
+    "tags": ["ports", "network", "process", "utility"]
+  },
+  {
     "name": "spell",
     "displayName": "Spell Check",
     "author": "eugenioenko",

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -1220,7 +1220,7 @@ Used in `items` arrays for both `tree` and `list` widgets.
 | `children`   | table   | `{}`    | Array of child node tables (recursive).      |
 | `actions`    | table   | `{}`    | Array of `{icon, command}` tables rendered as inline, always-visible icons on the right edge of the row — no submenu required. Clicking one triggers `on_command(command, node)`, same as `node_menu` and `key_commands`. Used by the Changes panel for its stage/unstage/discard icons. |
 
-**Callback argument:** `on_select` and `on_expand` callbacks receive a Lua table with the same fields as the node: `id`, `label`, `icon` (if non-empty), `badge` (if non-empty), `expanded`, `muted`, and `children` (if present). The `on_command` callback receives two arguments: `(command_string, node_table)`.
+**Callback argument:** `on_select` and `on_expand` callbacks receive a Lua table with the same fields as the node: `id`, `label`, `icon` (if non-empty), `badge` (if non-empty), `expanded`, `muted`, and `children` (if present). `expandable` and `actions` are not included — the node's `id` is enough to look the item back up, and `on_command`'s own `command_string` argument already tells you which action fired. The `on_command` callback receives two arguments: `(command_string, node_table)`, where `node_table` has the same shape.
 
 ### Menu Entry Format
 

--- a/docs-web/src/content/docs/guides/plugin-authoring.md
+++ b/docs-web/src/content/docs/guides/plugin-authoring.md
@@ -1218,6 +1218,7 @@ Used in `items` arrays for both `tree` and `list` widgets.
 | `expandable` | boolean | `false` | Show expand/collapse chevron indicator. Auto-set to `true` if `children` is non-empty. |
 | `expanded`   | boolean | `false` | Initial expanded state (only used on first render — see [Reconciliation and State Preservation](#reconciliation-and-state-preservation)). |
 | `children`   | table   | `{}`    | Array of child node tables (recursive).      |
+| `actions`    | table   | `{}`    | Array of `{icon, command}` tables rendered as inline, always-visible icons on the right edge of the row — no submenu required. Clicking one triggers `on_command(command, node)`, same as `node_menu` and `key_commands`. Used by the Changes panel for its stage/unstage/discard icons. |
 
 **Callback argument:** `on_select` and `on_expand` callbacks receive a Lua table with the same fields as the node: `id`, `label`, `icon` (if non-empty), `badge` (if non-empty), `expanded`, `muted`, and `children` (if present). The `on_command` callback receives two arguments: `(command_string, node_table)`.
 

--- a/internal/plugin/lua_callbacks.go
+++ b/internal/plugin/lua_callbacks.go
@@ -91,6 +91,23 @@ func luaTableToTreeNode(L *lua.LState, tbl *lua.LTable) *widgets.TreeNode {
 		}
 	}
 
+	if actions, ok := L.GetField(tbl, "actions").(*lua.LTable); ok {
+		actions.ForEach(func(_, v lua.LValue) {
+			at, ok := v.(*lua.LTable)
+			if !ok {
+				return
+			}
+			action := widgets.Action{}
+			if icon := L.GetField(at, "icon"); icon != lua.LNil {
+				action.Icon = icon.String()
+			}
+			if command := L.GetField(at, "command"); command != lua.LNil {
+				action.Command = command.String()
+			}
+			node.Actions = append(node.Actions, action)
+		})
+	}
+
 	if children, ok := L.GetField(tbl, "children").(*lua.LTable); ok {
 		node.Children = LuaTableToTreeNodes(L, children)
 		if len(node.Children) > 0 {

--- a/internal/plugin/lua_callbacks_test.go
+++ b/internal/plugin/lua_callbacks_test.go
@@ -103,3 +103,33 @@ func TestLuaTableToTreeNodes(t *testing.T) {
 		t.Error("expected node b to be muted")
 	}
 }
+
+func TestLuaTableToTreeNodesParsesActions(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	err := L.DoString(`
+		items = {
+			{ id = "a", label = "Alpha", actions = {
+				{ icon = "✕", command = "kill" },
+			}},
+		}
+	`)
+	if err != nil {
+		t.Fatalf("lua error: %v", err)
+	}
+
+	tbl := L.GetGlobal("items").(*lua.LTable)
+	nodes := LuaTableToTreeNodes(L, tbl)
+
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	if len(nodes[0].Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(nodes[0].Actions))
+	}
+	action := nodes[0].Actions[0]
+	if action.Icon != "✕" || action.Command != "kill" {
+		t.Errorf("got action %+v, want {Icon: ✕, Command: kill}", action)
+	}
+}

--- a/internal/plugin/widget_builder.go
+++ b/internal/plugin/widget_builder.go
@@ -148,7 +148,11 @@ func updateWidget(w widgets.Widget, desc WidgetDesc, p *Plugin) {
 	case WidgetInput:
 		if iw, ok := w.(*widgets.InputWidget); ok {
 			iw.Config.Placeholder = desc.Placeholder
-			iw.Config.Prefix = desc.Prefix
+			prefix := desc.Prefix
+			if !iw.Config.Bordered && prefix == "" {
+				prefix = widgets.DefaultPrefix
+			}
+			iw.Config.Prefix = prefix
 			wireInputCallbacks(iw, desc, p)
 		}
 	case WidgetVStack:

--- a/internal/plugin/widget_builder_test.go
+++ b/internal/plugin/widget_builder_test.go
@@ -109,6 +109,33 @@ func TestReconcilePreservesInputText(t *testing.T) {
 	}
 }
 
+// A plugin input with no explicit prefix must keep the default chevron across
+// reconciliation, not just on its first render. Reconcile used to overwrite
+// Config.Prefix with the zero-value desc.Prefix, wiping the chevron on the
+// very next redraw (#561 follow-up).
+func TestReconcilePreservesDefaultInputPrefix(t *testing.T) {
+	ws := NewWidgetState()
+	p := &Plugin{Name: "test", State: lua.NewState()}
+	defer p.State.Close()
+
+	descs := []WidgetDesc{
+		{Kind: WidgetInput, Key: "input:0", Placeholder: "Type..."},
+	}
+	ws.Reconcile(descs, p)
+
+	iw := ws.items[0].(*widgets.InputWidget)
+	if iw.Config.Prefix != widgets.DefaultPrefix {
+		t.Fatalf("expected default prefix %q after first render, got %q", widgets.DefaultPrefix, iw.Config.Prefix)
+	}
+
+	ws.Reconcile(descs, p)
+
+	iw2 := ws.items[0].(*widgets.InputWidget)
+	if iw2.Config.Prefix != widgets.DefaultPrefix {
+		t.Errorf("expected default prefix %q preserved after reconcile, got %q", widgets.DefaultPrefix, iw2.Config.Prefix)
+	}
+}
+
 func TestReconcileHandlesTypeChange(t *testing.T) {
 	ws := NewWidgetState()
 	p := &Plugin{Name: "test", State: lua.NewState()}

--- a/internal/widgets/input.go
+++ b/internal/widgets/input.go
@@ -35,9 +35,13 @@ type InputWidget struct {
 	clickCount    int
 }
 
+// DefaultPrefix is the chevron shown on a borderless input when the caller
+// doesn't supply its own prefix.
+const DefaultPrefix = " ❯ "
+
 func NewInputWidget(config InputConfig) *InputWidget {
 	if !config.Bordered && config.Prefix == "" {
-		config.Prefix = " ❯ "
+		config.Prefix = DefaultPrefix
 	}
 	return &InputWidget{
 		Config:   config,


### PR DESCRIPTION
## Summary
- Plugin input widgets (`panel:input()`) lost their default `❯` chevron prefix after the first render — the reconcile path in `widget_builder.go` unconditionally overwrote `Config.Prefix` with the zero-value `desc.Prefix`, wiping the constructor's default on every subsequent redraw. Factored the default into `widgets.DefaultPrefix` and reused it in both the constructor and the reconcile path so they can't diverge again.
- Tree/list items can now declare an `actions` array (`{icon, command}`), rendered as inline always-visible icons on the row's right edge and wired to `on_command`. This is the same mechanism the native Changes panel already uses for its stage/unstage/discard icons — previously only available to Go code, not to plugins.
- Documents the new `actions` field in the plugin authoring guide.

Both bugs/gaps were found live while building a new community plugin (registered separately in a follow-up PR).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/plugin/... ./internal/widgets/... ./internal/app/...`
- [x] New test `TestReconcilePreservesDefaultInputPrefix` (widget_builder_test.go)
- [x] New test `TestLuaTableToTreeNodesParsesActions` (lua_callbacks_test.go)
- [x] Manually verified both fixes live in a running ttt instance (headless sim screen): chevron + divider render correctly across redraws, and an inline action icon / key command both actually kill a real listening process

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tree nodes can now display inline action icons that trigger commands when selected.
  * Added documentation for configuring tree-node actions.
* **Bug Fixes**
  * Preserved the default chevron prefix for borderless input fields after updates and redraws.
  * Explicit input prefixes and bordered-field behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->