### PR TITLE
feat(changes): open unified diff view from root/section and PR root

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -665,7 +665,6 @@ func registerWidgetCallbacks(app *App) {
 	}
 	app.Changes.OnOpenCommitDiff = app.OpenCommitDiff
 	app.Changes.OnOpenCommit = app.OpenCommitDetail
-	app.Changes.OnOpenCurrentChanges = app.OpenCurrentChanges
 	app.Changes.OnOpenPRDetail = app.OpenPRDetail
 	app.Changes.OnOpenPRDiff = func(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
 		app.OpenPRDiff(group, status, extended)

--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -665,6 +665,8 @@ func registerWidgetCallbacks(app *App) {
 	}
 	app.Changes.OnOpenCommitDiff = app.OpenCommitDiff
 	app.Changes.OnOpenCommit = app.OpenCommitDetail
+	app.Changes.OnOpenCurrentChanges = app.OpenCurrentChanges
+	app.Changes.OnOpenPRDetail = app.OpenPRDetail
 	app.Changes.OnOpenPRDiff = func(group *ui.ChangesGroup, status git.FileStatus, extended bool) {
 		app.OpenPRDiff(group, status, extended)
 	}

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -894,10 +894,8 @@ func (cp *ChangesPanel) handleCommand(cmd string, node *widgets.TreeNode) {
 			return
 		}
 		ref, found := cp.workNodes[node.ID]
-		if found && ref.Kind == workNodePRRoot && ref.Group >= 0 && ref.Group < len(cp.PRGroups) {
-			if cp.OnOpenPRDetail != nil {
-				cp.OnOpenPRDetail(cp.toUIChangesGroup(&cp.PRGroups[ref.Group]))
-			}
+		if found && ref.Kind == workNodePRRoot && ref.Group >= 0 && ref.Group < len(cp.PRGroups) && cp.OnOpenPRDetail != nil {
+			cp.OnOpenPRDetail(cp.toUIChangesGroup(&cp.PRGroups[ref.Group]))
 			return
 		}
 		node.Expanded = !node.Expanded

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -70,23 +70,25 @@ type ChangesPanel struct {
 	workFiles          map[string]workFileRef
 	fileView           string
 
-	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
-	OnOpenCommitDiff func(dir, ref, short string, status git.FileStatus, extended bool)
-	OnOpenCommit     func(dir, ref, short string)
-	OnOpenPRDiff     func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
-	OnOpenFile       func(path string)
-	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
-	OnPanelMenu      func(screenX, screenY int)
-	OnCommit         func(dir string, message string)
-	OnGroupMenu      func(dir string, screenX, screenY int)
-	OnPRGroupMenu    func(group *ui.ChangesGroup, screenX, screenY int)
-	OnRefreshPR      func(url string)
-	OnConfirmDiscard func(message string, onConfirm func())
-	OnError          func(message string)
-	OnRefreshed      func()
-	OnRefresh        func()
-	OnStatusChanged  func()
-	OnHistoryResult  func(error)
+	OnOpenDiff           func(dir string, status git.FileStatus, extended bool)
+	OnOpenCommitDiff     func(dir, ref, short string, status git.FileStatus, extended bool)
+	OnOpenCommit         func(dir, ref, short string)
+	OnOpenCurrentChanges func()
+	OnOpenPRDiff         func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
+	OnOpenPRDetail       func(group *ui.ChangesGroup)
+	OnOpenFile           func(path string)
+	OnRightClick         func(dir string, status git.FileStatus, screenX, screenY int)
+	OnPanelMenu          func(screenX, screenY int)
+	OnCommit             func(dir string, message string)
+	OnGroupMenu          func(dir string, screenX, screenY int)
+	OnPRGroupMenu        func(group *ui.ChangesGroup, screenX, screenY int)
+	OnRefreshPR          func(url string)
+	OnConfirmDiscard     func(message string, onConfirm func())
+	OnError              func(message string)
+	OnRefreshed          func()
+	OnRefresh            func()
+	OnStatusChanged      func()
+	OnHistoryResult      func(error)
 
 	PRGroups []prGroup
 }
@@ -191,9 +193,10 @@ func NewChangesPanel(dirs ...string) *ChangesPanel {
 	})
 
 	cp.Tree = widgets.NewTreeWidget(widgets.TreeConfig{
-		Indent:       1,
-		EmptyText:    "No changes",
-		TruncateLeft: true,
+		Indent:             1,
+		EmptyText:          "No changes",
+		TruncateLeft:       true,
+		ActivateExpandable: true,
 		OnCommand: func(cmd string, node *widgets.TreeNode) {
 			cp.handleCommand(cmd, node)
 		},
@@ -889,6 +892,21 @@ func (cp *ChangesPanel) handleCommand(cmd string, node *widgets.TreeNode) {
 	case "activate":
 		if ok {
 			cp.openDiff(dir, status, staged, false)
+			return
+		}
+		ref, found := cp.workNodes[node.ID]
+		switch {
+		case found && (ref.Kind == workNodeRoot || ref.Kind == workNodeSection):
+			if cp.OnOpenCurrentChanges != nil {
+				cp.OnOpenCurrentChanges()
+			}
+		case found && ref.Kind == workNodePRRoot && ref.Group >= 0 && ref.Group < len(cp.PRGroups):
+			if cp.OnOpenPRDetail != nil {
+				cp.OnOpenPRDetail(cp.toUIChangesGroup(&cp.PRGroups[ref.Group]))
+			}
+		default:
+			node.Expanded = !node.Expanded
+			cp.Tree.SetItems(cp.Tree.Config.Items)
 		}
 	case "stage":
 		if ok && !staged {

--- a/internal/app/changes_panel.go
+++ b/internal/app/changes_panel.go
@@ -70,25 +70,24 @@ type ChangesPanel struct {
 	workFiles          map[string]workFileRef
 	fileView           string
 
-	OnOpenDiff           func(dir string, status git.FileStatus, extended bool)
-	OnOpenCommitDiff     func(dir, ref, short string, status git.FileStatus, extended bool)
-	OnOpenCommit         func(dir, ref, short string)
-	OnOpenCurrentChanges func()
-	OnOpenPRDiff         func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
-	OnOpenPRDetail       func(group *ui.ChangesGroup)
-	OnOpenFile           func(path string)
-	OnRightClick         func(dir string, status git.FileStatus, screenX, screenY int)
-	OnPanelMenu          func(screenX, screenY int)
-	OnCommit             func(dir string, message string)
-	OnGroupMenu          func(dir string, screenX, screenY int)
-	OnPRGroupMenu        func(group *ui.ChangesGroup, screenX, screenY int)
-	OnRefreshPR          func(url string)
-	OnConfirmDiscard     func(message string, onConfirm func())
-	OnError              func(message string)
-	OnRefreshed          func()
-	OnRefresh            func()
-	OnStatusChanged      func()
-	OnHistoryResult      func(error)
+	OnOpenDiff       func(dir string, status git.FileStatus, extended bool)
+	OnOpenCommitDiff func(dir, ref, short string, status git.FileStatus, extended bool)
+	OnOpenCommit     func(dir, ref, short string)
+	OnOpenPRDiff     func(group *ui.ChangesGroup, status git.FileStatus, extended bool)
+	OnOpenPRDetail   func(group *ui.ChangesGroup)
+	OnOpenFile       func(path string)
+	OnRightClick     func(dir string, status git.FileStatus, screenX, screenY int)
+	OnPanelMenu      func(screenX, screenY int)
+	OnCommit         func(dir string, message string)
+	OnGroupMenu      func(dir string, screenX, screenY int)
+	OnPRGroupMenu    func(group *ui.ChangesGroup, screenX, screenY int)
+	OnRefreshPR      func(url string)
+	OnConfirmDiscard func(message string, onConfirm func())
+	OnError          func(message string)
+	OnRefreshed      func()
+	OnRefresh        func()
+	OnStatusChanged  func()
+	OnHistoryResult  func(error)
 
 	PRGroups []prGroup
 }
@@ -895,19 +894,14 @@ func (cp *ChangesPanel) handleCommand(cmd string, node *widgets.TreeNode) {
 			return
 		}
 		ref, found := cp.workNodes[node.ID]
-		switch {
-		case found && (ref.Kind == workNodeRoot || ref.Kind == workNodeSection):
-			if cp.OnOpenCurrentChanges != nil {
-				cp.OnOpenCurrentChanges()
-			}
-		case found && ref.Kind == workNodePRRoot && ref.Group >= 0 && ref.Group < len(cp.PRGroups):
+		if found && ref.Kind == workNodePRRoot && ref.Group >= 0 && ref.Group < len(cp.PRGroups) {
 			if cp.OnOpenPRDetail != nil {
 				cp.OnOpenPRDetail(cp.toUIChangesGroup(&cp.PRGroups[ref.Group]))
 			}
-		default:
-			node.Expanded = !node.Expanded
-			cp.Tree.SetItems(cp.Tree.Config.Items)
+			return
 		}
+		node.Expanded = !node.Expanded
+		cp.Tree.SetItems(cp.Tree.Config.Items)
 	case "stage":
 		if ok && !staged {
 			cp.applied(git.Stage(dir, status.Path))

--- a/internal/app/pr.go
+++ b/internal/app/pr.go
@@ -3,7 +3,9 @@ package app
 import (
 	"fmt"
 
+	"github.com/eugenioenko/ttt/internal/core/diff"
 	"github.com/eugenioenko/ttt/internal/github"
+	"github.com/eugenioenko/ttt/internal/ui"
 
 	"github.com/gdamore/tcell/v3"
 )
@@ -47,4 +49,36 @@ func (a *App) FetchAndOpenPR(url string) {
 		diffs := github.SplitMultiFileDiff(diffText)
 		a.Screen.PostEvent(tcell.NewEventInterrupt(&PrFetchResult{URL: url, Info: info, Diffs: diffs}))
 	}()
+}
+
+func prDetailTabID(url string) string {
+	return "pr-detail:" + url
+}
+
+// OpenPRDetail shows every changed file in a PR as one unified scrollable
+// view, the same shape as a commit's detail tab. PR diffs are already fully
+// fetched, so unlike OpenCommitDetail this needs no async read.
+func (a *App) OpenPRDetail(group *ui.ChangesGroup) {
+	tabID := prDetailTabID(group.PRURL)
+	if existing := a.EditorGroup.CommitDetailWidgetByTab(tabID); existing != nil {
+		a.EditorGroup.SwitchToTabByPath(tabID)
+		a.FocusEditorIfEnabled()
+		return
+	}
+	files := make([]ui.CommitDetailFile, 0, len(group.Unstaged))
+	for _, f := range group.Unstaged {
+		file := ui.CommitDetailFile{Status: f.Status, Path: f.Path, OldPath: f.OldPath}
+		if diffText, ok := group.PRDiffs[f.Path]; ok && diffText != "" {
+			file.Diff = diff.Parse(diffText)
+		} else {
+			file.Error = "No diff available for " + f.Path
+		}
+		files = append(files, file)
+	}
+	detail := ui.NewCommitDetailWidget(group.Dir, group.PRURL, "", a.EditorGroup.SyntaxHighlight)
+	detail.Header = "Pull request"
+	a.EditorGroup.ApplyDiffDefaults(detail)
+	detail.SetDetail(fmt.Sprintf("%s\n%d file(s) changed", group.Name, len(files)), files, "")
+	a.EditorGroup.OpenPluginTab(tabID, group.Name, detail)
+	a.FocusEditorIfEnabled()
 }

--- a/internal/app/pr.go
+++ b/internal/app/pr.go
@@ -69,7 +69,12 @@ func (a *App) OpenPRDetail(group *ui.ChangesGroup) {
 	for _, f := range group.Unstaged {
 		file := ui.CommitDetailFile{Status: f.Status, Path: f.Path, OldPath: f.OldPath}
 		if diffText, ok := group.PRDiffs[f.Path]; ok && diffText != "" {
-			file.Diff = diff.Parse(diffText)
+			parsed := diff.Parse(diffText)
+			if len(parsed.Hunks) == 0 {
+				file.Error = "Empty diff for " + f.Path
+			} else {
+				file.Diff = parsed
+			}
 		} else {
 			file.Error = "No diff available for " + f.Path
 		}


### PR DESCRIPTION
## Summary
- Selecting a PR's root node in the Changes panel opens a new unified PR detail view: every changed file diffed in one scrollable `CommitDetailWidget`, matching how a single commit is shown. Since PR diffs are already fetched up front, this is built synchronously — no async read needed.
- Folder nodes keep their previous expand/collapse-only behavior.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/app/...`
- [ ] Manually verify: `ttt <pr-url>`, click the PR root node, opens the unified PR detail tab with all files diffed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added navigation from the changes panel to pull request detail views.
  * Pull request details now open or focus in a dedicated tab.
  * Selecting a pull request displays its changed files and available diffs.
  * Added expandable sections in the changes tree for easier navigation.
  * Files can be opened directly from the changes tree to view their diffs.
  * Missing or empty diff information is surfaced within the pull request detail view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->