### PR TITLE
chore: register port-finder in community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -90,6 +90,16 @@
     "tags": ["notes", "scratchpad", "productivity", "utility"]
   },
   {
+    "name": "port-finder",
+    "displayName": "Port Finder",
+    "author": "eugenioenko",
+    "description": "Find processes listening on TCP ports, filter by name or port, and kill them",
+    "repo": "https://github.com/eugenioenko/ttt-plugins",
+    "path": "port-finder",
+    "version": "0.1.0",
+    "tags": ["ports", "network", "process", "utility"]
+  },
+  {
     "name": "spell",
     "displayName": "Spell Check",
     "author": "eugenioenko",


### PR DESCRIPTION
## Summary
- Adds `port-finder` to `community-plugins.json`: sidebar panel listing processes with an open listening TCP port (name + port), filterable, with a one-click/one-key kill.
- Plugin source published at [eugenioenko/ttt-plugins#7](https://github.com/eugenioenko/ttt-plugins/pull/7).
- Split out from #562, which carries the core widget fixes this plugin surfaced.

## Test plan
- [x] `community-plugins.json` is valid JSON
- [x] Manually installed and exercised the plugin against a local ttt build

🤖 Generated with [Claude Code](https://claude.com/claude-code)