### PR TITLE
docs: add Herdr integration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ This produces an optimized binary at `bin/ttt`. Add it to your `PATH` or copy it
 cp bin/ttt ~/.local/bin/
 ```
 
+### Herdr
+
+TTT is available as a [Herdr](https://herdr.dev) plugin, so you can open it as a pane inside your Herdr terminal workspace.
+
+```sh
+herdr plugin install eugenioenko/ttt/herdr-plugin
+```
+
+Once installed, bind it to a key (e.g. `Ctrl+b e`) to launch TTT in the active worktree with a single keystroke. See the [Herdr plugin README](herdr-plugin/README.md) for setup and configuration details.
+
 ## Features
 
 ### Editor
@@ -434,16 +444,6 @@ ttt --listen &
 curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://127.0.0.1:4242/exec
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
-
-## Herdr Integration
-
-TTT is available as a [Herdr](https://herdr.dev) plugin, so you can open it as a pane inside your Herdr terminal workspace.
-
-```sh
-herdr plugin install eugenioenko/ttt/herdr-plugin
-```
-
-Once installed, bind it to a key (e.g. `Ctrl+b e`) to launch TTT in the active worktree with a single keystroke. See the [Herdr plugin README](herdr-plugin/README.md) for setup and configuration details.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,16 @@ curl -X POST --data "type hi; wait-for hi; screenshot /tmp/screen.txt" http://12
 curl -X POST --data "shutdown" http://127.0.0.1:4242/exec
 ```
 
+## Herdr Integration
+
+TTT is available as a [Herdr](https://herdr.dev) plugin, so you can open it as a pane inside your Herdr terminal workspace.
+
+```sh
+herdr plugin install eugenioenko/ttt/herdr-plugin
+```
+
+Once installed, bind it to a key (e.g. `Ctrl+b e`) to launch TTT in the active worktree with a single keystroke. See the [Herdr plugin README](herdr-plugin/README.md) for setup and configuration details.
+
 ## Architecture
 
 TTT uses dependency zones rather than a strict linear layer chain:


### PR DESCRIPTION
## Summary
- Adds a short "Herdr Integration" section to the main README with install command and link to the plugin README

## Test plan
- [ ] Verify the link to `herdr-plugin/README.md` resolves on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNBR3GicnGcN3HBRUwpcvV