### PR TITLE
fix(editor): don't resize sidebar when a selection drag crosses the divider

### DIFF
--- a/internal/ui/commit_detail_widget.go
+++ b/internal/ui/commit_detail_widget.go
@@ -1401,6 +1401,10 @@ func (d *CommitDetailWidget) clampScroll() {
 	}
 }
 
+func (d *CommitDetailWidget) OwnsPointerCapture() bool {
+	return d.selecting || d.scrollbar.IsDragging() || d.hscrollbar.IsDragging() || d.rhscroll.IsDragging()
+}
+
 func (d *CommitDetailWidget) HandleEvent(ev tcell.Event) EventResult {
 	if newTop, consumed := d.scrollbar.HandleEvent(ev); consumed {
 		d.TopLine = newTop

--- a/internal/ui/diff_widget.go
+++ b/internal/ui/diff_widget.go
@@ -940,6 +940,10 @@ func (d *DiffViewWidget) clampLeftCol() {
 	}
 }
 
+func (d *DiffViewWidget) OwnsPointerCapture() bool {
+	return d.selecting || d.scrollbar.IsDragging() || d.hscrollbar.IsDragging() || d.rhscrollbar.IsDragging()
+}
+
 func (d *DiffViewWidget) HandleEvent(ev tcell.Event) EventResult {
 	if d.extendedFetching || d.Loading {
 		return EventIgnored

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1952,7 +1952,14 @@ func (g *EditorGroupWidget) CancelPointerCapture() bool {
 }
 
 func (g *EditorGroupWidget) OwnsPointerCapture() bool {
-	return g.TabBar.OwnsPointerCapture() || (g.Editor != nil && g.Editor.OwnsPointerCapture())
+	if g.TabBar.OwnsPointerCapture() {
+		return true
+	}
+	if t := g.activeTab(); t != nil && t.Content != nil {
+		owner, ok := t.Content.(widgets.PointerCaptureOwner)
+		return ok && owner.OwnsPointerCapture()
+	}
+	return g.Editor != nil && g.Editor.OwnsPointerCapture()
 }
 
 func (g *EditorGroupWidget) InvalidatePointerInteraction() bool {

--- a/internal/ui/editor_group.go
+++ b/internal/ui/editor_group.go
@@ -1952,7 +1952,7 @@ func (g *EditorGroupWidget) CancelPointerCapture() bool {
 }
 
 func (g *EditorGroupWidget) OwnsPointerCapture() bool {
-	return g.TabBar.OwnsPointerCapture()
+	return g.TabBar.OwnsPointerCapture() || (g.Editor != nil && g.Editor.OwnsPointerCapture())
 }
 
 func (g *EditorGroupWidget) InvalidatePointerInteraction() bool {

--- a/internal/ui/editor_selection_capture_test.go
+++ b/internal/ui/editor_selection_capture_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v3"
+)
+
+// A text-selection drag that crosses the sidebar divider must not start a
+// divider resize: the editor keeps pointer capture for the whole gesture.
+func TestEditorSelectionDragDoesNotResizeSidebar(t *testing.T) {
+	eg := NewEditorGroupWidget(nil, 4, false, "extended")
+	eg.Editor.Buf.Lines = []string{strings.Repeat("abcde", 40)}
+
+	cs := NewContentSplitWidget()
+	cs.Top = eg
+
+	split := NewSplitPanelWidget()
+	split.Left = &mockWidget{renderChar: '.'}
+	split.Right = cs
+	split.DividerPos = 20
+	split.ShowLeft = true
+
+	resizeCalls := 0
+	split.OnResize = func(int) { resizeCalls++ }
+
+	root := NewRoot(split)
+	root.SetSize(80, 24)
+	root.Render(makeGrid(80, 24))
+
+	drag := func(x, y int) {
+		root.HandleEvent(tcell.NewEventMouse(x, y, tcell.Button1, 0))
+	}
+	drag(60, 18)
+	for _, x := range []int{45, 30, 22, 21, 15, 8} {
+		drag(x, 18-x/8)
+	}
+	root.HandleEvent(tcell.NewEventMouse(8, 12, tcell.ButtonNone, 0))
+
+	if resizeCalls != 0 {
+		t.Fatalf("divider resize fired %d times during a text selection drag", resizeCalls)
+	}
+	if split.dragging {
+		t.Fatal("split panel latched into a divider drag")
+	}
+}

--- a/internal/ui/editor_selection_capture_test.go
+++ b/internal/ui/editor_selection_capture_test.go
@@ -45,3 +45,28 @@ func TestEditorSelectionDragDoesNotResizeSidebar(t *testing.T) {
 		t.Fatal("split panel latched into a divider drag")
 	}
 }
+
+type capturingContentProbe struct {
+	BaseWidget
+	capturing bool
+}
+
+func (p *capturingContentProbe) HandleEvent(tcell.Event) EventResult { return EventIgnored }
+func (p *capturingContentProbe) Render(Surface)                      {}
+func (p *capturingContentProbe) OwnsPointerCapture() bool            { return p.capturing }
+
+// A diff/commit-detail content tab that captures the pointer during a scrollbar
+// drag or selection must be reported by the group, same as the editor pane.
+func TestEditorGroupOwnsPointerCaptureFollowsContentTab(t *testing.T) {
+	g := NewEditorGroupWidget(nil, 4, false, "extended")
+	probe := &capturingContentProbe{}
+	g.activeTab().Content = probe
+
+	if g.OwnsPointerCapture() {
+		t.Fatal("group owns capture while the content tab is idle")
+	}
+	probe.capturing = true
+	if !g.OwnsPointerCapture() {
+		t.Fatal("group dropped capture while the content tab held it")
+	}
+}

--- a/internal/ui/editor_widget_mouse.go
+++ b/internal/ui/editor_widget_mouse.go
@@ -6,6 +6,10 @@ import (
 	"github.com/gdamore/tcell/v3"
 )
 
+func (e *EditorPaneWidget) OwnsPointerCapture() bool {
+	return e.mouseDown || e.scrollbar.IsDragging() || e.hscrollbar.IsDragging()
+}
+
 func (e *EditorPaneWidget) handleMouse(mev *tcell.EventMouse) EventResult {
 	btn := mev.Buttons()
 


### PR DESCRIPTION
## Bug

Select text in the editor and drag left past the sidebar's left edge — the sidebar starts shrinking, as if the divider were being dragged.

## Cause

`EditorGroupWidget.OwnsPointerCapture()` only reported `TabBar.OwnsPointerCapture()`, never the active editor pane's in-progress mouse selection. During a selection drag the pane keeps returning `EventCaptured`, but because the group reports "not capturing", the capture chain unwinds every event:

- `ContentSplitWidget.OwnsPointerCapture()` drops its captured child
- `SplitPanelWidget.OwnsPointerCapture()` drops its captured child **and resets `wasPressed`**
- `Root` clears `capturedWidget`

With `wasPressed` reset, the next drag event looks like a fresh click to the split panel. When the cursor is over the divider grab zone at that moment, `dragging` latches and every subsequent move calls `OnResize` → the sidebar shrinks.

## Fix

`EditorPaneWidget.OwnsPointerCapture()` reports an active gesture (`mouseDown` or a scrollbar drag); `EditorGroupWidget` ORs it in. The capture chain now holds for the whole drag, so the split panel never sees a spurious fresh click.

## Test

`TestEditorSelectionDragDoesNotResizeSidebar` drives a press in the editor then a drag left across the divider and asserts `OnResize` never fires. Fails before the fix (resize fired 3×), passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Text selection drags in the editor now retain pointer capture when crossing the sidebar divider.
  - Editor interactions no longer unintentionally trigger or latch split-panel divider resizing.
  - Pointer capture is correctly recognized during text selection and scrollbar dragging in editor, diff, and commit detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->