### PR TITLE
feat: add Herdr plugin for TTT Editor

### DIFF
--- a/herdr-plugin/README.md
+++ b/herdr-plugin/README.md
@@ -50,7 +50,7 @@ When opening, the plugin resolves the target directory in this order:
 
 ## Keybinding
 
-Bind the editor to a key in your Herdr `config.toml`:
+Add this to your Herdr `config.toml` to open TTT with `Ctrl+b e` (or your custom prefix key followed by `e`):
 
 ```toml
 [[keys.command]]

--- a/herdr-plugin/README.md
+++ b/herdr-plugin/README.md
@@ -1,6 +1,17 @@
 # TTT Editor — Herdr Plugin
 
-A [Herdr](https://herdr.dev) plugin for [TTT Editor](https://tttedit.dev), a full IDE that runs in your terminal. Opens TTT as a first-class pane inside your Herdr workspace.
+A [Herdr](https://herdr.dev) plugin for [TTT Editor](https://tttedit.dev). Opens TTT as a first-class pane inside your Herdr workspace.
+
+## About TTT
+
+TTT (Terminal Text Tool) is a real alternative to VS Code, Zed, and Sublime that runs entirely in your terminal. Single Go binary, zero config.
+
+- **GUI in your terminal** — menus, dialogs, mouse support, right-click context menus, and a file explorer
+- **LSP intelligence** — completions, diagnostics, hover info, rename, references, and formatting for 23+ languages
+- **Git built in** — stage, commit, push, inline diffs, blame, and GitHub PR review directly from the terminal
+- **Integrated terminal** — full terminal emulator with true color rendering and multiple tabs
+- **Multi-cursor and search** — Ctrl+D selections, Alt+Click, and ripgrep-powered workspace search
+- **Workspaces** — multi-folder projects, quick open, tabs, and saveable layouts
 
 ## Install
 

--- a/herdr-plugin/README.md
+++ b/herdr-plugin/README.md
@@ -1,0 +1,77 @@
+# TTT Editor — Herdr Plugin
+
+A [Herdr](https://herdr.dev) plugin for [TTT Editor](https://tttedit.dev), a full IDE that runs in your terminal. Opens TTT as a first-class pane inside your Herdr workspace.
+
+## Install
+
+```sh
+herdr plugin install eugenioenko/ttt/herdr-plugin
+```
+
+This installs the `ttt` binary automatically if it's not already on your PATH.
+
+To link a local copy for development instead:
+
+```sh
+herdr plugin link /path/to/ttt/herdr-plugin
+```
+
+## What it does
+
+### Editor pane
+
+Opens TTT in a new Herdr tab, pointed at the active worktree or workspace directory.
+
+```sh
+herdr plugin pane open --plugin ttt.editor --entrypoint editor
+```
+
+### Actions
+
+| Action | Description |
+|--------|-------------|
+| `ttt.editor.open` | Open TTT in the current workspace |
+| `ttt.editor.open-worktree` | Open TTT in the active worktree |
+
+Invoke an action from the CLI:
+
+```sh
+herdr plugin action invoke ttt.editor.open
+```
+
+### Directory resolution
+
+When opening, the plugin resolves the target directory in this order:
+
+1. `checkout_path` — the active worktree's checkout directory
+2. `focused_pane_cwd` — the working directory of the focused pane
+3. `workspace_cwd` — the workspace root directory
+4. `.` — fallback to current directory
+
+## Keybinding
+
+Bind the editor to a key in your Herdr `config.toml`:
+
+```toml
+[[keys.command]]
+key = "prefix+e"
+type = "shell"
+command = "herdr plugin pane open --plugin ttt.editor --entrypoint editor"
+description = "open TTT editor"
+```
+
+## Requirements
+
+- [Herdr](https://herdr.dev) 0.7.0 or newer
+- Linux or macOS
+- [Git](https://git-scm.com/) and [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) for TTT's full feature set
+
+## Links
+
+- [TTT Editor](https://tttedit.dev) — documentation and features
+- [TTT on GitHub](https://github.com/eugenioenko/ttt) — source code and releases
+- [Herdr plugin docs](https://herdr.dev/docs/plugins) — plugin authoring reference
+
+## License
+
+Same as [TTT Editor](https://github.com/eugenioenko/ttt/blob/main/LICENSE).

--- a/herdr-plugin/herdr-plugin.toml
+++ b/herdr-plugin/herdr-plugin.toml
@@ -13,7 +13,7 @@ platforms = ["linux", "macos"]
 id = "open"
 title = "Open TTT"
 contexts = ["workspace"]
-command = ["ttt", "."]
+command = ["sh", "scripts/open-worktree.sh"]
 
 [[actions]]
 id = "open-worktree"
@@ -21,19 +21,8 @@ title = "Open TTT in worktree"
 contexts = ["workspace"]
 command = ["sh", "scripts/open-worktree.sh"]
 
-[[actions]]
-id = "open-link"
-title = "Open file link in TTT"
-contexts = ["workspace"]
-command = ["sh", "scripts/open-link.sh"]
-
 [[panes]]
 id = "editor"
 title = "TTT Editor"
+placement = "tab"
 command = ["sh", "scripts/open-worktree.sh"]
-
-[[link_handlers]]
-id = "open-file"
-title = "Open in TTT"
-pattern = "^[A-Za-z0-9_./-]+\\.[a-zA-Z0-9]+(:[0-9]+(:[0-9]+)?)?$"
-action = "open-link"

--- a/herdr-plugin/herdr-plugin.toml
+++ b/herdr-plugin/herdr-plugin.toml
@@ -1,0 +1,39 @@
+id = "ttt.editor"
+name = "TTT Editor"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+description = "Terminal Text Tool — a full IDE in your terminal"
+platforms = ["linux", "macos"]
+
+[[build]]
+command = ["sh", "scripts/install.sh"]
+platforms = ["linux", "macos"]
+
+[[actions]]
+id = "open"
+title = "Open TTT"
+contexts = ["workspace"]
+command = ["ttt", "."]
+
+[[actions]]
+id = "open-worktree"
+title = "Open TTT in worktree"
+contexts = ["workspace"]
+command = ["sh", "scripts/open-worktree.sh"]
+
+[[actions]]
+id = "open-link"
+title = "Open file link in TTT"
+contexts = ["workspace"]
+command = ["sh", "scripts/open-link.sh"]
+
+[[panes]]
+id = "editor"
+title = "TTT Editor"
+command = ["sh", "scripts/open-worktree.sh"]
+
+[[link_handlers]]
+id = "open-file"
+title = "Open in TTT"
+pattern = "^[A-Za-z0-9_./-]+\\.[a-zA-Z0-9]+(:[0-9]+(:[0-9]+)?)?$"
+action = "open-link"

--- a/herdr-plugin/scripts/install.sh
+++ b/herdr-plugin/scripts/install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if command -v ttt >/dev/null 2>&1; then
+  echo "ttt is already installed: $(ttt --version)"
+  exit 0
+fi
+
+echo "Installing ttt..."
+curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh

--- a/herdr-plugin/scripts/install.sh
+++ b/herdr-plugin/scripts/install.sh
@@ -8,3 +8,10 @@ fi
 
 echo "Installing ttt..."
 curl -sSfL https://raw.githubusercontent.com/eugenioenko/ttt/main/install.sh | sh
+
+if ! command -v ttt >/dev/null 2>&1; then
+  echo "ttt was installed but is not on PATH. Add the install directory to your PATH." >&2
+  exit 1
+fi
+
+echo "ttt installed: $(ttt --version)"

--- a/herdr-plugin/scripts/open-link.sh
+++ b/herdr-plugin/scripts/open-link.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+target="${HERDR_PLUGIN_CLICKED_URL:-}"
+if [ -z "$target" ]; then
+  exec ttt .
+fi
+
+exec ttt "$target"

--- a/herdr-plugin/scripts/open-link.sh
+++ b/herdr-plugin/scripts/open-link.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e
-
-target="${HERDR_PLUGIN_CLICKED_URL:-}"
-if [ -z "$target" ]; then
-  exec ttt .
-fi
-
-exec ttt "$target"

--- a/herdr-plugin/scripts/open-worktree.sh
+++ b/herdr-plugin/scripts/open-worktree.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+dir="."
+if [ -n "$HERDR_PLUGIN_CONTEXT_JSON" ]; then
+  worktree=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | grep -o '"worktree"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"worktree"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+  if [ -n "$worktree" ]; then
+    dir="$worktree"
+  fi
+fi
+
+exec ttt "$dir"

--- a/herdr-plugin/scripts/open-worktree.sh
+++ b/herdr-plugin/scripts/open-worktree.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
 set -e
 
-dir="."
-if [ -n "$HERDR_PLUGIN_CONTEXT_JSON" ]; then
-  worktree=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | grep -o '"worktree"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"worktree"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
-  if [ -n "$worktree" ]; then
-    dir="$worktree"
+dir=""
+if [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
+  dir=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | grep -o '"checkout_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"checkout_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+  if [ -z "$dir" ]; then
+    dir=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | grep -o '"focused_pane_cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"focused_pane_cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+  fi
+  if [ -z "$dir" ]; then
+    dir=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | grep -o '"workspace_cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"workspace_cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
   fi
 fi
 
-exec ttt "$dir"
+exec ttt "${dir:-.}"


### PR DESCRIPTION
## Summary
- Adds `herdr-plugin/` subdirectory with a Herdr plugin manifest and shell scripts
- Installable via `herdr plugin install eugenioenko/ttt/herdr-plugin`
- Provides: editor pane, open-worktree action, and file link handler (Ctrl-click `file:line` paths)
- Build step auto-installs `ttt` if not on PATH

## Test plan
- [ ] `herdr plugin link herdr-plugin/` and verify manifest is accepted
- [ ] Invoke `ttt.editor.open` action and confirm TTT opens
- [ ] Invoke `ttt.editor.open-worktree` and confirm it opens in the workspace directory
- [ ] Ctrl-click a file path in a terminal pane and confirm it opens in TTT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNBR3GicnGcN3HBRUwpcvV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace opening now uses the worktree-aware workflow and selects the directory from available workspace context.
  - Added automatic setup for the `ttt` command when it is not already installed, with version verification.
  - Editor panes now specify tab placement.

- **Changes**
  - Removed the `open-link` action and `open-file` link handling.
  - Workspace opening falls back to the current directory when no workspace context is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->