### PR TITLE
feat: allow using word under cursor for search

### DIFF
--- a/cmd/ttt/main.go
+++ b/cmd/ttt/main.go
@@ -359,8 +359,13 @@ Docs: https://tttedit.dev
 		w, h = flags.sizeW, flags.sizeH
 	}
 	editor.Root.SetSize(w, h)
-
 	editor.PendingFileTargets = fileTargets
+
+	// If the user only opened files and didn't explicitly open a folder/workspace,
+	// hide the sidebar by default to maximize the editor space.
+	if !editor.ExplicitFolders && len(fileTargets) > 0 {
+		editor.HideSidebar()
+	}
 
 	if flags.pluginFile != "" {
 		app.LoadPluginFromFile(editor, flags.pluginFile)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,6 +52,7 @@ type App struct {
 	Renderer               *render.Renderer
 	Settings               *config.Settings
 	Workspace              *workspace.Workspace
+	ExplicitFolders        bool
 	Palette                *ui.TerminalColorPalette
 	TerminalPanel          *ui.TerminalPanelWidget
 	Terminals              []TerminalTab

--- a/internal/app/commands_search.go
+++ b/internal/app/commands_search.go
@@ -137,4 +137,25 @@ func registerSearchCommands(app *App) {
 		Keywords: []string{"search"},
 		Handler:  app.ClearGlobalSearch,
 	})
+	reg.Register(command.Command{
+		ID: "search.useWordUnderCursor", Title: "Use Word Under Cursor for Search",
+		Keywords: []string{"search", "find", "cursor"},
+		Handler:  app.SearchUseWordUnderCursor,
+	})
+}
+
+func (a *App) SearchUseWordUnderCursor() {
+	if !a.EditorGroup.IsEditorActive() {
+		return
+	}
+	word := a.EditorGroup.WordAtCursor()
+	if word == "" {
+		return
+	}
+	matches, err := ui.FindInLines(a.EditorGroup.Editor.Buf.Lines, word, ui.SearchOptions{})
+	if err != nil {
+		a.StatusWarn("Invalid regex: " + err.Error())
+		return
+	}
+	a.EditorGroup.SetSearch(word, matches)
 }

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -83,7 +83,7 @@ func resolveLineColArg(arg string) (FileTarget, bool) {
 	return FileTarget{Path: abs, Line: line, Col: col}, true
 }
 
-func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile string, prURLs []string) {
+func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile string, prURLs []string, explicitFolders bool) {
 	var folders []string
 	var wsFile string
 
@@ -148,6 +148,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 		}
 		if info.IsDir() {
 			folders = append(folders, absPath)
+			explicitFolders = true
 		} else {
 			openFiles = append(openFiles, FileTarget{Path: absPath})
 		}
@@ -160,6 +161,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 			for _, f := range folders {
 				ws.AddFolder(f)
 			}
+			explicitFolders = true
 			return
 		}
 	}
