### PR TITLE
feat(changes): discover git repos in non-git root folder

### DIFF
--- a/internal/app/changes_async.go
+++ b/internal/app/changes_async.go
@@ -92,6 +92,7 @@ type CommitDetailResult struct {
 }
 
 func readChangesGroups(dirs []string) []changesGroup {
+	dirs = expandNonGitDirs(dirs)
 	var groups []changesGroup
 	seen := make(map[string]bool)
 	for _, dir := range dirs {

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -576,6 +576,7 @@ func readRepositoryStatus(ctx context.Context, dirs []string, seq uint64) *Repos
 }
 
 func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatusEntry {
+	dirs = expandNonGitDirs(dirs)
 	entries := make([]repositoryStatusEntry, 0, len(dirs))
 	seen := make(map[string]bool)
 	for _, dir := range dirs {
@@ -616,6 +617,26 @@ func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatus
 		})
 	}
 	return entries
+}
+
+// expandNonGitDirs replaces directories that are not git repositories with
+// any immediate child directories that are. Directories that are already
+// inside a git work tree are kept as-is.
+func expandNonGitDirs(dirs []string) []string {
+	expanded := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		if git.IsRepo(dir) {
+			expanded = append(expanded, dir)
+			continue
+		}
+		children := git.DiscoverChildRepos(dir)
+		if len(children) > 0 {
+			expanded = append(expanded, children...)
+		} else {
+			expanded = append(expanded, dir)
+		}
+	}
+	return expanded
 }
 
 func readRepositoryIdentity(ctx context.Context, filePath string, seq uint64) *RepositoryIdentityResult {

--- a/internal/app/repository_state.go
+++ b/internal/app/repository_state.go
@@ -576,7 +576,7 @@ func readRepositoryStatus(ctx context.Context, dirs []string, seq uint64) *Repos
 }
 
 func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatusEntry {
-	dirs = expandNonGitDirs(dirs)
+	dirs = expandNonGitDirsContext(ctx, dirs)
 	entries := make([]repositoryStatusEntry, 0, len(dirs))
 	seen := make(map[string]bool)
 	for _, dir := range dirs {
@@ -619,17 +619,24 @@ func scanRepositoryStatus(ctx context.Context, dirs []string) []repositoryStatus
 	return entries
 }
 
-// expandNonGitDirs replaces directories that are not git repositories with
-// any immediate child directories that are. Directories that are already
-// inside a git work tree are kept as-is.
 func expandNonGitDirs(dirs []string) []string {
+	return expandNonGitDirsContext(context.Background(), dirs)
+}
+
+// expandNonGitDirsContext replaces directories that are not git repositories
+// with any immediate child directories that are. Directories that are already
+// inside a git work tree are kept as-is.
+func expandNonGitDirsContext(ctx context.Context, dirs []string) []string {
 	expanded := make([]string, 0, len(dirs))
 	for _, dir := range dirs {
-		if git.IsRepo(dir) {
+		if ctx.Err() != nil {
+			return expanded
+		}
+		if git.IsRepoContext(ctx, dir) {
 			expanded = append(expanded, dir)
 			continue
 		}
-		children := git.DiscoverChildRepos(dir)
+		children := git.DiscoverChildReposContext(ctx, dir)
 		if len(children) > 0 {
 			expanded = append(expanded, children...)
 		} else {

--- a/internal/app/repository_state_test.go
+++ b/internal/app/repository_state_test.go
@@ -1636,3 +1636,50 @@ func testAppGit(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
 	}
 }
+
+func TestExpandNonGitDirsReplacesNonRepoWithChildren(t *testing.T) {
+	root := canonicalTestPath(t, t.TempDir())
+	repoA := filepath.Join(root, "alpha")
+	repoB := filepath.Join(root, "beta")
+	for _, d := range []string{repoA, repoB} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		testAppGit(t, d, "init")
+	}
+
+	got := expandNonGitDirs([]string{root})
+	if len(got) != 2 {
+		t.Fatalf("expandNonGitDirs = %v, want 2 child repos", got)
+	}
+	for i, want := range []string{repoA, repoB} {
+		g, _ := filepath.EvalSymlinks(got[i])
+		w, _ := filepath.EvalSymlinks(want)
+		if g != w {
+			t.Errorf("got[%d] = %q, want %q", i, g, w)
+		}
+	}
+}
+
+func TestExpandNonGitDirsKeepsExistingRepos(t *testing.T) {
+	repo := canonicalTestPath(t, t.TempDir())
+	testAppGit(t, repo, "init")
+
+	got := expandNonGitDirs([]string{repo})
+	if len(got) != 1 {
+		t.Fatalf("expandNonGitDirs = %v, want 1 entry", got)
+	}
+	g, _ := filepath.EvalSymlinks(got[0])
+	w, _ := filepath.EvalSymlinks(repo)
+	if g != w {
+		t.Errorf("got %q, want %q", g, w)
+	}
+}
+
+func TestExpandNonGitDirsKeepsDirWithNoChildren(t *testing.T) {
+	root := t.TempDir()
+	got := expandNonGitDirs([]string{root})
+	if len(got) != 1 || got[0] != root {
+		t.Fatalf("expandNonGitDirs = %v, want [%s]", got, root)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -79,17 +79,24 @@ func IsRepoContext(ctx context.Context, dir string) bool {
 // repositories. It is used when dir itself is not a git repo to find nested
 // repos whose changes should be shown.
 func DiscoverChildRepos(dir string) []string {
+	return DiscoverChildReposContext(context.Background(), dir)
+}
+
+func DiscoverChildReposContext(ctx context.Context, dir string) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
 	}
 	var repos []string
 	for _, e := range entries {
+		if ctx.Err() != nil {
+			return repos
+		}
 		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
 		child := filepath.Join(dir, e.Name())
-		if IsRepo(child) {
+		if IsRepoContext(ctx, child) {
 			repos = append(repos, child)
 		}
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -71,6 +73,28 @@ func IsRepoContext(ctx context.Context, dir string) bool {
 	cmd := gitCommandContext(ctx, "-C", dir, "rev-parse", "--is-inside-work-tree")
 	out, err := cmd.Output()
 	return err == nil && strings.TrimSpace(string(out)) == "true"
+}
+
+// DiscoverChildRepos returns immediate child directories of dir that are git
+// repositories. It is used when dir itself is not a git repo to find nested
+// repos whose changes should be shown.
+func DiscoverChildRepos(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var repos []string
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		child := filepath.Join(dir, e.Name())
+		if IsRepo(child) {
+			repos = append(repos, child)
+		}
+	}
+	sort.Strings(repos)
+	return repos
 }
 
 func StatusFiles(dir string) ([]FileStatus, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1058,6 +1058,76 @@ func TestStageReportsError(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// DiscoverChildRepos
+// ---------------------------------------------------------------------------
+
+func TestDiscoverChildReposFindsNestedGitRepos(t *testing.T) {
+	root := t.TempDir()
+	repoA := filepath.Join(root, "alpha")
+	repoB := filepath.Join(root, "beta")
+	notRepo := filepath.Join(root, "plain")
+	for _, d := range []string{repoA, repoB, notRepo} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, d := range []string{repoA, repoB} {
+		cmd := exec.Command("git", "init")
+		cmd.Dir = d
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git init in %s: %v\n%s", d, err, out)
+		}
+	}
+
+	repos := DiscoverChildRepos(root)
+	if len(repos) != 2 {
+		t.Fatalf("got %d repos, want 2: %v", len(repos), repos)
+	}
+	resolved := func(p string) string {
+		r, _ := filepath.EvalSymlinks(p)
+		return r
+	}
+	got0, _ := filepath.EvalSymlinks(repos[0])
+	got1, _ := filepath.EvalSymlinks(repos[1])
+	if got0 != resolved(repoA) || got1 != resolved(repoB) {
+		t.Errorf("repos = %v, want [%s %s]", repos, repoA, repoB)
+	}
+}
+
+func TestDiscoverChildReposSkipsDotDirs(t *testing.T) {
+	root := t.TempDir()
+	hidden := filepath.Join(root, ".hidden")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = hidden
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	repos := DiscoverChildRepos(root)
+	if len(repos) != 0 {
+		t.Errorf("expected no repos (hidden dir), got %v", repos)
+	}
+}
+
+func TestDiscoverChildReposEmptyDir(t *testing.T) {
+	root := t.TempDir()
+	repos := DiscoverChildRepos(root)
+	if len(repos) != 0 {
+		t.Errorf("expected no repos, got %v", repos)
+	}
+}
+
+func TestDiscoverChildReposNonexistentDir(t *testing.T) {
+	repos := DiscoverChildRepos("/nonexistent/path/that/does/not/exist")
+	if repos != nil {
+		t.Errorf("expected nil, got %v", repos)
+	}
+}
+
 func TestDiffWorkingTreeFileContextUsesExplicitRevisionAndRawPath(t *testing.T) {
 	dir := setupTestRepo(t)
 	rawPath := "raw\n\t界.txt"

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1122,7 +1122,7 @@ func TestDiscoverChildReposEmptyDir(t *testing.T) {
 }
 
 func TestDiscoverChildReposNonexistentDir(t *testing.T) {
-	repos := DiscoverChildRepos("/nonexistent/path/that/does/not/exist")
+	repos := DiscoverChildRepos(filepath.Join(t.TempDir(), "missing"))
 	if repos != nil {
 		t.Errorf("expected nil, got %v", repos)
 	}


### PR DESCRIPTION
## Summary
- When a workspace root is not a git repo, scans its immediate child directories for git repos and aggregates their changes in the Changes panel
- Adds `git.DiscoverChildRepos()` to find git repos among a directory's children
- Adds `expandNonGitDirs()` used by both async and sync status scan paths

Closes #584

## Test plan
- [ ] Open a non-git folder containing multiple git repo subdirectories — verify all repos appear in the Changes panel
- [ ] Open a single git repo — verify behavior is unchanged
- [ ] Open a non-git folder with no git children — verify no crash, empty panel
- [ ] Multi-root workspace (`ttt ~/repoA ~/repoB`) — verify still works as before
- [ ] Run `go test ./internal/git/ -run TestDiscoverChildRepos` — 4 tests pass
- [ ] Run `go test ./internal/app/ -run TestExpandNonGitDirs` — 3 tests pass
- [ ] Run `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZjzYEGEPKwTE8GMnCKhse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Directory-based repository scanning now automatically discovers immediate child Git repositories.
  * Existing Git repositories continue to be handled directly.
  * Directories without child repositories remain available for status scanning.
  * Hidden directories are excluded from repository discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->