### PR TITLE
feat(explorer): re-render workspace tree on filesystem changes

### DIFF
--- a/internal/app/callbacks.go
+++ b/internal/app/callbacks.go
@@ -535,6 +535,9 @@ func registerWidgetCallbacks(app *App) {
 		if id == "outline" {
 			app.RefreshSymbols()
 		}
+		if id == "explorer" {
+			app.Explorer.Reload()
+		}
 	}
 
 	revealSymbol := func(line, col int) {

--- a/internal/app/commands_view.go
+++ b/internal/app/commands_view.go
@@ -291,7 +291,6 @@ func registerViewCommands(app *App) {
 		ID: "sidebar.explorer", Title: "Show Explorer",
 		Keywords: []string{"view", "file", "tree", "browser"},
 		Handler: func() {
-			app.Explorer.Reload()
 			app.ShowPanel("explorer", app.Explorer.Adapter)
 		},
 	})

--- a/internal/app/eventloop.go
+++ b/internal/app/eventloop.go
@@ -404,6 +404,8 @@ func RunEventLoop(
 				app.ApplyDiffOpen(v)
 			case *FileChangedResult:
 				app.HandleFileChanged(v.Path)
+			case *ExplorerDirChangedResult:
+				app.HandleExplorerDirChanged(v.Dir)
 			case *ui.SearchBatch:
 				app.Search.ApplyBatch(v)
 			case *DiffContentResult:

--- a/internal/app/explorer.go
+++ b/internal/app/explorer.go
@@ -164,6 +164,37 @@ func (n *NavigationPanel) SetRoots(paths []string) {
 	n.Tree.RestoreExpanded(expanded)
 }
 
+// WatchedDirs returns every root plus every expanded folder: the directories
+// whose contents are currently materialized in the tree.
+func (n *NavigationPanel) WatchedDirs() []string {
+	if n.Tree == nil {
+		return nil
+	}
+	var dirs []string
+	seen := make(map[string]bool)
+	var walk func(node *widgets.TreeNode, isRoot bool)
+	walk = func(node *widgets.TreeNode, isRoot bool) {
+		if node == nil {
+			return
+		}
+		if (isRoot || node.Expanded) && !seen[node.ID] {
+			seen[node.ID] = true
+			dirs = append(dirs, node.ID)
+		}
+		if isRoot || node.Expanded {
+			for _, child := range node.Children {
+				if child.Expandable {
+					walk(child, false)
+				}
+			}
+		}
+	}
+	for _, root := range n.Tree.Config.Items {
+		walk(root, true)
+	}
+	return dirs
+}
+
 func (n *NavigationPanel) loadChildren(node *widgets.TreeNode) {
 	entries := ui.LoadDirEntries(node.ID, n.Settings)
 	node.Children = nil

--- a/internal/app/watch.go
+++ b/internal/app/watch.go
@@ -15,16 +15,16 @@ type FileChangedResult struct {
 	Path string
 }
 
-// ExplorerDirChangedResult is posted to the event loop when the contents of a
-// directory shown in the workspace explorer change on disk.
+// ExplorerDirChangedResult is posted to the event loop when a directory shown
+// in the workspace explorer gains, loses or renames an entry on disk.
 type ExplorerDirChangedResult struct {
 	Dir string
 }
 
 // StartWatcher creates the file watcher. The callbacks run on the watcher's
-// goroutine, so they only post an event; the reconciliation happens on the main
-// loop in HandleFileChanged / HandleExplorerDirChanged. a.Screen is read at
-// call time so it is safe even if the screen is wired up after Init.
+// goroutine, so they only post an event; reconciliation happens on the main
+// loop. a.Screen is read at call time so it is safe even if the screen is
+// wired up after Init.
 func (a *App) StartWatcher() {
 	w, err := watcher.New(
 		func(path string) {
@@ -44,9 +44,8 @@ func (a *App) StartWatcher() {
 	a.Watcher = w
 }
 
-// SyncWatched updates the watcher's tracked set to the currently open files and
-// the directories currently visible in the explorer. It is cheap to call
-// frequently — the watcher ignores paths it already tracks.
+// SyncWatched points the watcher at the currently open files and the
+// directories currently shown in the explorer. Cheap to call frequently.
 func (a *App) SyncWatched() {
 	if a.Watcher == nil {
 		return
@@ -95,5 +94,6 @@ func (a *App) HandleExplorerDirChanged(dir string) {
 	a.invalidateRepositoryPath(dir, RepositoryWorktree)
 	if a.Explorer != nil {
 		a.Explorer.Reload()
+		a.SyncWatched()
 	}
 }

--- a/internal/app/watch.go
+++ b/internal/app/watch.go
@@ -15,29 +15,46 @@ type FileChangedResult struct {
 	Path string
 }
 
-// StartWatcher creates the file watcher. onChange runs on the watcher's
-// goroutine, so it only posts an event; the reconciliation happens on the main
-// loop in HandleFileChanged. a.Screen is read at call time so it is safe even
-// if the screen is wired up after Init.
+// ExplorerDirChangedResult is posted to the event loop when the contents of a
+// directory shown in the workspace explorer change on disk.
+type ExplorerDirChangedResult struct {
+	Dir string
+}
+
+// StartWatcher creates the file watcher. The callbacks run on the watcher's
+// goroutine, so they only post an event; the reconciliation happens on the main
+// loop in HandleFileChanged / HandleExplorerDirChanged. a.Screen is read at
+// call time so it is safe even if the screen is wired up after Init.
 func (a *App) StartWatcher() {
-	w, err := watcher.New(func(path string) {
-		if a.Screen != nil {
-			a.Screen.PostEvent(tcell.NewEventInterrupt(&FileChangedResult{Path: path}))
-		}
-	})
+	w, err := watcher.New(
+		func(path string) {
+			if a.Screen != nil {
+				a.Screen.PostEvent(tcell.NewEventInterrupt(&FileChangedResult{Path: path}))
+			}
+		},
+		func(dir string) {
+			if a.Screen != nil {
+				a.Screen.PostEvent(tcell.NewEventInterrupt(&ExplorerDirChangedResult{Dir: dir}))
+			}
+		},
+	)
 	if err != nil {
 		return
 	}
 	a.Watcher = w
 }
 
-// SyncWatched updates the watcher's tracked set to the currently open files.
-// It is cheap to call frequently — the watcher ignores paths it already tracks.
+// SyncWatched updates the watcher's tracked set to the currently open files and
+// the directories currently visible in the explorer. It is cheap to call
+// frequently — the watcher ignores paths it already tracks.
 func (a *App) SyncWatched() {
 	if a.Watcher == nil {
 		return
 	}
 	a.Watcher.Sync(a.EditorGroup.OpenFilePaths())
+	if a.Explorer != nil {
+		a.Watcher.SyncDirs(a.Explorer.WatchedDirs())
+	}
 }
 
 // HandleFileChanged reconciles an open buffer with a change detected on disk.
@@ -70,4 +87,13 @@ func (a *App) HandleFileChanged(path string) {
 	a.EditorGroup.ReloadFile(path)
 	a.RequestGitGutterForActiveFile()
 	a.RefreshSymbols()
+}
+
+// HandleExplorerDirChanged re-reads the explorer tree after its backing
+// filesystem changed. Reload preserves expansion state and selection.
+func (a *App) HandleExplorerDirChanged(dir string) {
+	a.invalidateRepositoryPath(dir, RepositoryWorktree)
+	if a.Explorer != nil {
+		a.Explorer.Reload()
+	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,7 +1,9 @@
 // Package watcher reports when files open in the editor are modified on disk
 // by another process. It wraps fsnotify, watching the parent directories of
 // tracked files (the portable, rename-safe pattern) and debouncing bursts of
-// events into a single notification per file.
+// events into a single notification per file. It also watches a separate set
+// of directories on behalf of the workspace explorer, reporting when their
+// contents change so the tree can re-render.
 package watcher
 
 import (
@@ -20,33 +22,40 @@ const defaultDebounce = 150 * time.Millisecond
 // Watcher tracks a set of files and invokes onChange when one of them changes
 // on disk. onChange is called from an internal goroutine with the same path
 // string that was passed to Sync, so callers can match it back to their own
-// bookkeeping.
+// bookkeeping. SyncDirs adds a parallel set of directories whose entry
+// creation/removal/rename fires onDirChange.
 type Watcher struct {
-	fsw      *fsnotify.Watcher
-	onChange func(path string)
-	debounce time.Duration
+	fsw         *fsnotify.Watcher
+	onChange    func(path string)
+	onDirChange func(dir string)
+	debounce    time.Duration
 
-	mu     sync.Mutex
-	files  map[string]string // cleaned-abs path -> original path as tracked
-	dirs   map[string]int    // watched directory -> number of tracked files in it
-	timers map[string]*time.Timer
-	closed bool
+	mu        sync.Mutex
+	files     map[string]string // cleaned-abs file path -> original path as tracked
+	watchDirs map[string]string // cleaned-abs explorer dir -> original path as tracked
+	dirRefs   map[string]int    // fsnotify-watched directory -> refcount (files' parents + watchDirs)
+	timers    map[string]*time.Timer
+	dirTimers map[string]*time.Timer
+	closed    bool
 }
 
-// New creates a Watcher and starts its event loop. onChange must be safe to
-// call from another goroutine.
-func New(onChange func(path string)) (*Watcher, error) {
+// New creates a Watcher and starts its event loop. onChange and onDirChange
+// must be safe to call from another goroutine; either may be nil.
+func New(onChange func(path string), onDirChange func(dir string)) (*Watcher, error) {
 	fsw, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
 	}
 	w := &Watcher{
-		fsw:      fsw,
-		onChange: onChange,
-		debounce: defaultDebounce,
-		files:    make(map[string]string),
-		dirs:     make(map[string]int),
-		timers:   make(map[string]*time.Timer),
+		fsw:         fsw,
+		onChange:    onChange,
+		onDirChange: onDirChange,
+		debounce:    defaultDebounce,
+		files:       make(map[string]string),
+		watchDirs:   make(map[string]string),
+		dirRefs:     make(map[string]int),
+		timers:      make(map[string]*time.Timer),
+		dirTimers:   make(map[string]*time.Timer),
 	}
 	go w.run()
 	return w, nil
@@ -82,14 +91,71 @@ func (w *Watcher) Sync(paths []string) {
 	}
 }
 
-func (w *Watcher) trackLocked(key, orig string) {
-	dir := filepath.Dir(key)
-	if w.dirs[dir] == 0 {
-		if err := w.fsw.Add(dir); err != nil {
-			return
+// SyncDirs reconciles the tracked directory set with paths. A change to any
+// direct entry of one of these directories fires onDirChange with the path as
+// passed here. Like Sync, it is cheap to call frequently.
+func (w *Watcher) SyncDirs(paths []string) {
+	want := make(map[string]string, len(paths))
+	for _, p := range paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		want[filepath.Clean(abs)] = p
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+	for key := range w.watchDirs {
+		if _, ok := want[key]; !ok {
+			delete(w.watchDirs, key)
+			if t := w.dirTimers[key]; t != nil {
+				t.Stop()
+				delete(w.dirTimers, key)
+			}
+			w.releaseDirLocked(key)
 		}
 	}
-	w.dirs[dir]++
+	for key, orig := range want {
+		if _, ok := w.watchDirs[key]; !ok {
+			if w.retainDirLocked(key) {
+				w.watchDirs[key] = orig
+			}
+		}
+	}
+}
+
+// retainDirLocked adds an fsnotify watch on dir (or bumps its refcount) and
+// reports whether the directory is now watched.
+func (w *Watcher) retainDirLocked(dir string) bool {
+	if w.dirRefs[dir] == 0 {
+		if err := w.fsw.Add(dir); err != nil {
+			return false
+		}
+	}
+	w.dirRefs[dir]++
+	return true
+}
+
+// releaseDirLocked drops one reference to an fsnotify watch, removing it when
+// the last reference goes away.
+func (w *Watcher) releaseDirLocked(dir string) {
+	if w.dirRefs[dir] > 0 {
+		w.dirRefs[dir]--
+		if w.dirRefs[dir] == 0 {
+			delete(w.dirRefs, dir)
+			_ = w.fsw.Remove(dir)
+		}
+	}
+}
+
+func (w *Watcher) trackLocked(key, orig string) {
+	if !w.retainDirLocked(filepath.Dir(key)) {
+		return
+	}
 	w.files[key] = orig
 }
 
@@ -102,14 +168,7 @@ func (w *Watcher) untrackLocked(key string) {
 		t.Stop()
 		delete(w.timers, key)
 	}
-	dir := filepath.Dir(key)
-	if w.dirs[dir] > 0 {
-		w.dirs[dir]--
-		if w.dirs[dir] == 0 {
-			delete(w.dirs, dir)
-			_ = w.fsw.Remove(dir)
-		}
-	}
+	w.releaseDirLocked(filepath.Dir(key))
 }
 
 func (w *Watcher) run() {
@@ -124,7 +183,14 @@ func (w *Watcher) run() {
 			if ev.Op == fsnotify.Chmod {
 				continue
 			}
-			w.handle(filepath.Clean(ev.Name))
+			key := filepath.Clean(ev.Name)
+			w.handle(key)
+			// A plain write to an existing file doesn't change a directory
+			// listing, so it can't affect the explorer tree — only
+			// create/remove/rename events can.
+			if ev.Op&(fsnotify.Create|fsnotify.Remove|fsnotify.Rename) != 0 {
+				w.handleDir(key)
+			}
 		case _, ok := <-w.fsw.Errors:
 			if !ok {
 				return
@@ -156,6 +222,44 @@ func (w *Watcher) handle(key string) {
 	w.mu.Unlock()
 }
 
+// handleDir debounces events for an entry inside a watched explorer directory
+// (or for a watched directory itself being removed/renamed) into a single
+// onDirChange notification per directory.
+func (w *Watcher) handleDir(key string) {
+	if w.onDirChange == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return
+	}
+	// key is either a direct child of a watched dir (create/remove/rename of an
+	// entry) or a watched dir itself (that dir renamed/removed).
+	dirKey := filepath.Dir(key)
+	orig, ok := w.watchDirs[dirKey]
+	if !ok {
+		if orig, ok = w.watchDirs[key]; ok {
+			dirKey = key
+		} else {
+			return
+		}
+	}
+	if t := w.dirTimers[dirKey]; t != nil {
+		t.Stop()
+	}
+	w.dirTimers[dirKey] = time.AfterFunc(w.debounce, func() {
+		w.mu.Lock()
+		delete(w.dirTimers, dirKey)
+		_, still := w.watchDirs[dirKey]
+		closed := w.closed
+		w.mu.Unlock()
+		if still && !closed {
+			w.onDirChange(orig)
+		}
+	})
+}
+
 // Close stops watching and releases resources. The Watcher must not be used
 // afterwards.
 func (w *Watcher) Close() error {
@@ -168,6 +272,10 @@ func (w *Watcher) Close() error {
 	for key, t := range w.timers {
 		t.Stop()
 		delete(w.timers, key)
+	}
+	for key, t := range w.dirTimers {
+		t.Stop()
+		delete(w.dirTimers, key)
 	}
 	w.mu.Unlock()
 	return w.fsw.Close()

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,9 +1,8 @@
 // Package watcher reports when files open in the editor are modified on disk
 // by another process. It wraps fsnotify, watching the parent directories of
 // tracked files (the portable, rename-safe pattern) and debouncing bursts of
-// events into a single notification per file. It also watches a separate set
-// of directories on behalf of the workspace explorer, reporting when their
-// contents change so the tree can re-render.
+// events into a single notification per file. SyncDirs additionally watches a
+// set of directories for the workspace explorer.
 package watcher
 
 import (
@@ -21,9 +20,8 @@ const defaultDebounce = 150 * time.Millisecond
 
 // Watcher tracks a set of files and invokes onChange when one of them changes
 // on disk. onChange is called from an internal goroutine with the same path
-// string that was passed to Sync, so callers can match it back to their own
-// bookkeeping. SyncDirs adds a parallel set of directories whose entry
-// creation/removal/rename fires onDirChange.
+// string that was passed to Sync. SyncDirs tracks a parallel set of directories
+// whose entry creation/removal/rename fires onDirChange.
 type Watcher struct {
 	fsw         *fsnotify.Watcher
 	onChange    func(path string)
@@ -31,16 +29,16 @@ type Watcher struct {
 	debounce    time.Duration
 
 	mu        sync.Mutex
-	files     map[string]string // cleaned-abs file path -> original path as tracked
-	watchDirs map[string]string // cleaned-abs explorer dir -> original path as tracked
-	dirRefs   map[string]int    // fsnotify-watched directory -> refcount (files' parents + watchDirs)
+	files     map[string]string // cleaned-abs path -> path as tracked
+	watchDirs map[string]string // cleaned-abs dir -> path as tracked
+	dirRefs   map[string]int    // fsnotify-watched dir -> refcount (file parents + watchDirs)
 	timers    map[string]*time.Timer
 	dirTimers map[string]*time.Timer
 	closed    bool
 }
 
-// New creates a Watcher and starts its event loop. onChange and onDirChange
-// must be safe to call from another goroutine; either may be nil.
+// New creates a Watcher and starts its event loop. The callbacks run on an
+// internal goroutine; either may be nil.
 func New(onChange func(path string), onDirChange func(dir string)) (*Watcher, error) {
 	fsw, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -91,9 +89,9 @@ func (w *Watcher) Sync(paths []string) {
 	}
 }
 
-// SyncDirs reconciles the tracked directory set with paths. A change to any
-// direct entry of one of these directories fires onDirChange with the path as
-// passed here. Like Sync, it is cheap to call frequently.
+// SyncDirs reconciles the tracked directory set with paths. onDirChange fires
+// with the path as passed here when an entry in one of them is added, removed
+// or renamed. Like Sync, it is cheap to call frequently.
 func (w *Watcher) SyncDirs(paths []string) {
 	want := make(map[string]string, len(paths))
 	for _, p := range paths {
@@ -128,8 +126,8 @@ func (w *Watcher) SyncDirs(paths []string) {
 	}
 }
 
-// retainDirLocked adds an fsnotify watch on dir (or bumps its refcount) and
-// reports whether the directory is now watched.
+// retainDirLocked bumps dir's fsnotify refcount, adding the watch on the first
+// reference and reporting whether the directory ended up watched.
 func (w *Watcher) retainDirLocked(dir string) bool {
 	if w.dirRefs[dir] == 0 {
 		if err := w.fsw.Add(dir); err != nil {
@@ -140,8 +138,6 @@ func (w *Watcher) retainDirLocked(dir string) bool {
 	return true
 }
 
-// releaseDirLocked drops one reference to an fsnotify watch, removing it when
-// the last reference goes away.
 func (w *Watcher) releaseDirLocked(dir string) {
 	if w.dirRefs[dir] > 0 {
 		w.dirRefs[dir]--
@@ -178,16 +174,12 @@ func (w *Watcher) run() {
 			if !ok {
 				return
 			}
-			// Only Chmod-only events are uninteresting; writes, creates,
-			// renames and removes can all change the file's contents.
 			if ev.Op == fsnotify.Chmod {
 				continue
 			}
 			key := filepath.Clean(ev.Name)
 			w.handle(key)
-			// A plain write to an existing file doesn't change a directory
-			// listing, so it can't affect the explorer tree — only
-			// create/remove/rename events can.
+			// A write to an existing file can't change a directory listing.
 			if ev.Op&(fsnotify.Create|fsnotify.Remove|fsnotify.Rename) != 0 {
 				w.handleDir(key)
 			}
@@ -200,6 +192,9 @@ func (w *Watcher) run() {
 }
 
 func (w *Watcher) handle(key string) {
+	if w.onChange == nil {
+		return
+	}
 	w.mu.Lock()
 	orig, tracked := w.files[key]
 	if !tracked || w.closed {
@@ -222,9 +217,7 @@ func (w *Watcher) handle(key string) {
 	w.mu.Unlock()
 }
 
-// handleDir debounces events for an entry inside a watched explorer directory
-// (or for a watched directory itself being removed/renamed) into a single
-// onDirChange notification per directory.
+// handleDir debounces changes to a watched directory into one onDirChange call.
 func (w *Watcher) handleDir(key string) {
 	if w.onDirChange == nil {
 		return
@@ -234,8 +227,7 @@ func (w *Watcher) handleDir(key string) {
 	if w.closed {
 		return
 	}
-	// key is either a direct child of a watched dir (create/remove/rename of an
-	// entry) or a watched dir itself (that dir renamed/removed).
+	// key is either an entry of a watched dir or a watched dir itself (removed).
 	dirKey := filepath.Dir(key)
 	orig, ok := w.watchDirs[dirKey]
 	if !ok {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -21,7 +21,18 @@ func waitForChange(t *testing.T, ch <-chan string, timeout time.Duration) (strin
 func newTestWatcher(t *testing.T) (*Watcher, <-chan string) {
 	t.Helper()
 	ch := make(chan string, 8)
-	w, err := New(func(path string) { ch <- path })
+	w, err := New(func(path string) { ch <- path }, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { w.Close() })
+	return w, ch
+}
+
+func newTestDirWatcher(t *testing.T) (*Watcher, <-chan string) {
+	t.Helper()
+	ch := make(chan string, 8)
+	w, err := New(nil, func(dir string) { ch <- dir })
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -91,6 +102,74 @@ func TestWatcherStopsAfterUntrack(t *testing.T) {
 	}
 	if got, ok := waitForChange(t, ch, 500*time.Millisecond); ok {
 		t.Errorf("expected no notification after untracking, got %q", got)
+	}
+}
+
+func TestWatcherDetectsDirEntryCreated(t *testing.T) {
+	dir := t.TempDir()
+
+	w, ch := newTestDirWatcher(t)
+	w.SyncDirs([]string{dir})
+
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := waitForChange(t, ch, 3*time.Second)
+	if !ok {
+		t.Fatal("expected a directory change notification, got none")
+	}
+	if got != dir {
+		t.Errorf("expected dir %q, got %q", dir, got)
+	}
+}
+
+func TestWatcherDetectsDirEntryRemoved(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "gone.txt")
+	if err := os.WriteFile(file, []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w, ch := newTestDirWatcher(t)
+	w.SyncDirs([]string{dir})
+
+	if err := os.Remove(file); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := waitForChange(t, ch, 3*time.Second); !ok {
+		t.Fatal("expected a directory change notification, got none")
+	}
+}
+
+func TestWatcherIgnoresUnwatchedDirs(t *testing.T) {
+	watched := t.TempDir()
+	other := t.TempDir()
+
+	w, ch := newTestDirWatcher(t)
+	w.SyncDirs([]string{watched})
+
+	if err := os.WriteFile(filepath.Join(other, "x.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := waitForChange(t, ch, 500*time.Millisecond); ok {
+		t.Errorf("expected no notification for unwatched dir, got %q", got)
+	}
+}
+
+func TestWatcherStopsAfterDirUntrack(t *testing.T) {
+	dir := t.TempDir()
+
+	w, ch := newTestDirWatcher(t)
+	w.SyncDirs([]string{dir})
+	w.SyncDirs(nil)
+
+	if err := os.WriteFile(filepath.Join(dir, "x.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := waitForChange(t, ch, 500*time.Millisecond); ok {
+		t.Errorf("expected no notification after untracking dir, got %q", got)
 	}
 }
 

--- a/tests/e2e/explorer_watch_test.go
+++ b/tests/e2e/explorer_watch_test.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+// The explorer must re-render when the filesystem underneath it changes, not
+// only when the user hits `r`. HandleExplorerDirChanged is what the file
+// watcher posts to the event loop.
+func TestExplorerReloadsOnDirChange(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("sidebar.explorer")
+	h.redraw()
+
+	before := h.app.Explorer.Tree.ItemCount()
+	if err := os.WriteFile(filepath.Join(h.dir, "watched-new.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h.app.HandleExplorerDirChanged(h.dir)
+	h.redraw()
+
+	if got := h.app.Explorer.Tree.ItemCount(); got <= before {
+		t.Fatalf("expected the tree to grow after a dir change: had %d, got %d", before, got)
+	}
+	h.assertContains("watched-new.txt")
+}
+
+// WatchedDirs is the set the watcher subscribes to: the roots plus every
+// expanded folder, and nothing that is collapsed.
+func TestExplorerWatchedDirsTracksExpandedFolders(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("sidebar.explorer")
+	h.redraw()
+
+	dirs := h.app.Explorer.WatchedDirs()
+	if !slices.Contains(dirs, h.dir) {
+		t.Fatalf("expected root %q in watched dirs, got %v", h.dir, dirs)
+	}
+	sub := filepath.Join(h.dir, "subdir")
+	if slices.Contains(dirs, sub) {
+		t.Fatalf("collapsed subdir should not be watched yet, got %v", dirs)
+	}
+
+	subIdx := -1
+	for i, n := range h.app.Explorer.Tree.FlatList() {
+		if n.ID == sub {
+			subIdx = i
+			break
+		}
+	}
+	if subIdx < 0 {
+		t.Fatalf("subdir node not found in tree")
+	}
+	h.app.Explorer.Tree.SetSelectedIndex(subIdx)
+	h.pressKey(tcell.KeyEnter, tcell.ModNone)
+	h.redraw()
+
+	if dirs := h.app.Explorer.WatchedDirs(); !slices.Contains(dirs, sub) {
+		t.Fatalf("expected expanded subdir %q in watched dirs, got %v", sub, dirs)
+	}
+}
+
+// Switching away to another sidebar tab and back must show files that appeared
+// while the explorer was hidden.
+func TestExplorerReloadsWhenSwitchingBackToTab(t *testing.T) {
+	h := newTestHarness(t, 80, 24)
+	defer h.stop()
+
+	h.exec("sidebar.explorer")
+	h.redraw()
+
+	h.app.Sidebar.SetActivePanel("search")
+	h.redraw()
+
+	if err := os.WriteFile(filepath.Join(h.dir, "while-hidden.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h.app.Sidebar.SetActivePanel("explorer")
+	h.redraw()
+
+	h.assertContains("while-hidden.txt")
+}


### PR DESCRIPTION
Closes #570.

## Problem

The workspace explorer tree only refreshed on a manual `r` / `explorer.refresh`. Files created, deleted or renamed by another process didn't appear. Switching to another sidebar tab and back also left a stale tree.

## Changes

**`internal/watcher`**
- New `SyncDirs` / `onDirChange` alongside the existing file watching. It watches the directories the explorer currently shows (roots + expanded folders) and fires when an entry is created, removed or renamed inside one.
- The fsnotify registration per directory is shared between open-file parent-dir watches and explorer-dir watches via a refcount (`dirRefs`), so the two features never clobber each other's `Add`/`Remove`.
- Plain `Write` events are ignored for the tree — they can't change a directory listing.
- Notifications are debounced (150ms) per directory, same as the file path.

**`internal/app`**
- `StartWatcher` now wires the dir callback, posting `ExplorerDirChangedResult` to the event loop; `HandleExplorerDirChanged` reloads the tree (`Reload` preserves expansion state and selection).
- `SyncWatched` also syncs `Explorer.WatchedDirs()` — it already runs after every event, so expand/collapse/reload keep the watched set current with no new widget callbacks.
- The explorer reloads when its sidebar tab becomes active again (`OnPanelChange`), fixing the tab-switch case.

## Tests

- `internal/watcher`: dir entry created / removed detected, unwatched dirs ignored, stops after untrack.
- `tests/e2e/explorer_watch_test.go`: tree grows on dir change, `WatchedDirs` tracks expanded folders only, tab switch-away-and-back picks up new files.

`make test` + `make lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The file explorer now automatically updates when files or folders are created, removed, or renamed in watched directories.
  - Explorer refreshes preserve the current navigation state.
  - Returning to the Explorer panel refreshes its contents to show recent changes.
  - Only visible and expanded directories are monitored for changes.

- **Bug Fixes**
  - Improved Explorer synchronization so newly added files appear without manual refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->