### PR TITLE
fix(ci): bypass test cache in pre-release repeat runs

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           for i in $(seq 1 ${{ inputs.iterations }}); do
             echo "=== Iteration $i / ${{ inputs.iterations }} ==="
-            go test ./... || { echo "FAILED on iteration $i"; exit 1; }
+            go test -count=1 ./... || { echo "FAILED on iteration $i"; exit 1; }
           done
 
   test-race-repeat:
@@ -52,7 +52,7 @@ jobs:
         run: |
           for i in $(seq 1 ${{ inputs.iterations }}); do
             echo "=== Iteration $i / ${{ inputs.iterations }} ==="
-            go test -race ./... || { echo "FAILED on iteration $i"; exit 1; }
+            go test -race -count=1 ./... || { echo "FAILED on iteration $i"; exit 1; }
           done
 
   functional-tests:


### PR DESCRIPTION
## Problem

The `test-repeat` and `test-race-repeat` jobs in the pre-release workflow loop `go test ./...` N times, but without `-count=1`. Go caches passing test results, so only iteration 1 actually runs the tests — iterations 2..N return `(cached)` and the repeat loop provides no additional flake coverage.

This is a miss, not a regression: the workflow was added in #510 and never had cache-busting.

## Fix

Add `-count=1` to both repeat loops to force every iteration to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated repeated test runs to execute without cached results.
  * Improved reliability of repeated standard and race-condition test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->