@@ -174,8 +176,8 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 }
 
 func BuildApp(cfg *config.AppConfig, borders *term.BorderSet) (*App, []string, []FileTarget) {
-	ws, openFiles, _, prURLs := resolveArgs()
-	return BuildAppFromConfig(cfg, borders, ws, openFiles), prURLs, openFiles
+	ws, openFiles, _, prURLs, explicitFolders := resolveArgs()
+	return BuildAppFromConfig(cfg, borders, ws, openFiles, explicitFolders), prURLs, openFiles
 }
 
 var bracketColorSlots = []term.Style{
@@ -198,7 +200,7 @@ func ResolveBracketColorStyles(colors []string) []term.Style {
 	return bracketColorSlots[:n]
 }
 
-func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *workspace.Workspace, openFiles []FileTarget) *App {
+func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *workspace.Workspace, openFiles []FileTarget, explicitFolders bool) *App {
 
 	bracketStyles := ResolveBracketColorStyles(cfg.Theme.Editor.BracketColors)
 
@@ -285,6 +287,11 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	sidebar.Tabs.Config.Reorderable = true
 	hasFolders := len(ws.Paths()) > 0
 	sidebar.Visible = hasFolders
+	// If the user only opened files and didn't explicitly open a folder/workspace,
+	// hide the sidebar by default to maximize the editor space.
+	if !explicitFolders && len(openFiles) > 0 {
+		sidebar.Visible = false
+	}
 	sidebar.Borders = borders
 
 	splitPanel := ui.NewSplitPanelWidget()
@@ -341,6 +348,7 @@ func BuildAppFromConfig(cfg *config.AppConfig, borders *term.BorderSet, ws *work
 	app.Repository = NewRepositoryState(changes, ws.Paths())
 	app.Repository.SetCurrentChangesHandler(app.ApplyCurrentChanges)
 	app.applyMenuBarVisibility(cfg.Settings.Editor.IsMenuBarVisible())
+	app.ExplicitFolders = explicitFolders
 	// Rebuild the Diagnostics panel whenever any source (LSP or a plugin)
 	// changes its diagnostics.
 	app.EditorGroup.OnDiagnosticsChanged = app.refreshProblems

--- a/internal/app/widgets.go
+++ b/internal/app/widgets.go
@@ -165,7 +165,7 @@ func resolveArgs() (ws *workspace.Workspace, openFiles []FileTarget, configFile 
 	}
 
 	// Opening only files intentionally creates no workspace — a folder must be passed explicitly.
-	if len(folders) == 0 && len(prURLs) == 0 && len(openFiles) == 0 {
+	if len(folders) == 0 && len(prURLs) == 0 {
 		cwd, _ := os.Getwd()
 		folders = append(folders, cwd)
 	}

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -357,5 +357,6 @@ func DefaultKeybindings() []KeyBinding {
 		{Key: "alt+o", Command: "menu.options"},
 		{Key: "alt+h", Command: "menu.help"},
 		{Key: "alt+shift+m", Command: "menubar.toggle"},
+		{Key: "alt+y", Command: "search.useWordUnderCursor"},
 	}
 }

--- a/internal/term/tcell_screen.go
+++ b/internal/term/tcell_screen.go
@@ -83,9 +83,9 @@ func (t *TcellScreen) SetCell(x, y int, c Cell) {
 	if c.BgStyle != 0 {
 		bg := t.styleMap[c.BgStyle].GetBackground()
 		s = tcell.StyleDefault. //nolint:staticcheck // Attributes is deprecated but individual calls don't replicate the exact reset-and-copy semantics
-			Foreground(s.GetForeground()).
-			Background(bg).
-			Attributes(s.GetAttributes())
+					Foreground(s.GetForeground()).
+					Background(bg).
+					Attributes(s.GetAttributes())
 	}
 	if c.UlStyle != 0 {
 		us := t.styleMap[c.UlStyle]

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1562,6 +1562,24 @@ func (g *EditorGroupWidget) FindPrev() {
 	g.Editor.scrollViewport()
 }
 
+func (g *EditorGroupWidget) WordAtCursor() string {
+	if !g.IsEditorActive() || g.Editor == nil || g.Editor.Buf == nil {
+		return ""
+	}
+	if g.Editor.Selection != nil && g.Editor.Selection.Active {
+		selText := g.Editor.Selection.Text(g.Editor.Buf.Lines, g.Editor.Cursor.Line, g.Editor.Cursor.Col)
+		if selText != "" && !strings.Contains(selText, "\n") {
+			return selText
+		}
+	}
+	line := g.Editor.Cursor.Line
+	col := g.Editor.Cursor.Col
+	if line < 0 || line >= len(g.Editor.Buf.Lines) {
+		return ""
+	}
+	return wordAt(g.Editor.Buf.Lines[line], col)
+}
+
 func (g *EditorGroupWidget) MoveLineUp() {
 	if g.IsEditorActive() {
 		g.Editor.MoveLineUp()


### PR DESCRIPTION
    - Add `search.useWordUnderCursor` command
    - Implement `WordAtCursor` logic in `EditorGroup` to handle selections and plain text
    - Bind `alt+y` to the new search command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command to search for the word under the cursor, including selected single-line text.
  - Added the default **Alt+Y** shortcut for this search.
- **Usability Improvements**
  - The sidebar is now hidden by default when opening individual files without a folder or workspace.
  - Opening a folder or workspace continues to display the sidebar as expected.
- **Style**
  - Improved internal formatting with no user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->