### PR TITLE
fix: allow opening files without automatic workspace creation

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -359,8 +359,13 @@ Docs: https://tttedit.dev
 		w, h = flags.sizeW, flags.sizeH
 	}
 	editor.Root.SetSize(w, h)
-
 	editor.PendingFileTargets = fileTargets
+
+	// If the user only opened files and didn't explicitly open a folder/workspace,
+	// hide the sidebar by default to maximize the editor space.
+	if !editor.ExplicitFolders && len(fileTargets) > 0 {
+		editor.HideSidebar()
+	}
 
 	if flags.pluginFile != "" {
 		app.LoadPluginFromFile(editor, flags.pluginFile)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,6 +52,7 @@ type App struct {
 	Renderer               *render.Renderer
 	Settings               *config.Settings
 	Workspace              *workspace.Workspace
+	ExplicitFolders        bool
 	Palette                *ui.TerminalColorPalette
 	TerminalPanel          *ui.TerminalPanelWidget
 	Terminals              []TerminalTab

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -83,7 +83,7 @@ func resolveLineColArg(arg string) (FileTarget, bool) {
 	return FileTarget{Path: abs, Line: line, Col: col}, true
 }
 
-func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile string, prURLs []string) {
+func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile string, prURLs []string, explicitFolders bool) {
 	var folders []string
 	var wsFile string
 
@@ -148,6 +148,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 		}
 		if info.IsDir() {
 			folders = append(folders, absPath)
+			explicitFolders = true
 		} else {
 			openFiles = append(openFiles, FileTarget{Path: absPath})
 		}
@@ -160,6 +161,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 			for _, f := range folders {
 				ws.AddFolder(f)
 			}
+			explicitFolders = true
 			return
 		}
 	}
@@ -174,8 +176,8 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 }
 
 func BuildApp(cfg *config.AppConfig, borders *term.BorderSet) (*App, []string, []FileTarget) {
-	ws, openFiles, _, prURLs := resolveArgs()
-	return BuildAppFromConfig(cfg, borders, ws, openFiles), prURLs, openFiles
+	ws, openFiles, _, prURLs, explicitFolders := resolveArgs()
+	return BuildAppFromConfig(cfg, borders, ws, openFiles, explicitFolders), prURLs, openFiles
 }
 
 var bracketColorSlots = []term.Style{
@@ -198,7 +200,7 @@ func ResolveBracketColorStyles(colors []string) []term.Style {
 	return bracketColorSlots[:n]
 }
 
-func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *workspace.Workspace, openFiles []FileTarget) *App {
+func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *workspace.Workspace, openFiles []FileTarget, explicitFolders bool) *App {
 
 	bracketStyles := ResolveBracketColorStyles(cfg.Theme.Editor.BracketColors)
 
@@ -285,6 +287,11 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	sidebar.Tabs.Config.Reorderable = true
 	hasFolders := len(ws.Paths()) > 0
 	sidebar.Visible = hasFolders
+	// If the user only opened files and didn't explicitly open a folder/workspace,
+	// hide the sidebar by default to maximize the editor space.
+	if !explicitFolders && len(openFiles) > 0 {
+		sidebar.Visible = false
+	}
 	sidebar.Borders = borders
 
 	splitPanel := ui.NewSplitPanelWidget()
@@ -341,6 +348,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	app.Repository = NewRepositoryState(changes, ws.Paths())
 	app.Repository.SetCurrentChangesHandler(app.ApplyCurrentChanges)
 	app.applyMenuBarVisibility(cfg.Settings.Editor.IsMenuBarVisible())
+	app.ExplicitFolders = explicitFolders
 	// Rebuild the Diagnostics panel whenever any source (LSP or a plugin)
 	// changes its diagnostics.
 	app.EditorGroup.OnDiagnosticsChanged = app.refreshProblems

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -165,7 +165,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 	}
 
 	// Opening only files intentionally creates no workspace — a folder must be passed explicitly.
-	if len(folders) == 0 && len(prURLs) == 0 && len(openFiles) == 0 {
+	if len(folders) == 0 && len(prURLs) == 0 {
 		cwd, _ := os.Getwd()
 		folders = append(folders, cwd)
 	}

--- a/internal/term/tcell_screen.go
+++ b/internal/term/tcell_screen.go
@@ -83,9 +83,9 @@ func (t *TcellScreen) SetCell(x, y int, c Cell) {
 	if c.BgStyle != 0 {
 		bg := t.styleMap[c.BgStyle].GetBackground()
 		s = tcell.StyleDefault. //nolint:staticcheck // Attributes is deprecated but individual calls don't replicate the exact reset-and-copy semantics
-			Foreground(s.GetForeground()).
-			Background(bg).
-			Attributes(s.GetAttributes())
+					Foreground(s.GetForeground()).
+					Background(bg).
+					Attributes(s.GetAttributes())
 	}
 	if c.UlStyle != 0 {
 		us := t.styleMap[c.UlStyle]


### PR DESCRIPTION
- Update resolveArgs to ignore openFiles when determining default folder
- Fix indentation in tcell_screen.go

Problem:
When launching the application with a file argument (e.g., ./ttt foo.go), the sidebar explorer was completely empty. However, running ./ttt with no arguments worked correctly and displayed the current working directory.

Root Cause:
In internal/app/widgets.go, the resolveArgs() function determines which folders to load into the workspace. It only added the current working directory (CWD) as a fallback if no files, directories, or PR URLs were provided. Because foo.go was added to the openFiles list, the CWD was skipped, resulting in an empty workspace and an empty explorer pane.

Fix:
Updated the condition in resolveArgs() to ignore openFiles when deciding whether to fallback to the CWD. Now, the app ensures the current directory is loaded into the workspace whenever no explicit directories or PR URLs are provided, regardless of whether specific files were opened via the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Opening files explicitly no longer incorrectly adds the current directory as a workspace folder.
  * The current directory is used as a workspace only when no folders or pull request URLs are provided.

* **User Experience**
  * When files are opened without an explicitly selected folder or workspace, the sidebar is hidden by default to maximize editor space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->