### PR TITLE
feat: add VSCode Dark+ theme

### DIFF
--- a/internal/config/themes/vscode-dark-plus.json
+++ b/internal/config/themes/vscode-dark-plus.json
@@ -1,0 +1,190 @@
+{
+  "default": {
+    "fg": "#d4d4d4",
+    "bg": "#1e1e1e"
+  },
+  "muted": {
+    "fg": "#858585"
+  },
+  "success": {
+    "fg": "#23d18b"
+  },
+  "danger": {
+    "fg": "#f14c4c"
+  },
+  "warning": {
+    "fg": "#e5e510"
+  },
+  "border": {
+    "fg": "#454545"
+  },
+  "statusBar": {
+    "fg": "#ffffff",
+    "bg": "#007acc"
+  },
+  "commitHeader": {
+    "fg": "#569cd6"
+  },
+  "tabs": {
+    "active": {
+      "fg": "#ffffff",
+      "bg": "#1e1e1e"
+    },
+    "inactive": {
+      "fg": "#969696",
+      "bg": "#2d2d2d"
+    },
+    "selected": {
+      "fg": "#ffffff",
+      "bg": "#37373d"
+    }
+  },
+  "sidebar": {
+    "header": {
+      "fg": "#bbbbbb",
+      "bold": true
+    },
+    "item": {
+      "fg": "#cccccc"
+    },
+    "selected": {
+      "fg": "#ffffff",
+      "bg": "#094771"
+    }
+  },
+  "dialog": {
+    "input": {
+      "bg": "#3c3c3c"
+    },
+    "item": {
+      "fg": "#cccccc"
+    },
+    "selected": {
+      "fg": "#ffffff",
+      "bg": "#094771"
+    },
+    "muted": {
+      "fg": "#a6a6a6"
+    }
+  },
+  "editor": {
+    "lineNumber": {
+      "fg": "#858585"
+    },
+    "activeLine": {
+      "bg": "#2d2d2d"
+    },
+    "selection": {
+      "bg": "#264f78"
+    },
+    "searchMatch": {
+      "bg": "#515c6a"
+    },
+    "searchActive": {
+      "bg": "#613214"
+    },
+    "bracketMatch": {
+      "bg": "#3a3a3a"
+    },
+    "bracketColors": [
+      "#ffd700",
+      "#da70d6",
+      "#179fff"
+    ]
+  },
+  "menu": {
+    "item": {
+      "fg": "#cccccc"
+    },
+    "active": {
+      "fg": "#ffffff",
+      "bg": "#094771",
+      "bold": true
+    }
+  },
+  "diff": {
+    "added": {
+      "bg": "#1e3a1e"
+    },
+    "deleted": {
+      "bg": "#3a1e1e"
+    },
+    "modified": {
+      "bg": "#3a3a1e"
+    }
+  },
+  "scrollbar": {
+    "fg": "#424242",
+    "bg": "#2d2d2d"
+  },
+  "syntax": {
+    "comment": {
+      "fg": "#6a9955"
+    },
+    "string": {
+      "fg": "#ce9178"
+    },
+    "keyword": {
+      "fg": "#c586c0"
+    },
+    "number": {
+      "fg": "#b5cea8"
+    },
+    "operator": {
+      "fg": "#d4d4d4"
+    },
+    "function": {
+      "fg": "#dcdcaa"
+    },
+    "type": {
+      "fg": "#4ec9b0"
+    },
+    "builtin": {
+      "fg": "#4fc1ff"
+    },
+    "variable": {
+      "fg": "#9cdcfe"
+    },
+    "punctuation": {
+      "fg": "#d4d4d4"
+    },
+    "tag": {
+      "fg": "#569cd6"
+    },
+    "attribute": {
+      "fg": "#9cdcfe"
+    }
+  },
+  "terminal": {
+    "foreground": "#d4d4d4",
+    "background": "#1e1e1e",
+    "black": "#000000",
+    "red": "#cd3131",
+    "green": "#0dbc79",
+    "yellow": "#e5e510",
+    "blue": "#2472c8",
+    "magenta": "#bc3fbc",
+    "cyan": "#11a8cd",
+    "white": "#e5e5e5",
+    "brightBlack": "#666666",
+    "brightRed": "#f14c4c",
+    "brightGreen": "#23d18b",
+    "brightYellow": "#f5f543",
+    "brightBlue": "#3b8eea",
+    "brightMagenta": "#d670d6",
+    "brightCyan": "#29b8db",
+    "brightWhite": "#e5e5e5"
+  },
+  "borders": {
+    "horizontal": "─",
+    "vertical": "│",
+    "topLeft": "┌",
+    "topRight": "┐",
+    "bottomLeft": "└",
+    "bottomRight": "┘",
+    "topTee": "┬",
+    "bottomTee": "┴",
+    "leftTee": "├",
+    "rightTee": "┤"
+  }
+}


### PR DESCRIPTION
## What

Adds a faithful `vscode-dark-plus` theme reproducing the VS Code Dark+ palette
end to end, sourced from the official VS Code theme files:

- Editor/workbench colors from `dark_plus.json` / `dark_vs.json` — editor
  `#1E1E1E` background, `#D4D4D4` foreground, `#264F78` selection, `#094771`
  active list selection, `#37373D` selected tab, iconic `#007ACC` status bar.
- Syntax tokens from Dark+ `tokenColors` — comment `#6A9955`, string
  `#CE9178`, keyword.control `#C586C0`, function `#DCDCAA`, type `#4EC9B0`,
  variable `#9CDCFE`, constant/builtin `#4FC1FF`, tag `#569CD6`.
- Terminal ANSI palette from VS Code's `terminalColorRegistry.ts` dark
  defaults (red `#CD3131`, green `#0DBC79`, bright red `#F14C4C`, ...).
- Bracket pair colors `#FFD700` / `#DA70D6` / `#179FFF` (Dark+ bracket
  highlight palette).

## Why

`default-dark.json` reuses several Dark+ syntax colors but diverges on the
workbench and terminal surfaces, and colors `keyword` blue (`#569CD6`)
where Dark+ uses purple (`#C586C0`) for control flow. This theme gives the
actual Dark+ look across editor, tabs, sidebar, dialogs, status bar, and
terminal.

## Usage

Select in `settings.json`:

```json
{ "theme": "vscode-dark-plus" }
```

It is discovered automatically via the embedded themes FS
(`go:embed *.json`), so it also appears in the theme selector.

## Verification

- `TestBundledThemesLoad` and
  `TestBundledThemeSemanticDiffForegroundsMeetNormalTextContrast` pass with
  the new theme included.
- Built and smoke-tested: `--size 80x30 --exec` render of a Go file with the
  theme selected.
- `LoadTheme("vscode-dark-plus")` resolves Dark+ signature colors (keyword
  `#c586c0`, status bar `#007acc`, terminal red `#cd3131`).

## Sources

- VS Code Dark+ theme:
  https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_plus.json
- VS Code Dark workbench colors:
  https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_vs.json
- VS Code terminal ANSI palette:
  https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
