### PR TITLE
fix: transparent bg for commit header and input styles

### DIFF
--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -41,6 +41,15 @@ func BuildStyleMap(theme config.ThemeConfig, opts ...StyleMapOption) term.StyleM
 	}
 	m[term.StyleSelection] = base.Reverse(true)
 
+	if o.transparentBg {
+		if theme.CommitHeader.Bg == theme.Default.Bg {
+			theme.CommitHeader.Bg = ""
+		}
+		if theme.Input.Item.Bg == theme.Default.Bg {
+			theme.Input.Item.Bg = ""
+		}
+	}
+
 	applyStyleDef(&m, term.StyleStatusBar, theme.StatusBar)
 	applyStyleDef(&m, term.StyleCommitHeader, theme.CommitHeader)
 	applyStyleDef(&m, term.StyleActiveTab, theme.Tabs.Active)


### PR DESCRIPTION
## Summary
- `ResolveColors` copies `Default.Bg` into `CommitHeader` and `Input.Item` when the theme doesn't set an explicit bg
- In transparent/background-image mode, `BuildStyleMap` skips `Default.Bg` on the base style, but these resolved backgrounds bypass that — rendering opaque cells over the terminal background
- Clear resolved backgrounds that match `Default.Bg` before `applyStyleDef` runs, matching the existing pattern used for the base style and terminal palette

## Test plan
- [ ] Enable transparent background or background image in settings
- [ ] Open a commit detail view — commit header area should be transparent
- [ ] Open search or settings — input fields should have transparent background
- [ ] Disable transparent background — commit header and inputs should show their normal theme background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LefWAS7o3kaDNr4yRNwTaq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transparent background themes so commit headers and input items no longer inherit the default background color when transparency is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->